### PR TITLE
enable effect extensions for NodeJs gl

### DIFF
--- a/src/core/assets/effect-compiler/shdc-lib.js
+++ b/src/core/assets/effect-compiler/shdc-lib.js
@@ -1214,6 +1214,10 @@ const miscChecks = (() => {
 
 const finalTypeCheck = (() => {
     let gl = require('gl')(300, 150, { preserveDrawingBuffer: true });
+    const supportedExtensions = gl.getSupportedExtensions();
+    for (let i = 0; i !== supportedExtensions.length; ++i) {
+        gl.getExtension(supportedExtensions[i]);
+    }
     const getDefineString = (defines) =>
         defines.reduce((acc, cur) => {
             let value = 1; // enable all boolean swithces


### PR DESCRIPTION
Enable gl extensions when compiling effects.
If `webgl_draw_buffers` is missing, `#define gl_MaxDrawBuffers 1` will be added to the beginning of the shader source.
This will preclude `#version 100`, which must be at the beginning of the source.
