### PR TITLE
fix: add missing await in initEditorExtensions()

### DIFF
--- a/src/core/engine/index.ts
+++ b/src/core/engine/index.ts
@@ -326,7 +326,7 @@ class EngineManager implements IEngine {
 
     async initEditorExtensions() {
         // @ts-ignore
-        globalThis.EditorExtends.init();
+        await globalThis.EditorExtends.init();
     }
 
     /**


### PR DESCRIPTION
## Summary

- Fix missing `await` in `initEditorExtensions()` function
- This causes `EditorExtends.serialize is not a function` error during build

## Problem

In `src/core/engine/index.ts`, the `initEditorExtensions()` function calls `globalThis.EditorExtends.init()` without `await`:

```typescript
async initEditorExtensions() {
    // @ts-ignore
    globalThis.EditorExtends.init();  // Missing await!
}
```

Since `EditorExtends.init()` is async and returns a Promise, the function returns before initialization completes. This causes `serialize` to be `undefined` when used later in the build process.

## Solution

Add `await` to the `EditorExtends.init()` call:

```typescript
async initEditorExtensions() {
    // @ts-ignore
    await globalThis.EditorExtends.init();
}
```

## Error Message

```
TypeError: EditorExtends.serialize is not a function
    at saveImageAsset (...)
    at Object.import (...)
    at CustomImporter.import (...)
```

## Related

- Affects all cocos-cli versions (0.0.1-alpha.19 through 1.0.0-alpha.6)
- Prevents building any project with cocos-cli