### PR TITLE
Unify naming rule for duplicate nodes and components:

### DIFF
--- a/src/core/engine/editor-extends/manager/component.ts
+++ b/src/core/engine/editor-extends/manager/component.ts
@@ -3,6 +3,7 @@
 import { EventEmitter } from 'events';
 import pathManager from './node-path-manager';
 import { rsort } from 'semver';
+import { formatUniqueName } from './path-utils';
 
 interface MenuItem {
     component: Function,
@@ -136,7 +137,7 @@ export default class ComponentManager extends EventEmitter {
         const className = cc.js.getClassName(component);
         const nodeComponents = component.node.getComponents(className);
         const nodePath = pathManager.getNodePath(component.node.uuid);
-        return `${nodePath}/${className}_${nodeComponents.length}`;
+        return `${nodePath}/${formatUniqueName(className, nodeComponents.length - 1)}`;
     }
 
     /**
@@ -209,12 +210,6 @@ export default class ComponentManager extends EventEmitter {
         return { code: 0, errMsg: '', uuid: uuid };
     }
 
-    _tryAddUnderscore(componentName: string, componentPath: string): { code: number, errMsg: string, uuid: string } {
-        // 尝试添加 _1, 只支持这个
-        const newFullPath = componentPath + '/' + componentName + '_1';
-        return this._getUuidFromLowercasePath(newFullPath);
-    }
-
     getComponentFromPath(path: string) {
         const uuid = this._pathToUuid.get(path);
         if (uuid) {
@@ -232,46 +227,17 @@ export default class ComponentManager extends EventEmitter {
             const componentName = path.substring(index + 1).toLowerCase();
             const componentPath = path.substring(0, index).toLowerCase();
             if (componentName.startsWith('cc.')) {
-                // 尝试添加_1  a/b/c/cc.xxx_1 => a/b/c/cc.xxx_1
-                if (componentName.lastIndexOf('_') !== -1) {
-                    throw `No component found for this path(${path}).`;
-                }
-                result = this._tryAddUnderscore(componentName, componentPath);
-                if (result.code !== 0) {
-                    if (result.code === -1) {
-                        console.warn(result.errMsg);  // 这是修改后路径打印的日志
-                        throw `No component found for this path(${path}).`; // 这是输出返回提示的日志
-                    } else {
-                        throw result.errMsg;
-                    }
-                    
-                }
-                return this.getComponent(result.uuid);
+                throw `No component found for this path(${path}).`;
             }
-            // 添加'cc.',  a/b/c/xxx_1 => a/b/c/cc.xxx_1
+            // 添加'cc.',  a/b/c/xxx => a/b/c/cc.xxx
             const newFullPath = componentPath + '/cc.' + componentName;
             result = this._getUuidFromLowercasePath(newFullPath);
             if (result.code === 0) {
                 return this.getComponent(result.uuid);
             } else if (result.code === -2) {
-                // 这是已经找到路径，但是有多条
                 throw result.errMsg;
-            } else if (result.code === -1) {
-                // 添加'cc.',  a/b/c/xxx => a/b/c/cc.xxx_1
-                if (componentName.lastIndexOf('_') !== -1) {
-                    throw `No component found for this path(${path}).`;
-                }
-                result = this._tryAddUnderscore('cc.' + componentName, componentPath);
-                if (result.code !== 0) {
-                    if (result.code === -1) {
-                        console.warn(result.errMsg);  // 这是修改后路径打印的日志
-                        throw `No component found for this path(${path}).`; // 这是输出返回提示的日志
-                    } else {
-                        throw result.errMsg;
-                    }
-                }
-                return this.getComponent(result.uuid);
             }
+            throw `No component found for this path(${path}).`;
         }
     }
 

--- a/src/core/engine/editor-extends/manager/component.ts
+++ b/src/core/engine/editor-extends/manager/component.ts
@@ -135,9 +135,15 @@ export default class ComponentManager extends EventEmitter {
 
     _generateUniquePath(component: any) {
         const className = cc.js.getClassName(component);
-        const nodeComponents = component.node.getComponents(className);
         const nodePath = pathManager.getNodePath(component.node.uuid);
-        return `${nodePath}/${formatUniqueName(className, nodeComponents.length - 1)}`;
+        // 从基础名称开始扫描，复用已删除的名称
+        let count = 0;
+        let path = `${nodePath}/${formatUniqueName(className, count)}`;
+        while (this._pathToUuid.has(path)) {
+            count++;
+            path = `${nodePath}/${formatUniqueName(className, count)}`;
+        }
+        return path;
     }
 
     /**

--- a/src/core/engine/editor-extends/manager/node-path-manager.ts
+++ b/src/core/engine/editor-extends/manager/node-path-manager.ts
@@ -1,3 +1,5 @@
+import { formatUniqueName } from './path-utils';
+
 export class NodePathManager {
     private _uuidToPath: Map<string, string> = new Map();          // UUID -> 路径
     private _pathToUuid: Map<string, string> = new Map();          // 路径 -> UUID
@@ -128,17 +130,17 @@ export class NodePathManager {
             return baseName;
         }
 
-        // 名称已存在，添加自增后缀
-        let counter = nameMap.get(baseName)! + 1;
-        let newName = `${baseName}_${counter}`;
+        // 名称已存在，添加 _001, _002, ... 格式后缀
+        let counter = nameMap.get(baseName)!;
+        let newName = formatUniqueName(baseName, counter);
 
         // 确保新名称也不存在
         while (nameMap.has(newName)) {
             counter++;
-            newName = `${baseName}_${counter}`;
+            newName = formatUniqueName(baseName, counter);
         }
 
-        nameMap.set(baseName, counter);
+        nameMap.set(baseName, counter + 1);
         nameMap.set(newName, 1);
 
         return newName;

--- a/src/core/engine/editor-extends/manager/node-path-manager.ts
+++ b/src/core/engine/editor-extends/manager/node-path-manager.ts
@@ -4,7 +4,7 @@ export class NodePathManager {
     private _uuidToPath: Map<string, string> = new Map();          // UUID -> 路径
     private _pathToUuid: Map<string, string> = new Map();          // 路径 -> UUID
     private _lowerPathToUuids: Map<string, Set<string>> = new Map(); // 小写路径 -> UUID集合
-    private _nodeNames: Map<string, Map<string, number>> = new Map(); // 父节点UUID -> (节点名 -> 计数)
+    private _nodeNames: Map<string, Set<string>> = new Map(); // 父节点UUID -> 节点名集合
 
     /**
         * 清理名称中的非法字符
@@ -62,10 +62,10 @@ export class NodePathManager {
         this._nodeNames.delete(uuid);
         const parentUuid = this._getParentUuid(path);
         if (parentUuid && this._nodeNames.has(parentUuid)) {
-            const nameMap = this._nodeNames.get(parentUuid)!;
+            const nameSet = this._nodeNames.get(parentUuid)!;
             const nodeName = path ? path.split('/').pop() : undefined;
             if (nodeName) {
-                nameMap.delete(nodeName);
+                nameSet.delete(nodeName);
             }
         }
     }
@@ -120,28 +120,26 @@ export class NodePathManager {
     ensureUniqueName(parentUuid: string | undefined, baseName: string): string {
         const uuid = parentUuid || '';
         if (!this._nodeNames.has(uuid)) {
-            this._nodeNames.set(uuid, new Map());
+            this._nodeNames.set(uuid, new Set());
         }
 
-        const nameMap = this._nodeNames.get(uuid)!;
+        const nameSet = this._nodeNames.get(uuid)!;
 
-        if (!nameMap.has(baseName)) {
-            nameMap.set(baseName, 1);
+        if (!nameSet.has(baseName)) {
+            nameSet.add(baseName);
             return baseName;
         }
 
-        // 名称已存在，添加 _001, _002, ... 格式后缀
-        let counter = nameMap.get(baseName)!;
+        // 从 _001 开始扫描，复用已删除的名称
+        let counter = 1;
         let newName = formatUniqueName(baseName, counter);
 
-        // 确保新名称也不存在
-        while (nameMap.has(newName)) {
+        while (nameSet.has(newName)) {
             counter++;
             newName = formatUniqueName(baseName, counter);
         }
 
-        nameMap.set(baseName, counter + 1);
-        nameMap.set(newName, 1);
+        nameSet.add(newName);
 
         return newName;
     }
@@ -202,7 +200,7 @@ export class NodePathManager {
         this._lowerPathToUuids.get(newLowerPath)!.add(uuid);
     }
 
-    getNameMap(uuid: string): Map<string, number> | null {
+    getNameSet(uuid: string): Set<string> | null {
         if (!this._nodeNames.has(uuid)) {
             return null;
         }

--- a/src/core/engine/editor-extends/manager/node.ts
+++ b/src/core/engine/editor-extends/manager/node.ts
@@ -272,28 +272,17 @@ export default class NodeManager extends EventEmitter {
      * 更新名称计数
      */
     private _updateNameCount(parentUuid: string, oldName: string | null, newName: string | null) {
-        const nameMap = pathManager.getNameMap(parentUuid);
-        if (!nameMap) {
+        const nameSet = pathManager.getNameSet(parentUuid);
+        if (!nameSet) {
             return;
         }
 
-        // 减少旧名称的计数
-        if (oldName && nameMap.has(oldName)) {
-            const count = nameMap.get(oldName)!;
-            if (count > 1) {
-                nameMap.set(oldName, count - 1);
-            } else {
-                nameMap.delete(oldName);
-            }
+        if (oldName) {
+            nameSet.delete(oldName);
         }
 
-        // 增加新名称的计数
         if (newName) {
-            if (!nameMap.has(newName)) {
-                nameMap.set(newName, 1);
-            } else {
-                nameMap.set(newName, nameMap.get(newName)! + 1);
-            }
+            nameSet.add(newName);
         }
     }
 }

--- a/src/core/engine/editor-extends/manager/path-utils.ts
+++ b/src/core/engine/editor-extends/manager/path-utils.ts
@@ -1,0 +1,11 @@
+/**
+ * 生成唯一名称：无重复时返回原名，有重复时添加 _001, _002, ... 后缀
+ * @param baseName - 基础名称
+ * @param existingCount - 已存在的同名数量（0 表示无重复）
+ */
+export function formatUniqueName(baseName: string, existingCount: number): string {
+    if (existingCount <= 0) {
+        return baseName;
+    }
+    return `${baseName}_${String(existingCount).padStart(3, '0')}`;
+}

--- a/src/core/scene/test/component-proxy.testcase.ts
+++ b/src/core/scene/test/component-proxy.testcase.ts
@@ -76,7 +76,7 @@ describe('Component Proxy 测试', () => {
             try {
                 componentInfo = await ComponentProxy.addComponent(addComponentInfo);
                 componentPath = componentInfo.path;
-                expect(componentInfo.path).toBe(`${nodePath}/cc.Label_1`);
+                expect(componentInfo.path).toBe(`${nodePath}/cc.Label`);
                 // 删除当前添加的节点，方便后续测试
                 const removeComponentInfo: IRemoveComponentOptions = {
                     path: componentPath
@@ -97,7 +97,7 @@ describe('Component Proxy 测试', () => {
             try {
                 componentInfo = await ComponentProxy.addComponent(addComponentInfo);
                 componentPath = componentInfo.path;
-                expect(componentInfo.path).toBe(`${nodePath}/cc.Label_1`);
+                expect(componentInfo.path).toBe(`${nodePath}/cc.Label`);
                 // 删除当前添加的节点，方便后续测试
                 const removeComponentInfo: IRemoveComponentOptions = {
                     path: componentPath
@@ -118,7 +118,7 @@ describe('Component Proxy 测试', () => {
             try {
                 componentInfo = await ComponentProxy.addComponent(addComponentInfo);
                 componentPath = componentInfo.path;
-                expect(componentInfo.path).toBe(`${nodePath}/cc.Label_1`);
+                expect(componentInfo.path).toBe(`${nodePath}/cc.Label`);
 
                 // 删除当前添加的节点，方便后续测试
                 const removeComponentInfo: IRemoveComponentOptions = {
@@ -140,7 +140,7 @@ describe('Component Proxy 测试', () => {
             try {
                 componentInfo = await ComponentProxy.addComponent(addComponentInfo);
                 componentPath = componentInfo.path;
-                expect(componentInfo.path).toBe(`${nodePath}/cc.Label_1`);
+                expect(componentInfo.path).toBe(`${nodePath}/cc.Label`);
 
                 // 这里不需要删除，配合后续测试
             } catch (e) {
@@ -193,7 +193,7 @@ describe('Component Proxy 测试', () => {
         });
         it('queryComponent - 查询组件-根据模糊的匹配-Label', async () => {
             const queryComponent: IQueryComponentOptions = {
-                path: nodePath + '/Label_1'
+                path: nodePath + '/Label'
             };
             try {
                 componentInfo = await ComponentProxy.queryComponent(queryComponent) as IComponent;
@@ -214,7 +214,7 @@ describe('Component Proxy 测试', () => {
         });
         it('queryComponent - 查询组件-根据模糊的匹配-cc.label', async () => {
             const queryComponent: IQueryComponentOptions = {
-                path: nodePath + '/cc.label_1'
+                path: nodePath + '/cc.label'
             };
             try {
                 componentInfo = await ComponentProxy.queryComponent(queryComponent) as IComponent;
@@ -235,7 +235,7 @@ describe('Component Proxy 测试', () => {
         });
         it('queryComponent - 查询组件-根据模糊的匹配-Label', async () => {
             const queryComponent: IQueryComponentOptions = {
-                path: nodePath + '/Label_1'
+                path: nodePath + '/Label'
             };
             try {
                 componentInfo = await ComponentProxy.queryComponent(queryComponent) as IComponent;
@@ -256,7 +256,7 @@ describe('Component Proxy 测试', () => {
         });
         it('queryComponent - 查询组件-根据模糊的匹配-label', async () => {
             const queryComponent: IQueryComponentOptions = {
-                path: nodePath + '/label_1'
+                path: nodePath + '/label'
             };
             try {
                 componentInfo = await ComponentProxy.queryComponent(queryComponent) as IComponent;
@@ -320,7 +320,7 @@ describe('Component Proxy 测试', () => {
         });
         it('queryComponent - 查询不存在组件', async () => {
             const queryComponent: IQueryComponentOptions = {
-                path: nodePath + '/cc.Button_1'
+                path: nodePath + '/cc.Button'
             };
             try {
                 await ComponentProxy.queryComponent(queryComponent) as IComponent;
@@ -365,19 +365,19 @@ describe('Component Proxy 测试', () => {
 
                 const cameraComponentInfo = await ComponentProxy.addComponent(addComponentInfo);
                 componentPath = cameraComponentInfo.path;
-                expect(cameraComponentInfo.path).toBe(`${addComponentInfo.nodePathOrUuid}/cc.Label_1`);
+                expect(cameraComponentInfo.path).toBe(`${addComponentInfo.nodePathOrUuid}/cc.Label`);
 
                 const queryComponent: IQueryComponentOptions = {
-                    path: nodePath + '/cc.label_1'
+                    path: nodePath + '/cc.label'
                 };
                 await ComponentProxy.queryComponent(queryComponent) as IComponent;
 
             } catch (e) {
-                expect(e instanceof Error ? e.message : String(e)).toBe(`This path contains multiple component paths(TestNode/New Node/cc.Label_1,TestNode/new node/cc.Label_1). Please specify which one to use.`);
+                expect(e instanceof Error ? e.message : String(e)).toBe(`This path contains multiple component paths(TestNode/New Node/cc.Label,TestNode/new node/cc.Label). Please specify which one to use.`);
                 console.log((e as Error).message);
                 // 删除当前添加的节点，方便后续测试
                 const removeComponentInfo: IRemoveComponentOptions = {
-                    path: `${newNodePath}/cc.Label_1`
+                    path: `${newNodePath}/cc.Label`
                 };
                 const result = await ComponentProxy.removeComponent(removeComponentInfo);
                 expect(result).toBe(true);
@@ -454,7 +454,7 @@ describe('Component Proxy 测试', () => {
                     };
 
                     const component = await ComponentProxy.addComponent(componentInfo);
-                    expect(component.path).toBe(`${nodePath}/${componentName}_1`);
+                    expect(component.path).toBe(`${nodePath}/${componentName}`);
                     components.push(component);
                     const queryComponentInfo = await ComponentProxy.queryComponent({ path: component.path }) as IComponent;
                     if (queryComponentInfo!.cid) {
@@ -496,7 +496,7 @@ describe('Component Proxy 测试', () => {
                         component: testComponent
                     };
                     const component = await ComponentProxy.addComponent(componentInfo1);
-                    expect(component.path).toBe(`${nodePath}/${testComponent}_${i + 1}`);
+                    expect(component.path).toBe(`${nodePath}/${testComponent}${i === 0 ? '' : '_' + String(i).padStart(3, '0')}`);
                     components.push(component);
                     const queryComponentInfo = await ComponentProxy.queryComponent({ path: component.path }) as IComponent;
                     if (queryComponentInfo!.cid) {
@@ -527,7 +527,7 @@ describe('Component Proxy 测试', () => {
             try {
                 const component = await ComponentProxy.addComponent(addComponentInfo);
                 componentPath = component.path;
-                expect(component.path).toBe(`${nodePath}/cc.Label_1`);
+                expect(component.path).toBe(`${nodePath}/cc.Label`);
                 componentInfo = await ComponentProxy.queryComponent({ path: componentPath }) as IComponent;
                 expect(componentInfo).toBeDefined();
                 queryComponent.path = componentPath;
@@ -658,7 +658,7 @@ describe('Component Proxy 测试', () => {
             try {
                 const component = await ComponentProxy.addComponent(addComponentInfo);
                 componentPath = component.path;
-                expect(component.path).toBe(`${nodePath}/cc.Sprite_1`);
+                expect(component.path).toBe(`${nodePath}/cc.Sprite`);
                 componentInfo = await ComponentProxy.queryComponent({ path: componentPath }) as IComponent;
                 expect(componentInfo).toBeDefined();
                 queryComponent.path = componentPath;
@@ -815,7 +815,7 @@ describe('Component Proxy 测试', () => {
                     };
                     const component = await ComponentProxy.addComponent(componentInfo1);
                     expect(component).toBeDefined();
-                    expect(component.path).toBe(`${nodes[i].path}/cc.Layout_1`);
+                    expect(component.path).toBe(`${nodes[i].path}/cc.Layout`);
                 }
                 for (let i = 0; i < nodes.length; ++i) {
                     const componentInfo1: IAddComponentOptions = {
@@ -824,7 +824,7 @@ describe('Component Proxy 测试', () => {
                     };
                     const component = await ComponentProxy.addComponent(componentInfo1);
                     expect(component).toBeDefined();
-                    expect(component.path).toBe(`${nodes[i].path}/cc.Layout_2`);
+                    expect(component.path).toBe(`${nodes[i].path}/cc.Layout_001`);
                 }
             } catch (e) {
                 console.log(`添加多个不同的节点失败，原因：${e}`);
@@ -867,13 +867,13 @@ describe('Component Proxy 测试', () => {
             };
             let component = await ComponentProxy.addComponent(componentInfo);
             expect(component).toBeDefined();
-            expect(component.path).toBe(`${nodePath}/${testComponent}_1`);
+            expect(component.path).toBe(`${nodePath}/${testComponent}`);
             try {
                 component = await ComponentProxy.addComponent(componentInfo);
             } catch (e) {
                 // 添加接受相同组件添加的错误
                 expect(e instanceof Error ? e.message : String(e)).toBe(`Can't add component '${testComponent}' because ${nodeName} already contains the same component.`);
-                expect(component.path).toBe(`${nodePath}/${testComponent}_1`);
+                expect(component.path).toBe(`${nodePath}/${testComponent}`);
             }
             const result = await ComponentProxy.removeComponent({ path: component.path });
             expect(result).toBe(true);
@@ -887,7 +887,7 @@ describe('Component Proxy 测试', () => {
             };
             let component = await ComponentProxy.addComponent(componentInfo);
             expect(component).toBeDefined();
-            expect(component.path).toBe(`${nodePath}/${testComponent}_1`);
+            expect(component.path).toBe(`${nodePath}/${testComponent}`);
             try {
                 const componentConficts: IAddComponentOptions = {
                     nodePathOrUuid: nodePath,
@@ -897,7 +897,7 @@ describe('Component Proxy 测试', () => {
             } catch (e) {
                 // 添加异常冲突
                 expect(e instanceof Error ? e.message : String(e)).toBe(`Can't add component '${testConfictsComponent}' to ${nodeName} because it conflicts with the existing '${testComponent}' derived component.`);
-                expect(component.path).toBe(`${nodePath}/${testComponent}_1`);
+                expect(component.path).toBe(`${nodePath}/${testComponent}`);
             }
         });
     });
@@ -1020,7 +1020,7 @@ describe('Component Proxy 测试', () => {
 
         it('resetComponent - 重置不存在的组件应返回 false', async () => {
             const result = await ComponentProxy.resetComponent({
-                path: 'non-existent-path/cc.Label_1',
+                path: 'non-existent-path/cc.Label_001',
             });
             expect(result).toBe(false);
         });
@@ -1215,6 +1215,92 @@ describe('Component Proxy 测试', () => {
                     path: componentPath,
                 }) as IComponent;
                 expect(updated?.properties['string'].value).toBe('pink-test');
+            }
+        });
+    });
+
+    describe('16. 组件命名规则测试 - 同类型组件自动添加后缀', () => {
+        let testNodePath = '';
+        beforeAll(async () => {
+            const params: ICreateByNodeTypeParams = {
+                path: 'TestNode',
+                name: 'CompNamingTestNode',
+                nodeType: NodeType.EMPTY,
+                position: { x: 0, y: 0, z: 0 },
+            };
+            const testNode = await NodeProxy.createNodeByType(params);
+            expect(testNode).toBeDefined();
+            testNodePath = testNode!.path;
+        });
+        afterAll(async () => {
+            await NodeProxy.deleteNode({ path: testNodePath, keepWorldTransform: false });
+        });
+
+        it('addComponent - 唯一组件不添加后缀', async () => {
+            const component = await ComponentProxy.addComponent({
+                nodePathOrUuid: testNodePath,
+                component: 'cc.Label',
+            });
+            expect(component).toBeDefined();
+            expect(component.path).toBe(`${testNodePath}/cc.Label`);
+
+            await ComponentProxy.removeComponent({ path: component.path });
+        });
+
+        it('addComponent - 两个不同类型组件各自不添加后缀', async () => {
+            const comp1 = await ComponentProxy.addComponent({
+                nodePathOrUuid: testNodePath,
+                component: 'cc.Label',
+            });
+            const comp2 = await ComponentProxy.addComponent({
+                nodePathOrUuid: testNodePath,
+                component: 'cc.Layout',
+            });
+            expect(comp1.path).toBe(`${testNodePath}/cc.Label`);
+            expect(comp2.path).toBe(`${testNodePath}/cc.Layout`);
+
+            await ComponentProxy.removeComponent({ path: comp2.path });
+            await ComponentProxy.removeComponent({ path: comp1.path });
+        });
+
+        it('addComponent - 第二个同类型组件添加_001后缀', async () => {
+            const comp1 = await ComponentProxy.addComponent({
+                nodePathOrUuid: testNodePath,
+                component: 'cc.Layout',
+            });
+            expect(comp1.path).toBe(`${testNodePath}/cc.Layout`);
+
+            const comp2 = await ComponentProxy.addComponent({
+                nodePathOrUuid: testNodePath,
+                component: 'cc.Layout',
+            });
+            expect(comp2.path).toBe(`${testNodePath}/cc.Layout_001`);
+
+            await ComponentProxy.removeComponent({ path: comp2.path });
+            await ComponentProxy.removeComponent({ path: comp1.path });
+        });
+
+        it('addComponent - 多个同类型组件依次添加_001,_002,...后缀', async () => {
+            const totalCount = 5;
+            const testComponent = 'cc.Layout';
+            const components: IComponentIdentifier[] = [];
+
+            for (let i = 0; i < totalCount; i++) {
+                const comp = await ComponentProxy.addComponent({
+                    nodePathOrUuid: testNodePath,
+                    component: testComponent,
+                });
+                expect(comp).toBeDefined();
+                if (i === 0) {
+                    expect(comp.path).toBe(`${testNodePath}/${testComponent}`);
+                } else {
+                    expect(comp.path).toBe(`${testNodePath}/${testComponent}_${String(i).padStart(3, '0')}`);
+                }
+                components.push(comp);
+            }
+
+            for (const comp of components.reverse()) {
+                await ComponentProxy.removeComponent({ path: comp.path });
             }
         });
     });

--- a/src/core/scene/test/component-proxy.testcase.ts
+++ b/src/core/scene/test/component-proxy.testcase.ts
@@ -1303,5 +1303,33 @@ describe('Component Proxy 测试', () => {
                 await ComponentProxy.removeComponent({ path: comp.path });
             }
         });
+
+        it('addComponent - 删除中间组件后新增应复用已删除的名称', async () => {
+            const testComponent = 'cc.Layout';
+
+            // 添加3个同类型组件: cc.Layout, cc.Layout_001, cc.Layout_002
+            const comp0 = await ComponentProxy.addComponent({ nodePathOrUuid: testNodePath, component: testComponent });
+            const comp1 = await ComponentProxy.addComponent({ nodePathOrUuid: testNodePath, component: testComponent });
+            const comp2 = await ComponentProxy.addComponent({ nodePathOrUuid: testNodePath, component: testComponent });
+            expect(comp0.path).toBe(`${testNodePath}/${testComponent}`);
+            expect(comp1.path).toBe(`${testNodePath}/${testComponent}_001`);
+            expect(comp2.path).toBe(`${testNodePath}/${testComponent}_002`);
+
+            // 删除 _001
+            const removeResult = await ComponentProxy.removeComponent({ path: comp1.path });
+            expect(removeResult).toBe(true);
+
+            // 再添加2个，第一个应复用 _001，第二个为 _003
+            const comp3 = await ComponentProxy.addComponent({ nodePathOrUuid: testNodePath, component: testComponent });
+            const comp4 = await ComponentProxy.addComponent({ nodePathOrUuid: testNodePath, component: testComponent });
+            expect(comp3.path).toBe(`${testNodePath}/${testComponent}_001`);
+            expect(comp4.path).toBe(`${testNodePath}/${testComponent}_003`);
+
+            // 清理
+            await ComponentProxy.removeComponent({ path: comp4.path });
+            await ComponentProxy.removeComponent({ path: comp3.path });
+            await ComponentProxy.removeComponent({ path: comp2.path });
+            await ComponentProxy.removeComponent({ path: comp0.path });
+        });
     });
 });

--- a/src/core/scene/test/node-proxy.testcase.ts
+++ b/src/core/scene/test/node-proxy.testcase.ts
@@ -540,5 +540,33 @@ describe('Node Proxy 测试', () => {
                 createdNodes.push(node!);
             }
         });
+
+        it('createNode - 删除中间节点后新增应复用已删除的名称', async () => {
+            const baseName = 'GapNode';
+
+            // 添加3个同名节点: GapNode, GapNode_001, GapNode_002
+            const node0 = await NodeProxy.createNodeByType({ path: parentPath, name: baseName, nodeType: NodeType.EMPTY });
+            const node1 = await NodeProxy.createNodeByType({ path: parentPath, name: baseName, nodeType: NodeType.EMPTY });
+            const node2 = await NodeProxy.createNodeByType({ path: parentPath, name: baseName, nodeType: NodeType.EMPTY });
+            expect(node0!.path).toBe(baseName);
+            expect(node1!.path).toBe(`${baseName}_001`);
+            expect(node2!.path).toBe(`${baseName}_002`);
+
+            // 删除 _001
+            const deleteResult = await NodeProxy.deleteNode({ path: node1!.path, keepWorldTransform: false });
+            expect(deleteResult).toBeDefined();
+
+            // 再添加2个，第一个应复用 _001，第二个为 _003
+            const node3 = await NodeProxy.createNodeByType({ path: parentPath, name: baseName, nodeType: NodeType.EMPTY });
+            const node4 = await NodeProxy.createNodeByType({ path: parentPath, name: baseName, nodeType: NodeType.EMPTY });
+            expect(node3!.path).toBe(`${baseName}_001`);
+            expect(node4!.path).toBe(`${baseName}_003`);
+
+            // 清理
+            await NodeProxy.deleteNode({ path: node4!.path, keepWorldTransform: false });
+            await NodeProxy.deleteNode({ path: node3!.path, keepWorldTransform: false });
+            await NodeProxy.deleteNode({ path: node2!.path, keepWorldTransform: false });
+            await NodeProxy.deleteNode({ path: node0!.path, keepWorldTransform: false });
+        });
     });
 });

--- a/src/core/scene/test/node-proxy.testcase.ts
+++ b/src/core/scene/test/node-proxy.testcase.ts
@@ -371,9 +371,9 @@ describe('Node Proxy 测试', () => {
                         }
                     }
                     if (nodeType == NodeType.PAGE_VIEW) {
-                        expect(createdNode?.components?.at(0)?.path).toBe('Canvas/pageView/cc.UITransform_1');
-                        expect(createdNode?.components?.at(1)?.path).toBe('Canvas/pageView/cc.Sprite_1');
-                        expect(createdNode?.components?.at(2)?.path).toBe('Canvas/pageView/cc.PageView_1');
+                        expect(createdNode?.components?.at(0)?.path).toBe('Canvas/pageView/cc.UITransform');
+                        expect(createdNode?.components?.at(1)?.path).toBe('Canvas/pageView/cc.Sprite');
+                        expect(createdNode?.components?.at(2)?.path).toBe('Canvas/pageView/cc.PageView');
                     }
                     if (nodeType == NodeType.TERRAIN) {
                         expect(Array.isArray(createdNode?.children)).toBe(true);
@@ -474,6 +474,71 @@ describe('Node Proxy 测试', () => {
 
             // 清理
             await NodeProxy.deleteNode({ path: created!.path, keepWorldTransform: false });
+        });
+    });
+
+    describe('8. 节点命名规则测试 - 同名节点自动添加后缀', () => {
+        const createdNodes: INode[] = [];
+        const parentPath = '/';
+
+        afterAll(async () => {
+            for (const node of createdNodes.reverse()) {
+                try {
+                    await NodeProxy.deleteNode({ path: node.path, keepWorldTransform: false });
+                } catch (e) {
+                    console.log(`删除节点失败: ${node.path}, ${e}`);
+                }
+            }
+        });
+
+        it('createNode - 唯一名称不添加后缀', async () => {
+            const params: ICreateByNodeTypeParams = {
+                path: parentPath,
+                name: 'UniqueNode',
+                nodeType: NodeType.EMPTY,
+            };
+            const node = await NodeProxy.createNodeByType(params);
+            expect(node).toBeDefined();
+            expect(node!.name).toBe('UniqueNode');
+            expect(node!.path).toBe('UniqueNode');
+            createdNodes.push(node!);
+        });
+
+        it('createNode - 第二个同名节点添加_001后缀', async () => {
+            const params: ICreateByNodeTypeParams = {
+                path: parentPath,
+                name: 'DupNode',
+                nodeType: NodeType.EMPTY,
+            };
+            const node1 = await NodeProxy.createNodeByType(params);
+            expect(node1).toBeDefined();
+            expect(node1!.name).toBe('DupNode');
+            expect(node1!.path).toBe('DupNode');
+            createdNodes.push(node1!);
+
+            const node2 = await NodeProxy.createNodeByType(params);
+            expect(node2).toBeDefined();
+            expect(node2!.name).toBe('DupNode_001');
+            expect(node2!.path).toBe('DupNode_001');
+            createdNodes.push(node2!);
+        });
+
+        it('createNode - 多个同名节点依次添加_001,_002,...后缀', async () => {
+            const totalCount = 5;
+            const baseName = 'MultiDupNode';
+            for (let i = 0; i < totalCount; i++) {
+                const params: ICreateByNodeTypeParams = {
+                    path: parentPath,
+                    name: baseName,
+                    nodeType: NodeType.EMPTY,
+                };
+                const node = await NodeProxy.createNodeByType(params);
+                expect(node).toBeDefined();
+                const expectedName = i === 0 ? baseName : `${baseName}_${String(i).padStart(3, '0')}`;
+                expect(node!.name).toBe(expectedName);
+                expect(node!.path).toBe(expectedName);
+                createdNodes.push(node!);
+            }
         });
     });
 });


### PR DESCRIPTION
- Keep original name for first occurrence of a node/component
- Append _001, _002, etc. for subsequent duplicates