### PR TITLE
fix(workflow): add --tags to git fetch for shallow-cloned repos

### DIFF
--- a/workflow/update-repo.js
+++ b/workflow/update-repo.js
@@ -115,7 +115,7 @@ class UpdateRepo {
 
             // 获取远程更新
             console.log('获取远程更新...');
-            this.execCommand('git fetch origin', targetDir);
+            this.execCommand('git fetch origin --tags', targetDir);
 
             // 切换到指定分支或标签并更新
             if (branch) {


### PR DESCRIPTION
## Summary
- Shallow-cloned repos don't fetch tags by default, causing `git checkout <tag>` to fail during update
- Add `--tags` flag to `git fetch origin` to fix this

## Test plan
- [ ] Run `npm run update:repos` on a machine with existing shallow-cloned engine/external repos
- [ ] Verify tag checkout succeeds after fetch