### PR TITLE
feat(scene): add selective query options to node dump and enhance scene encoding

### DIFF
--- a/e2e/mcp/api/node.e2e.test.ts
+++ b/e2e/mcp/api/node.e2e.test.ts
@@ -664,7 +664,8 @@ describe('MCP Node API', () => {
                     const queryResult = await mcpClient.callTool('scene-query-node', {
                         options: {
                             path: createResult.data.path,
-                            queryChildren: false
+                            queryChildren: false,
+                            queryComponent: true
                         }
                     });
 

--- a/src/core/scene/scene-process/service/dump/encode.ts
+++ b/src/core/scene/scene-process/service/dump/encode.ts
@@ -193,6 +193,7 @@ export function encodeNode(node: Node): INode {
         }
     }
     data.__comps__.forEach((comp, index) => {
+        comp.path = `__comps__.${index}`;
         if (comp.value && typeof comp.value === 'object' && !Array.isArray(comp.value)) {
             for (const [key, prop] of Object.entries(comp.value as Record<string, unknown>)) {
                 if (prop && typeof prop === 'object' && !Array.isArray(prop) && 'type' in prop && 'value' in prop) {
@@ -214,10 +215,10 @@ export function encodeScene(scene: any): IScene {
 
     const data: IScene = {
         path: '/',
-        active: encodeObject(scene.active, { default: null }),
-        locked: encodeObject(false, { default: false }),
-        name: encodeObject(scene.name || ctor.name, { default: null }),
-        uuid: encodeObject(scene.uuid, { default: null }),
+        active: encodeObject(scene.active, { default: null, displayName: 'Active' }),
+        locked: encodeObject(false, { default: false, displayName: 'Locked' }),
+        name: encodeObject(scene.name || ctor.name, { default: null, displayName: 'Name' }),
+        uuid: encodeObject(scene.uuid, { default: null, displayName: 'UUID', visible: false }),
         autoReleaseAssets: encodeObject(scene.autoReleaseAssets, { displayName: 'Auto Release Assets', default: false }),
         children: scene.children
             .map((child: any) => {

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -267,7 +267,10 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             const path = params?.path;
             const node = (path && path !== '/') ? NodeMgr.getNodeByPath(path) : root;
             if (!node) return null;
-            return await sceneUtils.generateNodeDump(node);
+            return await sceneUtils.generateNodeDump(node, {
+                queryChildren: params?.queryChildren,
+                queryComponent: params?.queryComponent,
+            });
         } catch (error) {
             console.error(error);
             throw error;

--- a/src/core/scene/scene-process/service/scene/utils.ts
+++ b/src/core/scene/scene-process/service/scene/utils.ts
@@ -181,7 +181,7 @@ class SceneUtil {
         if (dump.__prefab__) {
             this.enrichPrefabDump(dump.__prefab__, node['_prefab']);
         }
-        if (queryComponent && dump.__comps__) {
+        if (dump.__comps__) {
             for (let i = 0; i < dump.__comps__.length && i < node.components.length; i++) {
                 const comp = node.components[i];
                 (dump.__comps__[i] as any).__component_path__ = compMgr.getPathFromUuid(comp.uuid) ?? '';

--- a/src/core/scene/scene-process/service/scene/utils.ts
+++ b/src/core/scene/scene-process/service/scene/utils.ts
@@ -141,7 +141,10 @@ class SceneUtil {
         return prefab;
     }
 
-    async generateNodeDump(node: cc.Node): Promise<INode | IScene> {
+    async generateNodeDump(node: cc.Node, options?: { queryChildren?: boolean; queryComponent?: boolean }): Promise<INode | IScene> {
+        const queryChildren = options?.queryChildren ?? true;
+        const queryComponent = options?.queryComponent ?? true;
+
         if (node instanceof Scene) {
             const sceneDump = await translateDumpI18n(dumpUtil.dumpNode(node)) as IScene;
 
@@ -153,15 +156,19 @@ class SceneUtil {
                 this.enrichPrefabDump(d.__prefab__, node['_prefab']);
             }
             d.__comps__ = [];
-            for (const comp of node.components) {
-                const compDump = await translateDumpI18n(dumpUtil.dumpComponent(comp as cc.Component)) as any;
-                compDump.__component_path__ = compMgr.getPathFromUuid(comp.uuid) ?? '';
-                compDump.__compPrefab__ = (comp as any).__prefab || null;
-                d.__comps__.push(compDump);
+            if (queryComponent) {
+                for (const comp of node.components) {
+                    const compDump = await translateDumpI18n(dumpUtil.dumpComponent(comp as cc.Component)) as any;
+                    compDump.__component_path__ = compMgr.getPathFromUuid(comp.uuid) ?? '';
+                    compDump.__compPrefab__ = (comp as any).__prefab || null;
+                    d.__comps__.push(compDump);
+                }
             }
             d.__childNodes__ = [];
-            for (const child of node.children) {
-                d.__childNodes__.push(await this.generateNodeDump(child) as INode);
+            if (queryChildren) {
+                for (const child of node.children) {
+                    d.__childNodes__.push(await this.generateNodeDump(child, options) as INode);
+                }
             }
             return sceneDump;
         }
@@ -174,7 +181,7 @@ class SceneUtil {
         if (dump.__prefab__) {
             this.enrichPrefabDump(dump.__prefab__, node['_prefab']);
         }
-        if (dump.__comps__) {
+        if (queryComponent && dump.__comps__) {
             for (let i = 0; i < dump.__comps__.length && i < node.components.length; i++) {
                 const comp = node.components[i];
                 (dump.__comps__[i] as any).__component_path__ = compMgr.getPathFromUuid(comp.uuid) ?? '';
@@ -183,8 +190,10 @@ class SceneUtil {
         }
 
         d.__childNodes__ = [];
-        for (const child of node.children) {
-            d.__childNodes__.push(await this.generateNodeDump(child));
+        if (queryChildren) {
+            for (const child of node.children) {
+                d.__childNodes__.push(await this.generateNodeDump(child, options));
+            }
         }
 
         return dump;

--- a/src/core/scene/test/node-for-editor.testcase.ts
+++ b/src/core/scene/test/node-for-editor.testcase.ts
@@ -22,7 +22,7 @@ const rpcRequest = (method: string, args?: any[]) =>
     (Rpc.getInstance() as any).request('Node', method, args);
 
 function queryNodeDump(path: string): Promise<INode | null> {
-    return rpcRequest('query', [{ path, queryChildren: false, queryComponent: false }]);
+    return rpcRequest('query', [{ path, queryChildren: false, queryComponent: true }]);
 }
 
 function setNodeProperty(options: ISetPropertyOptions): Promise<boolean> {
@@ -92,7 +92,7 @@ describe('Node ForEditor 接口测试', () => {
 
     describe('1. query - 查询节点 dump 数据', () => {
         it('query - 传入 path 返回 INode', async () => {
-            const result = await rpcRequest('query', [{ path: testNode!.path, queryChildren: false, queryComponent: false }]) as INode | null;
+            const result = await rpcRequest('query', [{ path: testNode!.path, queryChildren: false, queryComponent: true }]) as INode | null;
             expect(result).not.toBeNull();
             expect(result!.name).toBeDefined();
             expect(result!.name.value).toBe(testNodeName);

--- a/src/core/scene/test/prefab-proxy.testcase.ts
+++ b/src/core/scene/test/prefab-proxy.testcase.ts
@@ -245,7 +245,7 @@ describe('Prefab Proxy In Scene 测试', () => {
                 });
 
                 expect(uNode).toBeTruthy();
-                const node = await NodeProxy.query({ path: uNode?.path as string, queryChildren: false, queryComponent: false }) as INodeInfo | null;
+                const node = await NodeProxy.query({ path: uNode?.path as string, queryChildren: false, queryComponent: true }) as INodeInfo | null;
 
                 expect(node).toBeTruthy();
                 expect(node?.components?.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- Add `queryChildren`/`queryComponent` options to `generateNodeDump` for selective data loading, allowing callers to skip children and/or component data
- Add `displayName` and `visible` properties to scene-level `encodeObject` calls for better inspector display
- Add `comp.path` assignment in `encodeNode` for component path tracking

## Test plan
- [ ] Verify node dump with default options still returns full data (children + components)
- [ ] Verify `queryChildren: false` skips child node dumping
- [ ] Verify `queryComponent: false` skips component dumping
- [ ] Verify scene encoding includes correct `displayName` values