### PR TITLE
chore: update dependencies and rebuild configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
                 "express": "^5.1.0",
                 "figlet": "^1.9.3",
                 "fs-extra": "^10.0.0",
-                "gl": "^8.1.6",
+                "gl": "^9.0.0-rc.8",
                 "globby": "^14.1.0",
                 "glsl-parser": "^2.0.1",
                 "glsl-tokenizer": "^2.1.5",
@@ -114,6 +114,7 @@
                 "@vscode/test-cli": "^0.0.11",
                 "@vscode/test-electron": "^2.5.2",
                 "7zip-bin": "^5.2.0",
+                "baseline-browser-mapping": "^2.9.9",
                 "basic-ftp": "^5.0.5",
                 "eslint": "^9.34.0",
                 "globals": "^16.3.0",
@@ -3129,58 +3130,6 @@
                 "url": "https://opencollective.com/babel"
             }
         },
-        "node_modules/@cocos/creator-programming-rollup-plugin-mod-lo/node_modules/@babel/generator": {
-            "version": "7.16.8",
-            "resolved": "https://registry.npmmirror.com/@babel/generator/-/generator-7.16.8.tgz",
-            "integrity": "sha512-1ojZwE9+lOXzcWdWmO6TbUzDfqLD39CmEhN8+2cX9XkDo5yW1OpgfejfliysR2AWLpMamTiOiAp/mtroaymhpw==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.16.8",
-                "jsesc": "^2.5.1",
-                "source-map": "^0.5.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@cocos/creator-programming-rollup-plugin-mod-lo/node_modules/@babel/parser": {
-            "version": "7.16.12",
-            "resolved": "https://registry.npmmirror.com/@babel/parser/-/parser-7.16.12.tgz",
-            "integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A==",
-            "license": "MIT",
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@cocos/creator-programming-rollup-plugin-mod-lo/node_modules/@babel/template": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmmirror.com/@babel/template/-/template-7.16.7.tgz",
-            "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.16.7",
-                "@babel/parser": "^7.16.7",
-                "@babel/types": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@cocos/creator-programming-rollup-plugin-mod-lo/node_modules/jsesc": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmmirror.com/jsesc/-/jsesc-2.5.2.tgz",
-            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-            "license": "MIT",
-            "bin": {
-                "jsesc": "bin/jsesc"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/@cocos/creator-programming-rollup-plugin-mod-lo/node_modules/semver": {
             "version": "6.3.1",
             "resolved": "https://registry.npmmirror.com/semver/-/semver-6.3.1.tgz",
@@ -5171,6 +5120,18 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
+        "node_modules/@isaacs/fs-minipass": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmmirror.com/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+            "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.4"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
             "resolved": "https://registry.npmmirror.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -6288,37 +6249,40 @@
             }
         },
         "node_modules/@npmcli/agent": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmmirror.com/@npmcli/agent/-/agent-2.2.2.tgz",
-            "integrity": "sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmmirror.com/@npmcli/agent/-/agent-4.0.0.tgz",
+            "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
             "license": "ISC",
             "dependencies": {
                 "agent-base": "^7.1.0",
                 "http-proxy-agent": "^7.0.0",
                 "https-proxy-agent": "^7.0.1",
-                "lru-cache": "^10.0.1",
+                "lru-cache": "^11.2.1",
                 "socks-proxy-agent": "^8.0.3"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/@npmcli/agent/node_modules/lru-cache": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "license": "ISC"
+            "version": "11.2.4",
+            "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-11.2.4.tgz",
+            "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
         },
         "node_modules/@npmcli/fs": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmmirror.com/@npmcli/fs/-/fs-3.1.1.tgz",
-            "integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmmirror.com/@npmcli/fs/-/fs-5.0.0.tgz",
+            "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
             "license": "ISC",
             "dependencies": {
                 "semver": "^7.3.5"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/@opentelemetry/api": {
@@ -9183,12 +9147,12 @@
             "license": "MIT"
         },
         "node_modules/abbrev": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmmirror.com/abbrev/-/abbrev-2.0.0.tgz",
-            "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmmirror.com/abbrev/-/abbrev-4.0.0.tgz",
+            "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
             "license": "ISC",
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/accepts": {
@@ -9294,19 +9258,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 14"
-            }
-        },
-        "node_modules/aggregate-error": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmmirror.com/aggregate-error/-/aggregate-error-3.1.0.tgz",
-            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-            "license": "MIT",
-            "dependencies": {
-                "clean-stack": "^2.0.0",
-                "indent-string": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/ajv": {
@@ -10160,9 +10111,9 @@
             }
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.8.16",
-            "resolved": "https://registry.npmmirror.com/baseline-browser-mapping/-/baseline-browser-mapping-2.8.16.tgz",
-            "integrity": "sha512-OMu3BGQ4E7P1ErFsIPpbJh0qvDudM/UuJeHgkAvfWe+0HFJCXh+t/l8L6fVLR55RI/UbKrVLnAXZSVwd9ysWYw==",
+            "version": "2.9.9",
+            "resolved": "https://registry.npmmirror.com/baseline-browser-mapping/-/baseline-browser-mapping-2.9.9.tgz",
+            "integrity": "sha512-V8fbOCSeOFvlDj7LLChUcqbZrdKD9RU/VR260piF1790vT0mfLSwGc/Qzxv3IqiTukOpNtItePa0HBpMAj7MDg==",
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.js"
@@ -10807,73 +10758,79 @@
             }
         },
         "node_modules/cacache": {
-            "version": "18.0.4",
-            "resolved": "https://registry.npmmirror.com/cacache/-/cacache-18.0.4.tgz",
-            "integrity": "sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==",
+            "version": "20.0.3",
+            "resolved": "https://registry.npmmirror.com/cacache/-/cacache-20.0.3.tgz",
+            "integrity": "sha512-3pUp4e8hv07k1QlijZu6Kn7c9+ZpWWk4j3F8N3xPuCExULobqJydKYOTj1FTq58srkJsXvO7LbGAH4C0ZU3WGw==",
             "license": "ISC",
             "dependencies": {
-                "@npmcli/fs": "^3.1.0",
+                "@npmcli/fs": "^5.0.0",
                 "fs-minipass": "^3.0.0",
-                "glob": "^10.2.2",
-                "lru-cache": "^10.0.1",
+                "glob": "^13.0.0",
+                "lru-cache": "^11.1.0",
                 "minipass": "^7.0.3",
                 "minipass-collect": "^2.0.1",
                 "minipass-flush": "^1.0.5",
                 "minipass-pipeline": "^1.2.4",
-                "p-map": "^4.0.0",
-                "ssri": "^10.0.0",
-                "tar": "^6.1.11",
-                "unique-filename": "^3.0.0"
+                "p-map": "^7.0.2",
+                "ssri": "^13.0.0",
+                "unique-filename": "^5.0.0"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
-            }
-        },
-        "node_modules/cacache/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/cacache/node_modules/glob": {
-            "version": "10.4.5",
-            "resolved": "https://registry.npmmirror.com/glob/-/glob-10.4.5.tgz",
-            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-            "license": "ISC",
+            "version": "13.0.0",
+            "resolved": "https://registry.npmmirror.com/glob/-/glob-13.0.0.tgz",
+            "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
+                "minimatch": "^10.1.1",
                 "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^1.11.1"
+                "path-scurry": "^2.0.0"
             },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
