### PR TITLE
[break] Refine scene services: expand config APIs and add UIService

### DIFF
--- a/src/core/scene/common/camera.ts
+++ b/src/core/scene/common/camera.ts
@@ -1,27 +1,7 @@
 import type { Vec3 } from 'cc';
+import type { ICameraConfig, IOriginAxesConfig } from '../scene-configs';
 
-export interface IOriginAxesConfig {
-    x: boolean;
-    y: boolean;
-    z: boolean;
-}
-
-export interface ICameraConfigData {
-    color: number[];
-    fov: number;
-    far: number;
-    near: number;
-    wheelSpeed: number;
-    wanderSpeed: number;
-    enableAcceleration: boolean;
-    aperture: number;
-    shutter: number;
-    iso: number;
-    gridVisible: boolean;
-    gridColor: number[];
-    originAxis2D: IOriginAxesConfig;
-    originAxis3D: IOriginAxesConfig;
-}
+export type { ICameraConfig, IOriginAxesConfig };
 
 export interface ICameraService {
     init(): void;
@@ -35,8 +15,8 @@ export interface ICameraService {
     isGridVisible(): boolean;
     setCameraProperty(options: any): void;
     resetCameraProperty(): void;
-    queryConfig(): ICameraConfigData;
-    updateConfig(config: Partial<ICameraConfigData>): void;
+    queryConfig(): ICameraConfig;
+    updateConfig(config: Partial<ICameraConfig>): void;
     getCameraFov(): number;
     zoomUp(): void;
     zoomDown(): void;

--- a/src/core/scene/common/camera.ts
+++ b/src/core/scene/common/camera.ts
@@ -1,5 +1,28 @@
 import type { Vec3 } from 'cc';
 
+export interface IOriginAxesConfig {
+    x: boolean;
+    y: boolean;
+    z: boolean;
+}
+
+export interface ICameraConfigData {
+    color: number[];
+    fov: number;
+    far: number;
+    near: number;
+    wheelSpeed: number;
+    wanderSpeed: number;
+    enableAcceleration: boolean;
+    aperture: number;
+    shutter: number;
+    iso: number;
+    gridVisible: boolean;
+    gridColor: number[];
+    originAxis2D: IOriginAxesConfig;
+    originAxis3D: IOriginAxesConfig;
+}
+
 export interface ICameraService {
     init(): void;
     initFromConfig(): Promise<void>;
@@ -12,6 +35,8 @@ export interface ICameraService {
     isGridVisible(): boolean;
     setCameraProperty(options: any): void;
     resetCameraProperty(): void;
+    queryConfig(): ICameraConfigData;
+    updateConfig(config: Partial<ICameraConfigData>): void;
     getCameraFov(): number;
     zoomUp(): void;
     zoomDown(): void;
@@ -24,6 +49,7 @@ export interface ICameraService {
 export type IPublicCameraService = Pick<ICameraService,
     'focus' | 'defaultFocus' | 'rotateCameraToDir' | 'changeProjection' |
     'setGridVisible' | 'isGridVisible' | 'setCameraProperty' | 'resetCameraProperty' |
+    'queryConfig' | 'updateConfig' |
     'getCameraFov' | 'zoomUp' | 'zoomDown' | 'zoomReset' |
     'alignNodeToSceneView' | 'alignSceneViewToNode'
 > & { is2D: boolean };

--- a/src/core/scene/common/camera.ts
+++ b/src/core/scene/common/camera.ts
@@ -23,6 +23,9 @@ export interface ICameraService {
     zoomReset(): void;
     alignNodeToSceneView(nodes: string[]): void;
     alignSceneViewToNode(nodes: string[]): void;
+    setGridColor(color: number[]): void;
+    setOriginAxes2D(config: IOriginAxesConfig): void;
+    setOriginAxes3D(config: IOriginAxesConfig): void;
     onUpdate(deltaTime: number): void;
 }
 
@@ -31,7 +34,8 @@ export type IPublicCameraService = Pick<ICameraService,
     'setGridVisible' | 'isGridVisible' | 'setCameraProperty' | 'resetCameraProperty' |
     'queryConfig' | 'updateConfig' |
     'getCameraFov' | 'zoomUp' | 'zoomDown' | 'zoomReset' |
-    'alignNodeToSceneView' | 'alignSceneViewToNode'
+    'alignNodeToSceneView' | 'alignSceneViewToNode' |
+    'setGridColor' | 'setOriginAxes2D' | 'setOriginAxes3D'
 > & { is2D: boolean };
 
 export interface ICameraEvents {

--- a/src/core/scene/common/gizmo.ts
+++ b/src/core/scene/common/gizmo.ts
@@ -1,3 +1,7 @@
+import type { IOriginAxesConfig } from '../scene-configs';
+
+export type { IOriginAxesConfig };
+
 export interface IRectSnapConfigData {
     enableSnapping: boolean;
     snapThreshold: number;
@@ -35,6 +39,14 @@ export interface IGizmoService {
     queryIconGizmoSize(): number;
     setIconGizmoSize(size: number): void;
 
+    // 与 cocos-editor GizmoConfig 一致：显示配置方法
+    queryGridColor(): number[];
+    setGridColor(color: number[]): void;
+    queryOriginAxes2D(): IOriginAxesConfig;
+    setOriginAxes2D(config: IOriginAxesConfig): void;
+    queryOriginAxes3D(): IOriginAxesConfig;
+    setOriginAxes3D(config: IOriginAxesConfig): void;
+
     // 与 cocos-editor TransformGizmoManager 一致：snap 配置
     queryTransformSnapConfigs(): any;
     setTransformSnapConfigs(name: string, value: any): void;
@@ -58,6 +70,9 @@ export type IPublicGizmoService = Pick<IGizmoService,
     'queryToolsVisibility3d' | 'setToolsVisibility3d' |
     'isIconGizmo3D' | 'setIconGizmo3D' |
     'queryIconGizmoSize' | 'setIconGizmoSize' |
+    'queryGridColor' | 'setGridColor' |
+    'queryOriginAxes2D' | 'setOriginAxes2D' |
+    'queryOriginAxes3D' | 'setOriginAxes3D' |
     'queryTransformSnapConfigs' | 'setTransformSnapConfigs' |
     'queryRectSnapConfig' | 'setRectSnapConfig'
 >;

--- a/src/core/scene/common/gizmo.ts
+++ b/src/core/scene/common/gizmo.ts
@@ -10,7 +10,6 @@ export interface IGizmoService {
     transformToolData: any;
     transformToolName: string;
     isViewMode: boolean;
-    viewMode: string;
     is2D: boolean;
 
     init(): void;

--- a/src/core/scene/common/gizmo.ts
+++ b/src/core/scene/common/gizmo.ts
@@ -1,3 +1,8 @@
+export interface IRectSnapConfigData {
+    enableSnapping: boolean;
+    snapThreshold: number;
+}
+
 export interface IGizmoService {
     gizmoRootNode: any;
     foregroundNode: any;
@@ -5,6 +10,7 @@ export interface IGizmoService {
     transformToolData: any;
     transformToolName: string;
     isViewMode: boolean;
+    viewMode: string;
     is2D: boolean;
 
     init(): void;
@@ -33,6 +39,8 @@ export interface IGizmoService {
     // 与 cocos-editor TransformGizmoManager 一致：snap 配置
     queryTransformSnapConfigs(): any;
     setTransformSnapConfigs(name: string, value: any): void;
+    queryRectSnapConfig(): IRectSnapConfigData;
+    setRectSnapConfig(config: Partial<IRectSnapConfigData>): void;
 
     // 与 cocos-editor SelectionGizmoManager 一致：选中查询
     querySelectNodes(): any[];
@@ -51,7 +59,8 @@ export type IPublicGizmoService = Pick<IGizmoService,
     'queryToolsVisibility3d' | 'setToolsVisibility3d' |
     'isIconGizmo3D' | 'setIconGizmo3D' |
     'queryIconGizmoSize' | 'setIconGizmoSize' |
-    'queryTransformSnapConfigs' | 'setTransformSnapConfigs'
+    'queryTransformSnapConfigs' | 'setTransformSnapConfigs' |
+    'queryRectSnapConfig' | 'setRectSnapConfig'
 >;
 
 export interface IGizmoEvents {

--- a/src/core/scene/common/index.ts
+++ b/src/core/scene/common/index.ts
@@ -13,3 +13,4 @@ export * from './undo';
 export * from './camera';
 export * from './gizmo';
 export * from './scene-view';
+export * from './ui';

--- a/src/core/scene/common/ui.ts
+++ b/src/core/scene/common/ui.ts
@@ -1,0 +1,13 @@
+export type UIAlignType = 'top' | 'v-center' | 'bottom' | 'left' | 'h-center' | 'right';
+
+export interface IUIService {
+    alignSelection(type: UIAlignType): void;
+    distributeSelection(type: UIAlignType): void;
+}
+
+export type IPublicUIService = IUIService;
+
+export interface IUIEvents {
+    'ui:align-selection': [type: UIAlignType];
+    'ui:distribute-selection': [type: UIAlignType];
+}

--- a/src/core/scene/scene-configs.ts
+++ b/src/core/scene/scene-configs.ts
@@ -8,6 +8,26 @@ export interface ICameraConfig {
     wheelSpeed: number;
     wanderSpeed: number;
     enableAcceleration: boolean;
+    aperture: number;
+    shutter: number;
+    iso: number;
+    gridVisible: boolean;
+    gridColor: number[];
+    originAxis2D: {
+        x: boolean;
+        y: boolean;
+        z: boolean;
+    };
+    originAxis3D: {
+        x: boolean;
+        y: boolean;
+        z: boolean;
+    };
+}
+
+export interface IRectSnapConfig {
+    enableSnapping: boolean;
+    snapThreshold: number;
 }
 
 export interface IGizmoConfig {
@@ -26,6 +46,11 @@ export interface IGizmoConfig {
         isRotationSnapEnabled: boolean;
         isScaleSnapEnabled: boolean;
     };
+    rectSnapConfig?: IRectSnapConfig;
+}
+
+export interface ISceneViewConfig {
+    sceneLightOn: boolean;
 }
 
 export interface ISceneConfig {
@@ -41,6 +66,10 @@ export interface ISceneConfig {
      * Gizmo 配置，与 cocos-editor gizmos-infos profile 一致
      */
     gizmo: IGizmoConfig;
+    /**
+     * SceneView 配置
+     */
+    sceneView: ISceneViewConfig;
 }
 
 class SceneConfig {
@@ -54,6 +83,21 @@ class SceneConfig {
             wheelSpeed: 0.01,
             wanderSpeed: 10,
             enableAcceleration: true,
+            aperture: 19,
+            shutter: 7,
+            iso: 0,
+            gridVisible: true,
+            gridColor: [166, 166, 166, 255],
+            originAxis2D: {
+                x: true,
+                y: true,
+                z: false,
+            },
+            originAxis3D: {
+                x: true,
+                y: false,
+                z: true,
+            },
         },
         gizmo: {
             is2D: false,
@@ -63,6 +107,13 @@ class SceneConfig {
             pivot: 'pivot',
             coordinate: 'local',
             toolsVisibility3d: true,
+            rectSnapConfig: {
+                enableSnapping: true,
+                snapThreshold: 4,
+            },
+        },
+        sceneView: {
+            sceneLightOn: true,
         },
     };
 

--- a/src/core/scene/scene-configs.ts
+++ b/src/core/scene/scene-configs.ts
@@ -1,5 +1,11 @@
 import { configurationRegistry, ConfigurationScope, IBaseConfiguration } from '../configuration';
 
+export interface IOriginAxesConfig {
+    x: boolean;
+    y: boolean;
+    z: boolean;
+}
+
 export interface ICameraConfig {
     color: number[];
     fov: number;
@@ -11,18 +17,6 @@ export interface ICameraConfig {
     aperture: number;
     shutter: number;
     iso: number;
-    gridVisible: boolean;
-    gridColor: number[];
-    originAxis2D: {
-        x: boolean;
-        y: boolean;
-        z: boolean;
-    };
-    originAxis3D: {
-        x: boolean;
-        y: boolean;
-        z: boolean;
-    };
 }
 
 export interface IRectSnapConfig {
@@ -39,6 +33,10 @@ export interface IGizmoConfig {
     pivot: string;
     coordinate: string;
     toolsVisibility3d: boolean;
+    gridVisible: boolean;
+    gridColor: number[];
+    originAxis2D: IOriginAxesConfig;
+    originAxis3D: IOriginAxesConfig;
     snapConfigs?: {
         position: { x: number; y: number; z: number };
         rotation: number;
@@ -87,6 +85,16 @@ class SceneConfig {
             aperture: 19,
             shutter: 7,
             iso: 0,
+        },
+        gizmo: {
+            is2D: false,
+            is3DIcon: false,
+            iconSize: 2,
+            transformToolName: 'position',
+            viewMode: 'select',
+            pivot: 'pivot',
+            coordinate: 'local',
+            toolsVisibility3d: true,
             gridVisible: true,
             gridColor: [166, 166, 166, 255],
             originAxis2D: {
@@ -99,16 +107,6 @@ class SceneConfig {
                 y: false,
                 z: true,
             },
-        },
-        gizmo: {
-            is2D: false,
-            is3DIcon: false,
-            iconSize: 2,
-            transformToolName: 'position',
-            viewMode: 'select',
-            pivot: 'pivot',
-            coordinate: 'local',
-            toolsVisibility3d: true,
             rectSnapConfig: {
                 enableSnapping: true,
                 snapThreshold: 4,

--- a/src/core/scene/scene-configs.ts
+++ b/src/core/scene/scene-configs.ts
@@ -35,6 +35,7 @@ export interface IGizmoConfig {
     is3DIcon: boolean;
     iconSize: number;
     transformToolName: string;
+    viewMode: 'view' | 'select';
     pivot: string;
     coordinate: string;
     toolsVisibility3d: boolean;
@@ -104,6 +105,7 @@ class SceneConfig {
             is3DIcon: false,
             iconSize: 2,
             transformToolName: 'position',
+            viewMode: 'select',
             pivot: 'pivot',
             coordinate: 'local',
             toolsVisibility3d: true,

--- a/src/core/scene/scene-process/service/camera.ts
+++ b/src/core/scene/scene-process/service/camera.ts
@@ -8,7 +8,8 @@ import { CameraMoveMode, CameraUtils } from './camera/utils';
 import EditorCameraComponent from './camera/editor-camera-component';
 import { OperationPriority } from './operation/types';
 import { Rpc } from '../rpc';
-import type { ICameraConfigData, ICameraEvents, ICameraService, IOriginAxesConfig } from '../../common';
+import type { ICameraConfig, ICameraEvents, ICameraService, IOriginAxesConfig } from '../../common';
+import type { IGizmoConfig } from '../../scene-configs';
 
 /**
  * 相机服务，管理编辑器相机的 2D/3D 控制器切换、输入事件绑定和相机属性
@@ -129,22 +130,25 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
     async initFromConfig(): Promise<void> {
         try {
             const rpc = Rpc.getInstance();
-            const config = await rpc.request('sceneConfigInstance', 'get', ['camera']) as ICameraConfigData | undefined;
+            const config = await rpc.request('sceneConfigInstance', 'get', ['camera']) as ICameraConfig | undefined;
             if (config) {
-                if (!(config as any).originAxis2D && (config as any).originAxes) {
-                    (config as any).originAxis2D = {
-                        ...(config as any).originAxes,
-                        z: false,
-                    };
-                }
-                if (!(config as any).originAxis3D && (config as any).originAxes) {
-                    (config as any).originAxis3D = (config as any).originAxes;
-                }
                 this._applyConfig(config, false);
+            }
+            const gizmoConfig = await rpc.request('sceneConfigInstance', 'get', ['gizmo']) as Partial<IGizmoConfig> | undefined;
+            if (gizmoConfig) {
+                this._applyGizmoDisplay(gizmoConfig);
             }
         } catch {
             // 配置不可用时使用默认值
         }
+    }
+
+    private _applyGizmoDisplay(config: Partial<IGizmoConfig>): void {
+        if (config.gridVisible !== undefined) this.setGridVisible(config.gridVisible, false);
+        if (config.gridColor !== undefined) this._setGridColor(config.gridColor);
+        if (config.originAxis2D !== undefined) this._setOriginAxes2D(config.originAxis2D);
+        if (config.originAxis3D !== undefined) this._setOriginAxes3D(config.originAxis3D);
+        Service.Engine.repaintInEditMode();
     }
 
     private _setGridColor(color: number[]): void {
@@ -166,33 +170,7 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
         (this._controller3D as any).updateOriginAxisByConfig?.(originAxes);
     }
 
-    private _queryOriginAxes2D(): IOriginAxesConfig {
-        return {
-            x: Boolean((this._controller2D as any).originAxisX_Visible ?? true),
-            y: Boolean((this._controller2D as any).originAxisY_Visible ?? true),
-            z: Boolean((this._controller2D as any).originAxisZ_Visible ?? false),
-        };
-    }
-
-    private _queryOriginAxes3D(): IOriginAxesConfig {
-        return {
-            x: Boolean((this._controller3D as any).originAxisX_Visible ?? true),
-            y: Boolean((this._controller3D as any).originAxisY_Visible ?? false),
-            z: Boolean((this._controller3D as any).originAxisZ_Visible ?? true),
-        };
-    }
-
-    private _queryGridColor(): number[] {
-        const lineColor = (this._controller3D as any).lineColor ?? this._controller2D.lineColor;
-        return [
-            Math.round(lineColor?.r ?? 166),
-            Math.round(lineColor?.g ?? 166),
-            Math.round(lineColor?.b ?? 166),
-            255,
-        ];
-    }
-
-    private _applyConfig(config: Partial<ICameraConfigData>, persist: boolean): void {
+    private _applyConfig(config: Partial<ICameraConfig>, persist: boolean): void {
         if (config.color !== undefined) this.setCameraProperty({ clearColor: config.color }, false);
         if (config.fov !== undefined) this.setCameraProperty({ fov: config.fov }, false);
         if (config.far !== undefined) {
@@ -213,10 +191,6 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
                 iso: config.iso,
             }, false);
         }
-        if (config.gridVisible !== undefined) this.setGridVisible(config.gridVisible, false);
-        if (config.gridColor !== undefined) this._setGridColor(config.gridColor);
-        if (config.originAxis2D !== undefined) this._setOriginAxes2D(config.originAxis2D);
-        if (config.originAxis3D !== undefined) this._setOriginAxes3D(config.originAxis3D);
         Service.Engine.repaintInEditMode();
         if (persist) {
             void this._saveConfig();
@@ -292,7 +266,8 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
         deActiveCtrl.showGrid(false);
         Service.Engine.repaintInEditMode();
         if (persist) {
-            void this._saveConfig();
+            const rpc = Rpc.getInstance();
+            void rpc.request('sceneConfigInstance', 'set', ['gizmo.gridVisible', value]).catch(() => {});
         }
     }
 
@@ -338,7 +313,7 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
         Service.Engine.repaintInEditMode();
     }
 
-    queryConfig(): ICameraConfigData {
+    queryConfig(): ICameraConfig {
         const clearColor = this._camera?.clearColor;
         const camera: any = this._camera;
         return {
@@ -354,14 +329,10 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
             aperture: typeof camera?.aperture === 'number' ? camera.aperture : 19,
             shutter: typeof camera?.shutter === 'number' ? camera.shutter : 7,
             iso: typeof camera?.iso === 'number' ? camera.iso : 0,
-            gridVisible: this.isGridVisible(),
-            gridColor: this._queryGridColor(),
-            originAxis2D: this._queryOriginAxes2D(),
-            originAxis3D: this._queryOriginAxes3D(),
         };
     }
 
-    updateConfig(config: Partial<ICameraConfigData>): void {
+    updateConfig(config: Partial<ICameraConfig>): void {
         if (!config || typeof config !== 'object') return;
         this._applyConfig(config, true);
     }

--- a/src/core/scene/scene-process/service/camera.ts
+++ b/src/core/scene/scene-process/service/camera.ts
@@ -145,29 +145,32 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
 
     private _applyGizmoDisplay(config: Partial<IGizmoConfig>): void {
         if (config.gridVisible !== undefined) this.setGridVisible(config.gridVisible, false);
-        if (config.gridColor !== undefined) this._setGridColor(config.gridColor);
-        if (config.originAxis2D !== undefined) this._setOriginAxes2D(config.originAxis2D);
-        if (config.originAxis3D !== undefined) this._setOriginAxes3D(config.originAxis3D);
+        if (config.gridColor !== undefined) this.setGridColor(config.gridColor);
+        if (config.originAxis2D !== undefined) this.setOriginAxes2D(config.originAxis2D);
+        if (config.originAxis3D !== undefined) this.setOriginAxes3D(config.originAxis3D);
         Service.Engine.repaintInEditMode();
     }
 
-    private _setGridColor(color: number[]): void {
+    setGridColor(color: number[]): void {
         const [r = 166, g = 166, b = 166] = color;
         this._controller2D.lineColor = new Color(r, g, b, 255);
         (this._controller3D as any).lineColor = new Color(r, g, b, 50);
         this._controller2D.updateGrid();
         this._controller3D.updateGrid();
+        Service.Engine?.repaintInEditMode?.();
     }
 
-    private _setOriginAxes2D(originAxes: Partial<IOriginAxesConfig>): void {
+    setOriginAxes2D(originAxes: IOriginAxesConfig): void {
         (this._controller2D as any).updateOriginAxisByConfig?.({
             x: originAxes.x,
             y: originAxes.y,
         });
+        Service.Engine?.repaintInEditMode?.();
     }
 
-    private _setOriginAxes3D(originAxes: Partial<IOriginAxesConfig>): void {
+    setOriginAxes3D(originAxes: IOriginAxesConfig): void {
         (this._controller3D as any).updateOriginAxisByConfig?.(originAxes);
+        Service.Engine?.repaintInEditMode?.();
     }
 
     private _applyConfig(config: Partial<ICameraConfig>, persist: boolean): void {

--- a/src/core/scene/scene-process/service/camera.ts
+++ b/src/core/scene/scene-process/service/camera.ts
@@ -8,7 +8,7 @@ import { CameraMoveMode, CameraUtils } from './camera/utils';
 import EditorCameraComponent from './camera/editor-camera-component';
 import { OperationPriority } from './operation/types';
 import { Rpc } from '../rpc';
-import type { ICameraEvents, ICameraService } from '../../common';
+import type { ICameraConfigData, ICameraEvents, ICameraService, IOriginAxesConfig } from '../../common';
 
 /**
  * 相机服务，管理编辑器相机的 2D/3D 控制器切换、输入事件绑定和相机属性
@@ -129,24 +129,106 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
     async initFromConfig(): Promise<void> {
         try {
             const rpc = Rpc.getInstance();
-            const config: any = await rpc.request('sceneConfigInstance', 'get', ['camera']);
+            const config = await rpc.request('sceneConfigInstance', 'get', ['camera']) as ICameraConfigData | undefined;
             if (config) {
-                if (config.color !== undefined) this.setCameraProperty({ clearColor: config.color });
-                if (config.fov !== undefined) this.setCameraProperty({ fov: config.fov });
-                if (config.far !== undefined) {
-                    this._controller3D.far = config.far;
-                    this._camera.far = config.far;
+                if (!(config as any).originAxis2D && (config as any).originAxes) {
+                    (config as any).originAxis2D = {
+                        ...(config as any).originAxes,
+                        z: false,
+                    };
                 }
-                if (config.near !== undefined) {
-                    this._controller3D.near = config.near;
-                    this._camera.near = config.near;
+                if (!(config as any).originAxis3D && (config as any).originAxes) {
+                    (config as any).originAxis3D = (config as any).originAxes;
                 }
-                if (config.wheelSpeed !== undefined) this._controller3D.wheelSpeed = config.wheelSpeed;
-                if (config.wanderSpeed !== undefined) this._controller3D.wanderSpeed = config.wanderSpeed;
-                if (config.enableAcceleration !== undefined) this._controller3D.enableAcceleration = config.enableAcceleration;
+                this._applyConfig(config, false);
             }
         } catch {
             // 配置不可用时使用默认值
+        }
+    }
+
+    private _setGridColor(color: number[]): void {
+        const [r = 166, g = 166, b = 166] = color;
+        this._controller2D.lineColor = new Color(r, g, b, 255);
+        (this._controller3D as any).lineColor = new Color(r, g, b, 50);
+        this._controller2D.updateGrid();
+        this._controller3D.updateGrid();
+    }
+
+    private _setOriginAxes2D(originAxes: Partial<IOriginAxesConfig>): void {
+        (this._controller2D as any).updateOriginAxisByConfig?.({
+            x: originAxes.x,
+            y: originAxes.y,
+        });
+    }
+
+    private _setOriginAxes3D(originAxes: Partial<IOriginAxesConfig>): void {
+        (this._controller3D as any).updateOriginAxisByConfig?.(originAxes);
+    }
+
+    private _queryOriginAxes2D(): IOriginAxesConfig {
+        return {
+            x: Boolean((this._controller2D as any).originAxisX_Visible ?? true),
+            y: Boolean((this._controller2D as any).originAxisY_Visible ?? true),
+            z: Boolean((this._controller2D as any).originAxisZ_Visible ?? false),
+        };
+    }
+
+    private _queryOriginAxes3D(): IOriginAxesConfig {
+        return {
+            x: Boolean((this._controller3D as any).originAxisX_Visible ?? true),
+            y: Boolean((this._controller3D as any).originAxisY_Visible ?? false),
+            z: Boolean((this._controller3D as any).originAxisZ_Visible ?? true),
+        };
+    }
+
+    private _queryGridColor(): number[] {
+        const lineColor = (this._controller3D as any).lineColor ?? this._controller2D.lineColor;
+        return [
+            Math.round(lineColor?.r ?? 166),
+            Math.round(lineColor?.g ?? 166),
+            Math.round(lineColor?.b ?? 166),
+            255,
+        ];
+    }
+
+    private _applyConfig(config: Partial<ICameraConfigData>, persist: boolean): void {
+        if (config.color !== undefined) this.setCameraProperty({ clearColor: config.color }, false);
+        if (config.fov !== undefined) this.setCameraProperty({ fov: config.fov }, false);
+        if (config.far !== undefined) {
+            this._controller3D.far = config.far;
+            this._camera.far = config.far;
+        }
+        if (config.near !== undefined) {
+            this._controller3D.near = config.near;
+            this._camera.near = config.near;
+        }
+        if (config.wheelSpeed !== undefined) this._controller3D.wheelSpeed = config.wheelSpeed;
+        if (config.wanderSpeed !== undefined) this._controller3D.wanderSpeed = config.wanderSpeed;
+        if (config.enableAcceleration !== undefined) this._controller3D.enableAcceleration = config.enableAcceleration;
+        if (config.aperture !== undefined || config.shutter !== undefined || config.iso !== undefined) {
+            this.setCameraProperty({
+                aperture: config.aperture,
+                shutter: config.shutter,
+                iso: config.iso,
+            }, false);
+        }
+        if (config.gridVisible !== undefined) this.setGridVisible(config.gridVisible, false);
+        if (config.gridColor !== undefined) this._setGridColor(config.gridColor);
+        if (config.originAxis2D !== undefined) this._setOriginAxes2D(config.originAxis2D);
+        if (config.originAxis3D !== undefined) this._setOriginAxes3D(config.originAxis3D);
+        Service.Engine.repaintInEditMode();
+        if (persist) {
+            void this._saveConfig();
+        }
+    }
+
+    private async _saveConfig(): Promise<void> {
+        try {
+            const rpc = Rpc.getInstance();
+            await rpc.request('sceneConfigInstance', 'set', ['camera', this.queryConfig()]);
+        } catch {
+            // Config persistence not available
         }
     }
 
@@ -200,7 +282,7 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
         this._controller?.changeProjection();
     }
 
-    setGridVisible(value: boolean): void {
+    setGridVisible(value: boolean, persist = true): void {
         if (value === undefined || value === null) return;
         this._controller2D.isGridVisible = value;
         this._controller3D.isGridVisible = value;
@@ -209,13 +291,16 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
             : this._controller3D;
         deActiveCtrl.showGrid(false);
         Service.Engine.repaintInEditMode();
+        if (persist) {
+            void this._saveConfig();
+        }
     }
 
     isGridVisible(): boolean {
         return this._controller?.isGridVisible ?? true;
     }
 
-    setCameraProperty(options: any): void {
+    setCameraProperty(options: any, persist = true): void {
         if (typeof options !== 'object' || !this._camera) return;
         Object.keys(options).forEach((key) => {
             if (options[key] == null) return;
@@ -235,6 +320,9 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
             }
         });
         Service.Engine.repaintInEditMode();
+        if (persist) {
+            void this._saveConfig();
+        }
     }
 
     resetCameraProperty(): void {
@@ -248,6 +336,34 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
             this.setCameraProperty({ fov: 45, far: 10000, near: 0.01, clearColor: [48, 48, 48, 255] });
         }
         Service.Engine.repaintInEditMode();
+    }
+
+    queryConfig(): ICameraConfigData {
+        const clearColor = this._camera?.clearColor;
+        const camera: any = this._camera;
+        return {
+            color: clearColor
+                ? [Math.round(clearColor.r), Math.round(clearColor.g), Math.round(clearColor.b), Math.round(clearColor.a)]
+                : [48, 48, 48, 255],
+            fov: this._camera?.fov ?? 45,
+            far: this._camera?.far ?? this._controller3D.far,
+            near: this._camera?.near ?? this._controller3D.near,
+            wheelSpeed: this._controller3D.wheelSpeed,
+            wanderSpeed: this._controller3D.wanderSpeed,
+            enableAcceleration: this._controller3D.enableAcceleration,
+            aperture: typeof camera?.aperture === 'number' ? camera.aperture : 19,
+            shutter: typeof camera?.shutter === 'number' ? camera.shutter : 7,
+            iso: typeof camera?.iso === 'number' ? camera.iso : 0,
+            gridVisible: this.isGridVisible(),
+            gridColor: this._queryGridColor(),
+            originAxis2D: this._queryOriginAxes2D(),
+            originAxis3D: this._queryOriginAxes3D(),
+        };
+    }
+
+    updateConfig(config: Partial<ICameraConfigData>): void {
+        if (!config || typeof config !== 'object') return;
+        this._applyConfig(config, true);
     }
 
     getCameraFov(): number {

--- a/src/core/scene/scene-process/service/camera/camera-controller-3d.ts
+++ b/src/core/scene/scene-process/service/camera/camera-controller-3d.ts
@@ -200,6 +200,14 @@ export class CameraController3D extends CameraControllerBase {
     public mousePressing = false;
     public lastFocusNodeUUID: string[] = [];
 
+    public get lineColor() {
+        return this._lineColor;
+    }
+
+    public set lineColor(value: Color) {
+        this._lineColor = value;
+    }
+
     public get sceneViewCenter() {
         return this._sceneViewCenter;
     }

--- a/src/core/scene/scene-process/service/gizmo.ts
+++ b/src/core/scene/scene-process/service/gizmo.ts
@@ -407,7 +407,9 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
     async saveConfig(): Promise<void> {
         try {
             const rpc = Rpc.getInstance();
+            const current = await rpc.request('sceneConfigInstance', 'get', ['gizmo']) as Record<string, any> ?? {};
             const gizmoConfig = {
+                ...current,
                 is2D: this.is2D,
                 is3DIcon: this.isIconGizmo3D(),
                 iconSize: this.queryIconGizmoSize(),

--- a/src/core/scene/scene-process/service/gizmo.ts
+++ b/src/core/scene/scene-process/service/gizmo.ts
@@ -301,6 +301,7 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
         });
         this.transformToolData.on('coordinate-changed', () => { this.saveConfig(); });
         this.transformToolData.on('pivot-changed', () => { this.saveConfig(); });
+        this.transformToolData.on('view-mode-changed', () => { this.saveConfig(); });
 
         // 与 cocos-editor gizmos.ts 一致：dimension-changed → 同步相机 + 回调
         this.transformToolData.on('dimension-changed', (is2D: boolean) => {
@@ -382,6 +383,7 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
                 if (config.is3DIcon !== undefined) this.setIconGizmo3D(config.is3DIcon);
                 if (config.iconSize !== undefined) this.setIconGizmoSize(config.iconSize);
                 if (config.transformToolName !== undefined) this.transformToolName = config.transformToolName;
+                if (config.viewMode !== undefined) this.viewMode = config.viewMode;
                 if (config.pivot !== undefined) this.setPivot(config.pivot);
                 if (config.coordinate !== undefined) this.setCoordinate(config.coordinate);
                 if (config.toolsVisibility3d !== undefined) {
@@ -410,6 +412,7 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
                 is3DIcon: this.isIconGizmo3D(),
                 iconSize: this.queryIconGizmoSize(),
                 transformToolName: this.transformToolName,
+                viewMode: this.viewMode,
                 pivot: this.pivot,
                 coordinate: this.coordinate,
                 toolsVisibility3d: this.queryToolsVisibility3d(),

--- a/src/core/scene/scene-process/service/gizmo.ts
+++ b/src/core/scene/scene-process/service/gizmo.ts
@@ -9,10 +9,11 @@ import GizmoDefines from './gizmo/gizmo-defines';
 import GizmoBase from './gizmo/base/gizmo-base';
 import GizmoOperation from './gizmo/gizmo-operation';
 import { create3DNode } from './gizmo/utils/engine-utils';
+import { rectTransformSnapping } from './gizmo/utils/rect-transform-snapping';
 import WorldAxisController from './gizmo/controller/world-axis';
 import { NodeEventType } from '../../common';
 import { Rpc } from '../rpc';
-import type { IGizmoEvents, IGizmoService, IChangeNodeOptions } from '../../common';
+import type { IGizmoEvents, IGizmoService, IChangeNodeOptions, IRectSnapConfigData } from '../../common';
 
 // Import component gizmo modules so they self-register via registerGizmo()
 import './gizmo/components/camera';
@@ -310,6 +311,7 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
             }
             this.onDimensionChanged(is2D);
             ServiceEvents.broadcast('scene:dimension-changed', is2D);
+            this.saveConfig();
         });
 
         // 与 cocos-editor gizmos.ts 一致：只在 IDLE 解锁、WANDER 锁定
@@ -390,6 +392,9 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
                 if (config.snapConfigs) {
                     this.transformToolData.snapConfigs.initFromData(config.snapConfigs);
                 }
+                if (config.rectSnapConfig) {
+                    rectTransformSnapping.initFromData(config.rectSnapConfig);
+                }
             }
         } catch {
             // 配置不可用时使用默认值
@@ -409,6 +414,7 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
                 coordinate: this.coordinate,
                 toolsVisibility3d: this.queryToolsVisibility3d(),
                 snapConfigs: this.transformToolData.snapConfigs.getPureDataObject(),
+                rectSnapConfig: rectTransformSnapping.getPureDataObject(),
             };
             await rpc.request('sceneConfigInstance', 'set', ['gizmo', gizmoConfig]);
         } catch {
@@ -465,6 +471,7 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
             }
         }
         Service.Engine?.repaintInEditMode?.();
+        void this.saveConfig();
     }
 
     isIconGizmo3D(): boolean {
@@ -481,6 +488,7 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
             }
         });
         Service.Engine?.repaintInEditMode?.();
+        void this.saveConfig();
     }
 
     queryIconGizmoSize(): number {
@@ -497,6 +505,7 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
             }
         });
         Service.Engine?.repaintInEditMode?.();
+        void this.saveConfig();
     }
 
     setIconVisible(visible: boolean): void {
@@ -536,6 +545,19 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
 
     setTransformSnapConfigs(name: string, value: any): void {
         (this.transformToolData.snapConfigs as any)[name] = value;
+    }
+
+    queryRectSnapConfig(): IRectSnapConfigData {
+        return rectTransformSnapping.getPureDataObject();
+    }
+
+    setRectSnapConfig(config: Partial<IRectSnapConfigData>): void {
+        rectTransformSnapping.initFromData({
+            ...rectTransformSnapping.getPureDataObject(),
+            ...config,
+        });
+        Service.Engine?.repaintInEditMode?.();
+        void this.saveConfig();
     }
 
     // ── Pool management (与 cocos-editor GizmoPool 一致) ────────────────────────

--- a/src/core/scene/scene-process/service/gizmo.ts
+++ b/src/core/scene/scene-process/service/gizmo.ts
@@ -14,6 +14,7 @@ import WorldAxisController from './gizmo/controller/world-axis';
 import { NodeEventType } from '../../common';
 import { Rpc } from '../rpc';
 import type { IGizmoEvents, IGizmoService, IChangeNodeOptions, IRectSnapConfigData } from '../../common';
+import type { IOriginAxesConfig } from '../../scene-configs';
 
 // Import component gizmo modules so they self-register via registerGizmo()
 import './gizmo/components/camera';
@@ -45,6 +46,9 @@ class GizmoConfig {
     static toolsVisibility3d = true;
     static isIconGizmo3D = false;
     static iconGizmoSize = 2;
+    static gridColor: number[] = [166, 166, 166, 255];
+    static originAxis2D: IOriginAxesConfig = { x: true, y: true, z: false };
+    static originAxis3D: IOriginAxesConfig = { x: true, y: false, z: true };
 }
 
 // WeakMaps to associate components with their gizmo instances
@@ -397,6 +401,9 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
                 if (config.rectSnapConfig) {
                     rectTransformSnapping.initFromData(config.rectSnapConfig);
                 }
+                if (config.gridColor !== undefined) GizmoConfig.gridColor = config.gridColor;
+                if (config.originAxis2D !== undefined) GizmoConfig.originAxis2D = config.originAxis2D;
+                if (config.originAxis3D !== undefined) GizmoConfig.originAxis3D = config.originAxis3D;
             }
         } catch {
             // 配置不可用时使用默认值
@@ -420,6 +427,9 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
                 toolsVisibility3d: this.queryToolsVisibility3d(),
                 snapConfigs: this.transformToolData.snapConfigs.getPureDataObject(),
                 rectSnapConfig: rectTransformSnapping.getPureDataObject(),
+                gridColor: this.queryGridColor(),
+                originAxis2D: this.queryOriginAxes2D(),
+                originAxis3D: this.queryOriginAxes3D(),
             };
             await rpc.request('sceneConfigInstance', 'set', ['gizmo', gizmoConfig]);
         } catch {
@@ -510,6 +520,39 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
             }
         });
         Service.Engine?.repaintInEditMode?.();
+        void this.saveConfig();
+    }
+
+    queryGridColor(): number[] {
+        return GizmoConfig.gridColor;
+    }
+
+    setGridColor(color: number[]): void {
+        if (!color) return;
+        GizmoConfig.gridColor = [...color];
+        Service.Camera?.setGridColor?.(color);
+        void this.saveConfig();
+    }
+
+    queryOriginAxes2D(): IOriginAxesConfig {
+        return GizmoConfig.originAxis2D;
+    }
+
+    setOriginAxes2D(config: IOriginAxesConfig): void {
+        if (!config) return;
+        GizmoConfig.originAxis2D = { ...config };
+        Service.Camera?.setOriginAxes2D?.(config);
+        void this.saveConfig();
+    }
+
+    queryOriginAxes3D(): IOriginAxesConfig {
+        return GizmoConfig.originAxis3D;
+    }
+
+    setOriginAxes3D(config: IOriginAxesConfig): void {
+        if (!config) return;
+        GizmoConfig.originAxis3D = { ...config };
+        Service.Camera?.setOriginAxes3D?.(config);
         void this.saveConfig();
     }
 

--- a/src/core/scene/scene-process/service/index.ts
+++ b/src/core/scene/scene-process/service/index.ts
@@ -13,4 +13,5 @@ export * from './camera';
 export * from './gizmo';
 export * from './scene-view';
 export * from './particle';
+export * from './ui';
 export * from './core/global-events';

--- a/src/core/scene/scene-process/service/interfaces.ts
+++ b/src/core/scene/scene-process/service/interfaces.ts
@@ -25,6 +25,8 @@ import {
     IGizmoService,
     IPublicSceneViewService,
     ISceneViewService,
+    IPublicUIService,
+    IUIService,
 } from '../../common';
 
 /**
@@ -44,6 +46,7 @@ export interface IPublicServiceManager {
     Camera: IPublicCameraService,
     Gizmo: IPublicGizmoService,
     SceneView: IPublicSceneViewService,
+    UI: IPublicUIService,
 }
 
 export interface IServiceManager {
@@ -60,4 +63,5 @@ export interface IServiceManager {
     Camera: ICameraService,
     Gizmo: IGizmoService,
     SceneView: ISceneViewService,
+    UI: IUIService,
 }

--- a/src/core/scene/scene-process/service/scene-view.ts
+++ b/src/core/scene/scene-process/service/scene-view.ts
@@ -36,6 +36,10 @@ export class SceneViewService extends BaseService<ISceneViewEvents> implements I
         sceneViewData.on('is-scene-light-on', (isOn: boolean) => {
             this._onIsSceneLightOn(isOn);
         });
+
+        void this.initFromConfig().then(() => {
+            this._onIsSceneLightOn(sceneViewData.isSceneLightOn);
+        });
     }
 
     async initFromConfig(): Promise<void> {
@@ -48,6 +52,7 @@ export class SceneViewService extends BaseService<ISceneViewEvents> implements I
 
     setSceneLightOn(enable: boolean): void {
         sceneViewData.isSceneLightOn = enable;
+        void sceneViewData.saveConfig();
     }
 
     querySceneLightOn(): boolean {

--- a/src/core/scene/scene-process/service/scene-view/scene-view-data.ts
+++ b/src/core/scene/scene-process/service/scene-view/scene-view-data.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import { EventEmitter } from 'events';
+import { Rpc } from '../../rpc';
 
 export interface IResolutionData {
     width: number;
@@ -44,11 +45,26 @@ class SceneViewData extends EventEmitter {
     }
 
     async initFromConfig(): Promise<void> {
-        // CLI stub: no persisted config
+        try {
+            const rpc = Rpc.getInstance();
+            const config = await rpc.request('sceneConfigInstance', 'get', ['sceneView']) as { sceneLightOn?: boolean } | undefined;
+            if (typeof config?.sceneLightOn === 'boolean') {
+                this._isSceneLightOn = config.sceneLightOn;
+            }
+        } catch {
+            // Config persistence not available
+        }
     }
 
     async saveConfig(): Promise<void> {
-        // CLI stub: no persisted config
+        try {
+            const rpc = Rpc.getInstance();
+            await rpc.request('sceneConfigInstance', 'set', ['sceneView', {
+                sceneLightOn: this._isSceneLightOn,
+            }]);
+        } catch {
+            // Config persistence not available
+        }
     }
 }
 

--- a/src/core/scene/scene-process/service/ui.ts
+++ b/src/core/scene/scene-process/service/ui.ts
@@ -1,0 +1,217 @@
+'use strict';
+
+import { Mat4, Node, Rect, UITransform, Vec3 } from 'cc';
+import { BaseService, register, Service } from './core';
+import type { IUIService, IUIEvents, UIAlignType } from '../../common';
+
+const v3_a = new Vec3();
+const tempMatrix = new Mat4();
+
+interface Item {
+    node: Node;
+    bounds: Rect;
+}
+
+function getNodeByUuid(uuid: string): Node | null {
+    const EditorExtends = (cc as any).EditorExtends || (globalThis as any).EditorExtends;
+    return EditorExtends?.Node?.getNode?.(uuid) ?? null;
+}
+
+function getWorldBounds(node: Node): Rect {
+    let width = 0;
+    let height = 0;
+    const rect = new Rect(0, 0, width, height);
+
+    const uiTransComp: UITransform | null = node.getComponent(UITransform);
+    if (uiTransComp) {
+        const size = uiTransComp.contentSize;
+        width = size.width;
+        height = size.height;
+        const anchor = uiTransComp.anchorPoint;
+
+        rect.x = -anchor.x * width;
+        rect.y = -anchor.y * height;
+        rect.width = width;
+        rect.height = height;
+    }
+
+    node.getWorldMatrix(tempMatrix);
+    rect.transformMat4(tempMatrix);
+
+    return rect;
+}
+
+function filterTopLevelNodes(nodes: Node[]): Node[] {
+    return nodes.filter((node) => {
+        let parent = node.parent;
+        while (parent) {
+            if (nodes.indexOf(parent) !== -1) {
+                return false;
+            }
+            parent = parent.parent;
+        }
+        return true;
+    });
+}
+
+@register('UI')
+export class UIService extends BaseService<IUIEvents> implements IUIService {
+    public alignSelection(type: UIAlignType) {
+        const curSelectUuids = Service.Selection.query();
+
+        if (curSelectUuids.length <= 1) {
+            return;
+        }
+
+        let selectedNodes: Node[] = curSelectUuids.map((id: string) => {
+            return getNodeByUuid(id);
+        }).filter(Boolean) as Node[];
+
+        selectedNodes = filterTopLevelNodes(selectedNodes);
+
+        let minX = 1e10;
+        let minY = 1e10;
+        let maxX = -1e10;
+        let maxY = -1e10;
+
+        const items: Item[] = selectedNodes.map((node) => {
+            const bounds = getWorldBounds(node);
+
+            minX = Math.min(minX, bounds.x);
+            minY = Math.min(minY, bounds.y);
+            maxX = Math.max(maxX, bounds.xMax);
+            maxY = Math.max(maxY, bounds.yMax);
+
+            return {
+                node: node,
+                bounds: bounds,
+            };
+        });
+
+        const aabb = new Rect(minX, minY, maxX - minX, maxY - minY);
+
+        const uuids = selectedNodes.map((node) => node.uuid);
+        const undoID = Service.Undo.beginRecording(uuids);
+
+        items.forEach((item) => {
+            const node = item.node;
+
+            let dif;
+            switch (type) {
+                case 'top':
+                    dif = new Vec3(0, aabb.yMax - item.bounds.yMax, 0);
+                    break;
+                case 'v-center':
+                    dif = new Vec3(0, aabb.center.y - item.bounds.center.y, 0);
+                    break;
+                case 'bottom':
+                    dif = new Vec3(0, aabb.y - item.bounds.y, 0);
+                    break;
+                case 'left':
+                    dif = new Vec3(aabb.x - item.bounds.x, 0, 0);
+                    break;
+                case 'h-center':
+                    dif = new Vec3(aabb.center.x - item.bounds.center.x, 0, 0);
+                    break;
+                case 'right':
+                    dif = new Vec3(aabb.xMax - item.bounds.xMax, 0, 0);
+                    break;
+            }
+
+            const worldPos = node.getWorldPosition();
+            node.setWorldPosition(Vec3.add(v3_a, worldPos, dif));
+        });
+
+        Service.Undo.endRecording(undoID);
+        this.emit('ui:align-selection', type);
+    }
+
+    public distributeSelection(type: UIAlignType) {
+        const curSelectUuids = Service.Selection.query();
+
+        if (curSelectUuids.length <= 1) {
+            return;
+        }
+
+        let selectedNodes = curSelectUuids.map((id: string) => {
+            return getNodeByUuid(id);
+        }).filter(Boolean) as Node[];
+
+        selectedNodes = filterTopLevelNodes(selectedNodes);
+
+        const items: Item[] = selectedNodes.map((node) => {
+            const bounds = getWorldBounds(node);
+
+            return {
+                node: node,
+                bounds: bounds,
+            };
+        });
+
+        items.sort((a, b) => {
+            let result = 1;
+            switch (type) {
+                case 'top':
+                    result = a.bounds.yMax - b.bounds.yMax;
+                    break;
+                case 'v-center':
+                    result = a.bounds.center.y - b.bounds.center.y;
+                    break;
+                case 'bottom':
+                    result = a.bounds.y - b.bounds.y;
+                    break;
+                case 'left':
+                    result = a.bounds.x - b.bounds.x;
+                    break;
+                case 'h-center':
+                    result = a.bounds.center.x - b.bounds.center.x;
+                    break;
+                case 'right':
+                    result = a.bounds.xMax - b.bounds.xMax;
+                    break;
+            }
+
+            return result;
+        });
+
+        const length = items.length - 1;
+        const first = items[0].bounds;
+        const last = items[length].bounds;
+
+        const uuids = selectedNodes.map((node) => node.uuid);
+        const undoID = Service.Undo.beginRecording(uuids);
+
+        items.forEach((item, i) => {
+            const node = item.node;
+            const bounds = item.bounds;
+            let dif;
+
+            switch (type) {
+                case 'top':
+                    dif = new Vec3(0, first.yMax + ((last.yMax - first.yMax) * i) / length - bounds.yMax, 0);
+                    break;
+                case 'v-center':
+                    dif = new Vec3(0, first.center.y + ((last.center.y - first.center.y) * i) / length - bounds.center.y, 0);
+                    break;
+                case 'bottom':
+                    dif = new Vec3(0, first.y + ((last.y - first.y) * i) / length - bounds.y, 0);
+                    break;
+                case 'left':
+                    dif = new Vec3(first.x + ((last.x - first.x) * i) / length - bounds.x, 0, 0);
+                    break;
+                case 'h-center':
+                    dif = new Vec3(first.center.x + ((last.center.x - first.center.x) * i) / length - bounds.center.x, 0, 0);
+                    break;
+                case 'right':
+                    dif = new Vec3(first.xMax + ((last.xMax - first.xMax) * i) / length - bounds.xMax, 0, 0);
+                    break;
+            }
+
+            const worldPos = node.getWorldPosition();
+            node.setWorldPosition(Vec3.add(v3_a, worldPos, dif));
+        });
+
+        Service.Undo.endRecording(undoID);
+        this.emit('ui:distribute-selection', type);
+    }
+}

--- a/src/core/scene/test/scene-configs.test.ts
+++ b/src/core/scene/test/scene-configs.test.ts
@@ -58,6 +58,7 @@ describe('SceneConfig', () => {
             const gizmo = await sceneConfigInstance.get<Record<string, any>>('gizmo');
             expect(gizmo.is2D).toBe(false);
             expect(gizmo.transformToolName).toBe('position');
+            expect(gizmo.viewMode).toBe('select');
             expect(gizmo.pivot).toBe('pivot');
             expect(gizmo.coordinate).toBe('local');
             expect(gizmo.toolsVisibility3d).toBe(true);
@@ -90,6 +91,11 @@ describe('SceneConfig', () => {
         it('should update gizmo boolean flag', async () => {
             await sceneConfigInstance.set('gizmo.is2D', true);
             expect(await sceneConfigInstance.get('gizmo.is2D')).toBe(true);
+        });
+
+        it('should update gizmo viewMode', async () => {
+            await sceneConfigInstance.set('gizmo.viewMode', 'view');
+            expect(await sceneConfigInstance.get('gizmo.viewMode')).toBe('view');
         });
 
         it('should update gizmo snapConfigs as a whole object', async () => {

--- a/src/core/scene/test/scene-configs.test.ts
+++ b/src/core/scene/test/scene-configs.test.ts
@@ -1,0 +1,126 @@
+import { configurationRegistry } from '../../configuration';
+import { sceneConfigInstance, ISceneConfig } from '../scene-configs';
+
+describe('SceneConfig', () => {
+    let saveSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+        await sceneConfigInstance.init();
+        const instance = configurationRegistry.getInstance('scene')!;
+        saveSpy = jest.spyOn(instance, 'save').mockResolvedValue(true);
+    });
+
+    afterEach(async () => {
+        saveSpy.mockRestore();
+        await configurationRegistry.unregister('scene');
+    });
+
+    describe('init', () => {
+        it('should register scene config in configurationRegistry', () => {
+            const instance = configurationRegistry.getInstance('scene');
+            expect(instance).toBeDefined();
+            expect(instance!.moduleName).toBe('scene');
+        });
+
+        it('should return full default config when get() called without path', async () => {
+            const config = await sceneConfigInstance.get<ISceneConfig>();
+            expect(config.tick).toBe(false);
+            expect(config.camera).toBeDefined();
+            expect(config.gizmo).toBeDefined();
+            expect(config.sceneView).toBeDefined();
+        });
+    });
+
+    describe('get - read default values by path', () => {
+        it('should get top-level tick config', async () => {
+            expect(await sceneConfigInstance.get('tick')).toBe(false);
+        });
+
+        it('should get camera config object', async () => {
+            const camera = await sceneConfigInstance.get<Record<string, any>>('camera');
+            expect(camera.fov).toBe(45);
+            expect(camera.far).toBe(10000);
+            expect(camera.near).toBe(0.01);
+            expect(camera.color).toEqual([48, 48, 48, 255]);
+            expect(camera.enableAcceleration).toBe(true);
+            expect(camera.gridVisible).toBe(true);
+        });
+
+        it('should get nested camera properties via dot path', async () => {
+            expect(await sceneConfigInstance.get('camera.fov')).toBe(45);
+            expect(await sceneConfigInstance.get('camera.wheelSpeed')).toBe(0.01);
+            expect(await sceneConfigInstance.get('camera.originAxis3D')).toEqual({
+                x: true, y: false, z: true,
+            });
+        });
+
+        it('should get gizmo config', async () => {
+            const gizmo = await sceneConfigInstance.get<Record<string, any>>('gizmo');
+            expect(gizmo.is2D).toBe(false);
+            expect(gizmo.transformToolName).toBe('position');
+            expect(gizmo.pivot).toBe('pivot');
+            expect(gizmo.coordinate).toBe('local');
+            expect(gizmo.toolsVisibility3d).toBe(true);
+        });
+
+        it('should get deeply nested gizmo properties', async () => {
+            expect(await sceneConfigInstance.get('gizmo.rectSnapConfig')).toEqual({
+                enableSnapping: true,
+                snapThreshold: 4,
+            });
+            expect(await sceneConfigInstance.get('gizmo.rectSnapConfig.snapThreshold')).toBe(4);
+        });
+
+        it('should get sceneView config', async () => {
+            expect(await sceneConfigInstance.get('sceneView.sceneLightOn')).toBe(true);
+        });
+    });
+
+    describe('set + get - write then read back', () => {
+        it('should update tick value', async () => {
+            await sceneConfigInstance.set('tick', true);
+            expect(await sceneConfigInstance.get('tick')).toBe(true);
+        });
+
+        it('should update nested camera property', async () => {
+            await sceneConfigInstance.set('camera.fov', 60);
+            expect(await sceneConfigInstance.get('camera.fov')).toBe(60);
+        });
+
+        it('should update gizmo boolean flag', async () => {
+            await sceneConfigInstance.set('gizmo.is2D', true);
+            expect(await sceneConfigInstance.get('gizmo.is2D')).toBe(true);
+        });
+
+        it('should update gizmo snapConfigs as a whole object', async () => {
+            const newSnapConfigs = {
+                position: { x: 2, y: 2, z: 2 },
+                rotation: 15,
+                scale: 0.5,
+                isPositionSnapEnabled: true,
+                isRotationSnapEnabled: true,
+                isScaleSnapEnabled: false,
+            };
+            await sceneConfigInstance.set('gizmo.snapConfigs', newSnapConfigs);
+            expect(await sceneConfigInstance.get('gizmo.snapConfigs')).toEqual(newSnapConfigs);
+        });
+
+        it('should update sceneView config', async () => {
+            await sceneConfigInstance.set('sceneView.sceneLightOn', false);
+            expect(await sceneConfigInstance.get('sceneView.sceneLightOn')).toBe(false);
+        });
+    });
+
+    describe('set with scope', () => {
+        it('should write to default scope and read back', async () => {
+            await sceneConfigInstance.set('tick', true, 'default');
+            expect(await sceneConfigInstance.get('tick', 'default')).toBe(true);
+        });
+
+        it('should write to project scope and read back', async () => {
+            await sceneConfigInstance.set('camera.fov', 90, 'project');
+            expect(await sceneConfigInstance.get('camera.fov', 'project')).toBe(90);
+            expect(await sceneConfigInstance.get('camera.fov', 'default')).toBe(45);
+        });
+    });
+});

--- a/src/core/scene/test/scene-configs.test.ts
+++ b/src/core/scene/test/scene-configs.test.ts
@@ -43,15 +43,11 @@ describe('SceneConfig', () => {
             expect(camera.near).toBe(0.01);
             expect(camera.color).toEqual([48, 48, 48, 255]);
             expect(camera.enableAcceleration).toBe(true);
-            expect(camera.gridVisible).toBe(true);
         });
 
         it('should get nested camera properties via dot path', async () => {
             expect(await sceneConfigInstance.get('camera.fov')).toBe(45);
             expect(await sceneConfigInstance.get('camera.wheelSpeed')).toBe(0.01);
-            expect(await sceneConfigInstance.get('camera.originAxis3D')).toEqual({
-                x: true, y: false, z: true,
-            });
         });
 
         it('should get gizmo config', async () => {
@@ -62,6 +58,10 @@ describe('SceneConfig', () => {
             expect(gizmo.pivot).toBe('pivot');
             expect(gizmo.coordinate).toBe('local');
             expect(gizmo.toolsVisibility3d).toBe(true);
+            expect(gizmo.gridVisible).toBe(true);
+            expect(gizmo.gridColor).toEqual([166, 166, 166, 255]);
+            expect(gizmo.originAxis2D).toEqual({ x: true, y: true, z: false });
+            expect(gizmo.originAxis3D).toEqual({ x: true, y: false, z: true });
         });
 
         it('should get deeply nested gizmo properties', async () => {

--- a/tests/__snapshots__/dts-snapshot.test.ts.snap
+++ b/tests/__snapshots__/dts-snapshot.test.ts.snap
@@ -5334,6 +5334,9 @@ export declare interface ICameraService {
     zoomReset(): void;
     alignNodeToSceneView(nodes: string[]): void;
     alignSceneViewToNode(nodes: string[]): void;
+    setGridColor(color: number[]): void;
+    setOriginAxes2D(config: IOriginAxesConfig): void;
+    setOriginAxes3D(config: IOriginAxesConfig): void;
     onUpdate(deltaTime: number): void;
 }
 export declare interface IChangeNodeOptions {
@@ -5460,6 +5463,12 @@ export declare interface IGizmoService {
     setIconGizmo3D(value: boolean): void;
     queryIconGizmoSize(): number;
     setIconGizmoSize(size: number): void;
+    queryGridColor(): number[];
+    setGridColor(color: number[]): void;
+    queryOriginAxes2D(): IOriginAxesConfig;
+    setOriginAxes2D(config: IOriginAxesConfig): void;
+    queryOriginAxes3D(): IOriginAxesConfig;
+    setOriginAxes3D(config: IOriginAxesConfig): void;
     queryTransformSnapConfigs(): any;
     setTransformSnapConfigs(name: string, value: any): void;
     queryRectSnapConfig(): IRectSnapConfigData;
@@ -5558,6 +5567,11 @@ export declare interface IOperationService {
     requestPointerLock(): void;
     exitPointerLock(): void;
     changePointer(type: string): void;
+}
+export declare interface IOriginAxesConfig {
+    x: boolean;
+    y: boolean;
+    z: boolean;
 }
 export declare interface IPrefab {
     uuid: string;
@@ -7204,6 +7218,9 @@ export declare interface ICameraService {
     zoomReset(): void;
     alignNodeToSceneView(nodes: string[]): void;
     alignSceneViewToNode(nodes: string[]): void;
+    setGridColor(color: number[]): void;
+    setOriginAxes2D(config: IOriginAxesConfig): void;
+    setOriginAxes3D(config: IOriginAxesConfig): void;
     onUpdate(deltaTime: number): void;
 }
 export declare interface IChangeNodeOptions {
@@ -7460,6 +7477,12 @@ export declare interface IGizmoService {
     setIconGizmo3D(value: boolean): void;
     queryIconGizmoSize(): number;
     setIconGizmoSize(size: number): void;
+    queryGridColor(): number[];
+    setGridColor(color: number[]): void;
+    queryOriginAxes2D(): IOriginAxesConfig;
+    setOriginAxes2D(config: IOriginAxesConfig): void;
+    queryOriginAxes3D(): IOriginAxesConfig;
+    setOriginAxes3D(config: IOriginAxesConfig): void;
     queryTransformSnapConfigs(): any;
     setTransformSnapConfigs(name: string, value: any): void;
     queryRectSnapConfig(): IRectSnapConfigData;
@@ -7602,6 +7625,11 @@ export declare interface IOperationService {
     requestPointerLock(): void;
     exitPointerLock(): void;
     changePointer(type: string): void;
+}
+export declare interface IOriginAxesConfig {
+    x: boolean;
+    y: boolean;
+    z: boolean;
 }
 export declare interface IPhysicsConfig {
     gravity: IVec3Like; 

--- a/tests/__snapshots__/dts-snapshot.test.ts.snap
+++ b/tests/__snapshots__/dts-snapshot.test.ts.snap
@@ -5443,7 +5443,6 @@ export declare interface IGizmoService {
     transformToolData: any;
     transformToolName: string;
     isViewMode: boolean;
-    viewMode: string;
     is2D: boolean;
     init(): void;
     initFromConfig(): Promise<void>;
@@ -7453,7 +7452,6 @@ export declare interface IGizmoService {
     transformToolData: any;
     transformToolName: string;
     isViewMode: boolean;
-    viewMode: string;
     is2D: boolean;
     init(): void;
     initFromConfig(): Promise<void>;

--- a/tests/__snapshots__/dts-snapshot.test.ts.snap
+++ b/tests/__snapshots__/dts-snapshot.test.ts.snap
@@ -5302,6 +5302,22 @@ export declare interface IBaseIdentifier {
     assetUrl: string;
     assetType: string;
 }
+export declare interface ICameraConfigData {
+    color: number[];
+    fov: number;
+    far: number;
+    near: number;
+    wheelSpeed: number;
+    wanderSpeed: number;
+    enableAcceleration: boolean;
+    aperture: number;
+    shutter: number;
+    iso: number;
+    gridVisible: boolean;
+    gridColor: number[];
+    originAxis2D: IOriginAxesConfig;
+    originAxis3D: IOriginAxesConfig;
+}
 export declare interface ICameraService {
     init(): void;
     initFromConfig(): Promise<void>;
@@ -5314,6 +5330,8 @@ export declare interface ICameraService {
     isGridVisible(): boolean;
     setCameraProperty(options: any): void;
     resetCameraProperty(): void;
+    queryConfig(): ICameraConfigData;
+    updateConfig(config: Partial<ICameraConfigData>): void;
     getCameraFov(): number;
     zoomUp(): void;
     zoomDown(): void;
@@ -5425,6 +5443,7 @@ export declare interface IGizmoService {
     transformToolData: any;
     transformToolName: string;
     isViewMode: boolean;
+    viewMode: string;
     is2D: boolean;
     init(): void;
     initFromConfig(): Promise<void>;
@@ -5448,6 +5467,8 @@ export declare interface IGizmoService {
     setIconGizmoSize(size: number): void;
     queryTransformSnapConfigs(): any;
     setTransformSnapConfigs(name: string, value: any): void;
+    queryRectSnapConfig(): IRectSnapConfigData;
+    setRectSnapConfig(config: Partial<IRectSnapConfigData>): void;
     querySelectNodes(): any[];
     hasSelected(uuid: string): boolean;
     onResize(): void;
@@ -5543,6 +5564,11 @@ export declare interface IOperationService {
     exitPointerLock(): void;
     changePointer(type: string): void;
 }
+export declare interface IOriginAxesConfig {
+    x: boolean;
+    y: boolean;
+    z: boolean;
+}
 export declare interface IPrefab {
     uuid: string;
     fileId: string;
@@ -5631,6 +5657,10 @@ export declare interface IQueryNodeParams {
 }
 export declare interface IQueryNodeTreeParams {
     path?: string;
+}
+export declare interface IRectSnapConfigData {
+    enableSnapping: boolean;
+    snapThreshold: number;
 }
 export declare interface IRedirectInfo {
     type: string;
@@ -5765,6 +5795,7 @@ export declare interface IServiceManager {
     Camera: ICameraService;
     Gizmo: IGizmoService;
     SceneView: ISceneViewService;
+    UI: IUIService;
 }
 export declare interface ISetPropertyOptions {
     nodePath: string;
@@ -5795,6 +5826,10 @@ export declare interface ITargetOverrideInfo {
     propertyPath: string[];
     target: string;
     targetInfo?: string[];
+}
+export declare interface IUIService {
+    alignSelection(type: UIAlignType): void;
+    distributeSelection(type: UIAlignType): void;
 }
 export declare interface IUndoService {
     beginRecording(uuids: string[], options?: any): string;
@@ -6137,6 +6172,7 @@ export declare interface TextureCubeAssetUserData extends TextureBaseAssetUserDa
     bottom?: string;
 }
 export declare type TSceneTemplateType = typeof SCENE_TEMPLATE_TYPE[number];
+export declare type UIAlignType = 'top' | 'v-center' | 'bottom' | 'left' | 'h-center' | 'right';
 export declare interface Vec2 {
     x: number;
     y: number;
@@ -7146,6 +7182,22 @@ export declare interface IBaseIdentifier {
     assetUrl: string;
     assetType: string;
 }
+export declare interface ICameraConfigData {
+    color: number[];
+    fov: number;
+    far: number;
+    near: number;
+    wheelSpeed: number;
+    wanderSpeed: number;
+    enableAcceleration: boolean;
+    aperture: number;
+    shutter: number;
+    iso: number;
+    gridVisible: boolean;
+    gridColor: number[];
+    originAxis2D: IOriginAxesConfig;
+    originAxis3D: IOriginAxesConfig;
+}
 export declare interface ICameraService {
     init(): void;
     initFromConfig(): Promise<void>;
@@ -7158,6 +7210,8 @@ export declare interface ICameraService {
     isGridVisible(): boolean;
     setCameraProperty(options: any): void;
     resetCameraProperty(): void;
+    queryConfig(): ICameraConfigData;
+    updateConfig(config: Partial<ICameraConfigData>): void;
     getCameraFov(): number;
     zoomUp(): void;
     zoomDown(): void;
@@ -7399,6 +7453,7 @@ export declare interface IGizmoService {
     transformToolData: any;
     transformToolName: string;
     isViewMode: boolean;
+    viewMode: string;
     is2D: boolean;
     init(): void;
     initFromConfig(): Promise<void>;
@@ -7422,6 +7477,8 @@ export declare interface IGizmoService {
     setIconGizmoSize(size: number): void;
     queryTransformSnapConfigs(): any;
     setTransformSnapConfigs(name: string, value: any): void;
+    queryRectSnapConfig(): IRectSnapConfigData;
+    setRectSnapConfig(config: Partial<IRectSnapConfigData>): void;
     querySelectNodes(): any[];
     hasSelected(uuid: string): boolean;
     onResize(): void;
@@ -7561,6 +7618,11 @@ export declare interface IOperationService {
     exitPointerLock(): void;
     changePointer(type: string): void;
 }
+export declare interface IOriginAxesConfig {
+    x: boolean;
+    y: boolean;
+    z: boolean;
+}
 export declare interface IPhysicsConfig {
     gravity: IVec3Like; 
     allowSleep: boolean; 
@@ -7689,6 +7751,10 @@ export declare interface IQueryNodeParams {
 }
 export declare interface IQueryNodeTreeParams {
     path?: string;
+}
+export declare interface IRectSnapConfigData {
+    enableSnapping: boolean;
+    snapThreshold: number;
 }
 export declare interface IRedirectInfo {
     type: string;
@@ -7823,6 +7889,7 @@ export declare interface IServiceManager {
     Camera: ICameraService;
     Gizmo: IGizmoService;
     SceneView: ISceneViewService;
+    UI: IUIService;
 }
 export declare interface ISetPropertyOptions {
     nodePath: string;
@@ -7900,6 +7967,10 @@ export declare interface IUerDataConfigItem {
             value: string;
         }>;
     };
+}
+export declare interface IUIService {
+    alignSelection(type: UIAlignType): void;
+    distributeSelection(type: UIAlignType): void;
 }
 export declare interface IUndoService {
     beginRecording(uuids: string[], options?: any): string;
@@ -8470,6 +8541,7 @@ export declare interface ThumbnailInfo {
 }
 export declare type ThumbnailSize = 'large' | 'small' | 'middle' | 'origin';
 export declare type TSceneTemplateType = typeof SCENE_TEMPLATE_TYPE[number];
+export declare type UIAlignType = 'top' | 'v-center' | 'bottom' | 'left' | 'h-center' | 'right';
 export declare function unregister(): Promise<void>;
 export declare function updateAssetUserData(urlOrUuidOrPath: string, path: string, value: any): Promise<any>;
 export declare function updateDefaultUserData(handler: string, path: string, value: any): Promise<void>;

--- a/tests/__snapshots__/dts-snapshot.test.ts.snap
+++ b/tests/__snapshots__/dts-snapshot.test.ts.snap
@@ -5302,7 +5302,7 @@ export declare interface IBaseIdentifier {
     assetUrl: string;
     assetType: string;
 }
-export declare interface ICameraConfigData {
+export declare interface ICameraConfig {
     color: number[];
     fov: number;
     far: number;
@@ -5313,10 +5313,6 @@ export declare interface ICameraConfigData {
     aperture: number;
     shutter: number;
     iso: number;
-    gridVisible: boolean;
-    gridColor: number[];
-    originAxis2D: IOriginAxesConfig;
-    originAxis3D: IOriginAxesConfig;
 }
 export declare interface ICameraService {
     init(): void;
@@ -5330,8 +5326,8 @@ export declare interface ICameraService {
     isGridVisible(): boolean;
     setCameraProperty(options: any): void;
     resetCameraProperty(): void;
-    queryConfig(): ICameraConfigData;
-    updateConfig(config: Partial<ICameraConfigData>): void;
+    queryConfig(): ICameraConfig;
+    updateConfig(config: Partial<ICameraConfig>): void;
     getCameraFov(): number;
     zoomUp(): void;
     zoomDown(): void;
@@ -5562,11 +5558,6 @@ export declare interface IOperationService {
     requestPointerLock(): void;
     exitPointerLock(): void;
     changePointer(type: string): void;
-}
-export declare interface IOriginAxesConfig {
-    x: boolean;
-    y: boolean;
-    z: boolean;
 }
 export declare interface IPrefab {
     uuid: string;
@@ -7181,7 +7172,7 @@ export declare interface IBaseIdentifier {
     assetUrl: string;
     assetType: string;
 }
-export declare interface ICameraConfigData {
+export declare interface ICameraConfig {
     color: number[];
     fov: number;
     far: number;
@@ -7192,10 +7183,6 @@ export declare interface ICameraConfigData {
     aperture: number;
     shutter: number;
     iso: number;
-    gridVisible: boolean;
-    gridColor: number[];
-    originAxis2D: IOriginAxesConfig;
-    originAxis3D: IOriginAxesConfig;
 }
 export declare interface ICameraService {
     init(): void;
@@ -7209,8 +7196,8 @@ export declare interface ICameraService {
     isGridVisible(): boolean;
     setCameraProperty(options: any): void;
     resetCameraProperty(): void;
-    queryConfig(): ICameraConfigData;
-    updateConfig(config: Partial<ICameraConfigData>): void;
+    queryConfig(): ICameraConfig;
+    updateConfig(config: Partial<ICameraConfig>): void;
     getCameraFov(): number;
     zoomUp(): void;
     zoomDown(): void;
@@ -7615,11 +7602,6 @@ export declare interface IOperationService {
     requestPointerLock(): void;
     exitPointerLock(): void;
     changePointer(type: string): void;
-}
-export declare interface IOriginAxesConfig {
-    x: boolean;
-    y: boolean;
-    z: boolean;
 }
 export declare interface IPhysicsConfig {
     gravity: IVec3Like; 

--- a/tests/fixtures/projects/asset-operation/cocos.config.json
+++ b/tests/fixtures/projects/asset-operation/cocos.config.json
@@ -1210,9 +1210,31 @@
             "is3DIcon": false,
             "iconSize": 2,
             "transformToolName": "position",
+            "viewMode": "select",
             "pivot": "pivot",
             "coordinate": "local",
             "toolsVisibility3d": true,
+            "gridVisible": true,
+            "gridColor": [
+                166,
+                166,
+                166,
+                255
+            ],
+            "originAxis2D": {
+                "x": true,
+                "y": true,
+                "z": false
+            },
+            "originAxis3D": {
+                "x": true,
+                "y": false,
+                "z": true
+            },
+            "rectSnapConfig": {
+                "enableSnapping": true,
+                "snapThreshold": 4
+            },
             "snapConfigs": {
                 "position": {
                     "x": 1,
@@ -1224,10 +1246,6 @@
                 "isPositionSnapEnabled": false,
                 "isRotationSnapEnabled": false,
                 "isScaleSnapEnabled": false
-            },
-            "rectSnapConfig": {
-                "enableSnapping": true,
-                "snapThreshold": 4
             }
         }
     }

--- a/tests/fixtures/projects/asset-operation/cocos.config.json
+++ b/tests/fixtures/projects/asset-operation/cocos.config.json
@@ -1203,5 +1203,32 @@
                 "visible": true
             }
         }
+    },
+    "scene": {
+        "gizmo": {
+            "is2D": false,
+            "is3DIcon": false,
+            "iconSize": 2,
+            "transformToolName": "position",
+            "pivot": "pivot",
+            "coordinate": "local",
+            "toolsVisibility3d": true,
+            "snapConfigs": {
+                "position": {
+                    "x": 1,
+                    "y": 1,
+                    "z": 1
+                },
+                "rotation": 1,
+                "scale": 1,
+                "isPositionSnapEnabled": false,
+                "isRotationSnapEnabled": false,
+                "isScaleSnapEnabled": false
+            },
+            "rectSnapConfig": {
+                "enableSnapping": true,
+                "snapThreshold": 4
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Expand `ICameraConfig` with full editor camera properties (aperture, shutter, ISO, wheel/wander speed, acceleration) and add `queryConfig` / `updateConfig` API to `CameraService`
- Expand `IGizmoConfig` with view mode, snap configs, rect snap config, icon size, tools visibility, and grid/axis display settings
- Move grid color and origin axis (2D/3D) config from `ICameraConfig` to `IGizmoConfig`, matching cocos-editor's `gizmos-infos` profile ownership
- Expose `setGridColor`, `setOriginAxes2D`, `setOriginAxes3D` as public API on both `ICameraService` and `IGizmoService`, with `GizmoService` as the config owner delegating rendering to `CameraService`
- Add `viewMode` (`'view' | 'select'`) to `IGizmoConfig` and persist on `view-mode-changed` event
- Introduce `UIService` with `alignSelection` and `distributeSelection` for 2D UI node layout alignment
- Add `SceneViewService` config persistence: init scene light from config on startup, persist on toggle
- Add `ISceneViewConfig` section to `ISceneConfig` with `sceneLightOn` default
- Add unit tests for `SceneConfig` init/get/set (dot-path reads, set+get round-trip, scope forwarding)
- Update asset-operation fixture and DTS snapshots to reflect new interfaces

## Test plan

- [ ] Verify camera config query/update round-trip through RPC
- [ ] Verify grid color and origin axes changes propagate from GizmoService to CameraService rendering
- [ ] Verify gizmo view mode persists across scene reloads
- [ ] Test rect snap config query/set in gizmo interactions
- [ ] Test UI align/distribute with multi-node selection in 2D scene
- [ ] Confirm scene light state persists across scene reloads
- [ ] Run `npm test` — SceneConfig unit tests pass
- [ ] Run `generate:dts` — snapshot matches