### PR TITLE
[feat] refactor asset thumbnail system: remove old icon logic, add generateThumbnail handler API

### DIFF
--- a/src/api/assets/schema.ts
+++ b/src/api/assets/schema.ts
@@ -250,12 +250,6 @@ export type TUpdateAssetUserDataValue = z.infer<typeof SchemaUpdateAssetUserData
 export const SchemaUpdateAssetUserDataResult = z.any().describe('Updated user data object'); // 更新后的用户数据对象
 export type TUpdateAssetUserDataResult = z.infer<typeof SchemaUpdateAssetUserDataResult>;
 
-// Asset Config Map related Schema // Asset Config Map 相关 Schema
-export const SchemaThumbnailInfo = z.object({
-    type: z.enum(['icon', 'image']).describe('Thumbnail type: icon or image'), // 缩略图类型：icon 或 image
-    value: z.string().describe('Specific icon name or image path, supports absolute path, db://, project:// paths'), // 具体 icon 名字或者 image 路径，支持绝对路径、db://、project:// 下的路径
-}).describe('Thumbnail information'); // 缩略图信息
-
 // Recursively defined user data configuration item // 递归定义用户数据配置项
 const SchemaUserDataConfigItem: z.ZodType<any> = z.lazy(() => z.object({
     key: z.string().optional().describe('Unique identifier'), // 唯一标识符
@@ -282,7 +276,6 @@ export const SchemaAssetConfig = z.object({
     description: z.string().optional().describe('Asset description'), // 资源描述
     docURL: z.string().optional().describe('Document URL'), // 文档 URL
     userDataConfig: z.record(z.string(), SchemaUserDataConfigItem).optional().describe('User data configuration'), // 用户数据配置
-    iconInfo: SchemaThumbnailInfo.optional().describe('Icon information'), // 图标信息
 }).describe('Asset configuration information'); // 资源配置信息
 
 export const SchemaAssetConfigMapResult = z.record(z.string(), SchemaAssetConfig).describe('Asset configuration map, key is asset handler name, value is corresponding configuration information'); // 资源配置映射表，键为资源处理器名称，值为对应的配置信息

--- a/src/core/assets/@types/protected/asset-handler.d.ts
+++ b/src/core/assets/@types/protected/asset-handler.d.ts
@@ -131,6 +131,11 @@ export interface AssetHandlerBase extends CustomHandlerBase {
 
     // 虚拟资源可以实例化成实体的话，会带上这个扩展名
     instantiation?: string;
+
+    /**
+     * 生成资源缩略图，可选。
+     */
+    generateThumbnail?(asset: IAsset, size?: ThumbnailSize): Promise<ThumbnailInfo | null>;
 }
 
 export interface FileNameCheckConfig {

--- a/src/core/assets/@types/protected/asset-handler.d.ts
+++ b/src/core/assets/@types/protected/asset-handler.d.ts
@@ -106,18 +106,6 @@ export interface AssetHandlerBase extends CustomHandlerBase {
         generate?(asset: IAsset): Promise<Record<string, IUerDataConfigItem>>;
     };
 
-    // 指定资源的缩略图信息，默认值为必填项，thumbnail 为可选性
-    iconInfo?: {
-        default: ThumbnailInfo;
-
-        /**
-         * 获取某个资源的预览图信息（预览图地址，icon 图标等）
-         * @return 缩略图信息
-         * @param asset 
-         */
-        generateThumbnail?(asset: IAsset): ThumbnailInfo | Promise<ThumbnailInfo>;
-    };
-
     /**
      * 资源创建信息
      */
@@ -270,11 +258,6 @@ export interface ThumbnailInfo {
     value: string; // 具体 icon 名字或者 image 路径，image 路径支持绝对路径、 db:// 、 project:// 、和 packages:// 下的路径
 }
 
-export interface ICONConfig extends ThumbnailInfo {
-    // 是否支持缩略图，如存在可以单独像 db 查询缩略图信息
-    thumbnail?: boolean;
-}
-
 export type UIType = 'ui-select' | 'ui-checkbox' | 'ui-input' | 'ui-textarea' | 'ui-number-input' | 'ui-checkbox';
 
 export interface IUerDataConfigItem {
@@ -305,5 +288,4 @@ export interface IAssetConfig {
     description?: string;
     docURL?: string;
     userDataConfig?: Record<string, IUerDataConfigItem>;
-    iconInfo?: ThumbnailInfo;
 }

--- a/src/core/assets/@types/public.d.ts
+++ b/src/core/assets/@types/public.d.ts
@@ -49,6 +49,7 @@ export interface IAssetInfo {
     mtime?: number; // 资源文件的 mtime
     depends?: string[]; // 依赖的资源 uuid 信息
     dependeds?: string[]; // 被依赖的资源 uuid 信息
+    temp?: string; // 资源临时文件目录
 }
 
 export interface AssetOperationOption {

--- a/src/core/assets/asset-handler/assets/directory.ts
+++ b/src/core/assets/asset-handler/assets/directory.ts
@@ -30,26 +30,6 @@ const DirectoryHandler: AssetHandler = {
         },
     },
 
-    iconInfo: {
-        default: {
-            value: 'directory',
-            type: 'icon',
-        },
-        generateThumbnail(asset) {
-            const userData = asset.userData as DirectoryAssetUserData;
-            if (userData.isBundle) {
-                return {
-                    value: 'bundle-folder',
-                    type: 'icon',
-                };
-            }
-            return {
-                value: 'directory',
-                type: 'icon',
-            };
-        },
-    },
-
     createInfo: {
         generateMenuInfo() {
             return [

--- a/src/core/assets/asset-handler/assets/gltf/image.ts
+++ b/src/core/assets/asset-handler/assets/gltf/image.ts
@@ -13,7 +13,7 @@ import { imageMimeTypeToExt } from '../utils/image-mime-type-to-ext';
 import { decodeBase64ToArrayBuffer } from '../utils/base64';
 import { ImageAsset } from 'cc';
 import { getDependUUIDList } from '../../utils';
-import { defaultIconConfig, handleImageUserData } from '../image/utils';
+import { handleImageUserData } from '../image/utils';
 import { AssetHandler } from '../../../@types/protected';
 import FbxHandler from '../fbx';
 import GltfHandler from '../gltf';
@@ -24,15 +24,6 @@ export const GltfImageHandler: AssetHandler = {
 
     // 引擎内对应的类型
     assetType: 'cc.ImageAsset',
-    iconInfo: {
-        default: defaultIconConfig,
-        generateThumbnail(asset: Asset) {
-            return {
-                type: 'image',
-                value: asset.library + asset.getData('imageExtName'),
-            };
-        },
-    },
     importer: {
         // 版本号如果变更，则会强制重新导入
         version: '1.0.3',

--- a/src/core/assets/asset-handler/assets/gltf/mesh.ts
+++ b/src/core/assets/asset-handler/assets/gltf/mesh.ts
@@ -6,7 +6,7 @@ import { gfx } from 'cc';
 import fs from 'fs-extra';
 import { unwrapLightmapUV } from '../utils/uv-unwrap';
 import { ensureDir } from 'fs-extra';
-import { AssetHandler, ThumbnailInfo } from '../../../@types/protected';
+import { AssetHandler } from '../../../@types/protected';
 import { optimizeMesh, clusterizeMesh, simplifyMesh, getDefaultSimplifyOptions, compressMesh } from './meshOptimizer';
 import FbxHandler from '../fbx';
 import GltfHandler from '../gltf';
@@ -17,22 +17,6 @@ export const GltfMeshHandler: AssetHandler = {
 
     // 引擎内对应的类型
     assetType: 'cc.Mesh',
-
-    iconInfo: {
-        default: {
-            type: 'icon',
-            value: 'gltf-mesh',
-        },
-        async generateThumbnail(asset: Asset) {
-            const result: ThumbnailInfo = {
-                type: 'icon',
-                value: 'gltf-mesh',
-            };
-
-            // TODO: 实现生成 mesh 的缩略图
-            return result;
-        },
-    },
 
     /**
      * 允许这种类型的资源进行实例化

--- a/src/core/assets/asset-handler/assets/image/alpha.ts
+++ b/src/core/assets/asset-handler/assets/image/alpha.ts
@@ -1,6 +1,6 @@
 import { Asset, VirtualAsset } from '@cocos/asset-db';
 import { AssetHandler } from '../../../@types/protected';
-import { defaultIconConfig, handleImageUserData, importWithType, isCapableToFixAlphaTransparencyArtifacts, saveImageAsset } from './utils';
+import { handleImageUserData, importWithType, isCapableToFixAlphaTransparencyArtifacts, saveImageAsset } from './utils';
 import utils from '../../../../base/utils';
 
 export const AlphaImageHandler: AssetHandler = {
@@ -9,15 +9,6 @@ export const AlphaImageHandler: AssetHandler = {
 
     // 引擎内对应的类型
     assetType: 'cc.ImageAsset',
-    iconInfo: {
-        default: defaultIconConfig,
-        generateThumbnail(asset: Asset) {
-            return {
-                type: 'image',
-                value: asset.library + '.png',
-            };
-        },
-    },
 
     importer: {
         // 版本号如果变更，则会强制重新导入

--- a/src/core/assets/asset-handler/assets/image/index.ts
+++ b/src/core/assets/asset-handler/assets/image/index.ts
@@ -7,7 +7,6 @@ import { ImageAssetUserData } from '../../../@types/userDatas';
 
 import { join } from 'path';
 import {
-    defaultIconConfig,
     handleImageUserData,
     importWithType,
     isCapableToFixAlphaTransparencyArtifacts,
@@ -26,16 +25,6 @@ export const ImageHandler: AssetHandler = {
     // 引擎内对应的类型
     assetType: 'cc.ImageAsset',
     open: openImageAsset,
-    iconInfo: {
-        default: defaultIconConfig,
-        generateThumbnail(asset: Asset) {
-            const extname = asset.meta.files.find((extName) => extName !== '.json') || '.png';
-            return {
-                type: 'image',
-                value: asset.library + extname,
-            };
-        },
-    },
     importer: {
         // 版本号如果变更，则会强制重新导入
         version: '1.0.27',

--- a/src/core/assets/asset-handler/assets/image/sign.ts
+++ b/src/core/assets/asset-handler/assets/image/sign.ts
@@ -1,6 +1,6 @@
 import { Asset, VirtualAsset } from '@cocos/asset-db';
-import { AssetHandler, ThumbnailInfo } from '../../../@types/protected';
-import { defaultIconConfig, handleImageUserData, importWithType, isCapableToFixAlphaTransparencyArtifacts, saveImageAsset } from './utils';
+import { AssetHandler } from '../../../@types/protected';
+import { handleImageUserData, importWithType, isCapableToFixAlphaTransparencyArtifacts, saveImageAsset } from './utils';
 import utils from '../../../../base/utils';
 
 export const SignImageHandler: AssetHandler = {
@@ -9,16 +9,6 @@ export const SignImageHandler: AssetHandler = {
 
     // 引擎内对应的类型
     assetType: 'cc.ImageAsset',
-
-    iconInfo: {
-        default: defaultIconConfig,
-        generateThumbnail(asset: Asset) {
-            return {
-                type: 'image',
-                value: asset.library + '.png',
-            };
-        },
-    },
 
     importer: {
         // 版本号如果变更，则会强制重新导入

--- a/src/core/assets/asset-handler/assets/sprite-frame.ts
+++ b/src/core/assets/asset-handler/assets/sprite-frame.ts
@@ -1,12 +1,11 @@
 'use strict';
 
-import { Asset, VirtualAsset, queryPath, queryUUID, queryAsset } from '@cocos/asset-db';
+import { Asset, VirtualAsset, queryPath, queryUUID } from '@cocos/asset-db';
 import * as cc from 'cc';
 
 import { AssetHandler } from '../../@types/protected';
 import { SpriteFrameBaseAssetUserData, SpriteFrameAssetUserData } from '../../@types/userDatas';
 import { getTrimRect, getDependUUIDList } from '../utils';
-import { defaultIconConfig } from './image/utils';
 import i18n from '../../../base/i18n';
 
 try {
@@ -25,33 +24,6 @@ export const SpriteFrameHandler: AssetHandler = {
     name: 'sprite-frame',
 
     assetType: 'cc.SpriteFrame',
-    iconInfo: {
-        default: defaultIconConfig,
-        async generateThumbnail(asset: Asset) {
-            let parentAsset = queryAsset(asset.meta.userData.imageUuidOrDatabaseUri) as Asset;
-            if (parentAsset.meta.importer !== 'image') {
-                parentAsset = parentAsset.parent as Asset;
-            }
-            if (parentAsset.invalid) {
-                return defaultIconConfig;
-            }
-            const extname = parentAsset.meta.files.find((extName) => extName !== '.json') || '.png';
-            const imagePath = parentAsset.library + extname;
-            const dest = asset.library + '_sprite_trim_' + extname;
-            const userData = asset.userData as SpriteFrameBaseAssetUserData;
-            try {
-                await trimImage(imagePath, dest, userData);
-            } catch (error) {
-                console.warn(`trim image {file(${imagePath})} to generate thumbnail failed~`);
-                console.warn(error);
-                return defaultIconConfig;
-            }
-            return {
-                type: 'image',
-                value: dest,
-            };
-        },
-    },
 
     userDataConfig: {
         default: {

--- a/src/core/assets/asset-handler/assets/texture-cube-face.ts
+++ b/src/core/assets/asset-handler/assets/texture-cube-face.ts
@@ -1,27 +1,11 @@
 import { Asset, AssetHandler, VirtualAsset } from '../../@types/protected';
 import { getDependUUIDList } from '../utils';
 import { IFaceSwapSpace } from './erp-texture-cube';
-import { defaultIconConfig } from './image/utils';
-
 export const TextureCubeFaceHandler: AssetHandler = {
     // Handler 的名字，用于指定 Handler as 等
     name: 'texture-cube-face',
     // 引擎内对应的类型
     assetType: 'cc.ImageAsset',
-    iconInfo: {
-        default: defaultIconConfig,
-        generateThumbnail(asset: Asset) {
-            const parentAsset = asset.parent!.parent as Asset;
-            if (parentAsset.invalid) {
-                return defaultIconConfig;
-            }
-            const extname = parentAsset.meta.files.find((extName) => extName !== '.json') || '.png';
-            return {
-                type: 'image',
-                value: asset.library + extname,
-            };
-        },
-    },
 
     importer: {
         // 版本号如果变更，则会强制重新导入

--- a/src/core/assets/asset-handler/assets/texture.ts
+++ b/src/core/assets/asset-handler/assets/texture.ts
@@ -1,11 +1,11 @@
-import { VirtualAsset, Asset, queryAsset } from '@cocos/asset-db';
+import { VirtualAsset, Asset } from '@cocos/asset-db';
 
 import { ImageAsset } from 'cc';
 
 import { AssetHandler } from '../../@types/protected';
 import { Texture2DAssetUserData } from '../../@types/userDatas';
 import { getDependUUIDList } from '../utils';
-import { defaultIconConfig, makeDefaultTexture2DAssetUserData } from './image/utils';
+import { makeDefaultTexture2DAssetUserData } from './image/utils';
 import { applyTextureBaseAssetUserData } from './texture-base';
 import { url2uuid } from '../../utils';
 
@@ -15,24 +15,6 @@ export const TextureHandler: AssetHandler = {
 
     // 引擎内对应的类型
     assetType: 'cc.Texture2D',
-    iconInfo: {
-        default: defaultIconConfig,
-        generateThumbnail(asset: Asset) {
-            const imageUuid = getImageUuid(asset);
-            if (!imageUuid) {
-                return defaultIconConfig;
-            }
-            const imageAsset = queryAsset(imageUuid) as Asset;
-            if (imageAsset.invalid) {
-                return defaultIconConfig;
-            }
-            const extname = imageAsset.meta.files.find((extName) => extName !== '.json') || '.png';
-            return {
-                type: 'image',
-                value: imageAsset.library + extname,
-            };
-        },
-    },
 
     importer: {
         // 版本号如果变更，则会强制重新导入

--- a/src/core/assets/asset-handler/assets/unknown.ts
+++ b/src/core/assets/asset-handler/assets/unknown.ts
@@ -13,34 +13,6 @@ export const UnknownHandler: AssetHandler = {
     // 引擎内对应的类型
     assetType: 'cc.Asset',
 
-    iconInfo: {
-        default: {
-            type: 'icon',
-            value: 'file',
-        },
-        generateThumbnail(asset: Asset) {
-            let val = 'file';
-            switch (asset.extname) {
-                case '.zip':
-                    val = 'zip';
-                    break;
-                case '.html':
-                    val = 'html5';
-                    break;
-                case '.bin':
-                    val = 'bin';
-                    break;
-                case '.svg':
-                    val = 'svg';
-                    break;
-            }
-            return {
-                type: 'icon',
-                value: val,
-            };
-        },
-    },
-
     async open() {
 
         return false;

--- a/src/core/assets/manager/asset-handler.ts
+++ b/src/core/assets/manager/asset-handler.ts
@@ -1,13 +1,13 @@
 import { Importer as AssetDBImporter, Asset, setDefaultUserData, get } from '@cocos/asset-db';
-import { copy, copyFile, ensureDir, existsSync, outputFile, outputJSON } from 'fs-extra';
-import { basename, dirname, extname, isAbsolute, join } from 'path';
+import { copy, ensureDir, existsSync, outputFile, outputJSON } from 'fs-extra';
+import { basename, extname, isAbsolute, join } from 'path';
 import { url2path } from '../utils';
 import lodash from 'lodash';
 import fg from 'fast-glob';
-import Sharp from 'sharp';
+
 import i18n from '../../base/i18n';
 import { IAsset, IExportData } from '../@types/protected/asset';
-import { ICONConfig, AssetHandler, CustomHandler, CustomAssetHandler, ICreateMenuInfo, CreateAssetOptions, ThumbnailSize, ThumbnailInfo, IExportOptions, IAssetConfig, ImporterHook } from '../@types/protected/asset-handler';
+import { AssetHandler, CustomHandler, CustomAssetHandler, ICreateMenuInfo, CreateAssetOptions, IExportOptions, IAssetConfig, ImporterHook } from '../@types/protected/asset-handler';
 import type { AssetHandlerInfo } from '../asset-handler/config';
 import assetConfig from '../asset-config';
 import eol from 'eol';
@@ -16,12 +16,6 @@ interface HandlerInfo extends AssetHandlerInfo {
     pkgName: string;
     internal: boolean;
 }
-
-const databaseIconConfig: ICONConfig = {
-    type: 'icon',
-    value: 'database',
-    thumbnail: false,
-};
 
 export class CustomImporter extends AssetDBImporter {
     constructor(extensions: string[], assetHandler: AssetHandler) {
@@ -67,8 +61,6 @@ class AssetHandlerManager {
     name2custom: Record<string, CustomHandler> = {};
     importer2custom: Record<string, CustomHandler[]> = {};
 
-    _iconConfigMap: Record<string, ICONConfig> | null = null;
-
     // 用户配置里的 userData 缓存
     _userDataCache: Record<string, any> = {};
     // 导入器里注册的默认 userData 值， 注册后不可修改
@@ -81,7 +73,6 @@ class AssetHandlerManager {
         this.name2custom = {};
         this.importer2OperateRecord = {};
         this.importer2custom = {};
-        this._iconConfigMap = null;
     }
 
     compileEffect(_force: boolean) {
@@ -377,36 +368,9 @@ class AssetHandlerManager {
         return true;
     }
 
-    async queryIconConfigMap(): Promise<Record<string, ICONConfig>> {
-        if (this._iconConfigMap) {
-            return this._iconConfigMap;
-        }
-        const result: Record<string, ICONConfig> = {};
-        for (const importer of Object.keys(this.name2handler)) {
-            const handler = this.name2handler[importer];
-            if (!handler.iconInfo) {
-                result[importer] = {
-                    type: 'icon',
-                    value: importer,
-                    thumbnail: false,
-                };
-                continue;
-            }
-            const { default: defaultConfig, generateThumbnail } = handler.iconInfo;
-            result[importer] = {
-                ...defaultConfig,
-                thumbnail: !!generateThumbnail,
-            };
-        }
-        // 手动补充 database 的资源处理器
-        result['database'] = databaseIconConfig;
-        this._iconConfigMap = result;
-        return result;
-    }
-
     /**
      * 创建资源
-     * @param options 
+     * @param options
      * @returns 返回资源创建地址
      */
     async createAsset(options: CreateAssetOptions): Promise<string> {
@@ -479,69 +443,6 @@ class AssetHandlerManager {
         return true;
     }
 
-    async generateThumbnail(asset: IAsset, size: number | ThumbnailSize = 'large'): Promise<ThumbnailInfo | null> {
-        if (!asset) {
-            return null;
-        }
-
-        // 无效资源需要等待重新导入
-        if (asset.invalid) {
-            return {
-                type: 'icon',
-                value: 'file',
-            };
-        }
-
-        const configMap = await this.queryIconConfigMap();
-        if (!configMap[asset.meta.importer]) {
-            return null;
-        }
-
-        const cacheDest = join(asset.temp, `thumbnail-${size}.png`);
-        if (existsSync(cacheDest)) {
-            return {
-                type: 'image',
-                value: cacheDest,
-            };
-        }
-        let data: ThumbnailInfo;
-        if (!configMap[asset.meta.importer].thumbnail) {
-            data = configMap[asset.meta.importer];
-        } else {
-            const assetHandler = this.name2handler[asset.meta.importer];
-            try {
-                data = await assetHandler.iconInfo!.generateThumbnail!(asset);
-            } catch (error) {
-                console.warn(error);
-                console.warn(`generateThumbnail failed for ${asset.url}`);
-                return null;
-            }
-        }
-        if (data.type === 'image') {
-            const file = isAbsolute(data.value) ? data.value : url2path(data.value);
-            // SVG 无需 resize
-            if (file.endsWith('.svg')) {
-                return data;
-            }
-            if (!existsSync(file)) {
-                return null;
-            }
-            try {
-                data.value = await resizeThumbnail(file, cacheDest, size);
-            } catch (error) {
-                console.warn(error);
-                console.warn(`resizeThumbnail failed for ${asset.url}`);
-            }
-        }
-        return data;
-    }
-
-    /**
-     * 生成某个资源的导出文件信息
-     * @param asset 
-     * @param options 
-     * @returns 
-     */
     async generateExportData(asset: IAsset, options?: IExportOptions): Promise<IExportData | null> {
         const assetHandler = this.name2handler[asset.meta.importer];
         if (!assetHandler || !assetHandler.exporter || !assetHandler.exporter.generateExportData) {
@@ -579,9 +480,6 @@ class AssetHandlerManager {
                 description: handler.description,
                 docURL: handler.docURL,
             };
-            if (handler.iconInfo) {
-                config.iconInfo = handler.iconInfo.default;
-            }
 
             if (handler.userDataConfig) {
                 config.userDataConfig = handler.userDataConfig.default;
@@ -777,31 +675,6 @@ async function queryUserTemplates(templateDir: string) {
 
 function getUserTemplateDir(importer: string) {
     return join(AssetHandlerManager.createTemplateRoot, importer);
-}
-
-const SizeMap = {
-    large: 512,
-    small: 16,
-    middle: 128,
-};
-
-async function resizeThumbnail(src: string, dest: string, size: number | ThumbnailSize): Promise<string> {
-    if (size === 'origin') {
-        return src;
-    }
-    if (typeof size === 'string') {
-        size = SizeMap[size] || 16;
-    }
-    await ensureDir(dirname(dest));
-    const img = Sharp(src);
-    const width = (await img.metadata()).width;
-    // 如果图片尺寸小于缩略图尺寸，则直接拷贝
-    if (width && width <= size) {
-        await copyFile(src, dest);
-        return dest;
-    }
-    await img.resize(size).toFile(dest);
-    return dest;
 }
 
 async function afterCreateAsset(paths: string | string[], options: CreateAssetOptions) {

--- a/src/core/assets/manager/asset-handler.ts
+++ b/src/core/assets/manager/asset-handler.ts
@@ -7,7 +7,7 @@ import fg from 'fast-glob';
 
 import i18n from '../../base/i18n';
 import { IAsset, IExportData } from '../@types/protected/asset';
-import { AssetHandler, CustomHandler, CustomAssetHandler, ICreateMenuInfo, CreateAssetOptions, IExportOptions, IAssetConfig, ImporterHook } from '../@types/protected/asset-handler';
+import { AssetHandler, CustomHandler, CustomAssetHandler, ICreateMenuInfo, CreateAssetOptions, IExportOptions, IAssetConfig, ImporterHook, ThumbnailInfo, ThumbnailSize } from '../@types/protected/asset-handler';
 import type { AssetHandlerInfo } from '../asset-handler/config';
 import assetConfig from '../asset-config';
 import eol from 'eol';
@@ -487,6 +487,19 @@ class AssetHandlerManager {
             result[importer] = config;
         }
         return result;
+    }
+
+    queryThumbnailHandlers(): string[] {
+        return Object.keys(this.name2handler)
+            .filter(name => typeof this.name2handler[name].generateThumbnail === 'function');
+    }
+
+    async generateThumbnail(asset: IAsset, size?: ThumbnailSize): Promise<ThumbnailInfo | null> {
+        const handler = this.name2handler[asset.meta.importer];
+        if (handler && typeof handler.generateThumbnail === 'function') {
+            return handler.generateThumbnail(asset, size);
+        }
+        return null;
     }
 
     async queryUserDataConfig(asset: IAsset) {

--- a/src/core/assets/manager/asset.ts
+++ b/src/core/assets/manager/asset.ts
@@ -3,6 +3,7 @@ import assetDBManager from './asset-db';
 import { url2path, url2uuid } from '../utils';
 import EventEmitter from 'events';
 import { AssetManagerEvents, IAsset, IAssetInfo, IAssetDBInfo } from '../@types/private';
+import type { ThumbnailInfo, ThumbnailSize } from '../@types/protected/asset-handler';
 import assetQuery from './query';
 import assetOperation from './operation';
 import assetHandlerManager from './asset-handler';
@@ -50,6 +51,13 @@ class AssetManager extends EventEmitter {
     updateDefaultUserData = assetHandlerManager.updateDefaultUserData.bind(assetHandlerManager);
     getCreateMap = assetHandlerManager.getCreateMap.bind(assetHandlerManager);
     queryAssetUserDataConfig = assetHandlerManager.queryUserDataConfig.bind(assetHandlerManager);
+    queryThumbnailHandlers = assetHandlerManager.queryThumbnailHandlers.bind(assetHandlerManager);
+
+    async generateThumbnail(urlOrUUIDOrPath: string, size?: ThumbnailSize): Promise<ThumbnailInfo | null> {
+        const asset = this.queryAsset(urlOrUUIDOrPath);
+        if (!asset) { return null; }
+        return assetHandlerManager.generateThumbnail(asset, size);
+    }
     getEffectBinPath() {
         return assetHandlerManager.getEffectBinPath();
     };
@@ -347,7 +355,10 @@ export interface TypedAssetManager extends EventEmitter {
     updateDefaultUserData: typeof assetHandlerManager.updateDefaultUserData;
     getCreateMap: typeof assetHandlerManager.getCreateMap;
     queryAssetUserDataConfig: typeof assetHandlerManager.queryUserDataConfig;
+    queryThumbnailHandlers: typeof assetHandlerManager.queryThumbnailHandlers;
     getEffectBinPath: typeof assetHandlerManager.getEffectBinPath;
+
+    generateThumbnail(urlOrUUIDOrPath: string, size?: ThumbnailSize): Promise<ThumbnailInfo | null>;
 
     onReady: typeof assetManager.onReady;
     onDBReady: typeof assetManager.onDBReady;

--- a/src/core/assets/manager/asset.ts
+++ b/src/core/assets/manager/asset.ts
@@ -46,7 +46,6 @@ class AssetManager extends EventEmitter {
     updateUserData = assetOperation.updateUserData.bind(assetOperation);
 
     // ----------- assetHandlerManager ------------
-    queryIconConfigMap = assetHandlerManager.queryIconConfigMap.bind(assetHandlerManager);
     queryAssetConfigMap = assetHandlerManager.queryAssetConfigMap.bind(assetHandlerManager);
     updateDefaultUserData = assetHandlerManager.updateDefaultUserData.bind(assetHandlerManager);
     getCreateMap = assetHandlerManager.getCreateMap.bind(assetHandlerManager);
@@ -344,7 +343,6 @@ export interface TypedAssetManager extends EventEmitter {
     createAssetByType: typeof assetOperation.createAssetByType;
     updateUserData: typeof assetOperation.updateUserData;
 
-    queryIconConfigMap: typeof assetHandlerManager.queryIconConfigMap;
     queryAssetConfigMap: typeof assetHandlerManager.queryAssetConfigMap;
     updateDefaultUserData: typeof assetHandlerManager.updateDefaultUserData;
     getCreateMap: typeof assetHandlerManager.getCreateMap;

--- a/src/core/assets/manager/query.ts
+++ b/src/core/assets/manager/query.ts
@@ -573,6 +573,8 @@ class AssetQueryManager {
                     });
                     return usedList;
                 }
+            case 'temp':
+                return asset.temp;
         }
     }
 

--- a/src/core/engine/metadata.ts
+++ b/src/core/engine/metadata.ts
@@ -166,6 +166,32 @@ export function createEngineMetadataNodes(options: IEngineMetadataOptions): ICoc
                 title: 'i18n:configuration.engine.moduleConfig.noDeprecatedFeatures.title',
                 description: 'i18n:configuration.engine.moduleConfig.noDeprecatedFeatures.description',
             },
+            'engine.globalConfigKey': {
+                type: 'string',
+                default: '',
+                title: 'i18n:configuration.engine.projectConfig.globalConfigKey.title',
+            },
+            'engine.configs': objectSchema(undefined, {
+                title: 'i18n:configuration.engine.projectConfig.configs.title',
+                additionalProperties: objectSchema({
+                    includeModules: dynamicMetadata.includeModules,
+                    flags: dynamicMetadata.flagsObject,
+                    noDeprecatedFeatures: objectSchema({
+                        value: {
+                            type: 'boolean',
+                            title: 'i18n:configuration.engine.projectConfig.noDeprecatedFeatureConfig.value.title',
+                        },
+                        version: {
+                            type: 'string',
+                            title: 'i18n:configuration.engine.projectConfig.noDeprecatedFeatureConfig.version.title',
+                        },
+                    }, {
+                        title: 'i18n:configuration.engine.projectConfig.noDeprecatedFeatureConfig.title',
+                    }),
+                }, {
+                    title: 'i18n:configuration.engine.projectConfig.configItem.title',
+                }),
+            }),
         }, 4),
 
         createNode('engine.rendering', 'i18n:configuration.engine.rendering.title', 'engine', {
@@ -221,48 +247,22 @@ export function createEngineMetadataNodes(options: IEngineMetadataOptions): ICoc
             }),
         }, 6),
 
-        createNode('engine.layers', 'i18n:configuration.engine.layers.title', 'engine', {
+        createNode('engine.customLayers', 'i18n:configuration.engine.layers.customLayers.title', 'engine', {
             'engine.customLayers': {
                 type: 'array',
                 default: options.defaultConfig.customLayers,
                 title: 'i18n:configuration.engine.layers.customLayers.title',
                 description: 'i18n:configuration.engine.layers.customLayers.description',
             },
+        }, 7),
+
+        createNode('engine.sortingLayers', 'i18n:configuration.engine.layers.sortingLayers.title', 'engine', {
             'engine.sortingLayers': {
                 type: 'array',
                 default: options.defaultConfig.sortingLayers,
                 title: 'i18n:configuration.engine.layers.sortingLayers.title',
                 description: 'i18n:configuration.engine.layers.sortingLayers.description',
             },
-        }, 7),
-
-        createNode('engine.projectConfig', 'i18n:configuration.engine.projectConfig.title', 'engine', {
-            'engine.globalConfigKey': {
-                type: 'string',
-                default: '',
-                title: 'i18n:configuration.engine.projectConfig.globalConfigKey.title',
-            },
-            'engine.configs': objectSchema(undefined, {
-                title: 'i18n:configuration.engine.projectConfig.configs.title',
-                additionalProperties: objectSchema({
-                    includeModules: dynamicMetadata.includeModules,
-                    flags: dynamicMetadata.flagsObject,
-                    noDeprecatedFeatures: objectSchema({
-                        value: {
-                            type: 'boolean',
-                            title: 'i18n:configuration.engine.projectConfig.noDeprecatedFeatureConfig.value.title',
-                        },
-                        version: {
-                            type: 'string',
-                            title: 'i18n:configuration.engine.projectConfig.noDeprecatedFeatureConfig.version.title',
-                        },
-                    }, {
-                        title: 'i18n:configuration.engine.projectConfig.noDeprecatedFeatureConfig.title',
-                    }),
-                }, {
-                    title: 'i18n:configuration.engine.projectConfig.configItem.title',
-                }),
-            }),
         }, 8),
     ];
 }

--- a/src/lib/assets/assets.ts
+++ b/src/lib/assets/assets.ts
@@ -1,5 +1,5 @@
 import type { AssetOperationOption, CreateAssetByTypeOptions, IAssetInfo, IAssetMeta, ISupportCreateType, QueryAssetsOption } from '../../core/assets/@types/public';
-import type { CreateAssetOptions, IAssetConfig, IAssetDBInfo, ICreateMenuInfo, IUerDataConfigItem, QueryAssetType } from '../../core/assets/@types/protected';
+import type { CreateAssetOptions, IAssetConfig, IAssetDBInfo, ICreateMenuInfo, IUerDataConfigItem, QueryAssetType, ThumbnailInfo, ThumbnailSize } from '../../core/assets/@types/protected';
 import type { FilterPluginOptions, IPluginScriptInfo } from '../../core/scripting/interface';
 import { assetDBManager, assetManager } from '../../core/assets';
 
@@ -284,6 +284,22 @@ export async function updateAssetUserData(
  */
 export async function queryAssetConfigMap(): Promise<Record<string, IAssetConfig>> {
     return await assetManager.queryAssetConfigMap();
+}
+
+/**
+ * Query Thumbnail Handlers // 查询支持缩略图生成的资源处理器列表
+ */
+export function queryThumbnailHandlers(): string[] {
+    return assetManager.queryThumbnailHandlers();
+}
+
+/**
+ * Generate Thumbnail // 生成资源缩略图
+ */
+export async function generateThumbnail(
+    urlOrUUIDOrPath: string, size?: ThumbnailSize
+): Promise<ThumbnailInfo | null> {
+    return assetManager.generateThumbnail(urlOrUUIDOrPath, size);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Remove old `iconInfo` / `queryIconConfigMap` / `generateThumbnail` implementation from all asset handlers (image, texture, directory, unknown, sprite-frame, gltf, etc.) and `AssetHandlerManager`
- Remove `ThumbnailSize`, `ThumbnailInfo`, `ICONConfig` types from `asset-handler.d.ts` (moved to PinK side)
- Remove `api/assets/schema.ts` (unused after icon logic removal)
- `AssetHandlerBase`: add new optional `generateThumbnail(asset, size?)` method for handlers to implement custom thumbnail generation
- `AssetHandlerManager`: add `queryThumbnailHandlers()` and `generateThumbnail(asset, size?)` as new streamlined interfaces for PinK to query and invoke
- `AssetManager` / `lib/assets`: expose `queryThumbnailHandlers()` and `generateThumbnail()` as public API
- `IAssetInfo`: add `temp` as a dataKey field for accessing asset temp directory path
- `queryAssetProperty`: add `case 'temp'` to support the new dataKey
- `TypedAssetManager`: update interface with new methods