+            "engines": {
+                "node": "20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/cacache/node_modules/lru-cache": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "license": "ISC"
+            "version": "11.2.4",
+            "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-11.2.4.tgz",
+            "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
         },
         "node_modules/cacache/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-            "license": "ISC",
+            "version": "10.1.1",
+            "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-10.1.1.tgz",
+            "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "@isaacs/brace-expansion": "^5.0.0"
             },
             "engines": {
-                "node": ">=16 || 14 >=14.17"
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/cacache/node_modules/path-scurry": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmmirror.com/path-scurry/-/path-scurry-2.0.1.tgz",
+            "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -11061,12 +11018,12 @@
             }
         },
         "node_modules/chownr": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmmirror.com/chownr/-/chownr-2.0.0.tgz",
-            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-            "license": "ISC",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmmirror.com/chownr/-/chownr-3.0.0.tgz",
+            "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+            "license": "BlueOak-1.0.0",
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             }
         },
         "node_modules/chrome-trace-event": {
@@ -11126,15 +11083,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/clean-stack": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmmirror.com/clean-stack/-/clean-stack-2.2.0.tgz",
-            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/cli-cursor": {
@@ -14017,22 +13965,21 @@
             "license": "MIT"
         },
         "node_modules/gl": {
-            "version": "8.1.6",
-            "resolved": "https://registry.npmmirror.com/gl/-/gl-8.1.6.tgz",
-            "integrity": "sha512-BcvkgW+jWiX2SjTddgq4lOfkFmeiKE/n1N3zFnq/JlSwemIvQvH1rLURz5oMdfp4ZT5bzseuIOE608zQI0DRYA==",
+            "version": "9.0.0-rc.8",
+            "resolved": "https://registry.npmmirror.com/gl/-/gl-9.0.0-rc.8.tgz",
+            "integrity": "sha512-cgoFHhhIvYUczaos+BNGgjoUm+1EPev66bY/94CShHLYgLy55lsON/y7yXtC6y0S4hDbDCysewwuu2cI7bFblQ==",
             "hasInstallScript": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "bindings": "^1.5.0",
                 "bit-twiddle": "^1.0.2",
                 "glsl-tokenizer": "^2.1.5",
-                "nan": "^2.22.0",
-                "node-abi": "^3.71.0",
-                "node-gyp": "^10.2.0",
-                "prebuild-install": "^7.1.2"
+                "nan": "^2.24.0",
+                "node-gyp": "^12.1.0",
+                "prebuild-install": "^7.1.3"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/glob": {
@@ -15083,15 +15030,6 @@
                 "node": ">=0.8.19"
             }
         },
