### PR TITLE
Fix: align camera service with cocos-editor behavior.

### DIFF
--- a/src/core/scene/scene-process/service/camera.ts
+++ b/src/core/scene/scene-process/service/camera.ts
@@ -1,4 +1,4 @@
-import { Canvas, Color, Layers, Node, Vec3, gfx } from 'cc';
+import { Camera, Canvas, Color, Layers, Node, Vec3, gfx } from 'cc';
 import { BaseService } from './core';
 import { register, Service } from './core/decorator';
 import { CameraController2D } from './camera/camera-controller-2d';
@@ -29,6 +29,7 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
     get camera() { return this._camera; }
 
     set is2D(value: boolean) {
+        if (this._controller && this.is2D === value) return;
         if (this._controller) {
             this._controller.active = false;
         }
@@ -38,10 +39,10 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
             this.defaultFocus(this._currentUuid);
             this._controllerFirstChange = true;
         }
+        // 同步 transformToolData.is2D，触发 dimension-changed 事件
         const ttd = Service.Gizmo?.transformToolData;
-        if (ttd) {
+        if (ttd && ttd.is2D !== value) {
             ttd.is2D = value;
-            ttd.toolName = value ? 'rect' : 'position';
         }
         Service.Engine.repaintInEditMode();
     }
@@ -74,6 +75,7 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
                 this._camera = cam;
                 this._controller2D.init(cam);
                 this._controller3D.init(cam);
