### PR TITLE
Fix: The assets-query-asset-meta and assets-update-default-user-data APIs previously returned success even when the asset or processor did not exist. This has been corrected to properly return error codes.

### DIFF
--- a/src/api/assets/assets.ts
+++ b/src/api/assets/assets.ts
@@ -182,6 +182,10 @@ export class AssetsApi {
 
         try {
             ret.data = await assetManager.queryAssetMeta(urlOrUUIDOrPath);
+            if (!ret.data) {
+                ret.code = COMMON_STATUS.FAIL;
+                ret.reason = `Asset not found: ${urlOrUUIDOrPath}`;
+            }
         } catch (e) {
             ret.code = COMMON_STATUS.FAIL;
             console.error('query asset meta fail:', e instanceof Error ? e.message : String(e));

--- a/src/core/assets/manager/asset-handler.ts
+++ b/src/core/assets/manager/asset-handler.ts
@@ -621,6 +621,9 @@ class AssetHandlerManager {
      * 更新默认配置数据并保存（偏好设置的用户操作修改入口）
      */
     public async updateDefaultUserData(handler: string, key: string, value: any): Promise<void> {
+        if (!this.name2handler[handler]) {
+            throw new Error(`Asset handler not found: ${handler}`);
+        }
         lodash.set(this._userDataCache, `${handler}.${key}`, value);
         this._updateDefaultUserDataToHandler(handler, key, value);
         const combineUserData = {


### PR DESCRIPTION
Related issue: https://zentao.sud.tech/index.php?m=bug&f=view&bugID=156