### PR TITLE
feat: add layer query APIs, engine metadata refactor, and multi-module enhancements

### DIFF
--- a/src/core/engine/index.ts
+++ b/src/core/engine/index.ts
@@ -19,6 +19,8 @@ export interface IEngine {
     init(enginePath: string): Promise<this>;
     initEngine(info: IInitEngineInfo): Promise<this>;
     queryRenderConfig(): ModuleRenderConfig;
+    queryLayerBuiltin(): Promise<{ name: string; value: number }[]>;
+    querySortingLayerBuiltin(): Promise<ReadonlyArray<{ id: number; name: string; value: number }>>;
 }
 
 const layerMask: number[] = [];
@@ -469,6 +471,24 @@ class EngineManager implements IEngine {
             throw new Error('Engine not init');
         }
         return getEngineRenderConfig(this._info.typescript.path);
+    }
+
+    async queryLayerBuiltin() {
+        const { Layers } = await import('cc');
+
+        const LAYER_NONE = 0;
+        const LAYER_ALL = 0xffffffff;
+        const entries = Object.entries(Layers.Enum) as [string, number][];
+
+        return entries
+            .filter(([, value]) => value !== LAYER_NONE && value !== LAYER_ALL)
+            .map(([name, value]) => ({ name, value }));
+    }
+
+    async querySortingLayerBuiltin() {
+        const { SortingLayers } = await import('cc');
+
+        return SortingLayers.getBuiltinLayers();
     }
 }
 

--- a/src/core/scene/scene-process/service/core/global-events.ts
+++ b/src/core/scene/scene-process/service/core/global-events.ts
@@ -108,7 +108,7 @@ class GlobalEventManager {
             args: [...args]
         };
         globalEventEmitter.emit(event, ...args);
-        if ('connected' in process) {
+        if ('connected' in process && process.connected) {
             process.send?.(message);
         }
     }

--- a/src/lib/engine/engine.ts
+++ b/src/lib/engine/engine.ts
@@ -25,3 +25,13 @@ export async function startEngineCompilation(force: boolean = false) {
     const { startCompileEngineProcess } = await import('../../core/engine/compile-process');
     await startCompileEngineProcess(force);
 }
+
+export async function queryLayerBuiltin() {
+    const { Engine } = await import('../../core/engine');
+    return Engine.queryLayerBuiltin();
+}
+
+export async function querySortingLayerBuiltin() {
+    const { Engine } = await import('../../core/engine');
+    return Engine.querySortingLayerBuiltin();
+}

--- a/static/i18n/en/configuration.json
+++ b/static/i18n/en/configuration.json
@@ -250,11 +250,11 @@
       "title": "Layer Settings",
       "customLayers": {
         "title": "Custom Layers",
-        "description": "List of custom layers"
+        "description": "Layers are most commonly used by Cameras to render only a part of the scene, and by Lights to illuminate only parts of the scene. \n You can customise User Layers form 0 to 19. The last twelve Builtin Layers are defaults used by Engine."
       },
       "sortingLayers": {
         "title": "Sorting Layers",
-        "description": "List of sorting layers"
+        "description": "Sort the layer list by dragging the layer list."
       }
     },
     "projectConfig": {

--- a/static/i18n/zh/configuration.json
+++ b/static/i18n/zh/configuration.json
@@ -250,11 +250,11 @@
       "title": "图层配置",
       "customLayers": {
         "title": "自定义图层",
-        "description": "自定义图层列表"
+        "description": "Layers 能让相机渲染部分场景，让灯光照亮部分场景。\n 可自定义 0 到 19 个 Layers， 而后 12 个 Layers 是引擎内置的。"
       },
       "sortingLayers": {
         "title": "排序图层",
-        "description": "排序图层列表"
+        "description": "排序图层列表，通过拖动可进行排序"
       }
     },
     "projectConfig": {


### PR DESCRIPTION
## Summary

- Add `queryLayerBuiltin` / `querySortingLayerBuiltin` engine APIs and lib facade
- Refactor engine metadata: merge projectConfig into moduleConfig, split layers node
- Expose configuration file path and `onDidSave` event in public API
- Add `uuid` field to `INodeTreeItem` interface
- Improve component interface completeness with comments and additional APIs
- Add `queryNodeTree` API and fix `EditorExtends` global aliasing
- Add MCP and Scene lib facade modules
- Refactor preview middleware and server lifecycle
- Fix CORS headers, plugin script loading, and MCP server path issues
- Update i18n descriptions for layers and sortingLayers settings
- Fix `process.connected` guard in global-events IPC send

## Test plan

- [ ] Verify `queryLayerBuiltin` / `querySortingLayerBuiltin` return correct engine layer data
- [ ] Verify configuration metadata APIs work correctly
- [ ] Verify component interface changes are compatible with Pink
- [ ] Run existing test suites (`npm test`)
- [ ] Verify MCP server and preview server work in CLI mode