### PR TITLE
[fix] set internal assets readonly to true

### DIFF
--- a/src/core/assets/asset-config.ts
+++ b/src/core/assets/asset-config.ts
@@ -95,7 +95,7 @@ class AssetConfig {
         }, {
             name: 'internal',
             target: join(enginePath, 'editor/assets'),
-            readonly: false,
+            readonly: true,
             visible: true,
             library: join(enginePath, 'editor/library'),
         }];


### PR DESCRIPTION
## Summary
- Set `internal` asset directory `readonly` to `true` to prevent unintended modifications to engine internal assets