### PR TITLE
Feat(gizmo): sync component gizmos and align interaction logic with cocos-editor.

### DIFF
--- a/src/core/scene/scene-process/service/gizmo.ts
+++ b/src/core/scene/scene-process/service/gizmo.ts
@@ -9,7 +9,8 @@ import GizmoDefines from './gizmo/gizmo-defines';
 import GizmoBase from './gizmo/base/gizmo-base';
 import GizmoOperation from './gizmo/gizmo-operation';
 import { create3DNode } from './gizmo/utils/engine-utils';
-import type { IGizmoEvents, IGizmoService } from '../../common';
+import { NodeEventType } from '../../common';
+import type { IGizmoEvents, IGizmoService, IChangeNodeOptions } from '../../common';
 
 // Import component gizmo modules so they self-register via registerGizmo()
 import './gizmo/components/camera';
@@ -436,16 +437,59 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
         this.clearAllGizmos();
     }
 
-    onNodeChanged(node: Node): void {
+    onNodeChanged(node: Node, opts?: IChangeNodeOptions): void {
         if (!node) return;
+
+        const has = this._selection.includes(node.uuid);
+
         walkNodeComponent(node, (component: Component) => {
-            const compGizmo = getGizmoProperty('component', component);
-            if (compGizmo && compGizmo.checkVisible()) {
-                if ((compGizmo as any).onNodeChanged) {
-                    (compGizmo as any).onNodeChanged({ node });
+            const isHackComp = (component as any).__classname__ === '_EditorHackTransformComponent_';
+            if (!isHackComp && (!component.enabled || !node.active || !node.parent)) {
+                if (has) this._removeGizmo('component', component);
+                this._removeGizmo('icon', component);
+                this._removeGizmo('persistent', component);
+                return;
+            }
+
+            let gizmo: GizmoBase | null | undefined;
+
+            if (has) {
+                gizmo = getGizmoProperty('component', component);
+                if (gizmo) {
+                    if ((gizmo as any).onNodeChanged && gizmo.checkVisible()) {
+                        (gizmo as any).onNodeChanged(opts);
+                    }
+                } else {
+                    this._showGizmo('component', component);
                 }
             }
+
+            gizmo = getGizmoProperty('persistent', component);
+            if (gizmo) {
+                if ((gizmo as any).onNodeChanged && gizmo.checkVisible()) {
+                    (gizmo as any).onNodeChanged(opts);
+                }
+            } else {
+                this._showGizmo('persistent', component);
+            }
+
+            gizmo = getGizmoProperty('icon', component);
+            if (gizmo) {
+                if ((gizmo as any).onNodeChanged && gizmo.checkVisible()) {
+                    (gizmo as any).onNodeChanged(opts);
+                }
+            } else {
+                this._showGizmo('icon', component);
+            }
         });
+
+        if (opts?.type !== NodeEventType.CHILD_CHANGED) {
+            node.children.forEach((child) => {
+                this.onNodeChanged(child, opts);
+            });
+        }
+
+        Service.Engine?.repaintInEditMode?.();
     }
 
     onComponentAdded(comp: Component): void {

--- a/src/core/scene/scene-process/service/gizmo.ts
+++ b/src/core/scene/scene-process/service/gizmo.ts
@@ -17,6 +17,20 @@ import './gizmo/components/box-collider';
 import './gizmo/components/directional-light';
 import './gizmo/components/canvas';
 import './gizmo/components/ui-transform';
+import './gizmo/components/sphere-light';
+import './gizmo/components/spot-light';
+import './gizmo/components/sphere-collider';
+import './gizmo/components/capsule-collider';
+import './gizmo/components/cone-collider';
+import './gizmo/components/cylinder-collider';
+import './gizmo/components/plane-collider';
+import './gizmo/components/simplex-collider';
+import './gizmo/components/mesh-collider';
+import './gizmo/components/box-collider-2d';
+import './gizmo/components/circle-collider-2d';
+import './gizmo/components/polygon-collider-2d';
+import './gizmo/components/mesh-renderer';
+import './gizmo/components/skinned-mesh-renderer';
 
 type TGizmoType = 'icon' | 'persistent' | 'component';
 

--- a/src/core/scene/scene-process/service/gizmo/components/box-collider-2d/index.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/box-collider-2d/index.ts
@@ -1,0 +1,239 @@
+'use strict';
+
+import { BoxCollider2D, Color, js, Mat4, Quat, Size, Vec2, Vec3 } from 'cc';
+import GizmoBase from '../../base/gizmo-base';
+import { RectangleController } from '../../node/rectangle-controller';
+import { registerGizmo } from '../../gizmo-defines';
+
+function toPrecision(val: number, n: number): number {
+    return Math.round(val * Math.pow(10, n)) / Math.pow(10, n);
+}
+
+function makeVec2InPrecision(v: Vec2, p: number): Vec2 {
+    const pow = Math.pow(10, p);
+    v.x = Math.round(v.x * pow) / pow;
+    v.y = Math.round(v.y * pow) / pow;
+    return v;
+}
+
+const HandleType = RectangleController.RectHandleType;
+
+const tempQuat_a = new Quat();
+const tempMat4 = new Mat4();
+const tempVec2 = new Vec2();
+
+class BoxCollider2DGizmo extends GizmoBase<BoxCollider2D> {
+    private _controller!: RectangleController;
+
+    private _size: Size = new Size();
+    private _offset: Vec2 = new Vec2();
+    private _anchor: Vec2 = new Vec2(0.5, 0.5);
+    private _altKey = false;
+    private _propPath: string | null = null;
+
+    init() {
+        this.createController();
+        this._isInitialized = true;
+    }
+
+    onShow() {
+        this._controller.show();
+        this.updateController();
+    }
+
+    onHide() {
+        this._controller.hide();
+    }
+
+    createController() {
+        this._controller = new RectangleController(this.getGizmoRoot());
+        this._controller.editable = true;
+        this._controller.setColor(new Color(107, 194, 53));
+        this._controller.setEditHandlesColor(new Color(107, 194, 53));
+        this._controller.setAreaOpacity(50);
+
+        this._controller.onControllerMouseDown = this.onControllerMouseDown.bind(this);
+        this._controller.onControllerMouseMove = this.onControllerMouseMove.bind(this);
+        this._controller.onControllerMouseUp = this.onControllerMouseUp.bind(this);
+    }
+
+    onControllerMouseDown() {
+        if (!this.target) {
+            return;
+        }
+        this._size = this.target.size.clone();
+        this._offset = this.target.offset.clone();
+        this._propPath = this.getCompPropPath('size');
+    }
+
+    onControllerMouseMove() {
+        if (this._controller.updated) {
+            this.onControlUpdate(this._propPath);
+            const handleType = this._controller.getCurHandleType();
+            const deltaSize = this._controller.getDeltaSize();
+            if (handleType === HandleType.Area) {
+                this.handleAreaMove(deltaSize);
+            } else {
+                const keepCenter: boolean = this._altKey;
+                this.handleTargetSize(handleType, deltaSize, keepCenter);
+            }
+        }
+    }
+
+    onControllerMouseUp() {
+        this.onControlEnd(this._propPath);
+    }
+
+    onKeyDown(event: any) {
+        this._altKey = event.altKey;
+    }
+
+    onKeyUp(event: any) {
+        this._altKey = event.altKey;
+    }
+
+    handleAreaMove(delta: Vec3) {
+        if (!this.target) {
+            return;
+        }
+        const node = this.target.node;
+
+        const posDelta: Vec3 = delta.clone();
+        if (node) {
+            node.getWorldMatrix(tempMat4);
+            Mat4.invert(tempMat4, tempMat4);
+            tempMat4.m12 = tempMat4.m13 = 0;
+            Vec3.transformMat4(posDelta, posDelta, tempMat4);
+        }
+
+        posDelta.z = 0;
+        tempVec2.set(this._offset);
+        tempVec2.add2f(posDelta.x, posDelta.y);
+        makeVec2InPrecision(tempVec2, 1);
+
+        this.target.offset.set(tempVec2);
+        this.onComponentChanged(node);
+    }
+
+    modifyPosDeltaWithAnchor(type: any, posDelta: Vec3, sizeDelta: Vec2, anchor: Vec2, keepCenter: boolean) {
+        if (type === HandleType.Right ||
+            type === HandleType.TopRight ||
+            type === HandleType.BottomRight) {
+            if (keepCenter) {
+                sizeDelta.x /= (1 - anchor.x);
+            }
+            posDelta.x = sizeDelta.x * anchor.x;
+        } else {
+            if (keepCenter) {
+                sizeDelta.x /= anchor.x;
+            }
+            posDelta.x = -sizeDelta.x * (1 - anchor.x);
+        }
+
+        if (type === HandleType.Bottom ||
+            type === HandleType.BottomRight ||
+            type === HandleType.BottomLeft) {
+            if (keepCenter) {
+                sizeDelta.y /= anchor.y;
+            }
+            posDelta.y = -sizeDelta.y * (1 - anchor.y);
+        } else {
+            if (keepCenter) {
+                sizeDelta.y /= (1 - anchor.y);
+            }
+            posDelta.y = sizeDelta.y * anchor.y;
+        }
+    }
+
+    handleTargetSize(type: any, delta: Vec3, keepCenter: boolean) {
+        const posDelta = delta.clone();
+        const sizeDelta = new Vec2(delta.x, delta.y);
+
+        sizeDelta.x = toPrecision(sizeDelta.x, 3);
+        sizeDelta.y = toPrecision(sizeDelta.y, 3);
+
+        this.modifyPosDeltaWithAnchor(type, posDelta, sizeDelta, this._anchor, keepCenter);
+
+        if (!this.target) {
+            return;
+        }
+        const node = this.target.node;
+        node.getWorldMatrix(tempMat4);
+        Mat4.invert(tempMat4, tempMat4);
+        tempMat4.m12 = tempMat4.m13 = 0;
+        Vec3.transformMat4(posDelta, posDelta, tempMat4);
+
+        if (!keepCenter) {
+            const localRot = tempQuat_a;
+            node.getRotation(localRot);
+            Vec3.transformQuat(posDelta, posDelta, localRot);
+            posDelta.z = 0;
+            tempVec2.set(this._offset);
+            tempVec2.add2f(posDelta.x, posDelta.y);
+            makeVec2InPrecision(tempVec2, 1);
+            this.target.offset.set(tempVec2);
+        }
+
+        const worldScale = new Vec3();
+        node.getWorldScale(worldScale);
+        sizeDelta.x = sizeDelta.x / worldScale.x;
+        sizeDelta.y = sizeDelta.y / worldScale.y;
+
+        let width = this._size.width + sizeDelta.x;
+        let height = this._size.height + sizeDelta.y;
+        width = toPrecision(width, 1);
+        height = toPrecision(height, 1);
+        this.target.size.set(new Size(width, height));
+
+        this.onComponentChanged(node);
+    }
+
+    updateControllerData() {
+        if (!this._isInitialized || this.target === null) {
+            return;
+        }
+
+        const boxCollider2D = this.target;
+        if (boxCollider2D) {
+            const node = boxCollider2D.node;
+            if (node) {
+                node.getWorldMatrix(tempMat4);
+            }
+
+            const size = boxCollider2D.size;
+            const offset = boxCollider2D.offset;
+            const center = new Vec3();
+            center.x = offset.x;
+            center.y = offset.y;
+            const worldScale = node.getWorldScale();
+            Vec3.transformMat4(center, center, tempMat4);
+            const worldRot = tempQuat_a;
+            node.getWorldRotation(worldRot);
+            this._controller.setPosition(center);
+            this._controller.setRotation(worldRot);
+            this._controller.updateSize(Vec3.ZERO, new Vec2(size.width * worldScale.x, size.height * worldScale.y));
+            this._controller.edit = boxCollider2D.editing;
+        } else {
+            this._controller.hide();
+        }
+    }
+
+    updateController() {
+        this.updateControllerData();
+    }
+
+    onTargetUpdate() {
+        this.updateController();
+    }
+
+    onNodeChanged() {
+        this.updateController();
+    }
+}
+
+export const name = js.getClassName(BoxCollider2D);
+export const SelectGizmo = BoxCollider2DGizmo;
+export const IconGizmo = null;
+export const PersistentGizmo = null;
+
+registerGizmo(name, { SelectGizmo });

--- a/src/core/scene/scene-process/service/gizmo/components/capsule-collider/index.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/capsule-collider/index.ts
@@ -1,0 +1,133 @@
+'use strict';
+
+import { CapsuleCollider, Color, js, Quat, Vec3 } from 'cc';
+import GizmoBase from '../../base/gizmo-base';
+import CapsuleController from '../../controller/capsule';
+import { registerGizmo } from '../../gizmo-defines';
+
+function toPrecision(val: number, n: number): number {
+    return Math.round(val * Math.pow(10, n)) / Math.pow(10, n);
+}
+
+const tempQuat_a = new Quat();
+
+class CapsuleColliderComponentGizmo extends GizmoBase<CapsuleCollider> {
+    private _controller!: CapsuleController;
+    private _maxScale = 1;
+    private _radius = 0;
+    private _height = 0;
+    private _propPath: string | null = null;
+
+    init() {
+        this.createController();
+        this._isInitialized = true;
+    }
+
+    onShow() {
+        this._controller.show();
+        this.updateControllerData();
+    }
+
+    onHide() {
+        this._controller.hide();
+    }
+
+    createController() {
+        const gizmoRoot = this.getGizmoRoot();
+        this._controller = new CapsuleController(gizmoRoot);
+
+        this._controller.setColor(Color.GREEN);
+        this._controller.editable = true;
+        this._controller.hoverColor = Color.YELLOW;
+        this._controller.onControllerMouseDown = this.onControllerMouseDown.bind(this);
+        this._controller.onControllerMouseMove = this.onControllerMouseMove.bind(this);
+        this._controller.onControllerMouseUp = this.onControllerMouseUp.bind(this);
+    }
+
+    onControllerMouseDown() {
+        if (!this._isInitialized || this.target === null) {
+            return;
+        }
+
+        this._radius = this.target.radius;
+        this._height = this.target.cylinderHeight;
+        const worldScale = this.target.node.getWorldScale();
+        this._maxScale = this.getMaxScale(worldScale);
+
+        this._propPath = this.getCompPropPath('size');
+    }
+
+    onControllerMouseMove() {
+        this.updateDataFromController();
+    }
+
+    onControllerMouseUp() {
+        this.onControlEnd(this._propPath);
+    }
+
+    updateDataFromController() {
+        if (this._controller.updated && this.target) {
+            this.onControlUpdate(this._propPath);
+            const deltaRadius = this._controller.getDeltaRadius();
+            const newRadius = toPrecision(this._radius + deltaRadius / this._maxScale, 3);
+            this.target.radius = newRadius;
+
+            const deltaHeight = this._controller.getDeltaHeight();
+            const newHeight = toPrecision(this._height + deltaHeight / this._maxScale, 3);
+            this.target.cylinderHeight = newHeight;
+
+            const node = this.target.node;
+            this.onComponentChanged(node);
+        }
+    }
+
+    updateControllerTransform() {
+        this.updateControllerData();
+    }
+
+    updateControllerData() {
+        if (!this._isInitialized || this.target == null) {
+            return;
+        }
+
+        if (this.target instanceof CapsuleCollider) {
+            const node = this.target.node;
+
+            this._controller.show();
+            this._controller.checkEdit();
+
+            const worldScale = node.getWorldScale();
+            const worldPos = node.getWorldPosition();
+            const worldRot = tempQuat_a;
+            node.getWorldRotation(worldRot);
+            const xzNorm = Math.max(Math.abs(worldScale.x), Math.abs(worldScale.z));
+            this._controller.setScale(new Vec3(xzNorm, worldScale.y, xzNorm));
+            this._controller.setPosition(worldPos);
+            this._controller.setRotation(worldRot);
+
+            this._controller.direction = this.target.direction;
+            this._controller.updateSize(this.target.center, this.target.radius, this.target.cylinderHeight);
+        } else {
+            this._controller.hide();
+        }
+    }
+
+    onTargetUpdate() {
+        this.updateControllerData();
+    }
+
+    onNodeChanged() {
+        this.updateControllerData();
+    }
+
+    private getMaxScale(inScale: Vec3) {
+        return Math.max(inScale.x, inScale.y, inScale.z);
+    }
+}
+
+export const name = js.getClassName(CapsuleCollider);
+export const SelectGizmo = CapsuleColliderComponentGizmo;
+export const IconGizmo = null;
+export const PersistentGizmo = null;
+
+registerGizmo(name, { SelectGizmo });

--- a/src/core/scene/scene-process/service/gizmo/components/circle-collider-2d/index.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/circle-collider-2d/index.ts
@@ -1,0 +1,174 @@
+'use strict';
+
+import { CircleCollider2D, Color, js, Mat4, Quat, Vec2, Vec3 } from 'cc';
+import GizmoBase from '../../base/gizmo-base';
+import DiscController from '../../controller/disc';
+import { registerGizmo } from '../../gizmo-defines';
+
+function toPrecision(val: number, n: number): number {
+    return Math.round(val * Math.pow(10, n)) / Math.pow(10, n);
+}
+
+function makeVec3InPrecision(v: Vec3, p: number): Vec3 {
+    const pow = Math.pow(10, p);
+    v.x = Math.round(v.x * pow) / pow;
+    v.y = Math.round(v.y * pow) / pow;
+    v.z = Math.round(v.z * pow) / pow;
+    return v;
+}
+
+const HandleType = DiscController.DiscHandleType;
+
+const tempQuat_a = new Quat();
+const tempMat4 = new Mat4();
+const tempVec2 = new Vec2();
+
+class CircleCollider2DGizmo extends GizmoBase<CircleCollider2D> {
+    private _controller!: DiscController;
+
+    private _radius = 0;
+    private _offset: Vec2 = new Vec2();
+    private _propRadiusPath: string | null = null;
+    private _propOffsetPath: string | null = null;
+    private _curHandleType: any;
+    private _maxScale = 1;
+
+    init() {
+        this.createController();
+        this._isInitialized = true;
+    }
+
+    onShow() {
+        this._controller.show();
+        this.updateController();
+    }
+
+    onHide() {
+        this._controller.hide();
+    }
+
+    createController() {
+        this._controller = new DiscController(this.getGizmoRoot());
+        this._controller.editable = true;
+        this._controller.setColor(new Color(107, 194, 53));
+        this._controller.setEditHandlesColor(new Color(107, 194, 53));
+        this._controller.setAreaOpacity(50);
+
+        this._controller.onControllerMouseDown = this.onControllerMouseDown.bind(this);
+        this._controller.onControllerMouseMove = this.onControllerMouseMove.bind(this);
+        this._controller.onControllerMouseUp = this.onControllerMouseUp.bind(this);
+    }
+
+    onControllerMouseDown() {
+        if (!this.target) {
+            return;
+        }
+        this._radius = this.target.radius;
+        this._offset = this.target.offset.clone();
+        this._propRadiusPath = this.getCompPropPath('radius');
+        this._propOffsetPath = this.getCompPropPath('offset');
+        const worldScale = this.target.node.getWorldScale();
+        this._maxScale = Math.max(worldScale.x, worldScale.y, worldScale.z);
+    }
+
+    onControllerMouseMove() {
+        if (this._controller.updated) {
+            const handleType = this._controller.getCurHandleType();
+            this._curHandleType = handleType;
+            if (handleType === HandleType.Area) {
+                this.onControlUpdate(this._propRadiusPath);
+                const deltaPos = this._controller.getDeltaPos();
+                this.handleAreaMove(deltaPos);
+            } else {
+                const deltaRadius = this._controller.getDeltaRadius();
+                this.handleRadius(deltaRadius);
+            }
+        }
+    }
+
+    onControllerMouseUp() {
+        if (this._curHandleType === HandleType.Area) {
+            this.onControlEnd(this._propOffsetPath);
+        } else {
+            this.onControlEnd(this._propRadiusPath);
+        }
+    }
+
+    handleAreaMove(delta: Vec3) {
+        if (!this.target) {
+            return;
+        }
+        const node = this.target.node;
+
+        const posDelta: Vec3 = delta.clone();
+        if (node) {
+            node.getWorldMatrix(tempMat4);
+            Mat4.invert(tempMat4, tempMat4);
+            tempMat4.m12 = tempMat4.m13 = 0;
+            Vec3.transformMat4(posDelta, posDelta, tempMat4);
+        }
+        makeVec3InPrecision(posDelta, 1);
+        posDelta.z = 0;
+        tempVec2.set(this._offset);
+        tempVec2.add2f(posDelta.x, posDelta.y);
+        this.target.offset = tempVec2;
+        this.onComponentChanged(node);
+    }
+
+    handleRadius(deltaRadius: number) {
+        if (!this.target) {
+            return;
+        }
+        const newRadius = toPrecision(this._radius + deltaRadius / this._maxScale, 1);
+        this.target.radius = newRadius;
+        this.onComponentChanged(this.target.node);
+    }
+
+    updateControllerData() {
+        if (!this._isInitialized || this.target === null) {
+            return;
+        }
+
+        const circleCollider2D = this.target;
+        if (circleCollider2D) {
+            const node = this.target.node;
+            node.getWorldMatrix(tempMat4);
+
+            const radius = circleCollider2D.radius;
+            const offset = circleCollider2D.offset;
+            const center = new Vec3();
+            center.x = offset.x;
+            center.y = offset.y;
+            const worldScale = node.getWorldScale();
+            Vec3.transformMat4(center, center, tempMat4);
+            const worldRot = tempQuat_a;
+            node.getWorldRotation(worldRot);
+            this._controller.setPosition(center);
+            this._controller.setRotation(worldRot);
+            const scale = worldScale.x;
+            this._controller.updateSize(Vec3.ZERO, radius * scale);
+            this._controller.edit = circleCollider2D.editing;
+        } else {
+            this._controller.hide();
+        }
+    }
+
+    updateController() {
+        this.updateControllerData();
+    }
+
+    onTargetUpdate() {
+        this.updateController();
+    }
+
+    onNodeChanged() {
+        this.updateController();
+    }
+}
+
+export const name = js.getClassName(CircleCollider2D);
+export const SelectGizmo = CircleCollider2DGizmo;
+export const IconGizmo = null;
+export const PersistentGizmo = null;
+
+registerGizmo(name, { SelectGizmo });

--- a/src/core/scene/scene-process/service/gizmo/components/cone-collider/index.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/cone-collider/index.ts
@@ -1,0 +1,133 @@
+'use strict';
+
+import { Color, ConeCollider, js, Quat, Vec3 } from 'cc';
+import GizmoBase from '../../base/gizmo-base';
+import ConeController from '../../controller/cone';
+import { registerGizmo } from '../../gizmo-defines';
+
+function toPrecision(val: number, n: number): number {
+    return Math.round(val * Math.pow(10, n)) / Math.pow(10, n);
+}
+
+const tempQuat_a = new Quat();
+
+class ConeColliderComponentGizmo extends GizmoBase<ConeCollider> {
+    private _controller!: ConeController;
+    private _maxScale = 1;
+    private _radius = 0;
+    private _height = 0;
+    private _propPath: string | null = null;
+
+    init() {
+        this.createController();
+        this._isInitialized = true;
+    }
+
+    onShow() {
+        this._controller.show();
+        this.updateControllerData();
+    }
+
+    onHide() {
+        this._controller.hide();
+    }
+
+    createController() {
+        const gizmoRoot = this.getGizmoRoot();
+        this._controller = new ConeController(gizmoRoot);
+
+        this._controller.setColor(Color.GREEN);
+        this._controller.editable = true;
+        this._controller.hoverColor = Color.YELLOW;
+        this._controller.onControllerMouseDown = this.onControllerMouseDown.bind(this);
+        this._controller.onControllerMouseMove = this.onControllerMouseMove.bind(this);
+        this._controller.onControllerMouseUp = this.onControllerMouseUp.bind(this);
+    }
+
+    onControllerMouseDown() {
+        if (!this._isInitialized || this.target === null) {
+            return;
+        }
+
+        this._radius = this.target.radius;
+        this._height = this.target.height;
+        const worldScale = this.target.node.getWorldScale();
+        this._maxScale = this.getMaxScale(worldScale);
+
+        this._propPath = this.getCompPropPath('size');
+    }
+
+    onControllerMouseMove() {
+        this.updateDataFromController();
+    }
+
+    onControllerMouseUp() {
+        this.onControlEnd(this._propPath);
+    }
+
+    updateDataFromController() {
+        if (this._controller.updated && this.target) {
+            this.onControlUpdate(this._propPath);
+            const deltaRadius = this._controller.getDeltaRadius();
+            const newRadius = toPrecision(this._radius + deltaRadius / this._maxScale, 3);
+            this.target.radius = newRadius;
+
+            const deltaHeight = this._controller.getDeltaHeight();
+            const newHeight = toPrecision(this._height + deltaHeight / this._maxScale, 3);
+            this.target.height = newHeight;
+
+            const node = this.target.node;
+            this.onComponentChanged(node);
+        }
+    }
+
+    updateControllerTransform() {
+        this.updateControllerData();
+    }
+
+    updateControllerData() {
+        if (!this._isInitialized || this.target === null) {
+            return;
+        }
+
+        if (this.target instanceof ConeCollider) {
+            const node = this.target.node;
+
+            this._controller.show();
+            this._controller.checkEdit();
+
+            const worldScale = node.getWorldScale();
+            const worldPos = node.getWorldPosition();
+            const worldRot = tempQuat_a;
+            node.getWorldRotation(worldRot);
+            const xzNorm = Math.max(Math.abs(worldScale.x), Math.abs(worldScale.z));
+            this._controller.setScale(new Vec3(xzNorm, worldScale.y, xzNorm));
+            this._controller.setPosition(worldPos);
+            this._controller.setRotation(worldRot);
+
+            this._controller.direction = this.target.direction;
+            this._controller.updateSize(this.target.center, this.target.radius, this.target.height);
+        } else {
+            this._controller.hide();
+        }
+    }
+
+    onTargetUpdate() {
+        this.updateControllerData();
+    }
+
+    onNodeChanged() {
+        this.updateControllerData();
+    }
+
+    private getMaxScale(inScale: Vec3) {
+        return Math.max(inScale.x, inScale.y, inScale.z);
+    }
+}
+
+export const name = js.getClassName(ConeCollider);
+export const SelectGizmo = ConeColliderComponentGizmo;
+export const IconGizmo = null;
+export const PersistentGizmo = null;
+
+registerGizmo(name, { SelectGizmo });

--- a/src/core/scene/scene-process/service/gizmo/components/cylinder-collider/index.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/cylinder-collider/index.ts
@@ -1,0 +1,415 @@
+'use strict';
+
+import { Color, CylinderCollider, EAxisDirection, js, MeshRenderer, Node, Quat, Vec2, Vec3 } from 'cc';
+import GizmoBase from '../../base/gizmo-base';
+import EditableController from '../../controller/editable';
+import ControllerShape from '../../utils/controller-shape';
+import ControllerUtils from '../../utils/controller-utils';
+import type { GizmoMouseEvent } from '../../utils/defines';
+import { setMeshColor, getModel, updatePositions } from '../../utils/engine-utils';
+import { registerGizmo } from '../../gizmo-defines';
+
+function toPrecision(val: number, n: number): number {
+    return Math.round(val * Math.pow(10, n)) / Math.pow(10, n);
+}
+
+const axisDirMap = ControllerUtils.axisDirectionMap;
+const tempVec3_a = new Vec3();
+const tempVec3_b = new Vec3();
+const tempVec3_c = new Vec3();
+const tempVec3_d = new Vec3();
+const tempVec3_e = new Vec3();
+const tempQuat_a = new Quat();
+const tempQuat_gizmo = new Quat();
+
+class CylinderController extends EditableController {
+    get radius() { return this._radius; }
+    set radius(value) {
+        this.updateSize(this._center, value, this._height);
+    }
+
+    get height() { return this._height; }
+    set height(value) {
+        this.updateSize(this._center, this._radius, value);
+    }
+
+    get direction() { return this._direction; }
+    set direction(value) {
+        this._direction = value;
+    }
+
+    private _direction: EAxisDirection = EAxisDirection.Y_AXIS;
+    private _center = new Vec3();
+    private _radius = 100;
+    private _height = 100;
+    private _halfHeight = this._height / 2;
+    private _deltaRadius = 0;
+    private _deltaHeight = 0;
+
+    private _mouseDeltaPos: Vec2 = new Vec2();
+    private _curDistScalar = 0;
+
+    private _upperCapMC: MeshRenderer[] = [];
+    private _lowerCapMC: MeshRenderer[] = [];
+    private _sideLineMC: MeshRenderer | null = null;
+
+    private _upperCapNode: Node[] = [];
+    private _lowerCapNode: Node[] = [];
+    private _sideLineNode: Node | null = null;
+
+    private _up = new Vec3(0, 1, 0);
+    private _right = new Vec3(1, 0, 0);
+    private _forward = new Vec3(0, 0, 1);
+    private _directionAxis: Vec3[] = [new Vec3(1, 0, 0), new Vec3(0, 1, 0), new Vec3(0, 0, 1)];
+
+    constructor(rootNode: Node) {
+        super(rootNode);
+        this._editHandleKeys = Object.keys(axisDirMap);
+        this.initShape();
+    }
+
+    public setColor(color: Color) {
+        this._upperCapNode.forEach((node) => {
+            setMeshColor(node, color);
+        });
+        this._lowerCapNode.forEach((node) => {
+            setMeshColor(node, color);
+        });
+        setMeshColor(this._sideLineNode!, color);
+        this.setEditHandlesColor(color);
+        this._color = color;
+    }
+
+    public _updateEditHandle(axisName: string) {
+        const node = this._handleDataMap[axisName].topNode;
+        const dir = axisDirMap[axisName];
+
+        const colliderDir = tempVec3_a.set(this._directionAxis[this._direction]);
+
+        const offset = tempVec3_b;
+        offset.set(0, 0, 0);
+
+        if (axisName === 'y') {
+            Vec3.multiplyScalar(offset, colliderDir, this._halfHeight);
+        } else if (axisName === 'neg_y') {
+            Vec3.multiplyScalar(offset, colliderDir, -this._halfHeight);
+        } else {
+            Vec3.multiplyScalar(offset, dir, this._radius);
+            if (this._direction !== EAxisDirection.Y_AXIS) {
+                const rot = tempQuat_a;
+                Quat.rotationTo(rot, this._up, colliderDir);
+                Vec3.transformQuat(offset, offset, rot);
+            }
+        }
+
+        offset.add(this._center);
+        Vec3.multiply(offset, offset, this.getScale());
+        node.setPosition(offset);
+    }
+
+    public initShape() {
+        this.createShapeNode('CylinderController');
+
+        const upperData = this.getUpperCapData(this._center, this._radius, this._height);
+        upperData.forEach((data: any, index: number) => {
+            this._upperCapNode[index] = ControllerUtils.createShapeByData(data, this._color);
+            this._upperCapNode[index].parent = this.shape;
+            this._upperCapMC[index] = getModel(this._upperCapNode[index])!;
+        });
+
+        const lowerData = this.getLowerCapData(this._center, this._radius, this._height);
+        lowerData.forEach((data: any, index: number) => {
+            this._lowerCapNode[index] = ControllerUtils.createShapeByData(data, this._color);
+            this._lowerCapNode[index].parent = this.shape;
+            this._lowerCapMC[index] = getModel(this._lowerCapNode[index])!;
+        });
+
+        const sideLinesData = this.getSideLinesData(this._center, this._radius, this._height);
+        this._sideLineNode = ControllerUtils.createShapeByData(sideLinesData, this._color);
+        this._sideLineNode!.parent = this.shape;
+        this._sideLineMC = getModel(this._sideLineNode);
+
+        this.hide();
+    }
+
+    public updateSize(center: Vec3, radius: number, height: number) {
+        this._center = center;
+        this._radius = radius;
+        this._height = height;
+        this._halfHeight = height / 2;
+
+        const upperData = this.getUpperCapData(this._center, this._radius, this._height);
+        upperData.forEach((data: any, i: number) => {
+            updatePositions(this._upperCapMC[i], data.positions);
+        });
+
+        const lowerData = this.getLowerCapData(this._center, this._radius, this._height);
+        lowerData.forEach((data: any, i: number) => {
+            updatePositions(this._lowerCapMC[i], data.positions);
+        });
+
+        const lineData = this.getSideLinesData(this._center, this._radius, this._height);
+        updatePositions(this._sideLineMC!, lineData.positions);
+
+        if (this._edit) {
+            this.updateEditHandles();
+        }
+
+        this.adjustEditHandlesSize();
+    }
+
+    public onMouseDown(event: GizmoMouseEvent) {
+        event.propagationStopped = true;
+        this._mouseDeltaPos = new Vec2(0, 0);
+        this._curDistScalar = super.getDistScalar();
+        this._deltaRadius = 0;
+        this._deltaHeight = 0;
+
+        if (this.onControllerMouseDown) {
+            this.onControllerMouseDown(event);
+        }
+    }
+
+    public onMouseMove(event: GizmoMouseEvent) {
+        event.propagationStopped = true;
+        if (this._isMouseDown) {
+            this._mouseDeltaPos.x += event.moveDeltaX;
+            this._mouseDeltaPos.y += event.moveDeltaY;
+
+            const axisDir = axisDirMap[event.handleName];
+
+            const colliderDir = tempVec3_a.set(this._directionAxis[this._direction]);
+            const rot = tempQuat_a;
+            Quat.rotationTo(rot, this._up, colliderDir);
+            Vec3.transformQuat(colliderDir, axisDir, rot);
+            const deltaDist = this.getAlignAxisMoveDistance(this.localToWorldDir(colliderDir),
+                this._mouseDeltaPos) * this._curDistScalar;
+            if (event.handleName === 'y' || event.handleName === 'neg_y') {
+                this._deltaHeight = deltaDist;
+            } else {
+                this._deltaRadius = deltaDist;
+            }
+
+            if (this.onControllerMouseMove) {
+                this.onControllerMouseMove(event);
+            }
+        }
+    }
+
+    public onMouseUp(event: GizmoMouseEvent) {
+        event.propagationStopped = true;
+        if (this.onControllerMouseUp) {
+            this.onControllerMouseUp(event);
+        }
+    }
+
+    public onMouseLeave(event: GizmoMouseEvent) {
+        this.onMouseUp(event);
+    }
+
+    public getDeltaRadius() {
+        return this._deltaRadius;
+    }
+
+    public getDeltaHeight() {
+        return this._deltaHeight;
+    }
+
+    private getUpperCapData(center: Vec3, radius: number, height: number) {
+        const upperData: any = [];
+        const halfHeight = height / 2;
+        const curUp = Vec3.copy(tempVec3_a, this._up);
+        const curRight = Vec3.copy(tempVec3_b, this._right);
+        const _curForward = Vec3.copy(tempVec3_c, this._forward);
+        const upperCenter = tempVec3_d;
+        const offset = tempVec3_e.set(0, halfHeight, 0);
+        if (this._direction !== EAxisDirection.Y_AXIS) {
+            const colliderDir = this._directionAxis[this._direction];
+            const rot = tempQuat_a;
+            Quat.rotationTo(rot, this._up, colliderDir);
+            Vec3.transformQuat(offset, offset, rot);
+            Vec3.transformQuat(curUp, curUp, rot);
+            Vec3.transformQuat(curRight, curRight, rot);
+            Vec3.transformQuat(_curForward, _curForward, rot);
+        }
+
+        Vec3.add(upperCenter, center, offset);
+        upperData[0] = ControllerShape.calcArcData(upperCenter, curUp, curRight, this._twoPI, radius);
+
+        return upperData;
+    }
+
+    private getLowerCapData(center: Vec3, radius: number, height: number) {
+        const lowerData: any = [];
+        const halfHeight = height / 2;
+        const curUp = Vec3.copy(tempVec3_a, this._up);
+        const curRight = Vec3.copy(tempVec3_b, this._right);
+        const _curForward = Vec3.copy(tempVec3_c, this._forward);
+        const lowerCenter = tempVec3_d;
+        const offset = tempVec3_e.set(0, -halfHeight, 0);
+
+        if (this._direction !== EAxisDirection.Y_AXIS) {
+            const colliderDir = this._directionAxis[this._direction];
+            const rot = tempQuat_a;
+            Quat.rotationTo(rot, this._up, colliderDir);
+            Vec3.transformQuat(offset, offset, rot);
+            Vec3.transformQuat(curUp, curUp, rot);
+            Vec3.transformQuat(curRight, curRight, rot);
+            Vec3.transformQuat(_curForward, _curForward, rot);
+        }
+
+        Vec3.add(lowerCenter, center, offset);
+        lowerData[0] = ControllerShape.calcArcData(lowerCenter, curUp, curRight, this._twoPI, radius);
+
+        return lowerData;
+    }
+
+    private getSideLinesData(center: Vec3, radius: number, height: number) {
+        const vertices: Vec3[] = [];
+        const indices: number[] = [];
+        const sideLineHeight = height / 2;
+
+        vertices.push(new Vec3(radius, sideLineHeight, 0));
+        vertices.push(new Vec3(radius, -sideLineHeight, 0));
+        vertices.push(new Vec3(-radius, sideLineHeight, 0));
+        vertices.push(new Vec3(-radius, -sideLineHeight, 0));
+        vertices.push(new Vec3(0, sideLineHeight, radius));
+        vertices.push(new Vec3(0, -sideLineHeight, radius));
+        vertices.push(new Vec3(0, sideLineHeight, -radius));
+        vertices.push(new Vec3(0, -sideLineHeight, -radius));
+
+        vertices.forEach((vert, index) => {
+            if (this._direction !== EAxisDirection.Y_AXIS) {
+                const colliderDir = this._directionAxis[this._direction];
+                const rot = tempQuat_a;
+                Quat.rotationTo(rot, this._up, colliderDir);
+                Vec3.transformQuat(vert, vert, rot);
+            }
+            Vec3.add(vert, vert, center);
+            indices.push(index);
+        });
+
+        return ControllerShape.calcLinesData(vertices, indices, false);
+    }
+}
+
+class CylinderColliderComponentGizmo extends GizmoBase<CylinderCollider> {
+    private _controller!: CylinderController;
+    private _maxScale = 1;
+    private _radius = 0;
+    private _height = 0;
+    private _propPath: string | null = null;
+
+    init() {
+        this.createController();
+        this._isInitialized = true;
+    }
+
+    onShow() {
+        this._controller.show();
+        this.updateControllerData();
+    }
+
+    onHide() {
+        this._controller.hide();
+    }
+
+    createController() {
+        const gizmoRoot = this.getGizmoRoot();
+        this._controller = new CylinderController(gizmoRoot);
+
+        this._controller.setColor(Color.GREEN);
+        this._controller.editable = true;
+        this._controller.hoverColor = Color.YELLOW;
+        this._controller.onControllerMouseDown = this.onControllerMouseDown.bind(this);
+        this._controller.onControllerMouseMove = this.onControllerMouseMove.bind(this);
+        this._controller.onControllerMouseUp = this.onControllerMouseUp.bind(this);
+    }
+
+    onControllerMouseDown() {
+        if (!this._isInitialized || this.target === null) {
+            return;
+        }
+
+        this._radius = this.target.radius;
+        this._height = this.target.height;
+        const worldScale = this.target.node.getWorldScale();
+        this._maxScale = this.getMaxScale(worldScale);
+
+        this._propPath = this.getCompPropPath('size');
+    }
+
+    onControllerMouseMove() {
+        this.updateDataFromController();
+    }
+
+    onControllerMouseUp() {
+        this.onControlEnd(this._propPath);
+    }
+
+    updateDataFromController() {
+        if (this._controller.updated && this.target) {
+            this.onControlUpdate(this._propPath);
+            const deltaRadius = this._controller.getDeltaRadius();
+            const newRadius = toPrecision(this._radius + deltaRadius / this._maxScale, 3);
+            this.target.radius = newRadius;
+
+            const deltaHeight = this._controller.getDeltaHeight();
+            const newHeight = toPrecision(this._height + deltaHeight / this._maxScale, 3);
+            this.target.height = newHeight;
+
+            const node = this.target.node;
+            this.onComponentChanged(node);
+        }
+    }
+
+    updateControllerTransform() {
+        this.updateControllerData();
+    }
+
+    updateControllerData() {
+        if (!this._isInitialized || this.target === null) {
+            return;
+        }
+
+        if (this.target instanceof CylinderCollider) {
+            const node = this.target.node;
+
+            this._controller.show();
+            this._controller.checkEdit();
+
+            const worldScale = node.getWorldScale();
+            const worldPos = node.getWorldPosition();
+            const worldRot = tempQuat_gizmo;
+            node.getWorldRotation(worldRot);
+            const xzNorm = Math.max(Math.abs(worldScale.x), Math.abs(worldScale.z));
+            this._controller.setScale(new Vec3(xzNorm, worldScale.y, xzNorm));
+            this._controller.setPosition(worldPos);
+            this._controller.setRotation(worldRot);
+
+            this._controller.direction = this.target.direction;
+            this._controller.updateSize(this.target.center, this.target.radius, this.target.height);
+        } else {
+            this._controller.hide();
+        }
+    }
+
+    onTargetUpdate() {
+        this.updateControllerData();
+    }
+
+    onNodeChanged() {
+        this.updateControllerData();
+    }
+
+    private getMaxScale(inScale: Vec3) {
+        return Math.max(inScale.x, inScale.y, inScale.z);
+    }
+}
+
+export const name = js.getClassName(CylinderCollider);
+export const SelectGizmo = CylinderColliderComponentGizmo;
+export const IconGizmo = null;
+export const PersistentGizmo = null;
+
+registerGizmo(name, { SelectGizmo });

--- a/src/core/scene/scene-process/service/gizmo/components/mesh-collider/index.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/mesh-collider/index.ts
@@ -1,0 +1,169 @@
+'use strict';
+
+import { Color, gfx, js, Mesh, MeshCollider, MeshRenderer, Node, Quat, Vec3 } from 'cc';
+import GizmoBase from '../../base/gizmo-base';
+import ControllerUtils from '../../utils/controller-utils';
+import ControllerBase from '../../controller/base';
+import { AttributeName, getModel, updateVBAttr, updateIB } from '../../utils/engine-utils';
+import { registerGizmo } from '../../gizmo-defines';
+
+const tempQuat_a = new Quat();
+
+class MeshController extends ControllerBase {
+    private _linesNode: Node | null = null;
+    private _linesMR: MeshRenderer | null = null;
+
+    constructor(rootNode: Node) {
+        super(rootNode);
+        this._color = Color.GREEN;
+        this.initShape();
+    }
+
+    initShape() {
+        this.createShapeNode('MeshController');
+        this._linesNode = ControllerUtils.lines([new Vec3(), new Vec3(0, 0, 1)], [0, 1], this._color, { forwardPipeline: true });
+        this._linesMR = getModel(this._linesNode);
+        this._linesNode.parent = this.shape;
+    }
+
+    updateData(points: number[], indices: number[]) {
+        updateVBAttr(this._linesMR!, AttributeName.ATTR_POSITION, points);
+        updateIB(this._linesMR!, indices);
+    }
+}
+
+class MeshColliderGizmo extends GizmoBase<MeshCollider> {
+    private _controller!: MeshController;
+
+    init() {
+        this._controller = new MeshController(this.getGizmoRoot());
+        this._isInitialized = true;
+    }
+
+    onShow() {
+        this.updateControllerData();
+    }
+
+    onHide() {
+        this._controller.hide();
+    }
+
+    updateControllerData() {
+        if (!this._isInitialized || this.target === null) {
+            return;
+        }
+
+        if (this.target instanceof MeshCollider) {
+            const node = this.target.node;
+
+            const worldScale = node.getWorldScale();
+            const worldPos = node.getWorldPosition();
+            const worldRot = tempQuat_a;
+            node.getWorldRotation(worldRot);
+            this._controller.setScale(worldScale);
+            this._controller.setPosition(worldPos);
+            this._controller.setRotation(worldRot);
+
+            const meshCollider = this.target;
+            const mesh = meshCollider.mesh;
+
+            if (mesh) {
+                this._controller.show();
+                const calcMeshData = this.calcMeshData(mesh);
+                const points = calcMeshData.points;
+
+                const center = meshCollider.center;
+                for (let i = 0; i < points.length; i += 3) {
+                    points[i] += center.x;
+                    points[i + 1] += center.y;
+                    points[i + 2] += center.z;
+                }
+
+                this._controller.updateData(points, calcMeshData.indices);
+            } else {
+                this._controller.hide();
+            }
+        }
+    }
+
+    calcMeshData(mesh: Mesh) {
+        let points: number[] = [];
+        let indices: number[] = [];
+
+        const len = mesh?.renderingSubMeshes.length;
+        for (let i = 0; i < len; i++) {
+            const subMesh = mesh.renderingSubMeshes[i];
+            const geoInfo = subMesh.geometricInfo;
+            if (geoInfo) {
+                const primitiveMode = subMesh.primitiveMode;
+                const vb: any = geoInfo.positions;
+                const ib: any = geoInfo.indices;
+                const wireFrameData = this._generateWireFrameData(vb, points.length / 3, ib, primitiveMode);
+                if (wireFrameData) {
+                    points = points.concat(wireFrameData.positions);
+                    indices = indices.concat(wireFrameData.edgeIndices);
+                }
+            }
+        }
+
+        return { points, indices };
+    }
+
+    private _generateWireFrameData(vb: Float32Array, pointsOffset: number, ib: number[], primitiveMode: gfx.PrimitiveMode) {
+        if (!ib) {
+            console.error('indexBuffer of mesh is undefined');
+            return null;
+        }
+
+        let positions: number[] = [];
+        const edgeIndices: number[] = [];
+
+        if (primitiveMode === gfx.PrimitiveMode.TRIANGLE_LIST) {
+            positions = Array.from(vb);
+            const triCount = ib.length / 3;
+            for (let i = 0; i < triCount; i++) {
+                const i0 = ib[i * 3 + 0] + pointsOffset;
+                const i1 = ib[i * 3 + 1] + pointsOffset;
+                const i2 = ib[i * 3 + 2] + pointsOffset;
+                edgeIndices.push(i0, i1, i1, i2, i2, i0);
+            }
+        } else if (primitiveMode === gfx.PrimitiveMode.TRIANGLE_STRIP) {
+            positions = Array.from(vb);
+            const triCount = ib.length - 2;
+            let rev = 0;
+            for (let i = 0; i < triCount; i++) {
+                const i0 = ib[i - rev] + pointsOffset;
+                const i1 = ib[i + rev + 1] + pointsOffset;
+                const i2 = ib[i + 2] + pointsOffset;
+                edgeIndices.push(i0, i1, i1, i2, i2, i0);
+                rev = ~rev;
+            }
+        } else if (primitiveMode === gfx.PrimitiveMode.TRIANGLE_FAN) {
+            positions = Array.from(vb);
+            const triCount = ib.length - 2;
+            const i0 = ib[0] + pointsOffset;
+            for (let i = 0; i < triCount; i += 1) {
+                const i1 = ib[i + 1] + pointsOffset;
+                const i2 = ib[i + 2] + pointsOffset;
+                edgeIndices.push(i0, i1, i1, i2, i2, i0);
+            }
+        }
+
+        return { positions, edgeIndices };
+    }
+
+    onTargetUpdate() {
+        this.updateControllerData();
+    }
+
+    onNodeChanged() {
+        this.updateControllerData();
+    }
+}
+
+export const name = js.getClassName(MeshCollider);
+export const SelectGizmo = MeshColliderGizmo;
+export const IconGizmo = null;
+export const PersistentGizmo = null;
+
+registerGizmo(name, { SelectGizmo });

--- a/src/core/scene/scene-process/service/gizmo/components/mesh-renderer/index.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/mesh-renderer/index.ts
@@ -1,0 +1,82 @@
+'use strict';
+
+import { geometry, js, MeshRenderer, Quat, Vec3 } from 'cc';
+import GizmoBase from '../../base/gizmo-base';
+import BoxController from '../../controller/box';
+import { registerGizmo } from '../../gizmo-defines';
+
+const tempQuat_a = new Quat();
+const tempSize = new Vec3();
+
+class ModelComponentGizmo extends GizmoBase<MeshRenderer> {
+    private _controller!: BoxController;
+
+    init() {
+        this._controller = new BoxController(this.getGizmoRoot());
+        this._isInitialized = true;
+    }
+
+    onShow() {
+        this._controller.show();
+        this.updateControllerData();
+    }
+
+    onHide() {
+        this._controller.hide();
+    }
+
+    updateControllerData() {
+        if (!this._isInitialized || this.target == null) {
+            return;
+        }
+
+        const node = this.target.node;
+        const boundingBox = this.getBoundingBox(this.target);
+        if (boundingBox) {
+            this._controller.show();
+
+            const worldScale = node.getWorldScale();
+            const worldPos = node.getWorldPosition();
+            const worldRot = tempQuat_a;
+            node.getWorldRotation(worldRot);
+            this._controller.setScale(worldScale);
+            this._controller.setPosition(worldPos);
+            this._controller.setRotation(worldRot);
+
+            Vec3.multiplyScalar(tempSize, boundingBox.halfExtents, 2);
+            this._controller.updateSize(boundingBox.center, tempSize);
+        } else {
+            this._controller.hide();
+        }
+    }
+
+    private getBoundingBox(component: MeshRenderer): geometry.AABB | null {
+        let bb = component.model && component.model.modelBounds;
+        if (!bb) {
+            const mesh = component.mesh;
+            if (mesh && mesh.minPosition && mesh.maxPosition) {
+                bb = geometry.AABB.fromPoints(geometry.AABB.create(), mesh.minPosition, mesh.maxPosition);
+            }
+        }
+        return bb || null;
+    }
+
+    updateControllerTransform() {
+        this.updateControllerData();
+    }
+
+    onTargetUpdate() {
+        this.updateControllerData();
+    }
+
+    onNodeChanged() {
+        this.updateControllerData();
+    }
+}
+
+export const name = js.getClassName(MeshRenderer);
+export const SelectGizmo = ModelComponentGizmo;
+export const IconGizmo = null;
+export const PersistentGizmo = null;
+
+registerGizmo(name, { SelectGizmo });

--- a/src/core/scene/scene-process/service/gizmo/components/plane-collider/index.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/plane-collider/index.ts
@@ -1,0 +1,100 @@
+'use strict';
+
+import { Color, js, Node, PlaneCollider, Quat, Vec3 } from 'cc';
+import GizmoBase from '../../base/gizmo-base';
+import ControllerUtils from '../../utils/controller-utils';
+import ControllerBase from '../../controller/base';
+import { setNodeOpacity } from '../../utils/engine-utils';
+import { registerGizmo } from '../../gizmo-defines';
+
+const tempVec3_a = new Vec3();
+const tempQuat_a = new Quat();
+
+class PlaneController extends ControllerBase {
+    private _planeNode: Node | null = null;
+    private _arrowNode: Node | null = null;
+
+    constructor(rootNode: Node) {
+        super(rootNode);
+        this._color = Color.GREEN;
+        this._lockSize = true;
+        this.initShape();
+        this.registerCameraMovedEvent();
+    }
+
+    initShape() {
+        this.createShapeNode('PlaneController');
+        this._planeNode = ControllerUtils.quad(Vec3.ZERO, 200, 200, Vec3.UNIT_Y, this._color, { unlit: true });
+        setNodeOpacity(this._planeNode, 128);
+        this._planeNode.parent = this.shape;
+        this._arrowNode = ControllerUtils.lineTo(Vec3.ZERO, new Vec3(0, 100, 0), this._color, {
+            forwardPipeline: true,
+        });
+        this._arrowNode.parent = this.shape;
+    }
+
+    updateData(center: Vec3, normal: Vec3) {
+        this._planeNode?.setPosition(center);
+        this._arrowNode?.setPosition(center);
+
+        Vec3.normalize(tempVec3_a, normal);
+        Quat.rotationTo(tempQuat_a, Vec3.UNIT_Y, tempVec3_a);
+        this._planeNode?.setRotation(tempQuat_a);
+        this._arrowNode?.setRotation(tempQuat_a);
+    }
+}
+
+class PlaneColliderGizmo extends GizmoBase<PlaneCollider> {
+    private _controller!: PlaneController;
+
+    init() {
+        this._controller = new PlaneController(this.getGizmoRoot());
+        this._isInitialized = true;
+    }
+
+    onShow() {
+        this._controller.show();
+        this.updateControllerData();
+    }
+
+    onHide() {
+        this._controller.hide();
+    }
+
+    updateControllerData() {
+        if (!this._isInitialized || this.target === null) {
+            return;
+        }
+
+        if (this.target instanceof PlaneCollider) {
+            const node = this.target.node;
+
+            this._controller.show();
+
+            const worldPos = node.getWorldPosition();
+            const worldRot = tempQuat_a;
+            node.getWorldRotation(worldRot);
+
+            this._controller.setPosition(worldPos);
+            this._controller.setRotation(worldRot);
+
+            const planeCollider = this.target;
+            this._controller.updateData(planeCollider.center, planeCollider.normal);
+        }
+    }
+
+    onTargetUpdate() {
+        this.updateControllerData();
+    }
+
+    onNodeChanged() {
+        this.updateControllerData();
+    }
+}
+
+export const name = js.getClassName(PlaneCollider);
+export const SelectGizmo = PlaneColliderGizmo;
+export const IconGizmo = null;
+export const PersistentGizmo = null;
+
+registerGizmo(name, { SelectGizmo });

--- a/src/core/scene/scene-process/service/gizmo/components/polygon-collider-2d/index.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/polygon-collider-2d/index.ts
@@ -1,0 +1,666 @@
+'use strict';
+
+import { Color, js, Mat4, MeshRenderer, Node, PolygonCollider2D, Quat, Vec2, Vec3 } from 'cc';
+import GizmoBase from '../../base/gizmo-base';
+import EditableController from '../../controller/editable';
+import LineController from '../../controller/line';
+import ControllerUtils from '../../utils/controller-utils';
+import ControllerShape from '../../utils/controller-shape';
+import type { GizmoMouseEvent, IHandleData } from '../../utils/defines';
+import {
+    getModel,
+    updatePositions,
+    updateIB,
+    setMeshColor,
+    setNodeOpacity,
+    getNodeOpacity,
+    updateBoundingBox,
+    create3DNode,
+} from '../../utils/engine-utils';
+import { registerGizmo } from '../../gizmo-defines';
+
+function toPrecision(val: number, n: number): number {
+    return Math.round(val * Math.pow(10, n)) / Math.pow(10, n);
+}
+
+function makeVec3InPrecision(v: Vec3, p: number): Vec3 {
+    const pow = Math.pow(10, p);
+    v.x = Math.round(v.x * pow) / pow;
+    v.y = Math.round(v.y * pow) / pow;
+    v.z = Math.round(v.z * pow) / pow;
+    return v;
+}
+
+const panPlaneLayer = 1 << 30;
+
+enum PolygonHandleType {
+    None = 'none',
+    Point = 'point',
+    Line = 'line',
+    Area = 'area',
+}
+
+interface IPolygonHandleData {
+    type: string;
+    deltaPos: Vec3;
+    index: number;
+    hitPos?: Vec3;
+}
+
+const flat = (arr: any, fn: any) => {
+    return arr.map(fn).reduce((acc: any, val: any) => acc.concat(val), []);
+};
+
+const tempVec3_a = new Vec3();
+const tempVec3_b = new Vec3();
+
+class PolygonController extends EditableController {
+    public static PolygonHandleType = PolygonHandleType;
+    private _panPlane: Node | null = null;
+    private _panPlaneMeshRenderer: MeshRenderer | null = null;
+    private _points: Vec3[] = [];
+    private _mouseDownOnPlanePos: Vec3 = new Vec3();
+    private _curHandleData: IPolygonHandleData = { type: PolygonHandleType.None, deltaPos: new Vec3(), index: -1 };
+    private _lineGroup: Node | null = null;
+    private _pointsHandleData: IHandleData[] = [];
+    private _linesHandleData: IHandleData[] = [];
+    private _hitPoint: Vec3 | null = null;
+    private _areaNode: Node | null = null;
+    private _areaMR: MeshRenderer | null = null;
+    private _areaOpacity = 80;
+    private _panSize = 100000;
+
+    public get points() {
+        return this._points;
+    }
+
+    constructor(
+        rootNode: Node,
+        public gizmo: PolygonCollider2DGizmo,
+    ) {
+        super(rootNode);
+        this._hoverColor = Color.YELLOW;
+        this.initShape();
+    }
+
+    initShape() {
+        this.createShapeNode('PolygonController');
+        this._lineGroup = create3DNode('LineGroup');
+        this._lineGroup.parent = this.shape;
+    }
+
+    onInitEditHandles() {
+        const panPlane = ControllerUtils.quad(new Vec3(), this._panSize, this._panSize);
+        panPlane.parent = this._rootNode;
+        panPlane.name = 'RectPanPlane';
+        panPlane.active = false;
+        panPlane.layer = panPlaneLayer;
+        setNodeOpacity(panPlane, 0);
+        this._panPlane = panPlane;
+        this._panPlaneMeshRenderer = getModel(panPlane);
+
+        this.createPolygonAreaHandle();
+    }
+
+    showEditHandles() {
+        super.showEditHandles();
+        if (this._areaNode) {
+            this._areaNode.active = true;
+        }
+    }
+
+    hideEditHandles() {
+        super.hideEditHandles();
+        if (this._areaNode) {
+            this._areaNode.active = false;
+        }
+    }
+
+    createPolygonAreaHandle() {
+        const polygonData = ControllerShape.calcPolygonData(this._points);
+        const areaNode = ControllerUtils.createShapeByData(polygonData, this._color, { unlit: true });
+        areaNode.name = 'RectArea';
+        areaNode.parent = this.shape;
+        areaNode.setPosition(new Vec3(0, 0, -0.1));
+        setNodeOpacity(areaNode, this._areaOpacity);
+        this._areaNode = areaNode;
+        this._areaMR = getModel(areaNode);
+        this.initHandle(areaNode, PolygonHandleType.Area);
+    }
+
+    setColor(color: Color) {
+        if (this._lineGroup) {
+            this._color = color;
+            this._lineGroup.children.forEach((child: Node) => {
+                setMeshColor(child, color);
+            });
+        }
+    }
+
+    updateData(points: Vec3[]) {
+        this.updatePanRectByPoints(points);
+        this.resetEditHandlesFromPoints(points);
+    }
+
+    updatePanRectByPoints(points: Vec3[]) {
+        if (!this._panPlane || !this._panPlaneMeshRenderer || !this.gizmo || !this.gizmo.target) return;
+
+        let maxX = 0, maxY = 0;
+        points.forEach((point) => {
+            maxX = Math.max(maxX, Math.abs(point.x));
+            maxY = Math.max(maxY, Math.abs(point.y));
+        });
+
+        const center = this.gizmo.target.node.position;
+        const size = (maxX > maxY ? maxX : maxY) * 2 + 1000;
+        if (size < this._panSize) return;
+
+        this._panSize = size;
+        const quadData = ControllerShape.calcPositionData(center, size, size, new Vec3(0, 0, 1), true);
+        updatePositions(this._panPlaneMeshRenderer, quadData.positions);
+        updateBoundingBox(this._panPlaneMeshRenderer, quadData.minPos, quadData.maxPos);
+    }
+
+    resetEditHandlesFromPoints(points: Vec3[]) {
+        this._points = points;
+
+        if (this._editHandlesShape) {
+            this._editHandleKeys = [];
+            this._points.forEach((_point: Vec3, index: number) => {
+                this._editHandleKeys.push('p' + index);
+            });
+
+            if (this._points.length > this._pointsHandleData.length) {
+                const curLen = this._pointsHandleData.length;
+                for (let i = curLen; i < this._points.length; i++) {
+                    const handleData = this.createEditHandle(this._editHandleKeys[i], this._editHandleColor);
+                    handleData.customData = {};
+                    handleData.customData.index = i;
+                    this._pointsHandleData.push(handleData);
+                }
+            } else if (this._points.length < this._pointsHandleData.length) {
+                for (let i = this._pointsHandleData.length - 1; i >= this._points.length; i--) {
+                    this._editHandlesShape.removeChild(this._pointsHandleData[i].topNode);
+                    this.removeHandle('p' + i);
+                }
+                this._pointsHandleData.length = this._points.length;
+            }
+
+            this._editHandleKeys.forEach((key: string) => {
+                this._updateEditHandle(key);
+            });
+
+            this.adjustEditHandlesSize();
+        }
+
+        if (this._lineGroup) {
+            if (this._points.length < 2) {
+                this._lineGroup.removeAllChildren();
+                this._linesHandleData.forEach((data) => {
+                    this.removeHandle(data.name);
+                });
+                this._linesHandleData = [];
+            }
+
+            if (this._points.length > this._linesHandleData.length) {
+                const curLen = this._linesHandleData.length;
+                for (let i = curLen; i < this._points.length; i++) {
+                    const next_i = i === this._points.length - 1 ? 0 : i + 1;
+                    const startPos = this._points[i];
+                    const endPos = this._points[next_i];
+
+                    const handleData = this.createLineHandle(startPos, endPos, i);
+                    handleData.customData = {};
+                    handleData.customData.index = i;
+                    handleData.customData.lineMR = getModel(handleData.topNode);
+                    this._linesHandleData.push(handleData);
+                }
+            } else if (this._points.length < this._linesHandleData.length) {
+                for (let i = this._linesHandleData.length - 1; i >= this._points.length; i--) {
+                    this._lineGroup.removeChild(this._linesHandleData[i].topNode);
+                    this.removeHandle('l' + i);
+                }
+                this._linesHandleData.length = this._points.length;
+            }
+
+            this._updateLinesHandle();
+        }
+
+        if (this._areaNode && this._areaMR) {
+            const polygonData = ControllerShape.calcPolygonData(this._points);
+            updatePositions(this._areaMR, polygonData.positions);
+            try {
+                const { earcut } = require('cc/editor/2d-misc');
+                const flatPositions = flat(polygonData.positions, (v: Vec3) => [v.x, v.y, v.z]);
+                const indices = earcut(flatPositions, [], 3);
+                updateIB(this._areaMR, indices);
+            } catch {
+                // earcut not available in CLI context
+            }
+            updateBoundingBox(this._areaMR, polygonData.minPos, polygonData.maxPos);
+        }
+    }
+
+    createLineHandle(startPos: Vec3, endPos: Vec3, index: number) {
+        const lineNode: Node = ControllerUtils.lineTo(startPos, endPos, this._color, { unlit: true });
+        lineNode.parent = this._lineGroup;
+        return this.initHandle(lineNode, 'l' + index);
+    }
+
+    _updateLinesHandle() {
+        this._linesHandleData.forEach((handleData: IHandleData, i: number) => {
+            const next_i = i === this._points.length - 1 ? 0 : i + 1;
+            const startPos = this._points[i];
+            const endPos = this._points[next_i];
+            const lineData = ControllerShape.calcLineData(startPos, endPos);
+            updatePositions(handleData.customData.lineMR, lineData.positions);
+            updateBoundingBox(handleData.customData.lineMR, lineData.minPos, lineData.maxPos);
+        });
+    }
+
+    _updateEditHandle(handleName: string) {
+        if (handleName) {
+            const handleData = this._handleDataMap[handleName];
+            const handleNode = handleData.topNode;
+            const index = handleData.customData.index;
+            const pos = this._points[index];
+            tempVec3_a.set(pos);
+            const curScale = this.getScale();
+            const baseScale = this._editHandleScales[handleName];
+            handleNode.setScale(baseScale / curScale.x, baseScale / curScale.y, baseScale / curScale.z);
+            Vec3.multiply(tempVec3_a, tempVec3_a, curScale);
+            handleNode.setPosition(tempVec3_a);
+        }
+    }
+
+    onMouseDown(event: GizmoMouseEvent) {
+        event.propagationStopped = true;
+        if (!this.edit || !this._panPlane) {
+            return;
+        }
+
+        if (event.handleName.charAt(0) === 'l') {
+            this._curHandleData.type = PolygonHandleType.Line;
+            this._curHandleData.hitPos = event.hitPoint;
+            const lineData = this._handleDataMap[event.handleName];
+            this._curHandleData.index = lineData.customData.index;
+        } else if (event.handleName.charAt(0) === 'p') {
+            this._curHandleData.type = PolygonHandleType.Point;
+            this._curHandleData.hitPos = event.hitPoint;
+            const lineData = this._handleDataMap[event.handleName];
+            this._curHandleData.index = lineData.customData.index;
+        } else if (event.handleName === PolygonHandleType.Area) {
+            this._curHandleData.type = PolygonHandleType.Area;
+            this._curHandleData.deltaPos = new Vec3();
+        }
+
+        this._panPlane.active = true;
+        this._mouseDownOnPlanePos = new Vec3();
+
+        this.getPositionOnPanPlane(this._mouseDownOnPlanePos, event.x, event.y, this._panPlane);
+        if (this.onControllerMouseDown) {
+            this.onControllerMouseDown(event);
+        }
+    }
+
+    onMouseMove(event: GizmoMouseEvent) {
+        event.propagationStopped = true;
+        if (!this.edit || !this._panPlane) {
+            return;
+        }
+
+        if (this._isMouseDown) {
+            if (event.handleName.charAt(0) !== 'l') {
+                const hitPos = new Vec3();
+                if (this.getPositionOnPanPlane(hitPos, event.x, event.y, this._panPlane)) {
+                    if (event.handleName.charAt(0) === 'p') {
+                        const deltaPos = new Vec3(hitPos);
+                        deltaPos.subtract(this._mouseDownOnPlanePos);
+                        this._curHandleData.type = PolygonHandleType.Point;
+                        this._curHandleData.deltaPos = deltaPos;
+                        this._curHandleData.index = this._handleDataMap[event.handleName].customData.index;
+                    } else if (event.handleName === PolygonHandleType.Area) {
+                        const deltaPos = new Vec3(hitPos);
+                        deltaPos.subtract(this._mouseDownOnPlanePos);
+                        this._curHandleData.type = PolygonHandleType.Area;
+                        this._curHandleData.deltaPos = deltaPos;
+                    }
+                }
+            }
+        }
+
+        if (this.onControllerMouseMove) {
+            this.onControllerMouseMove(event);
+        }
+    }
+
+    onMouseUp(event: GizmoMouseEvent) {
+        event.propagationStopped = true;
+        if (!this.edit || !this._panPlane) {
+            return;
+        }
+        this._hitPoint = null;
+        this._panPlane.active = false;
+        this._curHandleData.type = PolygonHandleType.None;
+        this._curHandleData.deltaPos = new Vec3();
+
+        if (this.onControllerMouseUp) {
+            this.onControllerMouseUp(event);
+        }
+    }
+
+    onHoverIn(event: GizmoMouseEvent<{ index: number }>) {
+        if (!this.edit) {
+            return;
+        }
+
+        if (event.handleName.charAt(0) === 'p' ||
+            event.handleName.charAt(0) === 'l') {
+            const handleData = this._handleDataMap[event.handleName];
+            event.customData = { index: handleData.customData.index };
+            this.setHandleColor(event.handleName, this._hoverColor);
+        } else if (event.handleName === PolygonHandleType.Area) {
+            if (this._areaNode) {
+                const opacity = getNodeOpacity(this._areaNode);
+                if (opacity > 0) {
+                    this.setHandleColor(event.handleName, this._hoverColor, opacity);
+                }
+            }
+        }
+
+        if (this.onControllerHoverIn) {
+            this.onControllerHoverIn(event);
+        }
+    }
+
+    onHoverOut(event: GizmoMouseEvent<{ hoverInNodeMap: Map<Node, boolean> }>) {
+        super.onHoverOut(event);
+        if (this.onControllerHoverOut) {
+            this.onControllerHoverOut(event);
+        }
+    }
+
+    getHitPoint() {
+        return this._hitPoint;
+    }
+
+    getHandleData() {
+        return this._curHandleData;
+    }
+}
+
+const HandleType = PolygonController.PolygonHandleType;
+
+const tempVec3_gizmo = new Vec3();
+const tempQuat_gizmo = new Quat();
+const tempMat4 = new Mat4();
+const tempVec2 = new Vec2();
+
+class PolygonCollider2DGizmo extends GizmoBase<PolygonCollider2D> {
+    private _controller!: PolygonController;
+
+    private _leftDeleteLine!: LineController;
+    private _rightDeleteLine!: LineController;
+    private _offset: Vec2 = new Vec2();
+    private _ctrlKey = false;
+    private _metaKey = false;
+    private _propPath: string | null = null;
+    private _3dPoints: Vec3[] = [];
+    private _points: Vec2[] = [];
+
+    private _curHoverInHandleType: string = HandleType.None;
+    private _curHoverInElemIndex = -1;
+    private _isDeletePointKeyDown = false;
+
+    init() {
+        this.createController();
+        this._isInitialized = true;
+    }
+
+    onShow() {
+        this._controller.show();
+        this.updateController();
+    }
+
+    onHide() {
+        this._controller.hide();
+    }
+
+    createController() {
+        const gizmoRoot = this.getGizmoRoot();
+        this._controller = new PolygonController(gizmoRoot, this);
+        this._controller.editable = true;
+        this._controller.setColor(new Color(107, 194, 53));
+        this._controller.setEditHandlesColor(new Color(107, 194, 53));
+
+        this._controller.onControllerMouseDown = this.onControllerMouseDown.bind(this);
+        this._controller.onControllerMouseMove = this.onControllerMouseMove.bind(this);
+        this._controller.onControllerMouseUp = this.onControllerMouseUp.bind(this);
+        this._controller.onControllerHoverIn = this.onControllerHoverIn.bind(this);
+        this._controller.onControllerHoverOut = this.onControllerHoverOut.bind(this);
+
+        this._leftDeleteLine = new LineController(gizmoRoot);
+        this._leftDeleteLine.setColor(Color.RED);
+        this._leftDeleteLine.hide();
+        this._rightDeleteLine = new LineController(gizmoRoot);
+        this._rightDeleteLine.setColor(Color.RED);
+        this._rightDeleteLine.hide();
+    }
+
+    onControllerMouseDown() {
+        const handleData = this._controller.getHandleData();
+        if (!handleData || !this.target) {
+            return;
+        }
+
+        if (handleData.type === HandleType.Line) {
+            const hitPoint = handleData.hitPos;
+            if (hitPoint) {
+                this._propPath = this.getCompPropPath('points');
+                this.onControlUpdate(this._propPath);
+                const points = this.target.points;
+                this.worldToLocalPos(tempVec3_gizmo, hitPoint);
+                const offset = this.target.offset;
+                const posX = toPrecision(tempVec3_gizmo.x - offset.x, 1);
+                const posY = toPrecision(tempVec3_gizmo.y - offset.y, 1);
+
+                points.splice(handleData.index + 1, 0, new Vec2(posX, posY));
+                this.target.points = points;
+                this.onComponentChanged(this.target.node);
+            }
+        } else if (handleData.type === HandleType.Point) {
+            this.onControlUpdate(this._propPath);
+            this._propPath = this.getCompPropPath('points');
+            if (this._isDeletePointKeyDown) {
+                const points = this.target.points;
+                points.splice(handleData.index, 1);
+                this.target.points = points;
+                this.onComponentChanged(this.target.node);
+                this._curHoverInHandleType = HandleType.None;
+                this._curHoverInElemIndex = -1;
+            }
+
+            this._points = [];
+            this.target.points.forEach((point: Vec2) => {
+                this._points.push(point.clone());
+            });
+        } else if (handleData.type === HandleType.Area) {
+            this._offset = this.target.offset.clone();
+            this._propPath = this.getCompPropPath('offset');
+        }
+    }
+
+    onControllerMouseMove(event: GizmoMouseEvent) {
+        this._ctrlKey = event.ctrlKey;
+        this._metaKey = event.metaKey;
+        this._isDeletePointKeyDown = this._ctrlKey || this._metaKey;
+        if (this._controller.updated) {
+            const handleData = this._controller.getHandleData();
+            if (handleData.type === HandleType.Point) {
+                this.onControlUpdate(this._propPath);
+                this.handlePoints(handleData);
+            } else if (handleData.type === HandleType.Area) {
+                this.onControlUpdate(this._propPath);
+                this.handleAreaMove(handleData.deltaPos);
+            }
+        }
+    }
+
+    onControllerMouseUp() {
+        this.onControlEnd(this._propPath);
+    }
+
+    onControllerHoverIn(event: GizmoMouseEvent<{ index: number }>) {
+        if (event.handleName.charAt(0) === 'l') {
+            this._curHoverInHandleType = HandleType.Line;
+            this._curHoverInElemIndex = event.customData?.index!;
+        } else if (event.handleName.charAt(0) === 'p') {
+            this._curHoverInHandleType = HandleType.Point;
+            this._curHoverInElemIndex = event.customData?.index!;
+        } else if (event.handleName === HandleType.Area) {
+            this._curHoverInHandleType = HandleType.Area;
+        }
+    }
+
+    onControllerHoverOut(event: GizmoMouseEvent) {
+        if (event.handleName.charAt(0) === 'l') {
+            if (this._curHoverInHandleType === HandleType.Line) {
+                this._curHoverInHandleType = HandleType.None;
+                this._curHoverInElemIndex = -1;
+            }
+        } else if (event.handleName.charAt(0) === 'p') {
+            if (this._curHoverInHandleType === HandleType.Point) {
+                this._curHoverInHandleType = HandleType.None;
+                this._curHoverInElemIndex = -1;
+            }
+        } else if (event.handleName === HandleType.Area) {
+            if (this._curHoverInHandleType === HandleType.Area) {
+                this._curHoverInHandleType = HandleType.None;
+            }
+        }
+    }
+
+    onKeyDown(event: any) {
+        this._ctrlKey = event.ctrlKey;
+        this._metaKey = event.metaKey;
+        this._isDeletePointKeyDown = this._ctrlKey || this._metaKey;
+    }
+
+    onKeyUp(event: any) {
+        this._ctrlKey = event.ctrlKey;
+        this._metaKey = event.metaKey;
+        this._isDeletePointKeyDown = this._ctrlKey || this._metaKey;
+    }
+
+    worldToLocalPos(out: Vec3, inPos: Vec3) {
+        if (this.target) {
+            const node = this.target.node;
+            node.getWorldMatrix(tempMat4);
+            Mat4.invert(tempMat4, tempMat4);
+            Vec3.transformMat4(out, inPos, tempMat4);
+        }
+    }
+
+    handleAreaMove(delta: Vec3) {
+        if (!this.target) {
+            return;
+        }
+        const node = this.target.node;
+
+        const posDelta: Vec3 = delta.clone();
+        node.getWorldMatrix(tempMat4);
+        Mat4.invert(tempMat4, tempMat4);
+        tempMat4.m12 = tempMat4.m13 = 0;
+        Vec3.transformMat4(posDelta, posDelta, tempMat4);
+        makeVec3InPrecision(posDelta, 1);
+        posDelta.z = 0;
+        tempVec2.set(this._offset);
+        tempVec2.add2f(posDelta.x, posDelta.y);
+
+        this.target.offset.set(tempVec2);
+        this.onComponentChanged(node);
+    }
+
+    handlePoints(handleMoveData: IPolygonHandleData) {
+        const index = handleMoveData.index;
+        if (index < 0 || !this.target) {
+            return;
+        }
+
+        const posDelta = handleMoveData.deltaPos.clone();
+
+        const node = this.target.node;
+        node.getWorldMatrix(tempMat4);
+        Mat4.invert(tempMat4, tempMat4);
+        tempMat4.m12 = tempMat4.m13 = 0;
+        Vec3.transformMat4(posDelta, posDelta, tempMat4);
+
+        const targetPoints = this.target.points;
+        const point = this._points[index];
+
+        let posX = point.x + posDelta.x;
+        let posY = point.y + posDelta.y;
+        posX = toPrecision(posX, 1);
+        posY = toPrecision(posY, 1);
+        targetPoints[index].set(posX, posY);
+        this.target.points = targetPoints;
+
+        this.onComponentChanged(node);
+    }
+
+    updateControllerData() {
+        if (!this._isInitialized || this.target === null) {
+            return;
+        }
+
+        const polygonCollider2D = this.target as PolygonCollider2D;
+        if (polygonCollider2D) {
+            const offset = polygonCollider2D.offset;
+            const center = tempVec3_gizmo;
+            center.x = offset.x;
+            center.y = offset.y;
+            center.z = 0;
+
+            const node = this.target.node;
+            if (node) {
+                node.getWorldMatrix(tempMat4);
+            }
+
+            if (this._3dPoints.length < polygonCollider2D.points.length) {
+                const len = polygonCollider2D.points.length - this._3dPoints.length;
+                for (let i = 0; i < len; i++) {
+                    this._3dPoints.push(new Vec3(0, 0, 0));
+                }
+            } else {
+                this._3dPoints.length = polygonCollider2D.points.length;
+            }
+            polygonCollider2D.points.forEach((point: Vec2, index: number) => {
+                this._3dPoints[index].set(point.x + center.x, point.y + center.y, 0);
+                Vec3.transformMat4(this._3dPoints[index], this._3dPoints[index], tempMat4);
+            });
+            this._controller.updateData(this._3dPoints);
+            this._controller.edit = polygonCollider2D.editing;
+        } else {
+            this._controller.hide();
+        }
+    }
+
+    updateController() {
+        this.updateControllerData();
+    }
+
+    onTargetUpdate() {
+        this.updateController();
+    }
+
+    onNodeChanged() {
+        this.updateController();
+    }
+}
+
+export const name = js.getClassName(PolygonCollider2D);
+export const SelectGizmo = PolygonCollider2DGizmo;
+export const IconGizmo = null;
+export const PersistentGizmo = null;
+
+registerGizmo(name, { SelectGizmo });

--- a/src/core/scene/scene-process/service/gizmo/components/simplex-collider/index.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/simplex-collider/index.ts
@@ -1,0 +1,135 @@
+'use strict';
+
+import { Color, js, Quat, SimplexCollider, Vec3 } from 'cc';
+import GizmoBase from '../../base/gizmo-base';
+import PointController from '../../controller/point';
+import LineController from '../../controller/line';
+import TriangleController from '../../controller/triangle';
+import TetrahedronController from '../../controller/tetrahedron';
+import { registerGizmo } from '../../gizmo-defines';
+
+const tempVec3_a = new Vec3();
+const tempVec3_b = new Vec3();
+const tempVec3_c = new Vec3();
+const tempVec3_d = new Vec3();
+const tempQuat_a = new Quat();
+
+class SimplexColliderGizmo extends GizmoBase<SimplexCollider> {
+    private _shapeControllers: any = {};
+    private _activeController: PointController | LineController | TriangleController | TetrahedronController | null = null;
+
+    init() {
+        this._isInitialized = true;
+    }
+
+    createControllerByShape(shape: SimplexCollider.ESimplexType) {
+        const gizmoRoot = this.getGizmoRoot();
+        let controller = null;
+        switch (shape) {
+            case SimplexCollider.ESimplexType.VERTEX:
+                controller = new PointController(gizmoRoot);
+                break;
+            case SimplexCollider.ESimplexType.LINE:
+                controller = new LineController(gizmoRoot);
+                break;
+            case SimplexCollider.ESimplexType.TRIANGLE:
+                controller = new TriangleController(gizmoRoot);
+                break;
+            case SimplexCollider.ESimplexType.TETRAHEDRON:
+                controller = new TetrahedronController(gizmoRoot);
+                break;
+            default:
+                console.error('Invalid Type:', shape);
+        }
+
+        if (controller) {
+            controller.setColor(Color.GREEN);
+        }
+
+        return controller;
+    }
+
+    getControllerByShape(shape: SimplexCollider.ESimplexType) {
+        let controller = this._shapeControllers[shape];
+        if (!controller) {
+            controller = this.createControllerByShape(shape);
+            this._shapeControllers[shape] = controller;
+        }
+
+        return controller;
+    }
+
+    onShow() {
+        this.updateControllerData();
+    }
+
+    onHide() {
+        if (this._activeController) {
+            this._activeController.hide();
+        }
+    }
+
+    updateControllerData() {
+        if (!this._isInitialized || this.target === null) {
+            return;
+        }
+
+        if (this.target instanceof SimplexCollider) {
+            const node = this.target.node;
+
+            const simplexCollider = this.target as SimplexCollider;
+
+            this._activeController?.hide();
+
+            this._activeController = this.getControllerByShape(simplexCollider.shapeType);
+            const worldScale = node.getWorldScale();
+            const worldPos = node.getWorldPosition();
+            const worldRot = tempQuat_a;
+            node.getWorldRotation(worldRot);
+            this._activeController?.setScale(worldScale);
+            this._activeController?.setPosition(worldPos);
+            this._activeController?.setRotation(worldRot);
+
+            switch (simplexCollider.shapeType) {
+                case SimplexCollider.ESimplexType.VERTEX:
+                    Vec3.add(tempVec3_a, simplexCollider.center, simplexCollider.vertex0);
+                    (this._activeController as PointController).updateData(tempVec3_a);
+                    break;
+                case SimplexCollider.ESimplexType.LINE:
+                    Vec3.add(tempVec3_a, simplexCollider.center, simplexCollider.vertex0);
+                    Vec3.add(tempVec3_b, simplexCollider.center, simplexCollider.vertex1);
+                    (this._activeController as LineController).updateData(tempVec3_a, tempVec3_b);
+                    break;
+                case SimplexCollider.ESimplexType.TRIANGLE:
+                    Vec3.add(tempVec3_a, simplexCollider.center, simplexCollider.vertex0);
+                    Vec3.add(tempVec3_b, simplexCollider.center, simplexCollider.vertex1);
+                    Vec3.add(tempVec3_c, simplexCollider.center, simplexCollider.vertex2);
+                    (this._activeController as TriangleController).updateData(tempVec3_a, tempVec3_b, tempVec3_c);
+                    break;
+                case SimplexCollider.ESimplexType.TETRAHEDRON:
+                    Vec3.add(tempVec3_a, simplexCollider.center, simplexCollider.vertex0);
+                    Vec3.add(tempVec3_b, simplexCollider.center, simplexCollider.vertex1);
+                    Vec3.add(tempVec3_c, simplexCollider.center, simplexCollider.vertex2);
+                    Vec3.add(tempVec3_d, simplexCollider.center, simplexCollider.vertex3);
+                    (this._activeController as TetrahedronController).updateData(tempVec3_a, tempVec3_b, tempVec3_c, tempVec3_d);
+            }
+
+            this._activeController?.show();
+        }
+    }
+
+    onTargetUpdate() {
+        this.updateControllerData();
+    }
+
+    onNodeChanged() {
+        this.updateControllerData();
+    }
+}
+
+export const name = js.getClassName(SimplexCollider);
+export const SelectGizmo = SimplexColliderGizmo;
+export const IconGizmo = null;
+export const PersistentGizmo = null;
+
+registerGizmo(name, { SelectGizmo });

--- a/src/core/scene/scene-process/service/gizmo/components/skinned-mesh-renderer/index.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/skinned-mesh-renderer/index.ts
@@ -1,0 +1,72 @@
+'use strict';
+
+import { js, SkinnedMeshRenderer, Vec3 } from 'cc';
+import GizmoBase from '../../base/gizmo-base';
+import BoxController from '../../controller/box';
+import { registerGizmo } from '../../gizmo-defines';
+
+const tempSize = new Vec3();
+const tempCenter = new Vec3();
+
+class SkinningModelComponentGizmo extends GizmoBase<SkinnedMeshRenderer> {
+    private _controller!: BoxController;
+
+    init() {
+        this._controller = new BoxController(this.getGizmoRoot());
+        this._controller.setOpacity(150);
+        this._isInitialized = true;
+    }
+
+    onShow() {
+        this._controller.show();
+        this.updateControllerData();
+    }
+
+    onHide() {
+        this._controller.hide();
+    }
+
+    updateControllerData() {
+        if (!this._isInitialized || this.target == null) {
+            return;
+        }
+
+        const rootBoneNode = this.target.skinningRoot;
+        if (!rootBoneNode) {
+            this._controller.hide();
+            return;
+        }
+
+        const bounds = this.target.model && this.target.model.worldBounds;
+        if (bounds) {
+            Vec3.multiplyScalar(tempSize, bounds.halfExtents, 2);
+            Vec3.copy(tempCenter, bounds.center);
+            this._controller.updateSize(tempCenter, tempSize);
+        } else {
+            this._controller.hide();
+        }
+    }
+
+    updateControllerTransform() {
+        this.updateControllerData();
+    }
+
+    onTargetUpdate() {
+        this.updateControllerData();
+    }
+
+    onNodeChanged() {
+        this.updateControllerData();
+    }
+
+    onUpdate() {
+        this.updateControllerData();
+    }
+}
+
+export const name = js.getClassName(SkinnedMeshRenderer);
+export const SelectGizmo = SkinningModelComponentGizmo;
+export const IconGizmo = null;
+export const PersistentGizmo = null;
+
+registerGizmo(name, { SelectGizmo });

--- a/src/core/scene/scene-process/service/gizmo/components/sphere-collider/index.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/sphere-collider/index.ts
@@ -1,0 +1,128 @@
+'use strict';
+
+import { Color, js, Quat, SphereCollider, Vec3 } from 'cc';
+import GizmoBase from '../../base/gizmo-base';
+import SphereController from '../../controller/sphere';
+import { registerGizmo } from '../../gizmo-defines';
+
+function toPrecision(val: number, n: number): number {
+    return Math.round(val * Math.pow(10, n)) / Math.pow(10, n);
+}
+
+const tempQuat_a = new Quat();
+
+class SphereColliderComponentGizmo extends GizmoBase<SphereCollider> {
+    private _controller!: SphereController;
+    private _radius = 0;
+    private _maxScale = 1;
+    private _propPath: string | null = null;
+
+    init() {
+        this.createController();
+        this._isInitialized = true;
+    }
+
+    onShow() {
+        this._controller.show();
+        this.updateControllerData();
+    }
+
+    onHide() {
+        this._controller.hide();
+    }
+
+    createController() {
+        const gizmoRoot = this.getGizmoRoot();
+        this._controller = new SphereController(gizmoRoot);
+        this._controller.setColor(Color.GREEN);
+        this._controller.editable = true;
+        this._controller.hoverColor = Color.YELLOW;
+        this._controller.onControllerMouseDown = this.onControllerMouseDown.bind(this);
+        this._controller.onControllerMouseMove = this.onControllerMouseMove.bind(this);
+        this._controller.onControllerMouseUp = this.onControllerMouseUp.bind(this);
+    }
+
+    onControllerMouseDown() {
+        if (!this._isInitialized || this.target == null) {
+            return;
+        }
+
+        const worldScale = this.target.node.getWorldScale();
+        this._maxScale = this.getMaxScale(worldScale);
+        this._radius = this.target.radius;
+
+        this._propPath = this.getCompPropPath('radius');
+    }
+
+    onControllerMouseMove() {
+        this.updateDataFromController();
+    }
+
+    onControllerMouseUp() {
+        this.onControlEnd(this._propPath);
+    }
+
+    getMaxScale(inScale: Vec3) {
+        return Math.max(inScale.x, inScale.y, inScale.z);
+    }
+
+    updateDataFromController() {
+        if (this._controller.updated && this.target) {
+            this.onControlUpdate(this._propPath);
+
+            const deltaRadius = this._controller.getDeltaRadius();
+
+            let newRadius = this._radius + deltaRadius / this._maxScale;
+            newRadius = Math.abs(newRadius);
+            newRadius = toPrecision(newRadius, 3);
+            this.target.radius = newRadius;
+
+            const node = this.target.node;
+            this.onComponentChanged(node);
+        }
+    }
+
+    updateControllerData() {
+        if (!this._isInitialized || this.target == null) {
+            return;
+        }
+
+        if (this.target instanceof SphereCollider) {
+            const node = this.target.node;
+
+            this._controller.show();
+            this._controller.checkEdit();
+
+            const worldScale = node.getWorldScale();
+            const maxScale = this.getMaxScale(worldScale);
+            const worldPos = node.getWorldPosition();
+            const worldRot = tempQuat_a;
+            node.getWorldRotation(worldRot);
+            this._controller.setScale(new Vec3(maxScale, maxScale, maxScale));
+            this._controller.setPosition(worldPos);
+            this._controller.setRotation(worldRot);
+            this._controller.updateSize(this.target.center, this.target.radius);
+        } else {
+            this._controller.hide();
+        }
+    }
+
+    updateControllerTransform() {
+        this.updateControllerData();
+    }
+
+    onTargetUpdate() {
+        this.updateControllerData();
+    }
+
+    onNodeChanged() {
+        this.updateControllerData();
+    }
+}
+
+export const name = js.getClassName(SphereCollider);
+export const SelectGizmo = SphereColliderComponentGizmo;
+export const IconGizmo = null;
+export const PersistentGizmo = null;
+
+registerGizmo(name, { SelectGizmo });

--- a/src/core/scene/scene-process/service/gizmo/components/sphere-light/index.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/sphere-light/index.ts
@@ -1,0 +1,179 @@
+'use strict';
+
+import { Color, js, Quat, SphereLight, Vec3 } from 'cc';
+import GizmoBase from '../../base/gizmo-base';
+import { IconGizmoBase } from '../../base';
+import SphereController from '../../controller/sphere';
+import { registerGizmo } from '../../gizmo-defines';
+import { create3DNode } from '../../utils/engine-utils';
+
+function toPrecision(val: number, n: number): number {
+    return Math.round(val * Math.pow(10, n)) / Math.pow(10, n);
+}
+
+class SphereLightComponentGizmo extends GizmoBase<SphereLight> {
+    private _lightGizmoColor: Color = new Color(255, 255, 50);
+    private _lightCtrlHoverColor: Color = new Color(0, 255, 0);
+
+    private _range = 0;
+    private _glowSize = 0.4;
+
+    private _controller!: SphereController;
+    private _sizeSphereCtrl!: SphereController;
+
+    private _propPath: string | null = null;
+
+    init() {
+        this.createController();
+        this._isInitialized = true;
+    }
+
+    onShow() {
+        this._controller.show();
+        this._sizeSphereCtrl.show();
+        this.updateController();
+    }
+
+    onHide() {
+        this._controller.hide();
+        this._sizeSphereCtrl.hide();
+    }
+
+    createController() {
+        const gizmoRoot = this.getGizmoRoot();
+        const SphereLightGizmoRoot = create3DNode('SphereLightGizmo');
+        SphereLightGizmoRoot.parent = gizmoRoot;
+        this._controller = new SphereController(SphereLightGizmoRoot);
+        this._controller.setColor(this._lightGizmoColor);
+
+        this._controller.onControllerMouseDown = this.onControllerMouseDown.bind(this);
+        this._controller.onControllerMouseMove = this.onControllerMouseMove.bind(this);
+        this._controller.onControllerMouseUp = this.onControllerMouseUp.bind(this);
+        this._controller.editable = true;
+        this._controller.hoverColor = this._lightCtrlHoverColor;
+
+        this._sizeSphereCtrl = new SphereController(SphereLightGizmoRoot);
+        this._sizeSphereCtrl.editable = false;
+    }
+
+    onControllerMouseDown() {
+        if (!this._isInitialized || this.target === null) {
+            return;
+        }
+
+        this._range = this.target.range;
+        this._propPath = this.getCompPropPath('range');
+    }
+
+    onControllerMouseMove() {
+        this.updateDataFromController();
+    }
+
+    onControllerMouseUp() {
+        this.onControlEnd(this._propPath);
+    }
+
+    updateDataFromController() {
+        if (this._controller.updated && this.target) {
+            this.onControlUpdate(this._propPath);
+            const node = this.target.node;
+
+            const deltaRange = this._controller.getDeltaRadius();
+            let newRange = this._range + deltaRange;
+            newRange = toPrecision(newRange, 3);
+            newRange = Math.abs(newRange);
+            this.target.range = newRange;
+
+            this.onComponentChanged(node);
+        }
+    }
+
+    updateControllerTransform() {
+        if (!this._isInitialized || this.target === null) {
+            return;
+        }
+
+        const node = this.target.node;
+        const worldPos = node.getWorldPosition();
+
+        this._controller.setPosition(worldPos);
+        this._sizeSphereCtrl.setPosition(worldPos);
+    }
+
+    updateControllerData() {
+        if (!this._isInitialized || this.target === null) {
+            return;
+        }
+
+        this._controller.checkEdit();
+        const lightComp = this.target;
+        this._controller.radius = lightComp.range;
+
+        const color = lightComp.color.clone();
+
+        if (lightComp.useColorTemperature) {
+            // @ts-ignore
+            const colorTemperatureRGB = lightComp._light?.colorTemperatureRGB;
+            if (colorTemperatureRGB) {
+                color.r *= colorTemperatureRGB.x;
+                color.g *= colorTemperatureRGB.y;
+                color.b *= colorTemperatureRGB.z;
+            }
+        }
+
+        this._sizeSphereCtrl.setColor(color);
+        this._sizeSphereCtrl.radius = lightComp.size;
+    }
+
+    updateController() {
+        this.updateControllerTransform();
+        this.updateControllerData();
+    }
+
+    onTargetUpdate() {
+        this.updateController();
+    }
+
+    onNodeChanged() {
+        this.updateController();
+    }
+}
+
+class SphereLightIconGizmo extends IconGizmoBase<SphereLight> {
+    disableOnSelected = true;
+    createController() {
+        super.createController();
+        this._controller.setTextureByUUID('c78f78a5-3553-4d1f-ad3b-177fe55af68b@6c48a');
+
+        this.updateController();
+    }
+
+    updateController() {
+        if (!this._isInitialized || this.target === null) {
+            return;
+        }
+
+        this.updateControllerTransform();
+
+        const lightComp = this.target;
+        const color = lightComp.color.clone();
+        if (lightComp.useColorTemperature) {
+            // @ts-ignore
+            const colorTemperatureRGB = lightComp._light?.colorTemperatureRGB;
+            if (colorTemperatureRGB) {
+                color.r *= colorTemperatureRGB.x;
+                color.g *= colorTemperatureRGB.y;
+                color.b *= colorTemperatureRGB.z;
+            }
+        }
+
+        this._controller.setColor(color);
+    }
+}
+
+export const name = js.getClassName(SphereLight);
+export const SelectGizmo = SphereLightComponentGizmo;
+export const IconGizmo = SphereLightIconGizmo;
+export const PersistentGizmo = null;
+
+registerGizmo(name, { SelectGizmo, IconGizmo });

--- a/src/core/scene/scene-process/service/gizmo/components/spot-light/index.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/spot-light/index.ts
@@ -1,0 +1,240 @@
+'use strict';
+
+import { Color, js, Quat, EAxisDirection, Vec3, SpotLight } from 'cc';
+import GizmoBase from '../../base/gizmo-base';
+import { IconGizmoBase } from '../../base';
+import ConeController from '../../controller/cone';
+import SphereController from '../../controller/sphere';
+import { registerGizmo } from '../../gizmo-defines';
+import { create3DNode } from '../../utils/engine-utils';
+
+const D2R = Math.PI / 180;
+const R2D = 180 / Math.PI;
+
+function toPrecision(val: number, n: number): number {
+    return Math.round(val * Math.pow(10, n)) / Math.pow(10, n);
+}
+
+const tempQuat_a = new Quat();
+
+class SpotLightComponentGizmo extends GizmoBase<SpotLight> {
+    private _lightGizmoColor: Color = new Color(255, 255, 50);
+    private _lightCtrlHoverColor: Color = new Color(0, 255, 0);
+
+    private _range = 0;
+    private _angle = 0;
+    private _baseSize = 0.5;
+    private _glowSize = 0.4;
+
+    private _controller!: ConeController;
+    private _sizeSphereCtrl!: SphereController;
+
+    private _rangePropPath: string | null = null;
+    private _anglePropPath: string | null = null;
+
+    private _rangeChanged = false;
+    private _angleChanged = false;
+
+    private _coneTopPos = new Vec3();
+
+    init() {
+        this.createController();
+        this._isInitialized = true;
+    }
+
+    onShow() {
+        this._controller.show();
+        this._sizeSphereCtrl.show();
+        this.updateControllerData();
+    }
+
+    onHide() {
+        this._controller.hide();
+        this._sizeSphereCtrl.hide();
+    }
+
+    createController() {
+        const gizmoRoot = this.getGizmoRoot();
+        const SpotLightGizmoRoot = create3DNode('SpotLightGizmo');
+        SpotLightGizmoRoot.parent = gizmoRoot;
+        this._controller = new ConeController(SpotLightGizmoRoot);
+        this._controller.direction = EAxisDirection.Z_AXIS;
+        this._controller.setColor(this._lightGizmoColor);
+
+        this._controller.onControllerMouseDown = this.onControllerMouseDown.bind(this);
+        this._controller.onControllerMouseMove = this.onControllerMouseMove.bind(this);
+        this._controller.onControllerMouseUp = this.onControllerMouseUp.bind(this);
+        this._controller.editable = true;
+        this._controller.hoverColor = this._lightCtrlHoverColor;
+
+        this._sizeSphereCtrl = new SphereController(SpotLightGizmoRoot);
+        this._sizeSphereCtrl.editable = false;
+    }
+
+    onControllerMouseDown() {
+        if (!this._isInitialized || this.target === null) {
+            return;
+        }
+
+        this._range = this.target.range;
+        this._angle = this.target.spotAngle;
+
+        this._rangePropPath = this.getCompPropPath('range');
+        this._anglePropPath = this.getCompPropPath('spotAngle');
+
+        this._rangeChanged = false;
+        this._angleChanged = false;
+    }
+
+    onControllerMouseMove() {
+        this.updateDataFromController();
+    }
+
+    onControllerMouseUp() {
+        if (this._rangeChanged) {
+            this.onControlEnd(this._rangePropPath);
+        }
+        if (this._angleChanged) {
+            this.onControlEnd(this._anglePropPath);
+        }
+    }
+
+    getConeRadius(angle: number, height: number) {
+        return Math.tan((angle / 2) * D2R) * height;
+    }
+
+    updateDataFromController() {
+        if (this._controller.updated && this.target) {
+            const node = this.target.node;
+
+            const deltaRadius = this._controller.getDeltaRadius();
+            const deltaHeight = this._controller.getDeltaHeight();
+
+            let newHeight = this._range;
+            if (deltaHeight !== 0) {
+                newHeight = this._range + deltaHeight;
+                newHeight = toPrecision(newHeight, 3);
+                newHeight = Math.abs(newHeight);
+                if (newHeight < 0.01) {
+                    newHeight = 0.01;
+                }
+
+                this._rangeChanged = true;
+            }
+
+            let newRadius = this.getConeRadius(this._angle, newHeight);
+            let angle = this._angle;
+            if (deltaRadius !== 0) {
+                newRadius = this.getConeRadius(this._angle, newHeight) + deltaRadius;
+                newRadius = Math.abs(newRadius);
+
+                angle = Math.atan2(newRadius, newHeight) * 2;
+                if (angle < D2R) {
+                    angle = D2R;
+                }
+                angle = angle * R2D;
+                angle = toPrecision(angle, 3);
+
+                this._angleChanged = true;
+            }
+
+            if (this._rangeChanged) {
+                this.onControlUpdate(this._rangePropPath);
+            }
+            if (this._angleChanged) {
+                this.onControlUpdate(this._anglePropPath);
+            }
+
+            this.target.spotAngle = angle;
+            this.target.range = newHeight;
+
+            this.onComponentChanged(node);
+        }
+    }
+
+    updateControllerTransform() {
+        if (!this.target) {
+            return;
+        }
+        const node = this.target.node;
+        const worldRot = tempQuat_a;
+        node.getWorldRotation(worldRot);
+        const worldPos = node.getWorldPosition();
+
+        this._controller.setPosition(worldPos);
+        this._controller.setRotation(worldRot);
+        this._sizeSphereCtrl.setPosition(worldPos);
+    }
+
+    updateControllerData() {
+        if (!this._isInitialized || this.target === null) {
+            return;
+        }
+
+        this.updateControllerTransform();
+
+        this._controller.checkEdit();
+        const lightComp = this.target;
+        const radius = this.getConeRadius(lightComp.spotAngle, lightComp.range);
+        this._controller.updateSize(this._coneTopPos.set(0, 0, -lightComp.range / 2), radius, lightComp.range);
+
+        const color = lightComp.color.clone();
+        if (lightComp.useColorTemperature) {
+            // @ts-ignore
+            const colorTemperatureRGB = lightComp._light?.colorTemperatureRGB;
+            if (colorTemperatureRGB) {
+                color.r *= colorTemperatureRGB.x;
+                color.g *= colorTemperatureRGB.y;
+                color.b *= colorTemperatureRGB.z;
+            }
+        }
+
+        this._sizeSphereCtrl.setColor(color);
+        this._sizeSphereCtrl.radius = lightComp.size;
+    }
+
+    onTargetUpdate() {
+        this.updateControllerData();
+    }
+
+    onNodeChanged() {
+        this.updateControllerData();
+    }
+}
+
+class SpotLightIconGizmo extends IconGizmoBase<SpotLight> {
+    disableOnSelected = true;
+    createController() {
+        super.createController();
+        this._controller.setTextureByUUID('191b676f-175b-41fa-8283-ac539875bfd8@6c48a');
+    }
+
+    updateController() {
+        if (!this._isInitialized || this.target === null) {
+            return;
+        }
+
+        this.updateControllerTransform();
+
+        const lightComp = this.target;
+        const color = lightComp.color.clone();
+        if (lightComp.useColorTemperature) {
+            // @ts-ignore
+            const colorTemperatureRGB = lightComp._light?.colorTemperatureRGB;
+            if (colorTemperatureRGB) {
+                color.r *= colorTemperatureRGB.x;
+                color.g *= colorTemperatureRGB.y;
+                color.b *= colorTemperatureRGB.z;
+            }
+        }
+
+        this._controller.setColor(color);
+    }
+}
+
+export const name = js.getClassName(SpotLight);
+export const SelectGizmo = SpotLightComponentGizmo;
+export const IconGizmo = SpotLightIconGizmo;
+export const PersistentGizmo = null;
+
+registerGizmo(name, { SelectGizmo, IconGizmo });

--- a/src/core/scene/scene-process/service/gizmo/controller/capsule.ts
+++ b/src/core/scene/scene-process/service/gizmo/controller/capsule.ts
@@ -1,0 +1,315 @@
+'use strict';
+
+import { Color, MeshRenderer, Node, Vec2, Vec3, Quat, EAxisDirection } from 'cc';
+
+import ControllerShape from '../utils/controller-shape';
+import ControllerUtils from '../utils/controller-utils';
+import EditableController from './editable';
+import type { GizmoMouseEvent } from '../utils/defines';
+import { setMeshColor, getModel, updatePositions } from '../utils/engine-utils';
+
+const axisDirMap = ControllerUtils.axisDirectionMap;
+
+const tempVec3_a = new Vec3();
+const tempVec3_b = new Vec3();
+const tempVec3_c = new Vec3();
+const tempVec3_d = new Vec3();
+const tempVec3_e = new Vec3();
+const tempQuat_a = new Quat();
+
+class CapsuleController extends EditableController {
+    get radius() {
+        return this._radius;
+    }
+    set radius(value) {
+        this.updateSize(this._center, value, this._height);
+    }
+
+    get height() {
+        return this._height;
+    }
+    set height(value) {
+        this.updateSize(this._center, this._radius, value);
+    }
+    get direction() {
+        return this._direction;
+    }
+    set direction(value) {
+        this._direction = value;
+    }
+    private _oriDir = new Vec3(0, 1, 0);
+    private _direction: EAxisDirection = EAxisDirection.Y_AXIS;
+    private _center = new Vec3();
+    private _radius = 100;
+    private _height = 100;
+    private _halfHeight = this._height / 2;
+    private _deltaRadius = 0;
+    private _deltaHeight = 0;
+
+    private _mouseDeltaPos: Vec2 = new Vec2();
+    private _curDistScalar = 0;
+
+    private _upperCapMC: (MeshRenderer | null)[] = [];
+    private _lowerCapMC: (MeshRenderer | null)[] = [];
+    private _sideLineMC: MeshRenderer | null = null;
+
+    private _upperCapNode: Node[] = [];
+    private _lowerCapNode: Node[] = [];
+    private _sideLineNode!: Node;
+
+    private _up = new Vec3(0, 1, 0);
+    private _right = new Vec3(1, 0, 0);
+    private _forward = new Vec3(0, 0, 1);
+    private _directionAxis: Vec3[] = [new Vec3(1, 0, 0), new Vec3(0, 1, 0), new Vec3(0, 0, 1)];
+
+    constructor(rootNode: Node) {
+        super(rootNode);
+
+        this._editHandleKeys = Object.keys(axisDirMap);
+
+        this.initShape();
+    }
+
+    public setColor(color: Color) {
+        this._upperCapNode.forEach((node) => {
+            setMeshColor(node, color);
+        });
+
+        this._lowerCapNode.forEach((node) => {
+            setMeshColor(node, color);
+        });
+
+        setMeshColor(this._sideLineNode, color);
+
+        this.setEditHandlesColor(color);
+
+        this._color = color;
+    }
+
+    public _updateEditHandle(axisName: string) {
+        const node = this._handleDataMap[axisName].topNode;
+        const dir = axisDirMap[axisName];
+
+        const colliderDir = tempVec3_a.set(this._directionAxis[this._direction]);
+
+        const offset = tempVec3_b;
+        offset.set(0, 0, 0);
+
+        if (axisName === 'y') {
+            Vec3.multiplyScalar(offset, colliderDir, this._halfHeight);
+        } else if (axisName === 'neg_y') {
+            Vec3.multiplyScalar(offset, colliderDir, -this._halfHeight);
+        } else {
+            Vec3.multiplyScalar(offset, dir, this._radius);
+            if (this._direction !== EAxisDirection.Y_AXIS) {
+                const rot = tempQuat_a;
+                Quat.rotationTo(rot, this._up, colliderDir);
+                Vec3.transformQuat(offset, offset, rot);
+            }
+        }
+
+        offset.add(this._center);
+        Vec3.multiply(offset, offset, this.getScale());
+        node.setPosition(offset);
+    }
+
+    public initShape() {
+        this.createShapeNode('CapsuleController');
+
+        const upperData = this.getUpperCapData(this._center, this._radius, this._height);
+        upperData.forEach((data: any, index: number) => {
+            this._upperCapNode[index] = ControllerUtils.createShapeByData(data, this._color);
+            this._upperCapNode[index].parent = this.shape;
+            this._upperCapMC[index] = getModel(this._upperCapNode[index]);
+        });
+
+        const lowerData = this.getLowerCapData(this._center, this._radius, this._height);
+        lowerData.forEach((data: any, index: number) => {
+            this._lowerCapNode[index] = ControllerUtils.createShapeByData(data, this._color);
+            this._lowerCapNode[index].parent = this.shape;
+            this._lowerCapMC[index] = getModel(this._lowerCapNode[index]);
+        });
+
+        const sideLinesData = this.getSideLinesData(this._center, this._radius, this._height);
+        this._sideLineNode = ControllerUtils.createShapeByData(sideLinesData, this._color);
+        this._sideLineNode.parent = this.shape;
+        this._sideLineMC = getModel(this._sideLineNode);
+
+        this.hide();
+    }
+
+    public updateSize(center: Vec3, radius: number, height: number) {
+        this._center = center;
+        this._radius = radius;
+        this._height = height;
+        this._halfHeight = height / 2;
+
+        const upperData = this.getUpperCapData(this._center, this._radius, this._height);
+        upperData.forEach((data: any, i: number) => {
+            const mesh = this._upperCapMC[i];
+            if (mesh) {
+                updatePositions(mesh, data.positions);
+            }
+        });
+
+        const lowerData = this.getLowerCapData(this._center, this._radius, this._height);
+        lowerData.forEach((data: any, i: number) => {
+            const mesh = this._lowerCapMC[i];
+            if (mesh) {
+                updatePositions(mesh, data.positions);
+            }
+        });
+
+        const lineData = this.getSideLinesData(this._center, this._radius, this._height);
+        this._sideLineMC && updatePositions(this._sideLineMC, lineData.positions);
+
+        if (this._edit) {
+            this.updateEditHandles();
+        }
+
+        this.adjustEditHandlesSize();
+    }
+
+    public onMouseDown(event: GizmoMouseEvent) {
+        event.propagationStopped = true;
+        this._mouseDeltaPos = new Vec2(0, 0);
+        this._curDistScalar = super.getDistScalar();
+        this._deltaRadius = 0;
+        this._deltaHeight = 0;
+
+        if (this.onControllerMouseDown) {
+            this.onControllerMouseDown(event);
+        }
+    }
+
+    public onMouseMove(event: GizmoMouseEvent) {
+        event.propagationStopped = true;
+        if (this._isMouseDown) {
+            this._mouseDeltaPos.x += event.moveDeltaX;
+            this._mouseDeltaPos.y += event.moveDeltaY;
+
+            const axisDir = axisDirMap[event.handleName];
+
+            const colliderDir = tempVec3_a.set(this._directionAxis[this._direction]);
+            const rot = tempQuat_a;
+            Quat.rotationTo(rot, this._up, colliderDir);
+            Vec3.transformQuat(colliderDir, axisDir, rot);
+            const deltaDist = this.getAlignAxisMoveDistance(this.localToWorldDir(colliderDir), this._mouseDeltaPos) * this._curDistScalar;
+            if (event.handleName === 'y' || event.handleName === 'neg_y') {
+                this._deltaHeight = deltaDist;
+            } else {
+                this._deltaRadius = deltaDist;
+            }
+
+            if (this.onControllerMouseMove) {
+                this.onControllerMouseMove(event);
+            }
+        }
+    }
+
+    public onMouseUp(event: GizmoMouseEvent) {
+        event.propagationStopped = true;
+        if (this.onControllerMouseUp) {
+            this.onControllerMouseUp(event);
+        }
+    }
+
+    public onMouseLeave(event: GizmoMouseEvent) {
+        this.onMouseUp(event);
+    }
+
+    public getDeltaRadius() {
+        return this._deltaRadius;
+    }
+
+    public getDeltaHeight() {
+        return this._deltaHeight;
+    }
+
+    private getUpperCapData(center: Vec3, radius: number, height: number) {
+        const upperData: any = [];
+        const halfHeight = height / 2;
+        const curUp = Vec3.copy(tempVec3_a, this._up);
+        const curRight = Vec3.copy(tempVec3_b, this._right);
+        const curForward = Vec3.copy(tempVec3_c, this._forward);
+        const upperCenter = tempVec3_d;
+        const offset = tempVec3_e.set(0, halfHeight, 0);
+        if (this._direction !== EAxisDirection.Y_AXIS) {
+            const colliderDir = this._directionAxis[this._direction];
+            const rot = tempQuat_a;
+            Quat.rotationTo(rot, this._up, colliderDir);
+            Vec3.transformQuat(offset, offset, rot);
+            Vec3.transformQuat(curUp, curUp, rot);
+            Vec3.transformQuat(curRight, curRight, rot);
+            Vec3.transformQuat(curForward, curForward, rot);
+        }
+
+        Vec3.add(upperCenter, center, offset);
+        upperData[0] = ControllerShape.calcArcData(upperCenter, curUp, curRight, this._twoPI, radius);
+        upperData[1] = ControllerShape.calcArcData(upperCenter, curRight, curForward, -Math.PI, radius);
+        upperData[2] = ControllerShape.calcArcData(upperCenter, curForward, curRight, Math.PI, radius);
+
+        return upperData;
+    }
+
+    private getLowerCapData(center: Vec3, radius: number, height: number) {
+        const lowerData: any = [];
+        const halfHeight = height / 2;
+        const curUp = Vec3.copy(tempVec3_a, this._up);
+        const curRight = Vec3.copy(tempVec3_b, this._right);
+        const curForward = Vec3.copy(tempVec3_c, this._forward);
+        const lowerCenter = tempVec3_d;
+        const offset = tempVec3_e.set(0, -halfHeight, 0);
+
+        if (this._direction !== EAxisDirection.Y_AXIS) {
+            const colliderDir = this._directionAxis[this._direction];
+            const rot = tempQuat_a;
+            Quat.rotationTo(rot, this._up, colliderDir);
+            Vec3.transformQuat(offset, offset, rot);
+            Vec3.transformQuat(curUp, curUp, rot);
+            Vec3.transformQuat(curRight, curRight, rot);
+            Vec3.transformQuat(curForward, curForward, rot);
+        }
+
+        Vec3.add(lowerCenter, center, offset);
+        lowerData[0] = ControllerShape.calcArcData(lowerCenter, curUp, curRight, this._twoPI, radius);
+        lowerData[1] = ControllerShape.calcArcData(lowerCenter, curRight, curForward, Math.PI, radius);
+        lowerData[2] = ControllerShape.calcArcData(lowerCenter, curForward, curRight, -Math.PI, radius);
+
+        return lowerData;
+    }
+
+    private getSideLinesData(center: Vec3, radius: number, height: number) {
+        const vertices: Vec3[] = [];
+        const indices: number[] = [];
+        const halfHeight = height / 2;
+        const sideLineHeight = halfHeight;
+
+        vertices.push(new Vec3(radius, sideLineHeight, 0));
+        vertices.push(new Vec3(radius, -sideLineHeight, 0));
+
+        vertices.push(new Vec3(-radius, sideLineHeight, 0));
+        vertices.push(new Vec3(-radius, -sideLineHeight, 0));
+
+        vertices.push(new Vec3(0, sideLineHeight, radius));
+        vertices.push(new Vec3(0, -sideLineHeight, radius));
+
+        vertices.push(new Vec3(0, sideLineHeight, -radius));
+        vertices.push(new Vec3(0, -sideLineHeight, -radius));
+
+        vertices.forEach((vert, index) => {
+            if (this._direction !== EAxisDirection.Y_AXIS) {
+                const colliderDir = this._directionAxis[this._direction];
+                const rot = tempQuat_a;
+                Quat.rotationTo(rot, this._up, colliderDir);
+                Vec3.transformQuat(vert, vert, rot);
+            }
+            Vec3.add(vert, vert, center);
+            indices.push(index);
+        });
+
+        return ControllerShape.calcLinesData(vertices, indices, false);
+    }
+}
+
+export default CapsuleController;

--- a/src/core/scene/scene-process/service/gizmo/controller/cone.ts
+++ b/src/core/scene/scene-process/service/gizmo/controller/cone.ts
@@ -1,0 +1,259 @@
+'use strict';
+
+import { Vec3, Vec2, Node, Color, MeshRenderer, EAxisDirection, Quat } from 'cc';
+
+import EditableController from './editable';
+import ControllerShape from '../utils/controller-shape';
+import ControllerUtils from '../utils/controller-utils';
+import type { GizmoMouseEvent } from '../utils/defines';
+import { setMeshColor, getModel, updatePositions } from '../utils/engine-utils';
+
+const axisDirMap = ControllerUtils.axisDirectionMap;
+const AxisName = ControllerUtils.AxisName;
+
+const tempVec3A = new Vec3();
+const tempVec3B = new Vec3();
+const tempVec3C = new Vec3();
+const tempVec3D = new Vec3();
+const tempVec3E = new Vec3();
+const tempQuatA = new Quat();
+
+class ConeController extends EditableController {
+    private _oriDir = new Vec3(0, 0, -1);
+    private _center = new Vec3();
+    private _radius = 100;
+    private _height = 100;
+    private _halfHeight = this._height / 2;
+    private _deltaRadius = 0;
+    private _deltaHeight = 0;
+    private _circleFromDir = new Vec3(1, 0, 0);
+    private _sideLineMR: MeshRenderer | null = null;
+    private _lowerCapMR: MeshRenderer | null = null;
+
+    private _sideLineNode: Node | null = null;
+    private _lowerCapNode: Node | null = null;
+    private _mouseDeltaPos: Vec2 = new Vec2();
+    private _curDistScalar = 0;
+
+    private _directionAxis: Vec3[] = [new Vec3(1, 0, 0), new Vec3(0, 1, 0), new Vec3(0, 0, 1)];
+    private _direction: EAxisDirection = EAxisDirection.Y_AXIS;
+
+    get radius() {
+        return this._radius;
+    }
+    set radius(value) {
+        this.updateSize(this._center, value, this._height);
+    }
+
+    get height() {
+        return this._height;
+    }
+    set height(value) {
+        this.updateSize(this._center, this._radius, value);
+    }
+
+    get direction() { return this._direction; }
+    set direction(value) {
+        this._direction = value;
+    }
+
+    constructor(rootNode: Node) {
+        super(rootNode);
+
+        this._editHandleKeys = [
+            AxisName.x,
+            AxisName.z,
+            AxisName.neg_x,
+            AxisName.neg_y,
+            AxisName.neg_z,
+        ];
+
+        this.initShape();
+    }
+
+    setColor(color: Color) {
+        setMeshColor(this._sideLineNode!, color);
+        setMeshColor(this._lowerCapNode!, color);
+
+        this.setEditHandlesColor(color);
+
+        this._color = color;
+    }
+
+    _updateEditHandle(axisName: string) {
+        const node = this._handleDataMap[axisName].topNode;
+        const dir = axisDirMap[axisName];
+
+        const colliderDir = tempVec3A.set(this._directionAxis[this._direction]);
+
+        const offset = tempVec3B;
+        offset.set(0, 0, 0);
+
+        if (axisName === 'neg_y') {
+            Vec3.multiplyScalar(offset, colliderDir, -this._halfHeight);
+        } else {
+            Vec3.multiplyScalar(offset, dir, this._radius);
+            Vec3.multiplyScalar(tempVec3C, Vec3.UNIT_Y, -this._halfHeight);
+            offset.add(tempVec3C);
+            if (this._direction !== EAxisDirection.Y_AXIS) {
+                const rot = tempQuatA;
+                Quat.rotationTo(rot, Vec3.UNIT_Y, colliderDir);
+                Vec3.transformQuat(offset, offset, rot);
+            }
+        }
+
+        offset.add(this._center);
+        Vec3.multiply(offset, offset, this.getScale());
+        node.setPosition(offset);
+    }
+
+    initShape() {
+        this.createShapeNode('ConeController');
+
+        this._circleFromDir = new Vec3(1, 0, 0);
+        const sideLinesData = this.getSideLinesData(this._center, this._radius, this._height);
+        this._sideLineNode = ControllerUtils.createShapeByData(sideLinesData, this._color, { name: 'sideLines', forwardPipeline: true });
+        this._sideLineNode!.parent = this.shape;
+        this._sideLineMR = getModel(this._sideLineNode);
+
+        const lowerCapData = this.getLowerCapData(this._center, this._radius, this._height);
+        this._lowerCapNode = ControllerUtils.createShapeByData(lowerCapData, this._color, { name: 'lowerCap' });
+        this._lowerCapNode!.parent = this.shape;
+        this._lowerCapMR = getModel(this._lowerCapNode);
+
+        this.hide();
+    }
+
+    getSideLinesData(center: Vec3, radius: number, height: number) {
+        const vertices: Vec3[] = [];
+        const indices: number[] = [];
+        const sideLineHeight = height / 2;
+
+        vertices.push(new Vec3(0, sideLineHeight, 0));
+        vertices.push(new Vec3(radius, -sideLineHeight, 0));
+
+        vertices.push(new Vec3(0, sideLineHeight, 0));
+        vertices.push(new Vec3(-radius, -sideLineHeight, 0));
+
+        vertices.push(new Vec3(0, sideLineHeight, 0));
+        vertices.push(new Vec3(0, -sideLineHeight, radius));
+
+        vertices.push(new Vec3(0, sideLineHeight, -0));
+        vertices.push(new Vec3(0, -sideLineHeight, -radius));
+
+        vertices.forEach((vert, index) => {
+            if (this._direction !== EAxisDirection.Y_AXIS) {
+                const colliderDir = this._directionAxis[this._direction];
+                const rot = tempQuatA;
+                Quat.rotationTo(rot, Vec3.UNIT_Y, colliderDir);
+                Vec3.transformQuat(vert, vert, rot);
+            }
+            Vec3.add(vert, vert, center);
+            indices.push(index);
+        });
+
+        return ControllerShape.calcLinesData(vertices, indices, false);
+    }
+
+    getLowerCapData(center: Vec3, radius: number, height: number) {
+        let lowerData: any;
+        const halfHeight = height / 2;
+        const curUp = Vec3.copy(tempVec3A, Vec3.UNIT_Y);
+        const curRight = Vec3.copy(tempVec3B, Vec3.UNIT_X);
+        const curForward = Vec3.copy(tempVec3C, Vec3.UNIT_Z);
+        const lowerCenter = tempVec3D;
+        const offset = tempVec3E.set(0, -halfHeight, 0);
+
+        if (this._direction !== EAxisDirection.Y_AXIS) {
+            const colliderDir = this._directionAxis[this._direction];
+            const rot = tempQuatA;
+            Quat.rotationTo(rot, Vec3.UNIT_Y, colliderDir);
+            Vec3.transformQuat(offset, offset, rot);
+            Vec3.transformQuat(curUp, curUp, rot);
+            Vec3.transformQuat(curRight, curRight, rot);
+            Vec3.transformQuat(curForward, curForward, rot);
+        }
+
+        Vec3.add(lowerCenter, center, offset);
+        lowerData = ControllerShape.calcArcData(lowerCenter, curUp, curRight, this._twoPI, radius);
+
+        return lowerData;
+    }
+
+    updateSize(center: Vec3, radius: number, height: number) {
+        this._center = center;
+        this._radius = radius;
+        this._height = height;
+
+        this._halfHeight = this._height / 2;
+
+        const lineData = this.getSideLinesData(this._center, this._radius, this._height);
+        updatePositions(this._sideLineMR!, lineData.positions);
+
+        const lowerCapData = this.getLowerCapData(this._center, this._radius, this._height);
+        updatePositions(this._lowerCapMR!, lowerCapData.positions);
+
+        if (this._edit) {
+            this.updateEditHandles();
+        }
+
+        this.adjustEditHandlesSize();
+    }
+
+    onMouseDown(event: GizmoMouseEvent) {
+        event.propagationStopped = true;
+        this._mouseDeltaPos = new Vec2(0, 0);
+        this._curDistScalar = super.getDistScalar();
+        this._deltaRadius = 0;
+        this._deltaHeight = 0;
+
+        if (this.onControllerMouseDown) {
+            this.onControllerMouseDown(event);
+        }
+    }
+
+    onMouseMove(event: GizmoMouseEvent) {
+        event.propagationStopped = true;
+        if (this._isMouseDown) {
+            this._mouseDeltaPos.x += event.moveDeltaX;
+            this._mouseDeltaPos.y += event.moveDeltaY;
+
+            const axisDir = axisDirMap[event.handleName];
+            const colliderDir = tempVec3A.set(this._directionAxis[this._direction]);
+            const rot = tempQuatA;
+            Quat.rotationTo(rot, Vec3.UNIT_Y, colliderDir);
+            Vec3.transformQuat(colliderDir, axisDir, rot);
+            const deltaDist = this.getAlignAxisMoveDistance(this.localToWorldDir(colliderDir), this._mouseDeltaPos) * this._curDistScalar;
+            if (event.handleName === 'neg_y') {
+                this._deltaHeight = deltaDist;
+            } else {
+                this._deltaRadius = deltaDist;
+            }
+
+            if (this.onControllerMouseMove) {
+                this.onControllerMouseMove(event);
+            }
+        }
+    }
+
+    onMouseUp(event: GizmoMouseEvent) {
+        event.propagationStopped = true;
+        if (this.onControllerMouseUp) {
+            this.onControllerMouseUp(event);
+        }
+    }
+
+    onMouseLeave(event: GizmoMouseEvent) {
+        this.onMouseUp(event);
+    }
+
+    getDeltaRadius() {
+        return this._deltaRadius;
+    }
+
+    getDeltaHeight() {
+        return this._deltaHeight;
+    }
+}
+
+export default ConeController;

--- a/src/core/scene/scene-process/service/gizmo/controller/disc.ts
+++ b/src/core/scene/scene-process/service/gizmo/controller/disc.ts
@@ -1,0 +1,300 @@
+'use strict';
+
+import { Node, Vec3, Color, MeshRenderer, Vec2 } from 'cc';
+
+import EditableController from './editable';
+import ControllerShape from '../utils/controller-shape';
+import ControllerUtils from '../utils/controller-utils';
+import type { GizmoMouseEvent } from '../utils/defines';
+import {
+    setMeshColor,
+    setNodeOpacity,
+    getNodeOpacity,
+    getModel,
+    updatePositions,
+    updateBoundingBox,
+} from '../utils/engine-utils';
+
+const axisDirMap = ControllerUtils.axisDirectionMap;
+const AxisName = ControllerUtils.AxisName;
+
+const panPlaneLayer = 1 << 30;
+
+const tempVec3 = new Vec3();
+const tempVec3_a = new Vec3();
+
+enum DiscHandleType {
+    None = 'none',
+    Left = 'neg_x',
+    Right = 'x',
+    Top = 'y',
+    Bottom = 'neg_y',
+    Area = 'area',
+}
+
+class DiscController extends EditableController {
+    public static DiscHandleType = DiscHandleType;
+    private _oriDir: Vec3 = new Vec3(0, 0, -1);
+    private _center: Vec3 = new Vec3();
+    private _radius = 100;
+    private _arc = 360;
+    private _deltaRadius = 0;
+    private _deltaPos: Vec3 = new Vec3();
+    private _circleNode: Node | null = null;
+    private _circleFromDir = new Vec3(1, 0, 0);
+    private _circleMR: MeshRenderer | null = null;
+    private _panPlane: Node | null = null;
+    private _areaNode!: Node;
+    private _areaMR: MeshRenderer | null = null;
+    private _areaColor: Color = Color.GREEN;
+    private _areaOpacity = 0;
+
+    private _mouseDeltaPos: Vec2 = new Vec2();
+    private _mouseDownOnPlanePos: Vec3 = new Vec3();
+    private _curDistScalar = 0;
+    private _controlDir: Vec3 = new Vec3();
+    private _curHandleType: string = DiscHandleType.None;
+
+    constructor(rootNode: Node) {
+        super(rootNode);
+
+        this._editHandleKeys = [
+            AxisName.x,
+            AxisName.y,
+            AxisName.neg_x,
+            AxisName.neg_y,
+        ];
+
+        this.initShape();
+    }
+
+    get radius() {
+        return this._radius;
+    }
+    set radius(value) {
+        this.updateSize(this._center, value, this._arc);
+    }
+
+    setColor(color: Color) {
+        setMeshColor(this._circleNode!, color);
+
+        this.setEditHandlesColor(color);
+
+        this._color = color;
+    }
+
+    setAreaColor(color: Color) {
+        this._areaColor = color;
+        if (this._areaNode) {
+            setMeshColor(this._areaNode, color);
+        }
+    }
+
+    setAreaOpacity(opacity: number) {
+        this._areaOpacity = opacity;
+        if (this._areaNode) {
+            setNodeOpacity(this._areaNode, opacity);
+        }
+    }
+
+    showEditHandles() {
+        super.showEditHandles();
+        if (this._areaNode) {
+            this._areaNode.active = true;
+        }
+    }
+
+    hideEditHandles() {
+        super.hideEditHandles();
+        if (this._areaNode) {
+            this._areaNode.active = false;
+        }
+    }
+
+    isBorder(axisName: string) {
+        if (
+            axisName === DiscHandleType.Left ||
+            axisName === DiscHandleType.Right ||
+            axisName === DiscHandleType.Top ||
+            axisName === DiscHandleType.Bottom
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    initShape() {
+        this.createShapeNode('CircleController');
+
+        const circleNode = ControllerUtils.arc(this._center, this._oriDir, this._circleFromDir, this._twoPI, this._radius, this._color);
+        circleNode.parent = this.shape;
+
+        this._circleNode = circleNode;
+        this._circleMR = getModel(circleNode);
+
+        this.hide();
+    }
+
+    onInitEditHandles() {
+        const panPlane = ControllerUtils.quad(new Vec3(), 100000, 100000);
+        panPlane.parent = this._rootNode;
+        panPlane.name = 'DiscPanPlane';
+        panPlane.active = false;
+        panPlane.layer = panPlaneLayer;
+        setNodeOpacity(panPlane, 0);
+        this._panPlane = panPlane;
+
+        const areaNode = ControllerUtils.disc(new Vec3(), new Vec3(0, 0, 1), this._radius, this._areaColor, { unlit: true });
+        areaNode.name = 'DiscArea';
+        areaNode.parent = this.shape;
+        areaNode.setPosition(new Vec3(0, 0, -0.1));
+        setNodeOpacity(areaNode, this._areaOpacity);
+        this._areaNode = areaNode;
+        this._areaMR = getModel(areaNode);
+        this.initHandle(areaNode, DiscHandleType.Area);
+    }
+
+    _updateEditHandle(axisName: string) {
+        const node = this._handleDataMap[axisName].topNode;
+        const dir = axisDirMap[axisName];
+        const baseScale = this._editHandleScales[axisName];
+
+        const offset = tempVec3_a;
+        offset.x = dir.x * this._radius;
+        offset.y = dir.y * this._radius;
+
+        const pos = offset;
+        pos.add(this._center);
+        const curScale = this.getScale();
+        node.setScale(baseScale / curScale.x, baseScale / curScale.y, baseScale / curScale.z);
+        Vec3.multiply(pos, pos, curScale);
+        node.setPosition(pos);
+    }
+
+    updateSize(center: Readonly<Vec3>, radius: number, arc = 360) {
+        this._center.set(center);
+        this._radius = radius;
+        this._arc = arc;
+
+        const circlePoints = ControllerShape.calcArcPoints(
+            this._center,
+            this._oriDir,
+            this._circleFromDir,
+            -this._arc * this._degreeToRadianFactor,
+            this._radius,
+        );
+        updatePositions(this._circleMR!, circlePoints);
+
+        if (this._edit) {
+            this.updateEditHandles();
+            const discData = ControllerShape.calcDiscData(this._center, Vec3.UNIT_Z, this._radius);
+            updatePositions(this._areaMR!, discData.positions);
+            updateBoundingBox(this._areaMR!, discData.minPos, discData.maxPos);
+        }
+
+        this.adjustEditHandlesSize();
+    }
+
+    onMouseDown(event: GizmoMouseEvent) {
+        event.propagationStopped = true;
+        if (!this.edit) {
+            return;
+        }
+
+        this._mouseDeltaPos = new Vec2(0, 0);
+        Vec3.set(this._deltaPos, 0, 0, 0);
+
+        this._curDistScalar = super.getDistScalar();
+        this._deltaRadius = 0;
+        this._controlDir = new Vec3();
+
+        this._panPlane!.active = true;
+        this._mouseDownOnPlanePos = new Vec3();
+        this.getPositionOnPanPlane(this._mouseDownOnPlanePos, event.x, event.y, this._panPlane!);
+
+        if (this.onControllerMouseDown) {
+            this.onControllerMouseDown(event);
+        }
+    }
+
+    onMouseMove(event: GizmoMouseEvent) {
+        event.propagationStopped = true;
+        if (!this.edit) {
+            return;
+        }
+
+        if (this._isMouseDown) {
+            this._mouseDeltaPos.x += event.moveDeltaX;
+            this._mouseDeltaPos.y += event.moveDeltaY;
+
+            const hitPos = new Vec3();
+            if (this.getPositionOnPanPlane(hitPos, event.x, event.y, this._panPlane!)) {
+                const deltaPos = new Vec3(hitPos);
+                deltaPos.subtract(this._mouseDownOnPlanePos);
+                this._curHandleType = event.handleName;
+                const axisDir = axisDirMap[event.handleName];
+                this._controlDir = axisDir;
+                let deltaDist = 0;
+                if (this.isBorder(event.handleName)) {
+                    Vec3.transformQuat(tempVec3, axisDir, this.getRotation());
+                    deltaDist = deltaPos.dot(tempVec3);
+                } else {
+                    this._deltaPos = deltaPos;
+                }
+                this._deltaRadius = deltaDist;
+            }
+
+            if (this.onControllerMouseMove) {
+                this.onControllerMouseMove(event);
+            }
+        }
+    }
+
+    onMouseUp(event: GizmoMouseEvent) {
+        event.propagationStopped = true;
+        this._curHandleType = DiscHandleType.None;
+        this._panPlane!.active = false;
+
+        if (this.onControllerMouseUp) {
+            this.onControllerMouseUp(event);
+        }
+    }
+
+    onHoverIn(event: GizmoMouseEvent) {
+        if (!this.edit) {
+            return;
+        }
+
+        if (event.handleName !== DiscHandleType.Area) {
+            this.setHandleColor(event.handleName, Color.YELLOW);
+        } else {
+            const opacity = getNodeOpacity(this._areaNode);
+            if (opacity > 0) {
+                this.setHandleColor(event.handleName, Color.YELLOW, opacity);
+            }
+        }
+    }
+
+    onMouseLeave(event: GizmoMouseEvent) {
+        this.onMouseUp(event);
+    }
+
+    getDeltaRadius() {
+        return this._deltaRadius;
+    }
+
+    getControlDir() {
+        return this._controlDir;
+    }
+
+    getDeltaPos() {
+        return this._deltaPos;
+    }
+
+    getCurHandleType() {
+        return this._curHandleType;
+    }
+}
+
+export default DiscController;

--- a/src/core/scene/scene-process/service/gizmo/controller/line.ts
+++ b/src/core/scene/scene-process/service/gizmo/controller/line.ts
@@ -1,0 +1,55 @@
+'use strict';
+
+import { Color, MeshRenderer, Node, Vec3 } from 'cc';
+
+import ControllerBase from './base';
+import ControllerUtils from '../utils/controller-utils';
+import ControllerShape from '../utils/controller-shape';
+import {
+    getModel,
+    updatePositions,
+    setMeshColor,
+    setNodeOpacity,
+    updateBoundingBox,
+} from '../utils/engine-utils';
+
+class LineController extends ControllerBase {
+    private _lineNode: Node | null = null;
+    private _lineMR: MeshRenderer | null = null;
+
+    constructor(rootNode: Node) {
+        super(rootNode);
+        this.initShape();
+    }
+
+    initShape() {
+        this.createShapeNode('LineController');
+        this._lineNode = this.createLineNode(new Vec3(), new Vec3(), 'LineNode', this._color);
+        this._lineMR = getModel(this._lineNode);
+    }
+
+    setColor(color: Color) {
+        this._color = color;
+        setMeshColor(this._lineNode!, color);
+    }
+
+    setOpacity(opacity: number) {
+        setNodeOpacity(this._lineNode!, opacity);
+    }
+
+    createLineNode(startPos: Vec3, endPos: Vec3, name: string, color: Color) {
+        const lineData = ControllerShape.calcLineData(startPos, endPos);
+        const lineNode = ControllerUtils.createShapeByData(lineData, color, { unlit: true });
+        lineNode.name = name;
+        lineNode.parent = this.shape;
+        return lineNode;
+    }
+
+    updateData(startPos: Vec3, endPos: Vec3) {
+        const lineData = ControllerShape.calcLineData(startPos, endPos);
+        updatePositions(this._lineMR!, lineData.positions);
+        updateBoundingBox(this._lineMR!, lineData.minPos, lineData.maxPos);
+    }
+}
+
+export default LineController;

--- a/src/core/scene/scene-process/service/gizmo/controller/point.ts
+++ b/src/core/scene/scene-process/service/gizmo/controller/point.ts
@@ -1,0 +1,33 @@
+'use strict';
+
+import { Color, Node, Vec3 } from 'cc';
+
+import ControllerUtils from '../utils/controller-utils';
+import ControllerBase from './base';
+import { setMeshColor } from '../utils/engine-utils';
+
+class PointController extends ControllerBase {
+    private _pointNode: Node | null = null;
+    constructor(rootNode: Node) {
+        super(rootNode);
+        this._color = Color.GREEN;
+        this.initShape();
+    }
+
+    setColor(color: Color) {
+        this._color = color;
+        setMeshColor(this._pointNode!, color);
+    }
+
+    initShape() {
+        this.createShapeNode('PointController');
+        this._pointNode = ControllerUtils.sphere(new Vec3(), 0.05, this._color, { unlit: true });
+        this._pointNode.parent = this.shape;
+    }
+
+    updateData(pos: Vec3) {
+        this._pointNode?.setPosition(pos);
+    }
+}
+
+export default PointController;

--- a/src/core/scene/scene-process/service/gizmo/controller/tetrahedron.ts
+++ b/src/core/scene/scene-process/service/gizmo/controller/tetrahedron.ts
@@ -1,0 +1,39 @@
+'use strict';
+
+import { MeshRenderer, Node, Vec3, Color } from 'cc';
+
+import ControllerShape from '../utils/controller-shape';
+import ControllerUtils from '../utils/controller-utils';
+import ControllerBase from './base';
+import { getModel, setMeshColor, updatePositions } from '../utils/engine-utils';
+
+class TetrahedronController extends ControllerBase {
+    private _edgesNode!: Node;
+    private _edgesMR: MeshRenderer | null = null;
+    private _indices: number[] = [0, 1, 1, 2, 2, 0, 0, 3, 1, 3, 2, 3];
+
+    constructor(rootNode: Node) {
+        super(rootNode);
+        this.initShape();
+    }
+
+    public setColor(color: Color) {
+        this._color = color;
+        setMeshColor(this._edgesNode, color);
+    }
+
+    initShape() {
+        this.createShapeNode('TetrahedronController');
+        this._edgesNode = ControllerUtils.lines([new Vec3(), new Vec3(), new Vec3(), new Vec3()],
+            this._indices, this._color, { forwardPipeline: true });
+        this._edgesMR = getModel(this._edgesNode);
+        this._edgesNode.parent = this.shape;
+    }
+
+    updateData(v0: Vec3, v1: Vec3, v2: Vec3, v3: Vec3) {
+        const linesData = ControllerShape.calcLinesData([v0, v1, v2, v3], this._indices);
+        this._edgesMR && updatePositions(this._edgesMR, linesData.positions);
+    }
+}
+
+export default TetrahedronController;

--- a/src/core/scene/scene-process/service/gizmo/controller/triangle.ts
+++ b/src/core/scene/scene-process/service/gizmo/controller/triangle.ts
@@ -1,0 +1,43 @@
+'use strict';
+
+import { MeshRenderer, Node, Vec3, Color } from 'cc';
+
+import ControllerShape from '../utils/controller-shape';
+import ControllerUtils from '../utils/controller-utils';
+import ControllerBase from './base';
+import { getModel, setMeshColor, updatePositions } from '../utils/engine-utils';
+
+class TriangleController extends ControllerBase {
+    private _edgesNode!: Node;
+    private _edgesMR: MeshRenderer | null = null;
+    private _indices: number[] = [0, 1, 1, 2, 2, 0];
+
+    constructor(rootNode: Node) {
+        super(rootNode);
+        this.initShape();
+    }
+
+    public setColor(color: Color) {
+        this._color = color;
+        setMeshColor(this._edgesNode, color);
+    }
+
+    initShape() {
+        this.createShapeNode('TriangleController');
+        this._edgesNode = ControllerUtils.lines([new Vec3(), new Vec3(), new Vec3()],
+            this._indices, this._color, { unlit: true });
+        this._edgesMR = getModel(this._edgesNode);
+        this._edgesNode.parent = this.shape;
+    }
+
+    updateData(v0: Vec3, v1: Vec3, v2: Vec3) {
+        const linesData = ControllerShape.calcLinesData([v0, v1, v2], this._indices);
+        this._edgesMR && updatePositions(this._edgesMR, linesData.positions);
+    }
+
+    getDistScalar() {
+        return 1;
+    }
+}
+
+export default TriangleController;

--- a/src/core/scene/scene-process/service/gizmo/gizmo-operation.ts
+++ b/src/core/scene/scene-process/service/gizmo/gizmo-operation.ts
@@ -1,11 +1,12 @@
 'use strict';
 
-import { CCObject, Color, Layers, Node, Vec3 } from 'cc';
+import { CCObject, Color, Layers, Node, Vec3, director } from 'cc';
 import { OperationPriority } from '../operation/types';
 import type { ISceneMouseEvent, ISceneKeyboardEvent } from '../operation/types';
 import { GizmoMouseEvent } from './utils/defines';
-import { getRaycastResults } from './utils/engine-utils';
+import { getRaycastResults, raycast, RaycastResults } from './utils/engine-utils';
 import { getRaycastResultNodes, getRegionNodes } from './utils/node-utils';
+import { getSelectNode } from './utils/selection-utils';
 
 function getService(): any {
     try {
@@ -40,13 +41,17 @@ function adjustY(y: number): number {
 
 /**
  * Create a GizmoMouseEvent from an ISceneMouseEvent
- * Note: Our GizmoMouseEvent is a plain data class, NOT extending CCEvent
  */
 function createGizmoMouseEvent(type: string, event: ISceneMouseEvent): GizmoMouseEvent {
-    const gme = new GizmoMouseEvent();
-    gme.type = type;
+    const gme = new GizmoMouseEvent(type, true);
     gme.x = event.x;
     gme.y = adjustY(event.y);
+    gme.clientX = event.clientX;
+    gme.clientY = event.clientY;
+    gme.deltaX = event.deltaX;
+    gme.deltaY = event.deltaY;
+    gme.wheelDeltaX = event.wheelDeltaX;
+    gme.wheelDeltaY = event.wheelDeltaY;
     gme.ctrlKey = event.ctrlKey;
     gme.shiftKey = event.shiftKey;
     gme.altKey = event.altKey;
@@ -58,6 +63,8 @@ function createGizmoMouseEvent(type: string, event: ISceneMouseEvent): GizmoMous
     gme.moveDeltaY = -(event.moveDeltaY); // invert Y
     gme.button = event.button;
     gme.buttons = event.buttons;
+    gme.movementX = event.movementX;
+    gme.movementY = event.movementY;
     return gme;
 }
 
@@ -68,16 +75,31 @@ class GizmoOperation {
     private _curMouseDownInfos: { node: Node; hitPoint: Vec3 }[] = [];
     private _gizmoMouseDownEvent: GizmoMouseEvent | null = null;
     private _noGizmoMouseDownEvent: GizmoMouseEvent | null = null;
-    private _mouseDownRaycastGizmos: any[] = [];
+    private _mouseDownRaycastGizmos: RaycastResults | null = null;
     private _anyKeyDown = false;
 
     /**
      * Raycast against gizmo nodes
+     * 与编辑器一致：优先检测右上角 SceneGizmo，再检测 gizmo root
      */
-    private raycastGizmos(x: number, y: number): any[] {
+    private raycastGizmos(x: number, y: number): RaycastResults {
         const gizmoSvc = getServiceProp('Gizmo');
+
+        const sceneGizmoCamera = gizmoSvc?.sceneGizmoCamera?.camera;
+        if (sceneGizmoCamera) {
+            const results = raycast(
+                director.getScene()?.renderScene,
+                sceneGizmoCamera,
+                Layers.Enum.SCENE_GIZMO,
+                x, y,
+            );
+            if (results && results.length > 0) {
+                return results;
+            }
+        }
+
         const gizmoRoot = gizmoSvc?.gizmoRootNode;
-        if (!gizmoRoot) return [];
+        if (!gizmoRoot) return new RaycastResults(null as any);
 
         return getRaycastResults(gizmoRoot, x, y, Infinity, Layers.Enum.IGNORE_RAYCAST);
     }
@@ -133,7 +155,7 @@ class GizmoOperation {
 
     // --- Gizmo-hit handlers ---
 
-    private _onGizmoMouseDown(event: GizmoMouseEvent, results: any[]): boolean {
+    private _onGizmoMouseDown(event: GizmoMouseEvent, results: RaycastResults): boolean {
         // 与 cocos-editor 一致：相机移动中不处理 gizmo 交互
         const cameraCtrl = getServiceProp('Camera')?.controller;
         if (cameraCtrl?.isMoving?.()) return true;
@@ -180,7 +202,7 @@ class GizmoOperation {
         return true;
     }
 
-    private _onGizmoMouseMove(event: GizmoMouseEvent, results: any[]) {
+    private _onGizmoMouseMove(event: GizmoMouseEvent, results: RaycastResults) {
         if (this._curMouseDownInfos.length > 0) {
             const map = new Map<Node, Vec3>();
             results.forEach((info: any) => map.set(info.node, info.hitPoint || new Vec3()));
@@ -248,16 +270,37 @@ class GizmoOperation {
 
     public onMouseWheel() {}
 
-    private _changeMouseHover(event: GizmoMouseEvent, results: any[]): boolean {
+    private _changeMouseHover(event: GizmoMouseEvent, results: RaycastResults): boolean {
         if (this._anyKeyDown) return true;
+
+        // 与编辑器一致：vertexSnap 检查
+        const selection = getServiceProp('Selection');
+        const uuids: string[] = selection?.query?.() ?? [];
+        if (uuids[0]) {
+            const node = getNodeByUuid(uuids[0]);
+            if (node) {
+                const res = getServiceProp('Gizmo')?.callAllGizmoFuncOfNode?.(node, 'onVertexSnapMove', event);
+                if (res === false) {
+                    return false;
+                }
+            }
+        }
 
         let hoverInNode: Node | null = null;
         const tempSet: Set<Node> = new Set();
+        const hitPoint = new Vec3();
 
         if (results.length > 0) {
-            for (const info of results) {
-                event.hitPoint = info.hitPoint;
-                info.node.emit(event.type, event);
+            const ray = results.ray;
+            for (let i = 0; i < results.length; i++) {
+                if (ray) {
+                    Vec3.multiplyScalar(hitPoint, ray.d, results[i].distance);
+                    Vec3.add(hitPoint, ray.o, hitPoint);
+                    event.hitPoint = hitPoint;
+                } else {
+                    event.hitPoint = results[i].hitPoint;
+                }
+                results[i].node.emit(event.type, event);
             }
 
             for (const info of results) {
@@ -274,7 +317,7 @@ class GizmoOperation {
         this._hoverInNodeMap.forEach((_bool, node) => {
             if (!tempSet.has(node)) {
                 event.type = 'hoverOut';
-                (event as any).customData = { hoverInNodeMap: this._hoverInNodeMap };
+                event.customData = { hoverInNodeMap: this._hoverInNodeMap };
                 this._emitEventToNode(node, event);
                 this._hoverInNodeMap.delete(node);
             }
@@ -313,18 +356,20 @@ class GizmoOperation {
             }
             if (!resultNode) return;
 
+            const curSelections = selection?.query?.() ?? [];
+
             if (!event.ctrlKey && !event.shiftKey) {
                 selection?.clear?.();
             }
 
             if (event.ctrlKey) {
-                const selected = selection?.query?.() ?? [];
-                if (selected.includes(resultNode.uuid)) {
+                if (curSelections.includes(resultNode.uuid)) {
                     selection?.unselect?.(resultNode.uuid);
                 } else {
                     selection?.select?.(resultNode.uuid);
                 }
             } else {
+                resultNode = getSelectNode(nodes, curSelections[0]);
                 selection?.select?.(resultNode.uuid);
             }
         } else {
@@ -335,7 +380,7 @@ class GizmoOperation {
     }
 
     private _regionSelectNode(
-        left: number, right: number, top: number, bottom: number, multiple: boolean,
+        left: number, right: number, top: number, bottom: number, _multiple: boolean,
     ) {
         this._showSelectionRegion(left, right, top, bottom);
 
@@ -357,10 +402,8 @@ class GizmoOperation {
             }
             selectSet.delete(node.uuid);
         });
-        if (!multiple) {
-            for (const uuid of selectSet.keys()) {
-                selection?.unselect?.(uuid);
-            }
+        for (const uuid of selectSet.keys()) {
+            selection?.unselect?.(uuid);
         }
     }
 

--- a/src/core/scene/scene-process/service/gizmo/node/position.ts
+++ b/src/core/scene/scene-process/service/gizmo/node/position.ts
@@ -5,18 +5,6 @@ import type { GizmoMouseEvent } from '../utils/defines';
 import TransformBaseGizmo from './transform-base';
 import PositionController from './position-controller';
 
-/**
- * 获取 Service（惰性访问，避免循环依赖）
- */
-function getService(): any {
-    try {
-        const { Service } = require('../../core/decorator');
-        return Service;
-    } catch (e) {
-        return null;
-    }
-}
-
 function repaintEngine(): void {
     try {
         const { Service } = require('../../core/decorator');

--- a/src/core/scene/scene-process/service/gizmo/utils/defines.ts
+++ b/src/core/scene/scene-process/service/gizmo/utils/defines.ts
@@ -1,4 +1,4 @@
-import { Vec3, Vec2, primitives, Node, Color, MeshRenderer, IVec3Like } from 'cc';
+import { Vec3, Vec2, primitives, Node, Color, MeshRenderer, IVec3Like, Event as CCEvent } from 'cc';
 
 export interface IMeshPrimitive {
     primitiveType?: number; // 图元类型
@@ -116,26 +116,41 @@ export interface IHandleData {
  * 简化版 GizmoMouseEvent
  * 编辑器版本继承自 CCEvent，此处作为独立的纯数据类
  */
-export class GizmoMouseEvent<T extends Record<string, any> = {}> {
-    type = '';
-    x = 0;
-    y = 0;
-    button = 0;
-    buttons = 0;
+export class GizmoMouseEvent<T extends Record<string, any> = {}> extends CCEvent {
     ctrlKey = false;
     shiftKey = false;
     altKey = false;
     metaKey = false;
+
+    x = 0;
+    y = 0;
+    clientX = 0;
+    clientY = 0;
+    deltaX = 0;
+    deltaY = 0;
+    wheelDeltaX = 0;
+    wheelDeltaY = 0;
+    moveDeltaX = 0;
+    moveDeltaY = 0;
+
     leftButton = false;
     middleButton = false;
     rightButton = false;
-    moveDeltaX = 0;
-    moveDeltaY = 0;
+
+    button = 0;
+    buttons = 0;
+
+    movementX = 0;
+    movementY = 0;
+
     hitPoint?: Vec3;
     handleName = '';
     node?: Node;
     customData?: T;
-    propagationStopped = false;
+
+    constructor(type: string, bubbles = true) {
+        super(type, bubbles);
+    }
 }
 
 const zeroFloat32 = new Float32Array();

--- a/src/core/scene/scene-process/service/gizmo/utils/engine-utils.ts
+++ b/src/core/scene/scene-process/service/gizmo/utils/engine-utils.ts
@@ -17,6 +17,7 @@ import {
 } from 'cc';
 import type { IAddMeshToNodeOption, ICreateMeshOption, IMeshPrimitive, DynamicMeshPrimitive } from './defines';
 import raycastUtil from './raycast';
+import type { IRaycastResult } from './raycast';
 
 const flat = (arr: any, fn: any) => {
     return arr.map(fn).reduce((acc: any, val: any) => acc.concat(val), []);
@@ -25,6 +26,14 @@ const flat = (arr: any, fn: any) => {
 const cmp = (a: any, b: any) => a.distance - b.distance;
 export const ray = geometry.Ray.create();
 const triangles = gfx.PrimitiveMode.TRIANGLE_LIST;
+
+export class RaycastResults extends Array<IRaycastResult> {
+    ray: geometry.Ray;
+    constructor(r: geometry.Ray) {
+        super();
+        this.ray = r;
+    }
+}
 
 // 这边理论上用WeakMap更好，但是在场景原生化中会有问题，所以先用Map
 const vbMap = new Map();
@@ -415,8 +424,8 @@ export function updateBoundingBox(meshComp: MeshRenderer, minPos?: math.Vec3, ma
     model.createBoundingShape(minPos, maxPos);
 }
 
-export function getRaycastResultsByNodes(nodes: Node[], x: number, y: number, distance = Infinity, forSnap = false, excludeMask?: number): any[] {
-    const results: any[] = [];
+export function getRaycastResultsByNodes(nodes: Node[], x: number, y: number, distance = Infinity, forSnap = false, excludeMask?: number): RaycastResults {
+    const results = new RaycastResults(ray);
     const camera = getEditorCamera();
     if (!camera || !camera.camera) {
         return results;
@@ -447,16 +456,30 @@ export function getRaycastResultsByNodes(nodes: Node[], x: number, y: number, di
     return results;
 }
 
-export function getRaycastResults(rootNode: Node, x: number, y: number, distance = Infinity, excludeMask?: number): any[] {
+export function getRaycastResults(rootNode: Node, x: number, y: number, distance = Infinity, excludeMask?: number): RaycastResults {
     const scene = (rootNode as any).scene?.renderScene as renderer.RenderScene;
     const camera = getEditorCamera();
     if (!camera || !camera.camera || !scene) {
-        return [];
+        return new RaycastResults(ray);
     }
 
     camera.camera.screenPointToRay(ray, x, y);
-    const results: any[] = [];
+    const results = new RaycastResults(ray);
     if (raycastUtil.raycastAllModels(scene, ray, rootNode['_layer'], distance, false, excludeMask)) {
+        results.push(...raycastUtil.rayResultModels);
+        results.sort(cmp);
+    }
+    return results;
+}
+
+export function raycast(scene: any, camera: any, layer: any, x: number, y: number, distance = Infinity, excludeMask?: number): RaycastResults | null {
+    if (!camera || !camera.enabled) {
+        return null;
+    }
+
+    camera.screenPointToRay(ray, x, y);
+    const results = new RaycastResults(ray);
+    if (raycastUtil.raycastAllModels(scene, ray, layer, distance, false, excludeMask)) {
         results.push(...raycastUtil.rayResultModels);
         results.sort(cmp);
     }

--- a/src/core/scene/scene-process/service/gizmo/utils/node-utils.ts
+++ b/src/core/scene/scene-process/service/gizmo/utils/node-utils.ts
@@ -1,7 +1,17 @@
 'use strict';
 
-import { CCObject, geometry, Layers, Mat4, Node, Rect, UITransform, Vec3, director } from 'cc';
+import { CCObject, geometry, Layers, Mat4, Node, Rect, UITransform, Vec2, Vec3, director } from 'cc';
 import { ray } from './engine-utils';
+import raycastUtil from './raycast';
+
+function getEditorCamera(): any {
+    try {
+        const { Service } = require('../../core/decorator');
+        return Service.Camera?.getCamera?.();
+    } catch (e) {
+        return null;
+    }
+}
 
 /**
  * 判断是否编辑器节点
@@ -14,49 +24,8 @@ export function isEditorNode(node: Node): boolean {
 }
 
 /**
- * 2D 节点命中检测：用射线与节点所在 z 平面求交，再判断交点是否落在 UITransform 的世界包围盒内
- * 遍历顺序为逆序深度优先（后渲染的节点优先命中），与编辑器一致
- */
-function collect2DHits(
-    node: Node,
-    r: geometry.Ray,
-    mask: number,
-    results: { node: Node; distance: number }[],
-): void {
-    if (!node || isEditorNode(node)) return;
-    if (node._objFlags & CCObject.Flags.LockedInEditor) return;
-    if (node._objFlags & CCObject.Flags.HideInHierarchy) return;
-
-    // 逆序遍历子节点（后渲染的优先）
-    const children = node.children;
-    for (let i = children.length - 1; i >= 0; i--) {
-        collect2DHits(children[i], r, mask, results);
-    }
-
-    if (!(node.layer & mask)) return;
-
-    const uiTransform = node.getComponent('cc.UITransform') as any;
-    if (!uiTransform || !uiTransform.getBoundingBoxToWorld) return;
-
-    const bbox = uiTransform.getBoundingBoxToWorld();
-    if (!bbox) return;
-
-    // 射线与节点 z 平面求交
-    if (Math.abs(r.d.z) < 1e-6) return;
-    const t = (node.worldPosition.z - r.o.z) / r.d.z;
-    if (t < 0) return;
-
-    const hitX = r.o.x + r.d.x * t;
-    const hitY = r.o.y + r.d.y * t;
-
-    if (hitX >= bbox.x && hitX <= bbox.x + bbox.width &&
-        hitY >= bbox.y && hitY <= bbox.y + bbox.height) {
-        results.push({ node, distance: t });
-    }
-}
-
-/**
  * 对场景节点做射线检测，排除编辑器层和锁定节点
+ * 与编辑器一致：使用 raycastAll 合并 3D 模型和 2D Canvas 的检测结果
  * Returns array of nodes sorted by distance
  */
 export function getRaycastResultNodes(
@@ -72,50 +41,16 @@ export function getRaycastResultNodes(
     if (!scene) return [];
 
     const resultNodes: Node[] = [];
-    const allResults: { node: Node; distance: number }[] = [];
 
-    // 3D: raycast against scene models (MeshRenderer)
-    const models = scene.models;
-    if (models) {
-        for (let i = 0; i < models.length; i++) {
-            const model = models[i];
-            if (!model || !model.node || !model.enabled) continue;
-
-            // Check layer mask
-            if (!(model.node.layer & mask)) continue;
-
-            // Skip UI_2D layer — batched 2D nodes appear as a single model (Canvas/batch root),
-            // individual UI nodes are detected by the 2D check below
-            if (model.node.layer & Layers.Enum.UI_2D) continue;
-
-            // Check world bounds
-            const worldBounds = model.worldBounds;
-            if (!worldBounds) continue;
-
-            const dist = geometry.intersect.rayAABB(ray, worldBounds);
-            if (dist > 0) {
-                allResults.push({ node: model.node, distance: dist });
-            }
+    if (raycastUtil.raycastAll(scene, ray, mask, Infinity, false, undefined, new Vec2(x, y))) {
+        const allResults = raycastUtil.rayResultAll;
+        for (const result of allResults) {
+            const node = result.node;
+            if (isEditorNode(node)) continue;
+            if (node._objFlags & CCObject.Flags.LockedInEditor) continue;
+            if (node._objFlags & CCObject.Flags.HideInHierarchy) continue;
+            resultNodes.push(node);
         }
-    }
-
-    // 2D: UITransform-based hit detection (Sprite/Label 等通过 Batcher2D 渲染，不在 scene.models 中)
-    // Always run — editor combines 3D and 2D results via raycastAll
-    const sceneNode = director.getScene();
-    if (sceneNode) {
-        collect2DHits(sceneNode, ray, mask, allResults);
-    }
-
-    allResults.sort((a, b) => a.distance - b.distance);
-
-    for (const result of allResults) {
-        const node = result.node;
-        // Skip editor nodes
-        if (isEditorNode(node)) continue;
-        // Skip locked/hidden nodes
-        if (node._objFlags & CCObject.Flags.LockedInEditor) continue;
-        if (node._objFlags & CCObject.Flags.HideInHierarchy) continue;
-        resultNodes.push(node);
     }
 
     return resultNodes;
@@ -174,7 +109,10 @@ function collectNodesForRegion(shouldFilterForeground = true): RegionCollectMap 
         } else if (hasComponent(node, ['cc.MeshRenderer', 'cc.SkinnedMeshRenderer'])) {
             const com = (node.getComponent('cc.MeshRenderer') || node.getComponent('cc.SkinnedMeshRenderer')) as any;
             if (com?.model) {
-                collects.models.push(com.model);
+                const editorCam = getEditorCamera()?.camera;
+                if (!director.getScene()?.renderScene?.isCulledByLod?.(editorCam, com.model)) {
+                    collects.models.push(com.model);
+                }
             }
         }
     };

--- a/src/core/scene/scene-process/service/gizmo/utils/raycast.ts
+++ b/src/core/scene/scene-process/service/gizmo/utils/raycast.ts
@@ -1,7 +1,16 @@
 'use strict';
 
-import { geometry, gfx, Layers, Mat4, Node, renderer, Vec3 } from 'cc';
+import { geometry, gfx, Layers, Mat4, Node, renderer, Vec2, Vec3 } from 'cc';
 import intersect from './geom-utils/intersect';
+
+function getEditorCamera(): any {
+    try {
+        const { Service } = require('../../core/decorator');
+        return Service.Camera?.getCamera?.()?.camera;
+    } catch (e) {
+        return null;
+    }
+}
 
 type IBArray = Uint8Array | Uint16Array | Uint32Array;
 
@@ -85,6 +94,12 @@ const pool = new RecyclePool<IRaycastResult>(() => {
 }, 8);
 const resultModels: IRaycastResult[] = [];
 const resultSingleModel: IRaycastResult[] = [];
+const aabbUI = new geometry.AABB();
+const poolUI = new RecyclePool<IRaycastResult>(() => {
+    return { node: defaultNode, distance: Infinity, hitPoint: new Vec3() };
+}, 8);
+const resultCanvas: IRaycastResult[] = [];
+const resultAll: IRaycastResult[] = [];
 
 const narrowphase = (vb: Float32Array, ib: IBArray | undefined, pm: gfx.PrimitiveMode, sides: boolean, distance = Infinity, hitPos: Vec3) => {
     narrowDis = distance;
@@ -231,13 +246,21 @@ const narrowphaseForSnap = (vb: Float32Array, ib: IBArray | undefined, pm: gfx.P
     }
 };
 
-class Raycast {
+export class Raycast {
     get rayResultModels() {
         return resultModels;
     }
 
     get rayResultSingleModel() {
         return resultSingleModel;
+    }
+
+    get rayResultCanvas() {
+        return resultCanvas;
+    }
+
+    get rayResultAll() {
+        return resultAll;
     }
 
     private narrowPhaseStep(m: renderer.scene.Model, worldRay: ray, distance: number, d: number, forSnap = false): number {
@@ -295,8 +318,12 @@ class Raycast {
     public raycastAllModels(renderScene: renderer.RenderScene, worldRay: ray, mask = Layers.Enum.DEFAULT, distance = Infinity, forSnap: boolean, excludeMask?: number): boolean {
         pool.reset();
         const models: any[][] = [];
+        const editorCamera = getEditorCamera();
         for (const m of renderScene.models) {
             const transform = m.transform;
+            if (editorCamera && (renderScene as any).isCulledByLod?.(editorCamera, m)) {
+                continue;
+            }
             if (excludeMask && m.node.layer & excludeMask) {
                 continue;
             }
@@ -340,6 +367,85 @@ class Raycast {
 
         resultModels.length = pool.length;
         return resultModels.length > 0;
+    }
+
+    public raycastAll(
+        renderScene: renderer.RenderScene,
+        worldRay: ray,
+        mask = Layers.Enum.DEFAULT | Layers.Enum.UI_2D | Layers.Enum.IGNORE_RAYCAST,
+        distance = Infinity,
+        forSnap = false,
+        excludeMask?: number,
+        screenPos?: Vec2,
+    ): boolean {
+        const r_3d = this.raycastAllModels(renderScene, worldRay, mask, distance, forSnap, excludeMask);
+        const r_ui2d = this.raycastAllCanvas(worldRay, mask, distance, excludeMask, screenPos);
+        const isHit = r_3d || r_ui2d;
+        resultAll.length = 0;
+        if (isHit) {
+            Array.prototype.push.apply(resultAll, resultModels);
+            Array.prototype.push.apply(resultAll, resultCanvas);
+        }
+        return isHit;
+    }
+
+    public raycastAllCanvas(worldRay: ray, mask = Layers.Enum.UI_2D, distance = Infinity, excludeMask?: number, screenPos?: Vec2): boolean {
+        poolUI.reset();
+        const scene = (cc as any).director?.getScene?.();
+        const canvasComs = scene?.getComponentsInChildren?.((cc as any).Canvas);
+        if (canvasComs && canvasComs.length > 0) {
+            for (let i = canvasComs.length - 1; i >= 0; i--) {
+                const canvasNode = canvasComs[i].node;
+                if (canvasNode && canvasNode.active) {
+                    this._raycastUI2DNodeRecursiveChildren(worldRay, canvasNode, mask, distance, excludeMask, screenPos);
+                }
+            }
+        }
+        resultCanvas.length = poolUI.length;
+        return resultCanvas.length > 0;
+    }
+
+    private _raycastUI2DNode(worldRay: ray, ui2dNode: Node, mask: number, distance: number, excludeMask?: number, screenPos?: Vec2): IRaycastResult | null {
+        const uiTransform = (ui2dNode as any)._uiProps?.uiTransformComp;
+        if (!uiTransform || !(ui2dNode.layer & mask) || (excludeMask && ui2dNode.layer & excludeMask)) {
+            return null;
+        }
+
+        const uiSkewComp = (ui2dNode as any)._uiProps?._uiSkewComp;
+        if (uiSkewComp && screenPos && uiTransform.hitTest && !uiTransform.hitTest(screenPos)) {
+            return null;
+        }
+
+        if (!uiTransform.getComputeAABB) {
+            return null;
+        }
+        uiTransform.getComputeAABB(aabbUI);
+        const d = intersect.ray_aabb(worldRay, aabbUI);
+
+        if (d <= 0) {
+            return null;
+        } else if (d < distance) {
+            const r = poolUI.add();
+            r.node = ui2dNode;
+            r.distance = d;
+            return r;
+        }
+
+        return null;
+    }
+
+    private _raycastUI2DNodeRecursiveChildren(worldRay: ray, parent: Node, mask: number, distance: number, excludeMask?: number, screenPos?: Vec2) {
+        for (let i = parent.children.length - 1; i >= 0; i--) {
+            const node = parent.children[i];
+            if (node && node.active) {
+                this._raycastUI2DNodeRecursiveChildren(worldRay, node, mask, distance, excludeMask, screenPos);
+            }
+        }
+
+        const result = this._raycastUI2DNode(worldRay, parent, mask, distance, excludeMask, screenPos);
+        if (result) {
+            resultCanvas[poolUI.length - 1] = result;
+        }
     }
 }
 

--- a/src/core/scene/scene-process/service/gizmo/utils/selection-utils.ts
+++ b/src/core/scene/scene-process/service/gizmo/utils/selection-utils.ts
@@ -1,0 +1,77 @@
+'use strict';
+
+import { Node, js, director } from 'cc';
+
+const UI_GROUP_COMPONENTS = [
+    'cc.Button',
+    'cc.EditBox',
+    'cc.PageView',
+    'cc.ProgressBar',
+    'cc.RichText',
+    'cc.ScrollView',
+    'cc.Slider',
+    'cc.Toggle',
+    'cc.ToggleContainer',
+];
+
+function getUIRootNode(node: Node): Node | null {
+    let target = node.parent;
+    while (target) {
+        if (target === target.scene) {
+            return null;
+        }
+        for (const comp of UI_GROUP_COMPONENTS) {
+            if (target.getComponent(comp)) {
+                return target;
+            }
+        }
+        target = target.parent;
+    }
+    return null;
+}
+
+function getPrefabRootNode(node: Node): Node | null {
+    // @ts-ignore
+    return (node && node.prefab && node.prefab.root) || null;
+}
+
+function getEditingRootNode(): Node | null {
+    try {
+        const { Service } = require('../../core/decorator');
+        return Service?.Scene?.rootNode ?? director.getScene();
+    } catch (e) {
+        return director.getScene();
+    }
+}
+
+export function getSelectNode(rayResultNodes: Node[], selectionNodeUuid: string): Node {
+    const nodes: Node[] = rayResultNodes;
+    let rootNode: Node | null = null;
+    rootNode = getUIRootNode(rayResultNodes[0]);
+    if (!rootNode) {
+        rootNode = getPrefabRootNode(rayResultNodes[0]);
+        if (rootNode &&
+            (!selectionNodeUuid || selectionNodeUuid === rootNode.uuid) &&
+            getEditingRootNode() === rootNode) {
+            return rayResultNodes[0];
+        }
+    }
+    if (rootNode) {
+        const idx = rayResultNodes.indexOf(rootNode);
+        if (idx !== -1) {
+            nodes.splice(idx, 1);
+        }
+        nodes.unshift(rootNode);
+    }
+    let resultNode = nodes[0];
+    if (selectionNodeUuid) {
+        for (let i = 0; i < nodes.length; i++) {
+            if (nodes[i] && selectionNodeUuid === nodes[i].uuid) {
+                resultNode = nodes[i + 1];
+                resultNode = resultNode || nodes[0];
+                break;
+            }
+        }
+    }
+    return resultNode;
+}

--- a/src/core/scene/scene-process/service/operation/types.ts
+++ b/src/core/scene/scene-process/service/operation/types.ts
@@ -14,6 +14,8 @@ export interface ISceneMouseEvent {
     rightButton: boolean;
     button: number;
     buttons: number;
+    movementX: number;
+    movementY: number;
     ctrlKey: boolean;
     shiftKey: boolean;
     altKey: boolean;

--- a/src/core/scene/scene-process/service/service-manager.ts
+++ b/src/core/scene/scene-process/service/service-manager.ts
@@ -77,6 +77,7 @@ export class ServiceManager {
         '4736e978-c8fa-449f-9cf6-fe0158ded9d7', // internal/editor/grid-stroke
         '9d6c6bde-2fe2-44ee-883b-909608948b04', // internal/editor/gizmo
         'e4e4cb19-8dd2-450d-ad20-1a818263b8d3', // internal/editor/light
+        '084eba38-5336-4444-8c8c-aebb75d5c627', // internal/editor/box-height-light
     ];
 
     /**

--- a/static/web/gizmo-test.js
+++ b/static/web/gizmo-test.js
@@ -1,0 +1,336 @@
+/**
+ * Component Gizmo Test Module
+ * 扫描场景中的灯光/碰撞体组件，提供快速选中测试
+ */
+
+const GIZMO_COMPONENTS = {
+    Lights: [
+        'cc.SphereLight',
+        'cc.SpotLight',
+        'cc.DirectionalLight',
+    ],
+    '3D Colliders': [
+        'cc.BoxCollider',
+        'cc.SphereCollider',
+        'cc.CapsuleCollider',
+        'cc.ConeCollider',
+        'cc.CylinderCollider',
+        'cc.PlaneCollider',
+        'cc.SimplexCollider',
+        'cc.MeshCollider',
+    ],
+    '2D Colliders': [
+        'cc.BoxCollider2D',
+        'cc.CircleCollider2D',
+        'cc.PolygonCollider2D',
+    ],
+};
+
+// { componentType: [{uuid, name, path}] }
+let _scannedNodes = {};
+
+/**
+ * 递归遍历场景节点树，收集带目标组件的节点
+ */
+function collectComponentNodes(nodeInfo, parentPath, allTargetTypes) {
+    const results = [];
+    if (!nodeInfo) return results;
+
+    const path = parentPath ? parentPath + '/' + (nodeInfo.name || '?') : (nodeInfo.name || '?');
+
+    if (nodeInfo.components && nodeInfo.components.length > 0) {
+        for (const comp of nodeInfo.components) {
+            const typeName = comp.type || comp.cid || '';
+            if (allTargetTypes.has(typeName)) {
+                results.push({
+                    uuid: nodeInfo.uuid || nodeInfo.nodeId || '',
+                    name: nodeInfo.name || '?',
+                    path: path,
+                    componentType: typeName,
+                });
+            }
+        }
+    }
+
+    if (nodeInfo.children) {
+        for (const child of nodeInfo.children) {
+            results.push(...collectComponentNodes(child, path, allTargetTypes));
+        }
+    }
+
+    return results;
+}
+
+/**
+ * 扫描场景，查找所有灯光/碰撞体节点
+ */
+async function scanGizmoComponents() {
+    const statusEl = document.getElementById('gizmoScanStatus');
+    if (!window.cli || !window.cli.Scene || !window.cli.Scene.Node) {
+        if (statusEl) statusEl.textContent = 'Scene not loaded';
+        return;
+    }
+
+    if (statusEl) {
+        statusEl.textContent = 'Scanning...';
+        statusEl.className = 'info-text status-warn';
+    }
+
+    try {
+        const root = await window.cli.Scene.Node.queryNode({
+            path: '/',
+            queryChildren: true,
+            queryComponent: true,
+        });
+
+        const allTypes = new Set();
+        for (const group of Object.values(GIZMO_COMPONENTS)) {
+            for (const t of group) allTypes.add(t);
+        }
+
+        const foundNodes = collectComponentNodes(root, '', allTypes);
+        _scannedNodes = {};
+        for (const node of foundNodes) {
+            if (!_scannedNodes[node.componentType]) {
+                _scannedNodes[node.componentType] = [];
+            }
+            _scannedNodes[node.componentType].push(node);
+        }
+
+        renderGizmoTestList();
+
+        if (statusEl) {
+            statusEl.textContent = 'Found ' + foundNodes.length + ' component(s)';
+            statusEl.className = 'info-text status-ok';
+        }
+        if (typeof log === 'function') {
+            log('Gizmo scan: ' + foundNodes.length + ' components found', 'status-ok');
+        }
+    } catch (e) {
+        if (statusEl) {
+            statusEl.textContent = 'Scan failed';
+            statusEl.className = 'info-text status-err';
+        }
+        if (typeof log === 'function') {
+            log('Gizmo scan error: ' + e.message, 'status-err');
+        }
+    }
+}
+
+/**
+ * 渲染扫描结果到面板
+ */
+function renderGizmoTestList() {
+    const container = document.getElementById('gizmoTestList');
+    if (!container) return;
+    container.innerHTML = '';
+
+    for (const [groupName, types] of Object.entries(GIZMO_COMPONENTS)) {
+        const groupNodes = [];
+        for (const t of types) {
+            if (_scannedNodes[t]) {
+                groupNodes.push(..._scannedNodes[t].map(n => ({ ...n, shortType: t.replace('cc.', '') })));
+            }
+        }
+
+        const groupDiv = document.createElement('div');
+        groupDiv.style.marginBottom = '6px';
+
+        const groupLabel = document.createElement('div');
+        groupLabel.style.cssText = 'color:#aaa;font-size:11px;margin-bottom:2px;';
+        groupLabel.textContent = groupName + ' (' + groupNodes.length + ')';
+        groupDiv.appendChild(groupLabel);
+
+        if (groupNodes.length === 0) {
+            const emptyDiv = document.createElement('div');
+            emptyDiv.style.cssText = 'color:#666;font-size:10px;padding-left:8px;';
+            emptyDiv.textContent = 'No nodes in scene';
+            groupDiv.appendChild(emptyDiv);
+        } else {
+            for (const node of groupNodes) {
+                const row = document.createElement('div');
+                row.className = 'row';
+                row.style.marginLeft = '8px';
+
+                const btn = document.createElement('button');
+                btn.className = 'btn';
+                btn.textContent = node.name;
+                btn.title = node.path + ' [' + node.shortType + ']';
+                btn.onclick = () => selectGizmoNode(node.uuid, node.name, node.shortType);
+
+                const tag = document.createElement('span');
+                tag.style.cssText = 'color:#8cf;font-size:10px;';
+                tag.textContent = node.shortType;
+
+                row.appendChild(btn);
+                row.appendChild(tag);
+                groupDiv.appendChild(row);
+            }
+        }
+
+        container.appendChild(groupDiv);
+    }
+
+    // 显示 Gizmo 注册状态
+    renderGizmoRegistryStatus();
+}
+
+/**
+ * 选中节点以触发 Gizmo 显示
+ */
+function selectGizmoNode(uuid, name, type) {
+    if (!window.cli || !window.cli.Scene) return;
+
+    try {
+        // 先清除选中
+        window.cli.Scene.Selection.clear();
+        // 选中目标节点
+        window.cli.Scene.Selection.select(uuid);
+        // 聚焦
+        try {
+            window.cli.Scene.Camera.focus([uuid]);
+        } catch (_) {}
+
+        try { window.cli.Scene.Engine.repaintInEditMode(); } catch (_) {}
+
+        const selInfo = document.getElementById('gizmoSelInfo');
+        if (selInfo) {
+            selInfo.textContent = name + ' [' + type + ']';
+            selInfo.className = 'info-text status-ok';
+        }
+        if (typeof log === 'function') {
+            log('Selected: ' + name + ' (' + type + ')', 'status-ok');
+        }
+        if (typeof refreshState === 'function') {
+            setTimeout(refreshState, 100);
+        }
+    } catch (e) {
+        if (typeof log === 'function') {
+            log('Select error: ' + e.message, 'status-err');
+        }
+    }
+}
+
+/**
+ * 显示哪些 Gizmo 已注册
+ */
+function renderGizmoRegistryStatus() {
+    const container = document.getElementById('gizmoRegistryInfo');
+    if (!container) return;
+    container.innerHTML = '';
+
+    let registeredGizmos = null;
+    try {
+        // GizmoDefines.components 是 Map<string, GizmoClass>
+        const gizmoModule = window.cli?.Scene?.Gizmo;
+        if (gizmoModule && gizmoModule._gizmoDefines) {
+            registeredGizmos = gizmoModule._gizmoDefines;
+        }
+    } catch (_) {}
+
+    // 从 cc 引擎获取 className 来检查注册情况
+    const allTypes = [];
+    for (const group of Object.values(GIZMO_COMPONENTS)) {
+        for (const t of group) allTypes.push(t);
+    }
+
+    const checkDiv = document.createElement('div');
+    checkDiv.style.cssText = 'font-size:10px;line-height:1.6;';
+
+    for (const t of allTypes) {
+        const shortName = t.replace('cc.', '');
+        const found = _scannedNodes[t] && _scannedNodes[t].length > 0;
+        const line = document.createElement('div');
+
+        // 简单标记：场景中有此组件的节点
+        const icon = found ? '●' : '○';
+        const color = found ? '#6c6' : '#666';
+        line.innerHTML = '<span style="color:' + color + '">' + icon + '</span> ' + shortName;
+        checkDiv.appendChild(line);
+    }
+
+    container.appendChild(checkDiv);
+}
+
+/**
+ * 调试：列出 renderScene 中所有 model，帮助排查射线检测问题
+ */
+function debugSceneModels() {
+    const container = document.getElementById('gizmoTestList');
+    if (!container) return;
+
+    const cc = window.cc;
+    if (!cc || !cc.director) {
+        if (typeof log === 'function') log('cc.director not available', 'status-err');
+        return;
+    }
+
+    const scene = cc.director.getScene();
+    if (!scene) {
+        if (typeof log === 'function') log('No scene loaded', 'status-err');
+        return;
+    }
+
+    const renderScene = scene.renderScene || scene._renderScene;
+    if (!renderScene) {
+        if (typeof log === 'function') log('No renderScene', 'status-err');
+        return;
+    }
+
+    const models = renderScene.models;
+    const div = document.createElement('div');
+    div.style.cssText = 'margin-top:8px;font-size:10px;line-height:1.8;';
+
+    const title = document.createElement('div');
+    title.style.cssText = 'color:#ff0;font-size:11px;margin-bottom:4px;';
+    title.textContent = 'RenderScene Models (' + models.length + ')';
+    div.appendChild(title);
+
+    const editorMask = (cc.Layers.Enum.GIZMOS | cc.Layers.Enum.SCENE_GIZMO | cc.Layers.Enum.EDITOR);
+
+    for (let i = 0; i < models.length; i++) {
+        const m = models[i];
+        if (!m || !m.node) continue;
+        // 跳过编辑器自身的 model
+        if (m.node.layer & editorMask) continue;
+
+        const wb = m.worldBounds;
+        const line = document.createElement('div');
+        const layerHex = '0x' + m.node.layer.toString(16);
+        let info = (m.enabled ? '●' : '○') + ' ' + m.node.name
+            + ' | layer=' + layerHex
+            + ' | enabled=' + m.enabled;
+        if (wb) {
+            const c = wb.center;
+            const h = wb.halfExtents;
+            info += ' | bounds=(' + c.x.toFixed(1) + ',' + c.y.toFixed(1) + ',' + c.z.toFixed(1)
+                + ') half=(' + h.x.toFixed(1) + ',' + h.y.toFixed(1) + ',' + h.z.toFixed(1) + ')';
+        } else {
+            info += ' | NO worldBounds';
+        }
+
+        const comps = m.node.components || m.node._components || [];
+        const compNames = [];
+        for (const c of comps) {
+            const cn = c.constructor?.name || c.__classname__ || '?';
+            compNames.push(cn);
+        }
+        if (compNames.length > 0) {
+            info += ' | comps=[' + compNames.join(',') + ']';
+        }
+
+        line.textContent = info;
+        line.style.color = wb ? '#afa' : '#f88';
+        div.appendChild(line);
+    }
+
+    container.appendChild(div);
+    if (typeof log === 'function') {
+        log('Listed ' + models.length + ' models in renderScene', 'status-ok');
+    }
+}
+
+// 全局暴露
+window.scanGizmoComponents = scanGizmoComponents;
+window.selectGizmoNode = selectGizmoNode;
+window.debugSceneModels = debugSceneModels;

--- a/static/web/index.ejs
+++ b/static/web/index.ejs
@@ -329,6 +329,44 @@
                 <div class="row">
                     <label>Bounds</label>
                     <span id="rectBoundsInfo" class="info-text">-</span>
+        <!-- Component Gizmos -->
+        <div class="panel-section" id="sec-compgizmo">
+            <h3 onclick="toggleSection('sec-compgizmo')">Component Gizmos</h3>
+            <div class="section-body">
+                <div class="row">
+                    <button class="btn btn-primary" onclick="scanGizmoComponents()">Scan Components</button>
+                    <button class="btn" onclick="debugSceneModels()">Debug Models</button>
+                    <span id="gizmoScanStatus" class="info-text">Not scanned</span>
+                </div>
+                <div class="row">
+                    <label>Selected</label>
+                    <span id="gizmoSelInfo" class="info-text">none</span>
+                </div>
+                <div id="gizmoTestList"></div>
+                <div style="margin-top:6px;border-top:1px solid #444;padding-top:4px;">
+                    <div style="color:#aaa;font-size:11px;margin-bottom:2px;">Registry</div>
+                    <div id="gizmoRegistryInfo"></div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Component Gizmos -->
+        <div class="panel-section" id="sec-compgizmo">
+            <h3 onclick="toggleSection('sec-compgizmo')">Component Gizmos</h3>
+            <div class="section-body">
+                <div class="row">
+                    <button class="btn btn-primary" onclick="scanGizmoComponents()">Scan Components</button>
+                    <button class="btn" onclick="debugSceneModels()">Debug Models</button>
+                    <span id="gizmoScanStatus" class="info-text">Not scanned</span>
+                </div>
+                <div class="row">
+                    <label>Selected</label>
+                    <span id="gizmoSelInfo" class="info-text">none</span>
+                </div>
+                <div id="gizmoTestList"></div>
+                <div style="margin-top:6px;border-top:1px solid #444;padding-top:4px;">
+                    <div style="color:#aaa;font-size:11px;margin-bottom:2px;">Registry</div>
+                    <div id="gizmoRegistryInfo"></div>
                 </div>
             </div>
         </div>
@@ -686,6 +724,10 @@
             refreshState();
             refreshRectInfo();
             await refreshNodeList();
+            // Auto-scan component gizmos
+            if (typeof scanGizmoComponents === 'function') {
+                setTimeout(scanGizmoComponents, 300);
+            }
             // Auto-refresh every 2s
             setInterval(refreshState, 2000);
             setInterval(refreshRectInfo, 2000);

--- a/static/web/input-bridge.js
+++ b/static/web/input-bridge.js
@@ -27,6 +27,7 @@ function setupInputBridge(options) {
             deltaX: 0, deltaY: 0,
             wheelDeltaX: 0, wheelDeltaY: 0,
             moveDeltaX: dx, moveDeltaY: dy,
+            movementX: e.movementX || 0, movementY: e.movementY || 0,
             leftButton: (e.buttons & 1) !== 0,
             middleButton: (e.buttons & 4) !== 0,
             rightButton: (e.buttons & 2) !== 0,
@@ -52,7 +53,7 @@ function setupInputBridge(options) {
 
     function dispatchMouse(type, evt) {
         try {
-            var dpr = window.devicePixelRatio || 1;
+            var dpr = (typeof cc !== 'undefined' && cc.screen) ? cc.screen.devicePixelRatio : (window.devicePixelRatio || 1);
             operation.emitMouseEvent(type, evt, dpr);
             if (engine && engine.repaintInEditMode) engine.repaintInEditMode();
         } catch (ex) { /* ignore */ }
@@ -117,6 +118,18 @@ function setupInputBridge(options) {
     function onKeyUp(e) {
         if (isInputElement(e.target)) return;
         dispatchKey('keyup', toKeyEvent(e));
+    }
+
+    // DPR change monitoring — matches editor's bindEvent behavior
+    if (typeof window.matchMedia === 'function') {
+        var updateDPRChangeListener = function () {
+            var dpr = window.devicePixelRatio;
+            window.matchMedia('(resolution: ' + dpr + 'dppx)').addEventListener('change', function () {
+                window.dispatchEvent(new Event('resize'));
+                updateDPRChangeListener();
+            }, { once: true });
+        };
+        updateDPRChangeListener();
     }
 
     canvas.addEventListener('mousedown', onMouseDown);


### PR DESCRIPTION
  ## Summary
  - Ported 14 component gizmos (lights, 3D/2D colliders, renderers) and 7 shared controllers from cocos-editor
  - Aligned gizmo interaction logic with cocos-editor to fix node selection, hover, and region-select behavior

  ## Key Changes

  ### New gizmos
  - Lights: sphere-light, spot-light
  - 3D colliders: sphere, capsule, cone, cylinder, plane, simplex, mesh
  - 2D colliders: box, circle, polygon
  - Renderers: mesh-renderer, skinned-mesh-renderer
  - Controllers: capsule, cone, disc, line, point, triangle, tetrahedron

  ### Interaction fixes (aligned with cocos-editor)
  - Fix DPR handling: use `cc.screen.devicePixelRatio` instead of `window.devicePixelRatio`
  - GizmoMouseEvent extends CCEvent with full field parity
  - RaycastResults carries originating ray for correct hitPoint calculation
  - Combined 3D model + 2D Canvas raycast via `raycastAll`
  - LOD culling in raycast and region selection
  - SceneGizmo camera priority raycast
  - VertexSnap check in hover processing
  - 2D skew UI hitTest via screenPos parameter
  - DPR change triggers resize event
  - Prefab root check uses editing root node