### PR TITLE
Fix: Enable particle system preview when selected, and add Gizmo placeholder display for WebView/VideoPlayer components, matching the behavior of Cocos Editor.

### DIFF
--- a/src/core/scene/scene-process/service/engine.ts
+++ b/src/core/scene/scene-process/service/engine.ts
@@ -1,14 +1,26 @@
 'use strict';
 
 import Time from './engine/time';
-import { director, GeometryRenderer as CCGeometryRenderer } from 'cc';
+import { Component, director, GeometryRenderer as CCGeometryRenderer, Node } from 'cc';
 import { GeometryRenderer, methods as GeometryMethods } from './engine/geometry_renderer';
 import { BaseService, register } from './core';
 import { Service } from './core/decorator';
 import { IEngineEvents, IEngineService } from '../../common';
+import { NodeEventType } from '../../common';
 import { Rpc } from '../rpc';
 
 const tickTime = 1000 / 60;
+
+// 与 cocos-editor 一致：控制连续 tick 的状态枚举
+enum NeedAnimState {
+    CAMERA_ORBIT,
+    CAMERA_PAN,
+    CAMERA_WANDER,
+    ANIMATION_MODE,
+    PARTICLE_SYSTEM_MODE,
+    TERRAIN_SYSTEM_MODE,
+    GAME_VIEW_MODE,
+}
 
 /**
  * 引擎管理器，用于引擎相关操作
@@ -28,6 +40,10 @@ export class EngineService extends BaseService<IEngineEvents> implements IEngine
     private _bindTick = this._tick.bind(this);
     private geometryRenderer!: GeometryRenderer & Pick<CCGeometryRenderer, typeof GeometryMethods[number]>;
     private _sceneTick = false;// tick 是否暂停
+
+    // 与 cocos-editor ParticleManager 一致：跟踪选中的粒子和手动停止状态
+    private _particleSelectedUUIDs: string[] = [];
+    private _stoppedParticleSet = new WeakSet<Component>();
     public async init() {
         cc.game.pause(); // 暂停引擎的 mainLoop
         this.geometryRenderer = new GeometryRenderer() as GeometryRenderer & Pick<CCGeometryRenderer, typeof GeometryMethods[number]>;
@@ -91,6 +107,16 @@ export class EngineService extends BaseService<IEngineEvents> implements IEngine
         return this.geometryRenderer;
     }
 
+    public enterState(state: NeedAnimState) {
+        this._stateRecord |= 1 << state;
+        this._updateTickState();
+    }
+
+    public exitState(state: NeedAnimState) {
+        this._stateRecord &= ~(1 << state);
+        this._updateTickState();
+    }
+
     public resume() {
         this._paused = false;
         this.startTick();
@@ -99,6 +125,36 @@ export class EngineService extends BaseService<IEngineEvents> implements IEngine
     public pause() {
         this.stopTick();
         this._paused = true;
+    }
+
+    // 与 cocos-editor 一致：检查节点是否含有粒子/地形组件，控制连续 tick
+    public checkToSetAnimState(nodes: Node[]) {
+        let hasParticleComp = false;
+        let hasTerrain = false;
+        nodes.forEach((node: Node) => {
+            if (node && node.components) {
+                node.components.forEach((component: Component) => {
+                    const className = cc.js.getClassName(component);
+                    if (className === 'cc.ParticleSystem' || className === 'cc.ParticleSystem2D') {
+                        hasParticleComp = true;
+                    } else if (className === 'cc.Terrain') {
+                        hasTerrain = true;
+                    }
+                });
+            }
+        });
+
+        if (hasParticleComp) {
+            this.enterState(NeedAnimState.PARTICLE_SYSTEM_MODE);
+        } else {
+            this.exitState(NeedAnimState.PARTICLE_SYSTEM_MODE);
+        }
+
+        if (hasTerrain) {
+            this.enterState(NeedAnimState.TERRAIN_SYSTEM_MODE);
+        } else {
+            this.exitState(NeedAnimState.TERRAIN_SYSTEM_MODE);
+        }
     }
 
     private _tick() {
@@ -123,6 +179,10 @@ export class EngineService extends BaseService<IEngineEvents> implements IEngine
         }
     }
 
+    private _updateTickState() {
+        this._tickInEM = this._stateRecord > 0;
+    }
+
     private _isTickAllowed() {
         return this._sceneTick || this._shouldRepaintInEM || this._tickInEM;
     }
@@ -132,6 +192,11 @@ export class EngineService extends BaseService<IEngineEvents> implements IEngine
     }
     public set capture(b: boolean) {
         this._capture = b;
+    }
+
+    private _getNodeByUuid(uuid: string): Node | null {
+        const EditorExtends = (cc as any).EditorExtends || (globalThis as any).EditorExtends;
+        return EditorExtends?.Node?.getNode?.(uuid) ?? null;
     }
 
     //
@@ -148,15 +213,38 @@ export class EngineService extends BaseService<IEngineEvents> implements IEngine
         void this.repaintInEditMode();
     }
 
-    onNodeChanged() {
+    onNodeChanged(node: Node, opts?: any) {
+        const type = opts?.type;
+        if (type === NodeEventType.TRANSFORM_CHANGED ||
+            type === NodeEventType.SIZE_CHANGED ||
+            type === NodeEventType.ANCHOR_CHANGED ||
+            type === NodeEventType.COMPONENT_CHANGED ||
+            type === NodeEventType.PARENT_CHANGED ||
+            type === NodeEventType.CHILD_CHANGED) {
+            // 与 cocos-editor 一致：这些类型不需要重新检查状态
+        } else {
+            this.checkToSetAnimState([node]);
+        }
         void this.repaintInEditMode();
     }
 
-    onComponentAdded() {
+    onComponentAdded(comp: Component) {
+        const nodeUuids = Service.Selection?.query?.() ?? [];
+        if (comp.node && nodeUuids.includes(comp.node.uuid)) {
+            this.checkToSetAnimState([comp.node]);
+            // 与 cocos-editor ParticleManager 一致：新增的粒子组件自动播放
+            if (this._isParticleSystem3D(comp) && !(comp as any).isPlaying) {
+                (comp as any).play();
+            }
+        }
         void this.repaintInEditMode();
     }
 
-    onComponentRemoved() {
+    onComponentRemoved(comp: Component) {
+        const nodeUuids = Service.Selection?.query?.() ?? [];
+        if (comp.node && nodeUuids.includes(comp.node.uuid)) {
+            this.checkToSetAnimState([comp.node]);
+        }
         void this.repaintInEditMode();
     }
 
@@ -164,4 +252,130 @@ export class EngineService extends BaseService<IEngineEvents> implements IEngine
         void this.repaintInEditMode();
     }
 
+    // 与 cocos-editor SceneSelection 一致：选中/反选时检查粒子/地形组件
+    onSelectionSelect(uuid: string, uuids: string[]) {
+        const selectedUuids = uuids?.length ? uuids : (Service.Selection?.query?.() ?? []);
+        const nodes: Node[] = [];
+        for (const uid of selectedUuids) {
+            const node = this._getNodeByUuid(uid);
+            if (node) nodes.push(node);
+        }
+        this.checkToSetAnimState(nodes);
+        this._playParticlesOnSelect(selectedUuids);
+        void this.repaintInEditMode();
+    }
+
+    onSelectionUnselect(uuid: string, uuids: string[]) {
+        const selectedUuids = uuids?.length ? uuids : (Service.Selection?.query?.() ?? []);
+        const remaining = selectedUuids.filter((uid: string) => uid !== uuid);
+        const nodes: Node[] = [];
+        for (const uid of remaining) {
+            const node = this._getNodeByUuid(uid);
+            if (node) nodes.push(node);
+        }
+        this.checkToSetAnimState(nodes);
+        this._pauseParticlesOnUnselect(selectedUuids);
+        void this.repaintInEditMode();
+    }
+
+    onSelectionClear() {
+        this.checkToSetAnimState([]);
+        this._stopAllParticles();
+        void this.repaintInEditMode();
+    }
+
+    // 与 cocos-editor ParticleManager 一致：选中时播放粒子系统
+    private _playParticlesOnSelect(uuids: string[]) {
+        this._particleSelectedUUIDs = uuids.slice();
+        const components = this._getSelectedParticleSystems();
+        const willPlay = components.some(item => !this._stoppedParticleSet.has(item));
+        if (willPlay) {
+            components.forEach(item => this._stoppedParticleSet.delete(item));
+        }
+        components.forEach((ps: any) => {
+            if (!ps.isPlaying && !this._stoppedParticleSet.has(ps)) {
+                ps.play();
+            }
+        });
+    }
+
+    // 与 cocos-editor ParticleManager 一致：取消选中时暂停粒子系统
+    private _pauseParticlesOnUnselect(uuids: string[]) {
+        this._getSelectedParticleSystems().forEach((ps: any) => {
+            if (!uuids.includes(ps.node.uuid) && ps.isPlaying) {
+                ps.pause();
+            }
+        });
+        this._particleSelectedUUIDs = uuids.slice();
+    }
+
+    private _stopAllParticles() {
+        this._getSelectedParticleSystems().forEach((ps: any) => {
+            if (ps.isPlaying) {
+                ps.stop();
+            }
+        });
+        this._particleSelectedUUIDs = [];
+    }
+
+    // 与 cocos-editor ParticleManager.getSelectedParticleSystemComponents 一致
+    private _getSelectedParticleSystems(): Component[] {
+        const result: Component[] = [];
+        const self = this;
+
+        function addUnique(comps: Component[]) {
+            for (const comp of comps) {
+                if (!result.includes(comp)) {
+                    result.push(comp);
+                }
+            }
+        }
+
+        function collectInChildren(node: Node): Component[] {
+            const found: Component[] = [];
+            if (node.components) {
+                for (const comp of node.components) {
+                    if (self._isParticleSystem3D(comp)) {
+                        found.push(comp);
+                    }
+                }
+            }
+            if (node.children) {
+                for (const child of node.children) {
+                    found.push(...collectInChildren(child));
+                }
+            }
+            return found;
+        }
+
+        function recursivelyAdd(node: Node) {
+            const hasParticle = node.components?.some((c: Component) => self._isParticleSystem3D(c));
+            if (hasParticle) {
+                const parent = node.parent;
+                if (parent && parent.components?.some((c: Component) => self._isParticleSystem3D(c))) {
+                    recursivelyAdd(parent);
+                } else {
+                    addUnique(collectInChildren(node));
+                }
+            }
+        }
+
+        for (const uuid of this._particleSelectedUUIDs) {
+            const node = this._getNodeByUuid(uuid);
+            if (node) {
+                recursivelyAdd(node);
+            }
+        }
+
+        return result.filter((comp: any) => comp.enabled);
+    }
+
+    // 与 cocos-editor ParticleManager 一致：只处理 3D ParticleSystem
+    // ParticleSystem2D 通过 onFocusInEditor → _startPreview 自行处理
+    private _isParticleSystem3D(comp: Component): boolean {
+        return cc.js.getClassName(comp) === 'cc.ParticleSystem';
+    }
+
 }
+
+export { NeedAnimState };

--- a/src/core/scene/scene-process/service/gizmo.ts
+++ b/src/core/scene/scene-process/service/gizmo.ts
@@ -32,6 +32,8 @@ import './gizmo/components/circle-collider-2d';
 import './gizmo/components/polygon-collider-2d';
 import './gizmo/components/mesh-renderer';
 import './gizmo/components/skinned-mesh-renderer';
+import './gizmo/components/video-player';
+import './gizmo/components/web-view';
 
 type TGizmoType = 'icon' | 'persistent' | 'component';
 

--- a/src/core/scene/scene-process/service/gizmo/components/video-player/index.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/video-player/index.ts
@@ -1,0 +1,64 @@
+'use strict';
+
+import { Quat, UITransform, Vec3, Vec2, js, VideoPlayer } from 'cc';
+import GizmoBase from '../../base/gizmo-base';
+import ImageController from '../../controller/image';
+import { registerGizmo } from '../../gizmo-defines';
+
+const tempQuat = new Quat();
+
+class VideoPlayerPersistentGizmo extends GizmoBase {
+    protected _controller!: ImageController;
+
+    init() {
+        const gizmoRoot = this.getGizmoRoot();
+        this._controller = new ImageController(gizmoRoot, { texture: true });
+    }
+
+    onShow() {
+        this._controller.show();
+        this.updateController();
+    }
+
+    onHide() {
+        this._controller.hide();
+    }
+
+    updateControllerData() {
+        if (!this._isInitialized || !this.target) return;
+        const uiTransComp = this.target.node.getComponent(UITransform);
+        if (!uiTransComp) return;
+        const contentSize = uiTransComp.contentSize;
+        this._controller.updateSize(new Vec3(), new Vec2(contentSize.width, -contentSize.height));
+        this._controller.show();
+    }
+
+    updateControllerTransform() {
+        if (!this._isInitialized || !this.target) return;
+        const node = this.target.node;
+        const worldPos = node.getWorldPosition();
+        node.getWorldRotation(tempQuat);
+        this._controller.setPosition(worldPos);
+        this._controller.setRotation(tempQuat);
+    }
+
+    updateController() {
+        this.updateControllerData();
+        this.updateControllerTransform();
+    }
+
+    onTargetUpdate() {
+        this.updateController();
+    }
+
+    onNodeChanged() {
+        this.updateController();
+    }
+}
+
+export const name = js.getClassName(VideoPlayer);
+export const SelectGizmo = null;
+export const IconGizmo = null;
+export const PersistentGizmo = VideoPlayerPersistentGizmo;
+
+registerGizmo(name, { PersistentGizmo });

--- a/src/core/scene/scene-process/service/gizmo/components/web-view/index.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/web-view/index.ts
@@ -1,0 +1,78 @@
+'use strict';
+
+import { Quat, size, UITransform, Vec3, Vec2, js, WebView } from 'cc';
+import GizmoBase from '../../base/gizmo-base';
+import ImageController from '../../controller/image';
+import { registerGizmo } from '../../gizmo-defines';
+
+const tempQuat = new Quat();
+const imageSize = size(200, 150);
+
+class WebViewPersistentGizmo extends GizmoBase {
+    protected _controller!: ImageController;
+
+    init() {
+        const gizmoRoot = this.getGizmoRoot();
+        this._controller = new ImageController(gizmoRoot, { texture: true });
+    }
+
+    onShow() {
+        this._controller.show();
+        this.updateController();
+    }
+
+    onHide() {
+        this._controller.hide();
+    }
+
+    syncImageControllerData() {
+        if (!this._isInitialized || !this.target) return;
+        const uiTransComp = this.target.node.getComponent(UITransform);
+        if (!uiTransComp) return;
+        const contentSize = uiTransComp.contentSize;
+        this._controller.setTextureByUUID('b9f47df4-b2f0-4270-bd8a-07bb344a8253@6c48a');
+        this._controller.show();
+
+        let scaleX = 1, scaleY = 1;
+        if (imageSize.width > contentSize.width) {
+            scaleX = contentSize.width / imageSize.width;
+        }
+        if (imageSize.height > contentSize.height) {
+            scaleY = contentSize.height / imageSize.height;
+        }
+        const scale = scaleX < scaleY ? scaleX : scaleY;
+        this._controller.updateSize(new Vec3(), new Vec2(imageSize.width * scale, -imageSize.height * scale));
+    }
+
+    updateControllerTransform() {
+        if (!this._isInitialized || !this.target) return;
+        const node = this.target.node;
+        const worldPos = node.getWorldPosition();
+        node.getWorldRotation(tempQuat);
+        this._controller.setPosition(worldPos);
+        this._controller.setRotation(tempQuat);
+
+        const worldScale = node.getWorldScale();
+        this._controller.setScale(worldScale);
+    }
+
+    updateController() {
+        this.syncImageControllerData();
+        this.updateControllerTransform();
+    }
+
+    onTargetUpdate() {
+        this.updateController();
+    }
+
+    onNodeChanged() {
+        this.updateController();
+    }
+}
+
+export const name = js.getClassName(WebView);
+export const SelectGizmo = null;
+export const IconGizmo = null;
+export const PersistentGizmo = WebViewPersistentGizmo;
+
+registerGizmo(name, { PersistentGizmo });

--- a/src/core/scene/scene-process/service/gizmo/controller/image.ts
+++ b/src/core/scene/scene-process/service/gizmo/controller/image.ts
@@ -1,0 +1,85 @@
+import { assetManager, Color, Node, Vec2, Vec3 } from 'cc';
+
+import ControllerBase from './base';
+import ControllerUtils from '../utils/controller-utils';
+import ControllerShape from '../utils/controller-shape';
+import type { GizmoMouseEvent } from '../utils/defines';
+import { setMaterialProperty, updatePositions, getModel } from '../utils/engine-utils';
+
+function repaintEngine(): void {
+    try {
+        const { Service } = require('../../core/decorator');
+        Service.Engine?.repaintInEditMode?.();
+    } catch (e) {
+        // not ready
+    }
+}
+
+class ImageController extends ControllerBase {
+    private _center: Vec3 = new Vec3();
+    private _size: Vec2 = new Vec2(100, 100);
+    private _imageNode: Node | null = null;
+
+    constructor(rootNode: Node, opts?: any) {
+        super(rootNode);
+        this.initShape(opts);
+    }
+
+    initShape(opts?: any) {
+        this.createShapeNode('ImageController');
+        this._imageNode = ControllerUtils.quad(this._center, this._size.x, this._size.y, Vec3.UNIT_Z, Color.WHITE, opts);
+        this._imageNode!.parent = this.shape;
+        this._imageNode!.position = new Vec3(0, 0, -0.01);
+        this.registerMouseEvents(this._imageNode!, 'image');
+    }
+
+    setTexture(texture: any) {
+        setMaterialProperty(this._imageNode!, 'mainTexture', texture);
+    }
+
+    setTextureByUUID(uuid: string) {
+        assetManager.loadAny(uuid, (err: any, img: any) => {
+            if (img) {
+                this.setTexture(img);
+                repaintEngine();
+            }
+        });
+    }
+
+    updateSize(center: Vec3, size: Vec2) {
+        this._center = center;
+        this._size = size;
+
+        const quadData = ControllerShape.calcQuadData(this._center, this._size.x, this._size.y, Vec3.UNIT_Z);
+        if (!this._imageNode) return;
+        const mr = getModel(this._imageNode);
+        if (mr && mr.model) {
+            mr.model.createBoundingShape(quadData.minPos, quadData.maxPos);
+            mr.model.updateWorldBound();
+            updatePositions(mr, quadData.positions);
+        }
+    }
+
+    protected onMouseDown(event: GizmoMouseEvent) {
+        event.propagationStopped = true;
+        if (this.onControllerMouseDown) {
+            this.onControllerMouseDown(event);
+        }
+    }
+
+    protected onMouseMove(event: GizmoMouseEvent) {
+        event.propagationStopped = true;
+        if (this.onControllerMouseMove) {
+            this.onControllerMouseMove(event);
+        }
+    }
+
+    protected onMouseUp(event: GizmoMouseEvent) {
+        event.propagationStopped = true;
+        if (this.onControllerMouseUp) {
+            this.onControllerMouseUp(event);
+        }
+    }
+}
+
+export default ImageController;

--- a/src/core/scene/scene-process/service/index.ts
+++ b/src/core/scene/scene-process/service/index.ts
@@ -12,4 +12,5 @@ export * from './undo';
 export * from './camera';
 export * from './gizmo';
 export * from './scene-view';
+export * from './particle';
 export * from './core/global-events';

--- a/src/core/scene/scene-process/service/particle.ts
+++ b/src/core/scene/scene-process/service/particle.ts
@@ -1,0 +1,119 @@
+'use strict';
+
+import { Component, Node } from 'cc';
+import { BaseService, register } from './core';
+
+function getNodeByUuid(uuid: string): Node | null {
+    const EditorExtends = (cc as any).EditorExtends || (globalThis as any).EditorExtends;
+    return EditorExtends?.Node?.getNode?.(uuid) ?? null;
+}
+
+// 与 cocos-editor ParticleManager 一致：只处理 3D ParticleSystem
+function isParticleSystem(comp: Component): boolean {
+    return cc.js.getClassName(comp) === 'cc.ParticleSystem';
+}
+
+function getParticleSystemsInChildren(node: Node): Component[] {
+    const result: Component[] = [];
+    const components = node.components;
+    if (components) {
+        for (const comp of components) {
+            if (isParticleSystem(comp)) {
+                result.push(comp);
+            }
+        }
+    }
+    const children = node.children;
+    if (children) {
+        for (const child of children) {
+            result.push(...getParticleSystemsInChildren(child));
+        }
+    }
+    return result;
+}
+
+// 与 cocos-editor ParticleManager 一致：管理粒子系统在编辑模式下的播放
+@register('Particle')
+export class ParticleService extends BaseService<Record<string, never>> {
+    private _selectedUUIDs: string[] = [];
+    private _stoppedSet = new WeakSet<Component>();
+
+    // 与 cocos-editor ParticleManager.getSelectedParticleSystemComponents 一致：
+    // 递归查找父节点直到找到非粒子组件的节点，然后收集所有子粒子组件
+    private _getSelectedParticleSystemComponents(): Component[] {
+        const result: Component[] = [];
+
+        function addUnique(comps: Component[]) {
+            for (const comp of comps) {
+                if (!result.includes(comp)) {
+                    result.push(comp);
+                }
+            }
+        }
+
+        function recursivelyAdd(node: Node) {
+            const hasParticle = node.components?.some((c: Component) => isParticleSystem(c));
+            if (hasParticle) {
+                const parent = node.parent;
+                if (parent && parent.components?.some((c: Component) => isParticleSystem(c))) {
+                    recursivelyAdd(parent);
+                } else {
+                    addUnique(getParticleSystemsInChildren(node));
+                }
+            }
+        }
+
+        for (const uuid of this._selectedUUIDs) {
+            const node = getNodeByUuid(uuid);
+            if (node) {
+                recursivelyAdd(node);
+            }
+        }
+
+        return result.filter((comp: any) => comp.enabled);
+    }
+
+    onSelectionSelect(uuid: string, uuids: string[]) {
+        this._selectedUUIDs = uuids.slice();
+        const components = this._getSelectedParticleSystemComponents();
+        const willPlay = components.some(item => !this._stoppedSet.has(item));
+        if (willPlay) {
+            components.forEach(item => this._stoppedSet.delete(item));
+        }
+        components.forEach((ps: any) => {
+            if (!ps.isPlaying && !this._stoppedSet.has(ps)) {
+                ps.play();
+            }
+        });
+    }
+
+    onSelectionUnselect(uuid: string, uuids: string[]) {
+        this._getSelectedParticleSystemComponents().forEach((ps: any) => {
+            if (!uuids.includes(ps.node.uuid) && ps.isPlaying) {
+                ps.pause();
+            }
+        });
+        this._selectedUUIDs = uuids.slice();
+    }
+
+    onSelectionClear() {
+        this._getSelectedParticleSystemComponents().forEach((ps: any) => {
+            if (ps.isPlaying) {
+                ps.stop();
+            }
+        });
+        this._selectedUUIDs = [];
+    }
+
+    onComponentAdded(comp: Component) {
+        if (isParticleSystem(comp) && this._getSelectedParticleSystemComponents().includes(comp)) {
+            if (!(comp as any).isPlaying) {
+                (comp as any).play();
+            }
+        }
+    }
+
+    onSceneClosed() {
+        this._selectedUUIDs = [];
+    }
+}

--- a/src/core/scene/scene-process/service/selection.ts
+++ b/src/core/scene/scene-process/service/selection.ts
@@ -47,7 +47,7 @@ export class SelectionService extends BaseService<ISelectionEvents> implements I
 
     private _callFocusInEditor(uuid: string): void {
         try {
-            const EditorExtends = (cc as any).EditorExtends;
+            const EditorExtends = (cc as any).EditorExtends || (globalThis as any).EditorExtends;
             if (!EditorExtends) return;
             const node = EditorExtends.Node.getNode(uuid);
             if (!node?._components) return;
@@ -63,7 +63,7 @@ export class SelectionService extends BaseService<ISelectionEvents> implements I
 
     private _callLostFocusInEditor(uuid: string): void {
         try {
-            const EditorExtends = (cc as any).EditorExtends;
+            const EditorExtends = (cc as any).EditorExtends || (globalThis as any).EditorExtends;
             if (!EditorExtends) return;
             const node = EditorExtends.Node.getNode(uuid);
             if (!node?._components) return;


### PR DESCRIPTION
Related issue:   https://zentao.sud.tech/index.php?m=bug&f=view&bugID=295

  Summary

  - 选中节点时自动播放粒子系统预览，与 cocos-editor 行为一致
  - 修复 SelectionService 的 onFocusInEditor/onLostFocusInEditor 在 CLI 环境下不工作的问题
  - 新增 WebView 和 VideoPlayer 组件的 PersistentGizmo 显示
  - 新增 ImageController 用于 2D UI 组件 gizmo 渲染

  Changes

  粒子系统预览 (ParticleSystem)
  - engine.ts: 集成 3D ParticleSystem 的 play/pause/stop 管理（与 cocos-editor ParticleManager 一致）
  - particle.ts: 新增独立的 ParticleService
  - selection.ts: 修复 EditorExtends 查找路径，添加 globalThis fallback，使 onFocusInEditor 在 CLI
  环境正常工作（ParticleSystem2D 依赖此机制自动播放）

  WebView / VideoPlayer Gizmo
  - controller/image.ts: 新增 ImageController，支持按 center+size 缩放（与 cocos-editor 一致）
  - web-view/index.ts: 使用 ImageController + PersistentGizmo，根据 UITransform contentSize 缩放显示 webview
  图标
  - video-player/index.ts: 使用 ImageController + PersistentGizmo