-        "node_modules/indent-string": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmmirror.com/indent-string/-/indent-string-4.0.0.tgz",
-            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/infer-owner": {
             "version": "1.0.4",
             "resolved": "https://registry.npmmirror.com/infer-owner/-/infer-owner-1.0.4.tgz",
@@ -15196,9 +15134,9 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmmirror.com/ip-address/-/ip-address-10.0.1.tgz",
-            "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmmirror.com/ip-address/-/ip-address-10.1.0.tgz",
+            "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
             "license": "MIT",
             "engines": {
                 "node": ">= 12"
@@ -15411,12 +15349,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/is-lambda": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmmirror.com/is-lambda/-/is-lambda-1.0.1.tgz",
-            "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-            "license": "MIT"
         },
         "node_modules/is-module": {
             "version": "1.0.0",
@@ -18855,26 +18787,34 @@
             "license": "ISC"
         },
         "node_modules/make-fetch-happen": {
-            "version": "13.0.1",
-            "resolved": "https://registry.npmmirror.com/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
-            "integrity": "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==",
+            "version": "15.0.3",
+            "resolved": "https://registry.npmmirror.com/make-fetch-happen/-/make-fetch-happen-15.0.3.tgz",
+            "integrity": "sha512-iyyEpDty1mwW3dGlYXAJqC/azFn5PPvgKVwXayOGBSmKLxhKZ9fg4qIan2ePpp1vJIwfFiO34LAPZgq9SZW9Aw==",
             "license": "ISC",
             "dependencies": {
-                "@npmcli/agent": "^2.0.0",
-                "cacache": "^18.0.0",
+                "@npmcli/agent": "^4.0.0",
+                "cacache": "^20.0.1",
                 "http-cache-semantics": "^4.1.1",
-                "is-lambda": "^1.0.1",
                 "minipass": "^7.0.2",
-                "minipass-fetch": "^3.0.0",
+                "minipass-fetch": "^5.0.0",
                 "minipass-flush": "^1.0.5",
                 "minipass-pipeline": "^1.2.4",
-                "negotiator": "^0.6.3",
-                "proc-log": "^4.2.0",
+                "negotiator": "^1.0.0",
+                "proc-log": "^6.0.0",
                 "promise-retry": "^2.0.1",
-                "ssri": "^10.0.0"
+                "ssri": "^13.0.0"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/make-fetch-happen/node_modules/negotiator": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmmirror.com/negotiator/-/negotiator-1.0.0.tgz",
+            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/makeerror": {
@@ -19144,17 +19084,17 @@
             }
         },
         "node_modules/minipass-fetch": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmmirror.com/minipass-fetch/-/minipass-fetch-3.0.5.tgz",
