### PR TITLE
[feat] add uuid field to INodeTreeItem

### DIFF
--- a/src/core/scene/common/node.ts
+++ b/src/core/scene/common/node.ts
@@ -18,6 +18,7 @@ export interface INodeTreeItem {
     active: boolean;
     locked: boolean;
     type: string;
+    uuid: string;
     children: INodeTreeItem[];
     prefab: IPrefabStateInfo;
     parent: string;

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -430,6 +430,7 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
                     active: node.active,
                     locked: Boolean(node.objFlags & CCObject.Flags.LockedInEditor),
                     type: 'cc.' + node.constructor.name,
+                    uuid: node.uuid,
                     children,
                     prefab: prefabStateInfo,
                     parent: (node.parent && node.parent.uuid) || '',


### PR DESCRIPTION
## Summary
- Add `uuid` field to `INodeTreeItem` interface to expose node uuid in the tree structure
- Populate `uuid` from `node.uuid` when building the node tree in `NodeService`

## Test plan
- [ ] Verify node tree API returns `uuid` field for each node
- [ ] Confirm existing functionality (name, active, locked, parent, etc.) is unaffected