### PR TITLE
 Tool Result Error

### DIFF
--- a/src/mcp/mcp.middleware.ts
+++ b/src/mcp/mcp.middleware.ts
@@ -132,7 +132,8 @@ export class McpMiddleware {
                              console.debug(`call ${toolName} with args:${methodArgs.toString()} result: ${formattedResult}`);
                              return {
                                 content: [{ type: 'text' as const, text: formattedResult }],
-                                structuredContent: structuredContent
+                                structuredContent: structuredContent,
+                                isError: result.code == 500
                              };
 
                         } catch (error) {


### PR DESCRIPTION
Fix the issue where Tool Result is not returned correctly when the CLI error code is 500, and SUCCESS is mistakenly returned instead.