### PR TITLE
Fix CORS headers missing on error responses by reordering middleware

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -137,9 +137,9 @@ export class ServerService {
     }
 
     init() {
-        this.app.use(compression());
-        this.app.use(express.json());
         this.app.use(cors);
+        this.app.use(compression());
+        this.app.use(express.json({ limit: '50mb' }));
         this.app.use(consoleLogService.injectMiddleware);
         this.app.use(middlewareService.router);
         this.app.use(middlewareService.staticRouter);


### PR DESCRIPTION
Move cors middleware before compression and express.json so CORS headers are always set, even when body parsing fails. Also increase JSON body size limit to 50mb for large asset requests.