### PR TITLE
Fix the issue where the position passed to createNode and the retrieved position value are inconsistent.

### DIFF
--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -114,8 +114,9 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             setLayer(resultNode, parent.layer, true);
         }
 
+        // Compared to the editor, the position is set via API, so local coordinates are used here.
         if (params.position) {
-            resultNode.setWorldPosition(params.position);
+            resultNode.setPosition(params.position);
         }
 
         resultNode.setParent(parent, params.keepWorldTransform);


### PR DESCRIPTION
编辑器中的createByAsset由配置文件获取，cli的postion由api 提供，所以坐标的意义是不一样的。