-            "integrity": "sha512-2N8elDQAtSnFV0Dk7gt15KHsS0Fyz6CbYZ360h0WTYV1Ty46li3rAXVOQj1THMNLdmrD9Vt5pBPtWtVkpwGBqg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmmirror.com/minipass-fetch/-/minipass-fetch-5.0.0.tgz",
+            "integrity": "sha512-fiCdUALipqgPWrOVTz9fw0XhcazULXOSU6ie40DDbX1F49p1dBrSRBuswndTx1x3vEb/g0FT7vC4c4C2u/mh3A==",
             "license": "MIT",
             "dependencies": {
                 "minipass": "^7.0.3",
                 "minipass-sized": "^1.0.3",
-                "minizlib": "^2.1.2"
+                "minizlib": "^3.0.1"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^20.17.0 || >=22.9.0"
             },
             "optionalDependencies": {
                 "encoding": "^0.1.13"
@@ -19251,35 +19191,16 @@
             "license": "ISC"
         },
         "node_modules/minizlib": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmmirror.com/minizlib/-/minizlib-2.1.2.tgz",
-            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmmirror.com/minizlib/-/minizlib-3.1.0.tgz",
+            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
             "license": "MIT",
             "dependencies": {
-                "minipass": "^3.0.0",
-                "yallist": "^4.0.0"
+                "minipass": "^7.1.2"
             },
             "engines": {
-                "node": ">= 8"
+                "node": ">= 18"
             }
-        },
-        "node_modules/minizlib/node_modules/minipass": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmmirror.com/minipass/-/minipass-3.3.6.tgz",
-            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/minizlib/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmmirror.com/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "license": "ISC"
         },
         "node_modules/mississippi": {
             "version": "3.0.0",
@@ -19695,9 +19616,9 @@
             }
         },
         "node_modules/nan": {
-            "version": "2.23.0",
-            "resolved": "https://registry.npmmirror.com/nan/-/nan-2.23.0.tgz",
-            "integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
+            "version": "2.24.0",
+            "resolved": "https://registry.npmmirror.com/nan/-/nan-2.24.0.tgz",
+            "integrity": "sha512-Vpf9qnVW1RaDkoNKFUvfxqAbtI8ncb8OJlqZ9wwpXzWPEsvsB1nvdUi6oYrHIkQ1Y/tMDnr1h4nczS0VB9Xykg==",
             "license": "MIT"
         },
         "node_modules/nanomatch": {
@@ -19829,56 +19750,27 @@
             "license": "MIT"
         },
         "node_modules/node-gyp": {
-            "version": "10.3.1",
-            "resolved": "https://registry.npmmirror.com/node-gyp/-/node-gyp-10.3.1.tgz",
-            "integrity": "sha512-Pp3nFHBThHzVtNY7U6JfPjvT/DTE8+o/4xKsLQtBoU+j2HLsGlhcfzflAoUreaJbNmYnX+LlLi0qjV8kpyO6xQ==",
+            "version": "12.1.0",
+            "resolved": "https://registry.npmmirror.com/node-gyp/-/node-gyp-12.1.0.tgz",
+            "integrity": "sha512-W+RYA8jBnhSr2vrTtlPYPc1K+CSjGpVDRZxcqJcERZ8ND3A1ThWPHRwctTx3qC3oW99jt726jhdz3Y6ky87J4g==",
             "license": "MIT",
             "dependencies": {
                 "env-paths": "^2.2.0",
                 "exponential-backoff": "^3.1.1",
-                "glob": "^10.3.10",
                 "graceful-fs": "^4.2.6",
-                "make-fetch-happen": "^13.0.0",
-                "nopt": "^7.0.0",
-                "proc-log": "^4.1.0",
+                "make-fetch-happen": "^15.0.0",
+                "nopt": "^9.0.0",
+                "proc-log": "^6.0.0",
                 "semver": "^7.3.5",
-                "tar": "^6.2.1",
-                "which": "^4.0.0"
+                "tar": "^7.5.2",
+                "tinyglobby": "^0.2.12",
+                "which": "^6.0.0"
             },
             "bin": {
                 "node-gyp": "bin/node-gyp.js"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
-            }
-        },
-        "node_modules/node-gyp/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/node-gyp/node_modules/glob": {
-            "version": "10.4.5",
-            "resolved": "https://registry.npmmirror.com/glob/-/glob-10.4.5.tgz",
-            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-            "license": "ISC",
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/node-gyp/node_modules/isexe": {
@@ -19890,25 +19782,10 @@
                 "node": ">=16"
             }
         },
