### PR TITLE
fix(workflow): force fetch tags to handle re-tagged releases

### DIFF
--- a/workflow/update-repo.js
+++ b/workflow/update-repo.js
@@ -115,7 +115,7 @@ class UpdateRepo {
 
             // 获取远程更新
             console.log('获取远程更新...');
-            this.execCommand('git fetch origin --tags', targetDir);
+            this.execCommand('git fetch origin --tags --force', targetDir);
 
             // 切换到指定分支或标签并更新
             if (branch) {


### PR DESCRIPTION
## Summary
- When a tag is re-created pointing to a different commit, `git fetch --tags` refuses to overwrite the existing local tag
- Add `--force` to allow updating local tags that have been re-tagged on remote

## Test plan
- [ ] Run `npm run update:repos` on a CI machine where a tag (e.g. `4.0.0-alpha.15`) has been re-tagged
- [ ] Verify fetch succeeds without "would clobber existing tag" error