+                this._controller.active = true;
 
                 this._controller3D.on('mode', (mode: CameraMoveMode) => {
                     this.emit('camera:mode-change', mode);
@@ -353,7 +355,7 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
      * 新增的 Camera 组件也需要 detach，与原始编辑器 ScenePreview.onComponentAdded 一致
      */
     detachNewSceneCamera(comp: any): void {
-        if (!comp || !comp.camera) return;
+        if (!comp || !(comp instanceof Camera) || !comp.camera) return;
         const editorMask = Layers.makeMaskInclude([
             Layers.Enum.GIZMOS,
             Layers.Enum.SCENE_GIZMO,

--- a/src/core/scene/scene-process/service/camera/camera-controller-3d.ts
+++ b/src/core/scene/scene-process/service/camera/camera-controller-3d.ts
@@ -10,6 +10,7 @@ import PanMode from './modes/pan-mode';
 import WanderMode from './modes/wander-mode';
 import type ModeBase3D from './modes/mode-base-3d';
 import type { ISceneMouseEvent, ISceneKeyboardEvent } from '../operation/types';
+import { Service } from '../core/decorator';
 
 // ---------- node utility helpers ----------
 
@@ -529,12 +530,7 @@ export class CameraController3D extends CameraControllerBase {
 
         // 判定 pivot 模式
         let pivot = 'center';
-        try {
-            const { Service } = require('../core/decorator');
-            pivot = Service.Gizmo?.transformToolData?.pivot ?? 'center';
-        } catch (e) {
-            // Gizmo may not be initialized
-        }
+        pivot = Service.Gizmo?.transformToolData?.pivot ?? 'center';
 
         let targetPos: Vec3;
         if (pivot === 'pivot' && nodes.length === 1) {
@@ -608,12 +604,7 @@ export class CameraController3D extends CameraControllerBase {
             });
         }
 
-        try {
-            const { Service } = require('../core/decorator');
-            Service.Engine?.repaintInEditMode?.();
-        } catch (e) {
-            // Engine may not be ready
-        }
+        Service.Engine?.repaintInEditMode?.();
     }
 
     focus(nodeUuids: string[], editorCameraInfo?: EditorCameraInfo, immediate = false) {
@@ -640,12 +631,7 @@ export class CameraController3D extends CameraControllerBase {
             this.node.setWorldPosition(this._curEye);
             this.node.setWorldRotation(this._curRot);
             this.updateGrid();
-            try {
-                const { Service } = require('../core/decorator');
-                Service.Engine?.repaintInEditMode?.();
-            } catch (e) {
-                // Engine may not be ready
-            }
+            Service.Engine?.repaintInEditMode?.();
             return;
         }
 
@@ -703,12 +689,7 @@ export class CameraController3D extends CameraControllerBase {
             });
         }
 
-        try {
-            const { Service } = require('../core/decorator');
-            Service.Engine?.repaintInEditMode?.();
-        } catch (e) {
-            // Engine may not be ready
-        }
+        Service.Engine?.repaintInEditMode?.();
     }
 
     // ---------- 对齐 ----------
@@ -730,12 +711,7 @@ export class CameraController3D extends CameraControllerBase {
 
         // 开始撤销记录
         let undoId: string | undefined;
-        try {
-            const { Service } = require('../core/decorator');
-            undoId = Service.Undo?.beginRecording?.(nodeUuids);
-        } catch (e) {
-            // Undo may not be ready
-        }
+        undoId = Service.Undo?.beginRecording?.(nodeUuids);
 
         const camPos = this.node.getWorldPosition();
         const camRot = this.node.getWorldRotation();
@@ -751,20 +727,10 @@ export class CameraController3D extends CameraControllerBase {
 
         // 结束撤销记录
         if (undoId) {
-            try {
-                const { Service } = require('../core/decorator');
-                Service.Undo?.endRecording?.(undoId);
-            } catch (e) {
-                // Undo may not be ready
-            }
+            Service.Undo?.endRecording?.(undoId);
         }
 
-        try {
-            const { Service } = require('../core/decorator');
-            Service.Engine?.repaintInEditMode?.();
-        } catch (e) {
-            // Engine may not be ready
-        }
+        Service.Engine?.repaintInEditMode?.();
     }
 
     alignCameraOrthoHeightToNode(cameras: Camera[]) {
@@ -793,12 +759,7 @@ export class CameraController3D extends CameraControllerBase {
         this.updateViewCenterByDist(-this.viewDist);
         this.updateGrid();
 
-        try {
-            const { Service } = require('../core/decorator');
-            Service.Engine?.repaintInEditMode?.();
-        } catch (e) {
-            // Engine may not be ready
-        }
+        Service.Engine?.repaintInEditMode?.();
     }
 
     // ---------- 鼠标/键盘事件 ----------
@@ -828,11 +789,7 @@ export class CameraController3D extends CameraControllerBase {
             // Alt + 左键：进入旋转模式
             void this.changeMode('orbit');
         } else if (event.leftButton) {
-            let isViewMode = false;
-            try {
-                const { Service } = require('../core/decorator');
-                isViewMode = !!Service.Gizmo?.isViewMode;
-            } catch (e) { /* Gizmo not ready */ }
+            const isViewMode = !!Service.Gizmo?.isViewMode;
             if (isViewMode) {
                 void this.changeMode('pan');
             }
@@ -849,12 +806,7 @@ export class CameraController3D extends CameraControllerBase {
         const currentMode = this._modeFSM.currentState as ModeBase3D;
         currentMode.onMouseMove(event);
 
-        try {
-            const { Service } = require('../core/decorator');
-            Service.Engine?.repaintInEditMode?.();
-        } catch (e) {
-            // Engine may not be ready
-        }
+        Service.Engine?.repaintInEditMode?.();
     }
 
     onMouseUp(event: ISceneMouseEvent) {
@@ -880,12 +832,7 @@ export class CameraController3D extends CameraControllerBase {
             this.smoothScale(delta);
         }
 
-        try {
-            const { Service } = require('../core/decorator');
-            Service.Engine?.repaintInEditMode?.();
-        } catch (e) {
-            // Engine may not be ready
-        }
+        Service.Engine?.repaintInEditMode?.();
     }
 
     onKeyDown(event: ISceneKeyboardEvent) {
@@ -905,12 +852,7 @@ export class CameraController3D extends CameraControllerBase {
 
     onResize(size: ISizeLike) {
         this.updateGrid();
-        try {
-            const { Service } = require('../core/decorator');
-            Service.Engine?.repaintInEditMode?.();
-        } catch (e) {
-            // Engine may not be ready
-        }
+        Service.Engine?.repaintInEditMode?.();
     }
 
     // ---------- 网格 ----------
@@ -1023,12 +965,7 @@ export class CameraController3D extends CameraControllerBase {
 
     refresh() {
         this.updateGrid();
-        try {
-            const { Service } = require('../core/decorator');
-            Service.Engine?.repaintInEditMode?.();
-        } catch (e) {
-            // Engine may not be ready
-        }
+        Service.Engine?.repaintInEditMode?.();
     }
 
     // ---------- 旋转相机到指定方向 ----------
@@ -1065,12 +1002,7 @@ export class CameraController3D extends CameraControllerBase {
             this.updateGrid();
         });
 
-        try {
-            const { Service } = require('../core/decorator');
-            Service.Engine?.repaintInEditMode?.();
-        } catch (e) {
-            // Engine may not be ready
-        }
+        Service.Engine?.repaintInEditMode?.();
     }
 
     // ---------- 投影相关 ----------
@@ -1111,13 +1043,8 @@ export class CameraController3D extends CameraControllerBase {
         this._camera.orthoHeight = newOrthoHeight;
 
         // 尝试同步到 Gizmo
-        try {
-            const { Service } = require('../core/decorator');
-            if (Service.Gizmo?.transformToolData) {
-                Service.Gizmo.transformToolData.cameraOrthoHeight = newOrthoHeight;
-            }
-        } catch (e) {
-            // Gizmo may not be initialized
+        if (Service.Gizmo?.transformToolData) {
+            Service.Gizmo.transformToolData.cameraOrthoHeight = newOrthoHeight;
         }
     }
 
@@ -1138,12 +1065,7 @@ export class CameraController3D extends CameraControllerBase {
 
         this.updateGrid();
 
-        try {
-            const { Service } = require('../core/decorator');
-            Service.Engine?.repaintInEditMode?.();
-        } catch (e) {
-            // Engine may not be ready
-        }
+        Service.Engine?.repaintInEditMode?.();
     }
 
     // ---------- 缩放快捷键 ----------

--- a/src/core/scene/scene-process/service/camera/camera-controller-3d.ts
+++ b/src/core/scene/scene-process/service/camera/camera-controller-3d.ts
@@ -827,6 +827,15 @@ export class CameraController3D extends CameraControllerBase {
         } else if (event.leftButton && event.altKey) {
             // Alt + 左键：进入旋转模式
             void this.changeMode('orbit');
+        } else if (event.leftButton) {
+            let isViewMode = false;
+            try {
+                const { Service } = require('../core/decorator');
+                isViewMode = !!Service.Gizmo?.isViewMode;
+            } catch (e) { /* Gizmo not ready */ }
+            if (isViewMode) {
+                void this.changeMode('pan');
+            }
         }
 
         const currentMode = this._modeFSM.currentState as ModeBase3D;

--- a/src/core/scene/scene-process/service/gizmo.ts
+++ b/src/core/scene/scene-process/service/gizmo.ts
@@ -174,9 +174,14 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
             this.emit('gizmo:tool-changed', name);
         });
 
-        // 与 cocos-editor 一致：2D 视图下隐藏 IconGizmo，让 UI 编辑更干净
+        // 与 cocos-editor gizmos.ts 一致：dimension-changed 时切换相机 2D/3D 模式
         this.transformToolData.on('dimension-changed', (is2D: boolean) => {
             this.setIconVisible(!is2D);
+            try {
+                Service.Camera.is2D = is2D;
+            } catch (e) {
+                // Camera not ready yet
+            }
         });
 
         // Listen for camera mode changes to lock/unlock gizmo tool


### PR DESCRIPTION
 - 3D 模式下初始化时网格不显示，需切 2D 再切回才能显示 — 初始化后调用 controller.active = true 显示网格
  - 3D view 模式下左键无法拖动平移 — 添加 isViewMode 检查进入 pan 模式
  - 2D/3D 切换时强制重置 gizmo 工具为 rect/position，不记录用户选择 — 移除 toolName 强制设置，与 cocos-editor
  一致