-        "node_modules/node-gyp/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/node-gyp/node_modules/which": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmmirror.com/which/-/which-4.0.0.tgz",
-            "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmmirror.com/which/-/which-6.0.0.tgz",
+            "integrity": "sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==",
             "license": "ISC",
             "dependencies": {
                 "isexe": "^3.1.1"
@@ -19917,7 +19794,7 @@
                 "node-which": "bin/which.js"
             },
             "engines": {
-                "node": "^16.13.0 || >=18.0.0"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/node-int64": {
@@ -20065,18 +19942,18 @@
             }
         },
         "node_modules/nopt": {
-            "version": "7.2.1",
-            "resolved": "https://registry.npmmirror.com/nopt/-/nopt-7.2.1.tgz",
-            "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmmirror.com/nopt/-/nopt-9.0.0.tgz",
+            "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
             "license": "ISC",
             "dependencies": {
-                "abbrev": "^2.0.0"
+                "abbrev": "^4.0.0"
             },
             "bin": {
                 "nopt": "bin/nopt.js"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/normalize-path": {
@@ -20515,15 +20392,12 @@
             }
         },
         "node_modules/p-map": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmmirror.com/p-map/-/p-map-4.0.0.tgz",
-            "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+            "version": "7.0.4",
+            "resolved": "https://registry.npmmirror.com/p-map/-/p-map-7.0.4.tgz",
+            "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
             "license": "MIT",
-            "dependencies": {
-                "aggregate-error": "^3.0.0"
-            },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -21358,12 +21232,12 @@
             }
         },
         "node_modules/proc-log": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmmirror.com/proc-log/-/proc-log-4.2.0.tgz",
-            "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmmirror.com/proc-log/-/proc-log-6.1.0.tgz",
+            "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
             "license": "ISC",
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/process": {
@@ -23729,15 +23603,15 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/ssri": {
-            "version": "10.0.6",
-            "resolved": "https://registry.npmmirror.com/ssri/-/ssri-10.0.6.tgz",
-            "integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
+            "version": "13.0.0",
+            "resolved": "https://registry.npmmirror.com/ssri/-/ssri-13.0.0.tgz",
+            "integrity": "sha512-yizwGBpbCn4YomB2lzhZqrHLJoqFGXihNbib3ozhqF/cIp5ue+xSmOQrjNasEE62hFxsCcg/V/z23t4n8jMEng==",
             "license": "ISC",
             "dependencies": {
                 "minipass": "^7.0.3"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/stack-trace": {
@@ -24128,20 +24002,19 @@
             }
         },
         "node_modules/tar": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmmirror.com/tar/-/tar-6.2.1.tgz",
-            "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-            "license": "ISC",
+            "version": "7.5.2",
+            "resolved": "https://registry.npmmirror.com/tar/-/tar-7.5.2.tgz",
+            "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.0.0",
-                "minipass": "^5.0.0",
-                "minizlib": "^2.1.1",
-                "mkdirp": "^1.0.3",
-                "yallist": "^4.0.0"
+                "@isaacs/fs-minipass": "^4.0.0",
+                "chownr": "^3.0.0",
+                "minipass": "^7.1.2",
+                "minizlib": "^3.1.0",
+                "yallist": "^5.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             }
         },
         "node_modules/tar-fs": {
@@ -24192,56 +24065,14 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/tar/node_modules/fs-minipass": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmmirror.com/fs-minipass/-/fs-minipass-2.1.0.tgz",
-            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmmirror.com/minipass/-/minipass-3.3.6.tgz",
-            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/tar/node_modules/minipass": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmmirror.com/minipass/-/minipass-5.0.0.tgz",
-            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/tar/node_modules/mkdirp": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmmirror.com/mkdirp/-/mkdirp-1.0.4.tgz",
-            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-            "license": "MIT",
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/tar/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmmirror.com/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "license": "ISC"
+            "version": "5.0.0",
+            "resolved": "https://registry.npmmirror.com/yallist/-/yallist-5.0.0.tgz",
+            "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/teex": {
             "version": "1.0.1",
@@ -24501,6 +24332,51 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmmirror.com/tinycolor2/-/tinycolor2-1.6.0.tgz",
             "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.15",
+            "resolved": "https://registry.npmmirror.com/tinyglobby/-/tinyglobby-0.2.15.tgz",
+            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyglobby/node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmmirror.com/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/tinyglobby/node_modules/picomatch": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
         },
         "node_modules/tinygradient": {
             "version": "1.1.5",
@@ -25330,27 +25206,27 @@
             }
         },
         "node_modules/unique-filename": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmmirror.com/unique-filename/-/unique-filename-3.0.0.tgz",
