### PR TITLE
static compile check fail throw error

### DIFF
--- a/src/core/builder/@types/protected/options.ts
+++ b/src/core/builder/@types/protected/options.ts
@@ -375,6 +375,7 @@ export const enum BuildExitCode {
     BUILD_FAILED = 34,
     BUILD_SUCCESS = 0,
     BUILD_BUSY = 37,
+    STATIC_COMPILE_ERROR = 38,
     UNKNOWN_ERROR = 50,
 }
 

--- a/src/core/builder/error-map.ts
+++ b/src/core/builder/error-map.ts
@@ -5,6 +5,7 @@ const BuildErrorMap = {
     [BuildExitCode.BUILD_FAILED]: '构建失败，请参考错误日志排查错误原因',
     [BuildExitCode.PARAM_ERROR]: '构建参数错误，请参考错误日志调整构建参数后重试',
     [BuildExitCode.UNKNOWN_ERROR]: '未知错误，请联系 cocos 官方',
+    [BuildExitCode.STATIC_COMPILE_ERROR]: '静态编译检查失败，发现 assets 相关的 TypeScript 错误',
 };
 
 export default BuildErrorMap;

--- a/src/core/builder/index.ts
+++ b/src/core/builder/index.ts
@@ -90,7 +90,12 @@ export async function build<P extends Platform>(platformTmp: P, options?: IBuild
         const duration = formatMSTime(Date.now() - startTime);
         newConsole.error(error);
         newConsole.buildComplete(platform, duration, false);
-        return { code: BuildExitCode.BUILD_FAILED, reason: 'Build failed! ' + String(error) };
+        // 如果错误对象包含 code 属性，使用该错误码（如 500）
+        let errorCode = error?.code && typeof error.code === 'number' ? error.code as BuildExitCode : BuildExitCode.BUILD_FAILED;
+        if (errorCode === BuildExitCode.BUILD_SUCCESS) {
+            errorCode = BuildExitCode.BUILD_FAILED;
+        }
+        return { code: errorCode as Exclude<BuildExitCode, BuildExitCode.BUILD_SUCCESS>, reason: error?.message || String(error) };
     }
 }
 

--- a/src/core/builder/worker/builder/asset-handler/script/static-compile-check.ts
+++ b/src/core/builder/worker/builder/asset-handler/script/static-compile-check.ts
@@ -82,9 +82,9 @@ function filterAssetsErrors(output: string): string {
  * 执行静态编译检查
  * @param projectPath 项目路径
  * @param showOutput 是否显示输出信息（默认 true）
- * @returns 返回 true 表示检查通过（没有 assets 相关错误），false 表示有错误
+ * @returns 返回对象，包含检查结果和错误信息。passed 为 true 表示检查通过（没有 assets 相关错误），false 表示有错误
  */
-export async function runStaticCompileCheck(projectPath: string, showOutput: boolean = true): Promise<boolean> {
+export async function runStaticCompileCheck(projectPath: string, showOutput: boolean = true): Promise<{ passed: boolean; errorMessage?: string }> {
     if (showOutput) {
         console.log(chalk.blue('Running TypeScript static compile check...'));
         console.log(chalk.gray(`Project: ${projectPath}`));
@@ -119,7 +119,7 @@ export async function runStaticCompileCheck(projectPath: string, showOutput: boo
             if (showOutput) {
                 console.log(chalk.green('✓ No assets-related TypeScript errors found!'));
             }
-            return true;
+            return { passed: true };
         }
 
         // 过滤出包含 "assets" 的错误
@@ -130,13 +130,13 @@ export async function runStaticCompileCheck(projectPath: string, showOutput: boo
             if (showOutput) {
                 console.log(filteredOutput);
             }
-            return false;
+            return { passed: false, errorMessage: filteredOutput };
         } else {
             // 没有 assets 相关的错误
             if (showOutput) {
                 console.log(chalk.green('✓ No assets-related TypeScript errors found!'));
             }
-            return true;
+            return { passed: true };
         }
     } catch (error: any) {
         // execAsync 在命令返回非零退出码时会抛出错误
@@ -152,7 +152,7 @@ export async function runStaticCompileCheck(projectPath: string, showOutput: boo
             if (showOutput) {
                 console.log(chalk.green('✓ No assets-related TypeScript errors found!'));
             }
-            return true;
+            return { passed: true };
         }
 
         // 过滤出包含 "assets" 的错误
@@ -163,13 +163,13 @@ export async function runStaticCompileCheck(projectPath: string, showOutput: boo
             if (showOutput) {
                 console.log(filteredOutput);
             }
-            return false;
+            return { passed: false, errorMessage: filteredOutput };
         } else {
             // 没有 assets 相关的错误
             if (showOutput) {
                 console.log(chalk.green('✓ No assets-related TypeScript errors found!'));
             }
-            return true;
+            return { passed: true };
         }
     }
 }


### PR DESCRIPTION
If the static compilation check fails, an error is thrown and the build process is halted.