### PR TITLE
feat: sync import config into asset runtime

### DIFF
--- a/src/core/assets/asset-config.ts
+++ b/src/core/assets/asset-config.ts
@@ -5,6 +5,7 @@ import { configurationRegistry, ConfigurationScope, IBaseConfiguration } from '.
 import project from '../project';
 import { Engine } from '../engine';
 import { createImportMetadataNodes } from './metadata';
+import { DEFAULT_CREATE_TEMPLATE_ROOT, resolveImportTemplateRoot } from './import-config-defaults';
 
 export interface AssetDBConfig {
     restoreAssetDBFromCache: boolean;
@@ -75,7 +76,7 @@ class AssetConfig {
             defaults: {
                 restoreAssetDBFromCache: this._assetConfig.restoreAssetDBFromCache,
                 globList: this._assetConfig.globList ?? [],
-                createTemplateRoot: join(this._assetConfig.root, '.creator/templates'),
+                createTemplateRoot: DEFAULT_CREATE_TEMPLATE_ROOT,
             },
             nodes: () => createImportMetadataNodes(),
         });
@@ -86,6 +87,7 @@ class AssetConfig {
         const enginePath = Engine.getInfo().typescript.path;
         this._assetConfig.libraryRoot = this._assetConfig.libraryRoot || join(this._assetConfig.root, 'library');
         this._assetConfig.tempRoot = join(this._assetConfig.root, 'temp/cli/asset-db');
+        await this.syncRuntimeConfigFromConfiguration();
         this._assetConfig.assetDBList = [{
             name: 'assets',
             target: join(this._assetConfig.root, 'assets'),
@@ -141,6 +143,16 @@ class AssetConfig {
 
     setProject(path: string, value: any, scope?: ConfigurationScope) {
         return this._configInstance.set(path, value, scope);
+    }
+
+    private async syncRuntimeConfigFromConfiguration() {
+        const importConfig = await this._configInstance.get<Partial<Pick<AssetDBConfig, 'restoreAssetDBFromCache' | 'globList' | 'createTemplateRoot'>>>();
+        this._assetConfig.restoreAssetDBFromCache = importConfig.restoreAssetDBFromCache ?? false;
+        this._assetConfig.globList = importConfig.globList ?? [];
+        this._assetConfig.createTemplateRoot = resolveImportTemplateRoot(
+            this._assetConfig.root,
+            importConfig.createTemplateRoot ?? DEFAULT_CREATE_TEMPLATE_ROOT
+        );
     }
 }
 

--- a/src/core/assets/asset-handler/assets/typescript.ts
+++ b/src/core/assets/asset-handler/assets/typescript.ts
@@ -38,7 +38,7 @@ export const TypeScriptHandler: AssetHandler = {
                     name: 'default',
                 },
             ];
-            const templateDir = join(assetConfig.data.root, '.creator/asset-template/typescript');
+            const templateDir = join(assetConfig.data.createTemplateRoot, TypeScriptHandler.name);
             // TODO 文件夹初始化应该在点击查看脚本模板时处理
             // ensureDirSync(templateDir);
 

--- a/src/core/assets/import-config-defaults.ts
+++ b/src/core/assets/import-config-defaults.ts
@@ -1,0 +1,10 @@
+import { isAbsolute, join } from 'path';
+
+export const DEFAULT_CREATE_TEMPLATE_ROOT = '.creator/templates';
+
+export function resolveImportTemplateRoot(projectRoot: string, configuredPath = DEFAULT_CREATE_TEMPLATE_ROOT): string {
+    if (isAbsolute(configuredPath)) {
+        return configuredPath;
+    }
+    return join(projectRoot, configuredPath);
+}

--- a/src/core/assets/manager/asset-handler.ts
+++ b/src/core/assets/manager/asset-handler.ts
@@ -88,7 +88,7 @@ class AssetHandlerManager {
     async init() {
         const { assetHandlerInfos } = await import('../../assets/asset-handler/config');
         this.register('cocos-cli', assetHandlerInfos, true);
-        AssetHandlerManager.createTemplateRoot = await assetConfig.getProject('createTemplateRoot');
+        AssetHandlerManager.createTemplateRoot = assetConfig.data.createTemplateRoot;
         const { compileEffect, startAutoGenEffectBin, getEffectBinPath } = await import('../asset-handler');
         this.compileEffect = compileEffect;
         this.startAutoGenEffectBin = startAutoGenEffectBin;
@@ -103,6 +103,21 @@ class AssetHandlerManager {
             console.debug(`lazy register asset handler ${info.name}`);
             return this.activateRegister(info);
         }));
+    }
+
+    private async ensureHandler(importer: string) {
+        let handler = this.name2handler[importer];
+        if (handler) {
+            return handler;
+        }
+
+        const registerInfo = this.name2registerInfo[importer];
+        if (!registerInfo) {
+            return undefined;
+        }
+
+        await this.activateRegister(registerInfo);
+        return this.name2handler[importer];
     }
 
     private async activateRegister(registerInfos: HandlerInfo) {
@@ -284,7 +299,11 @@ class AssetHandlerManager {
      */
     async getCreateMap(): Promise<ICreateMenuInfo[]> {
         const result: Omit<ICreateMenuInfo, 'create'>[] = [];
-        for (const importer of Object.keys(this.name2handler)) {
+        const importers = Array.from(new Set([
+            ...Object.keys(this.name2registerInfo),
+            ...Object.keys(this.name2handler),
+        ]));
+        for (const importer of importers) {
             const createMenu = await this.getCreateMenuByName(importer);
             result.push(...createMenu);
         }
@@ -297,7 +316,7 @@ class AssetHandlerManager {
      * @returns 
      */
     async getCreateMenuByName(importer: string): Promise<ICreateMenuInfo[]> {
-        const handler = this.name2handler[importer];
+        const handler = await this.ensureHandler(importer);
         if (!handler || !handler.createInfo || !handler.createInfo.generateMenuInfo) {
             return [];
         }

--- a/src/core/assets/metadata.ts
+++ b/src/core/assets/metadata.ts
@@ -1,5 +1,6 @@
 import type { ICocosConfigurationNode } from '../configuration/script/metadata';
 import { createNode, objectSchema } from '../configuration/script/metadata';
+import { DEFAULT_CREATE_TEMPLATE_ROOT } from './import-config-defaults';
 
 export function createImportMetadataNodes(): ICocosConfigurationNode[] {
     return [
@@ -18,7 +19,7 @@ export function createImportMetadataNodes(): ICocosConfigurationNode[] {
             },
             'import.createTemplateRoot': {
                 type: 'string',
-                default: '',
+                default: DEFAULT_CREATE_TEMPLATE_ROOT,
                 title: 'i18n:configuration.import.createTemplateRoot.title',
             },
             'import.userDataTemplate': objectSchema(undefined, {
@@ -26,28 +27,11 @@ export function createImportMetadataNodes(): ICocosConfigurationNode[] {
                 description: 'i18n:configuration.import.userDataTemplate.description',
                 additionalProperties: true,
             }),
-            'import.fbx': objectSchema({
-                legacyFbxImporter: objectSchema({
-                    visible: {
-                        type: 'boolean',
-                        default: true,
-                        title: 'i18n:configuration.import.fbx.legacyFbxImporter.visible.title',
-                    },
-                }, {
-                    title: 'i18n:configuration.import.fbx.legacyFbxImporter.title',
-                }),
-                material: objectSchema({
-                    smart: {
-                        type: 'boolean',
-                        default: false,
-                        title: 'i18n:configuration.import.fbx.material.smart.title',
-                    },
-                }, {
-                    title: 'i18n:configuration.import.fbx.material.title',
-                }),
-            }, {
-                title: 'i18n:configuration.import.fbx.title',
-            }),
+            'import.fbx.material.smart': {
+                type: 'boolean',
+                default: false,
+                title: 'i18n:configuration.import.fbx.material.smart.title',
+            },
         }, 10),
     ];
 }

--- a/src/core/assets/test/config-sync.test.ts
+++ b/src/core/assets/test/config-sync.test.ts
@@ -1,0 +1,116 @@
+'use strict';
+
+import { join } from 'path';
+import { ensureDir, existsSync, readJSONSync, remove, writeJSONSync } from 'fs-extra';
+import { TestGlobalEnv } from '../../../tests/global-env';
+
+interface IAssetConfigRuntime {
+    configurationManager: typeof import('../../configuration').configurationManager;
+    project: typeof import('../../project').default;
+    Engine: typeof import('../../engine').Engine;
+    assetConfig: typeof import('../asset-config').default;
+    assetDBManager: typeof import('../manager/asset-db').default;
+    assetHandlerManager: typeof import('../manager/asset-handler').default;
+}
+
+const configPath = join(TestGlobalEnv.projectRoot, 'cocos.config.json');
+const originalConfig = readJSONSync(configPath);
+const legacyTemplateRoot = join(TestGlobalEnv.projectRoot, '.creator', 'asset-template');
+
+function createImportConfig(customTemplateRoot: string) {
+    return {
+        globList: ['!**/*.tmp', '!**/*.bak'],
+        restoreAssetDBFromCache: true,
+        createTemplateRoot: customTemplateRoot,
+        fbx: {
+            material: {
+                smart: true,
+            },
+        },
+    };
+}
+
+function writeProjectImportConfig(importConfig: Record<string, unknown>) {
+    const nextConfig = JSON.parse(JSON.stringify(originalConfig));
+    nextConfig.import = importConfig;
+    writeJSONSync(configPath, nextConfig, { spaces: 4 });
+}
+
+async function loadFreshRuntime(): Promise<IAssetConfigRuntime> {
+    jest.resetModules();
+    const { configurationManager } = require('../../configuration') as typeof import('../../configuration');
+    const project = (require('../../project') as typeof import('../../project')).default;
+    const { Engine } = require('../../engine') as typeof import('../../engine');
+    const assetConfig = (require('../asset-config') as typeof import('../asset-config')).default;
+    const assetDBManager = (require('../manager/asset-db') as typeof import('../manager/asset-db')).default;
+    const assetHandlerManager = (require('../manager/asset-handler') as typeof import('../manager/asset-handler')).default;
+
+    return {
+        configurationManager,
+        project,
+        Engine,
+        assetConfig,
+        assetDBManager,
+        assetHandlerManager,
+    };
+}
+
+describe('asset import config sync', () => {
+    afterEach(async () => {
+        writeJSONSync(configPath, JSON.parse(JSON.stringify(originalConfig)), { spaces: 4 });
+        await remove(legacyTemplateRoot);
+        const creatorRoot = join(TestGlobalEnv.projectRoot, '.creator');
+        if (existsSync(creatorRoot)) {
+            const entries = require('fs').readdirSync(creatorRoot);
+            for (const entry of entries) {
+                if (entry.startsWith('custom-template-root-')) {
+                    await remove(join(creatorRoot, entry));
+                }
+            }
+        }
+    });
+
+    it('should sync project import config into the runtime asset config and asset-db state', async () => {
+        const customTemplateRoot = `.creator/custom-template-root-${Date.now()}`;
+        writeProjectImportConfig(createImportConfig(customTemplateRoot));
+
+        const runtime = await loadFreshRuntime();
+        await runtime.configurationManager.initialize(TestGlobalEnv.projectRoot);
+        await runtime.project.open(TestGlobalEnv.projectRoot);
+        await runtime.Engine.init(TestGlobalEnv.engineRoot);
+        await ensureDir(join(TestGlobalEnv.projectRoot, 'library'));
+        await runtime.assetConfig.init();
+        await runtime.assetDBManager.init();
+
+        await expect(runtime.assetConfig.getProject<string[]>('globList')).resolves.toEqual(['!**/*.tmp', '!**/*.bak']);
+        await expect(runtime.assetConfig.getProject<boolean>('restoreAssetDBFromCache')).resolves.toEqual(true);
+        await expect(runtime.assetConfig.getProject<string>('createTemplateRoot')).resolves.toEqual(customTemplateRoot);
+        await expect(runtime.assetConfig.getProject<boolean>('fbx.material.smart')).resolves.toEqual(true);
+
+        expect(runtime.assetConfig.data.globList).toEqual(['!**/*.tmp', '!**/*.bak']);
+        expect(runtime.assetConfig.data.restoreAssetDBFromCache).toBe(true);
+        expect(runtime.assetConfig.data.createTemplateRoot).toBe(join(TestGlobalEnv.projectRoot, customTemplateRoot));
+        expect((runtime.assetDBManager as any).constructor.useCache).toBe(true);
+        expect(runtime.assetDBManager.assetDBInfo.assets.globList).toEqual(['!**/*.tmp', '!**/*.bak']);
+    });
+
+    it('should use the configured template root when preparing the TypeScript create menu', async () => {
+        const customTemplateRoot = `.creator/custom-template-root-${Date.now()}`;
+        writeProjectImportConfig(createImportConfig(customTemplateRoot));
+
+        const runtime = await loadFreshRuntime();
+        await runtime.configurationManager.initialize(TestGlobalEnv.projectRoot);
+        await runtime.project.open(TestGlobalEnv.projectRoot);
+        await runtime.Engine.init(TestGlobalEnv.engineRoot);
+        await runtime.assetConfig.init();
+        await runtime.assetDBManager.init();
+
+        const configuredGuideFile = join(TestGlobalEnv.projectRoot, customTemplateRoot, 'typescript', 'Custom Script Template Help Documentation.url');
+        const legacyGuideFile = join(legacyTemplateRoot, 'typescript', 'Custom Script Template Help Documentation.url');
+
+        await runtime.assetHandlerManager.getCreateMenuByName('typescript');
+
+        expect(existsSync(configuredGuideFile)).toBe(true);
+        expect(existsSync(legacyGuideFile)).toBe(false);
+    });
+});

--- a/src/core/configuration/test/metadata.test.ts
+++ b/src/core/configuration/test/metadata.test.ts
@@ -157,6 +157,8 @@ describe('configuration metadata', () => {
         const scriptNode = findNode(afterRegister, 'script');
 
         expect(findProperty(importNode, 'import.restoreAssetDBFromCache').type).toBe('boolean');
+        expect(findProperty(importNode, 'import.fbx.material.smart').type).toBe('boolean');
+        expect(importNode.properties['import.fbx']).toBeUndefined();
         expect(findProperty(scriptNode, 'script.useDefineForClassFields').type).toBe('boolean');
     });
 
@@ -166,7 +168,14 @@ describe('configuration metadata', () => {
         await runtime.Engine.init(TestGlobalEnv.engineRoot);
         await runtime.assetConfig.init();
 
+        const nodes = await runtime.getMetadata();
+        const importNode = findNode(nodes, 'import');
+
         await expect(runtime.assetConfig.getProject<string[]>('globList', 'default')).resolves.toEqual([]);
+        await expect(runtime.assetConfig.getProject<string>('createTemplateRoot', 'default')).resolves.toEqual('.creator/templates');
+        await expect(runtime.assetConfig.getProject<boolean>('fbx.material.smart', 'default')).resolves.toEqual(false);
+        expect(findProperty(importNode, 'import.createTemplateRoot').default).toBe('.creator/templates');
+        expect(findProperty(importNode, 'import.fbx.material.smart').default).toBe(false);
     });
 
     it('should preserve readable localized titles and descriptions in registered metadata', async () => {


### PR DESCRIPTION
- 对齐了 `import` 相关 metadata 的暴露方式，补齐可直接查询的叶子配置项，确保配置系统能稳定查到目标值。
- 在资源模块初始化时，将注册到 configuration 的配置同步到运行时 `assetConfig.data`，让资源侧实际消费到同一份配置数据。
- `AssetHandlerManager` 的创建入口与 handler 激活流程改为读取运行时配置，不再依赖分散/硬编码的默认值。
- TypeScript 资源创建模板目录改为使用配置化的 `createTemplateRoot`，默认值保持为 `.creator/templates`，运行时再解析为绝对路径。
- 补充了配置同步与 metadata 回归测试，覆盖“配置可查”和“资源实际接入”两条主链路。