-            "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmmirror.com/unique-filename/-/unique-filename-5.0.0.tgz",
+            "integrity": "sha512-2RaJTAvAb4owyjllTfXzFClJ7WsGxlykkPvCr9pA//LD9goVq+m4PPAeBgNodGZ7nSrntT/auWpJ6Y5IFXcfjg==",
             "license": "ISC",
             "dependencies": {
-                "unique-slug": "^4.0.0"
+                "unique-slug": "^6.0.0"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/unique-slug": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmmirror.com/unique-slug/-/unique-slug-4.0.0.tgz",
-            "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmmirror.com/unique-slug/-/unique-slug-6.0.0.tgz",
+            "integrity": "sha512-4Lup7Ezn8W3d52/xBhZBVdx323ckxa7DEvd9kPQHppTkLoJXw6ltrBCyj5pnrxj0qKDxYMJ56CoxNuFCscdTiw==",
             "license": "ISC",
             "dependencies": {
                 "imurmurhash": "^0.1.4"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/universalify": {
@@ -25891,25 +25767,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/watchpack-chokidar2/node_modules/fsevents": {
-            "version": "1.2.13",
-            "resolved": "https://registry.npmmirror.com/fsevents/-/fsevents-1.2.13.tgz",
-            "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-            "deprecated": "Upgrade to fsevents v2 to mitigate potential security issues",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "dependencies": {
-                "bindings": "^1.5.0",
-                "nan": "^2.12.1"
-            },
-            "engines": {
-                "node": ">= 4.0"
             }
         },
         "node_modules/watchpack-chokidar2/node_modules/glob-parent": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "start:mcp-debug": "node ./dist/cli.js start-mcp-server --project=./tests/fixtures/projects/asset-operation",
         "start:mcp-inspector": "npx @modelcontextprotocol/inspector",
         "cli": "node ./dist/cli.js",
-        "rebuild": "npx --yes patch-package && npx @electron/rebuild --force --version 37.6.0"
+        "rebuild": "npx @electron/rebuild --force --version 39.2.3"
     },
     "author": "cocos",
     "files": [
@@ -64,6 +64,9 @@
         "writablePath",
         "packages/cc-module"
     ],
+    "overrides": {
+        "fsevents": "2.3.3"
+    },
     "license": "ISC",
     "devDependencies": {
         "@types/cli-progress": "^3.11.6",
@@ -90,6 +93,7 @@
         "@vscode/test-cli": "^0.0.11",
         "@vscode/test-electron": "^2.5.2",
         "7zip-bin": "^5.2.0",
+        "baseline-browser-mapping": "^2.9.9",
         "basic-ftp": "^5.0.5",
         "eslint": "^9.34.0",
         "globals": "^16.3.0",
@@ -136,7 +140,7 @@
         "express": "^5.1.0",
         "figlet": "^1.9.3",
         "fs-extra": "^10.0.0",
-        "gl": "^8.1.6",
+        "gl": "^9.0.0-rc.8",
         "globby": "^14.1.0",
         "glsl-parser": "^2.0.1",
         "glsl-tokenizer": "^2.1.5",


### PR DESCRIPTION
- Updated Electron rebuild version from 37.6.0 to 39.2.3.
- Added overrides for fsevents to version 2.3.3.
- Added baseline-browser-mapping dependency at version ^2.9.9.
- Updated gl dependency from ^8.1.6 to ^9.0.0-rc.8.