### PR TITLE
[fix] improve asset retrieval error handling in scene middleware

### DIFF
--- a/src/core/server/scene.middleware.ts
+++ b/src/core/server/scene.middleware.ts
@@ -45,6 +45,15 @@ export default {
                 const { assetManager } = await import('../assets');
                 const assetInfo = assetManager.queryAssetInfo(uuid);
                 const filePath = assetInfo && assetInfo.library[`${nativeName}.${ext}`];
+                if (!filePath) {
+                    console.warn(`Asset not found: ${req.url}`);
+                    return res.status(404).json({
+                        error: 'Asset not found',
+                        requested: req.url,
+                        uuid,
+                        file: `${nativeName}.${ext}`
+                    });
+                }
                 res.status(200).send(filePath || req.url);
             },
         },
@@ -55,6 +64,14 @@ export default {
                 const { assetManager } = await import('../assets');
                 const assetInfo = assetManager.queryAssetInfo(uuid);
                 const filePath = assetInfo && assetInfo.library[`.${ext}`];
+                if (!filePath) {
+                    console.warn(`Asset not found: ${req.url}`);
+                    return res.status(404).json({
+                        error: 'Asset not found',
+                        requested: req.url,
+                        uuid,
+                    });
+                }
                 res.status(200).send(filePath || req.url);
             },
         }


### PR DESCRIPTION
- Added checks for missing asset file paths in the scene middleware.
- Implemented 404 error responses with detailed information when assets are not found.


https://www.tapd.cn/tapd_fe/55361134/bug/detail/1155361134001000099