### PR TITLE
feat: add MCP and Scene lib facade modules

### DIFF
--- a/src/core/scene/index.ts
+++ b/src/core/scene/index.ts
@@ -5,8 +5,14 @@ export * from './common';
 export * from './main-process';
 export { sceneConfigInstance };
 
-import { middlewareService } from '../../server/middleware/core';
+import { middlewareService } from '../../server/middleware';
 import SceneMiddleware from './scene.middleware';
+
+export async function init() {
+    middlewareService.register('Scene', SceneMiddleware);
+    // 场景配置初始化
+    await sceneConfigInstance.init();
+}
 
 /**
  * 启动场景
@@ -14,9 +20,7 @@ import SceneMiddleware from './scene.middleware';
  * @param projectPath 项目目录
  */
 export async function startupScene(enginePath: string, projectPath: string) {
-    middlewareService.register('Scene', SceneMiddleware);
-    // 场景配置初始化
-    await sceneConfigInstance.init();
+    await init();
     // 启动场景进程
     const { sceneWorker } = await import('./main-process/scene-worker');
     await sceneWorker.start(enginePath, projectPath);

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -4,5 +4,6 @@ export * as Configuration from './configuration/configuration';
 export * as Engine from './engine/engine';
 export * as Mcp from './mcp/mcp';
 export * as Project from './project/project';
+export * as Scene from './scene/scene';
 export * as Scripting from './scripting/scripting';
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,6 +2,7 @@ export * as Assets from './assets/assets';
 export * as Base from './base/base';
 export * as Configuration from './configuration/configuration';
 export * as Engine from './engine/engine';
+export * as Mcp from './mcp/mcp';
 export * as Project from './project/project';
 export * as Scripting from './scripting/scripting';
 

--- a/src/lib/mcp/mcp.ts
+++ b/src/lib/mcp/mcp.ts
@@ -1,8 +1,3 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) SUD. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
-
 /**
  * MCP Server Facade Module
  *

--- a/src/lib/mcp/mcp.ts
+++ b/src/lib/mcp/mcp.ts
@@ -1,0 +1,94 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) SUD. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * MCP Server Facade Module
+ *
+ * Called by the cocos-code utility process to start the MCP server
+ * in an already-initialized environment.
+ * Prerequisite: core modules (project/engine/assets/scripting/builder)
+ * have been initialized via their respective lib modules.
+ * This module only handles MCP-specific work: populating the toolRegistry,
+ * starting Express, and registering MCP routes.
+ */
+
+let mcpUrl: string | undefined;
+let isRunning = false;
+let startingPromise: Promise<string> | undefined;
+
+/**
+ * Start the MCP server.
+ *
+ * Note: does NOT call CocosAPI.startup() / Launcher because
+ * core modules are already initialized by the utility process.
+ * This function only:
+ * 1. Imports API modules to populate the toolRegistry (@tool decorator side-effects)
+ * 2. Starts the Express HTTP server
+ * 3. Creates McpMiddleware and registers routes
+ *
+ * @param port Optional port number; auto-selected if omitted
+ * @returns MCP server URL (e.g. http://localhost:9527/mcp)
+ */
+export async function startServer(port?: number): Promise<string> {
+	if (isRunning && mcpUrl) {
+		return mcpUrl;
+	}
+
+	// Concurrent startup guard: if already starting, wait for the existing promise
+	if (startingPromise) {
+		return startingPromise;
+	}
+
+	startingPromise = doStartServer(port);
+	try {
+		return await startingPromise;
+	} finally {
+		startingPromise = undefined;
+	}
+}
+
+async function doStartServer(port?: number): Promise<string> {
+	// 1. Import API modules to trigger @tool decorators and populate toolRegistry
+	const { CocosAPI } = await import('../../api/index');
+	await CocosAPI.create();
+
+	// 2. Start the Express HTTP server
+	const { serverService } = await import('../../server/server');
+	await serverService.start(port);
+
+	// 3. Create MCP middleware and register routes
+	const { McpMiddleware } = await import('../../mcp/mcp.middleware');
+	const middleware = new McpMiddleware();
+	serverService.register('mcp', middleware.getMiddlewareContribution());
+
+	mcpUrl = `${serverService.url}/mcp`;
+	isRunning = true;
+
+	console.log(`[MCP] Server started at: ${mcpUrl}`);
+	return mcpUrl;
+}
+
+/**
+ * Stop the MCP server.
+ */
+export async function stopServer(): Promise<void> {
+	if (!isRunning) {
+		return;
+	}
+
+	const { serverService } = await import('../../server/server');
+	await serverService.stop();
+
+	isRunning = false;
+	mcpUrl = undefined;
+	console.log('[MCP] Server stopped');
+}
+
+/**
+ * Get the MCP server status.
+ */
+export function getStatus(): { running: boolean; url?: string } {
+	return { running: isRunning, url: mcpUrl };
+}

--- a/src/lib/scene/scene.ts
+++ b/src/lib/scene/scene.ts
@@ -1,8 +1,3 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) SUD. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
-
 import { init as sceneInit } from '../../core/scene';
 import { GlobalPaths } from '../../global';
 

--- a/src/lib/scene/scene.ts
+++ b/src/lib/scene/scene.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) SUD. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { init as sceneInit } from '../../core/scene';
+import { GlobalPaths } from '../../global';
+
+/**
+ * Initialize the scene module.
+ * Registers the scene middleware and initializes scene config.
+ */
+export async function init(): Promise<void> {
+    await sceneInit();
+}
+
+/**
+ * Start the scene worker process.
+ *
+ * @param projectPath Path to the project directory
+ */
+export async function startupWorker(projectPath: string): Promise<void> {
+    const { sceneWorker } = await import('../../core/scene/main-process/scene-worker');
+    await sceneWorker.start(GlobalPaths.enginePath, projectPath);
+}


### PR DESCRIPTION
## Summary
- 新增 MCP Server facade 模块 (`src/lib/mcp/mcp.ts`)，提供独立的 MCP 服务器生命周期管理（启动/停止/状态查询）
- 新增 Scene lib 模块 (`src/lib/scene/scene.ts`)，封装 core scene 的初始化和 worker 启动
- 重构 `src/core/scene/index.ts`，提取 `init()` 函数，使中间件注册和配置初始化可以独立调用
- 在 `src/lib/index.ts` 中导出新的 Mcp 和 Scene 模块
