### PR TITLE
Fix memory leak.

### DIFF
--- a/src/core/scene/scene-process/service/gizmo/node/transform.ts
+++ b/src/core/scene/scene-process/service/gizmo/node/transform.ts
@@ -41,6 +41,9 @@ class TransformGizmo extends GizmoBase<Component> {
     private _gizmo: TransformBaseGizmo;
     protected updateControllerTransform?(): void;
 
+    private static _activeInstances = new Set<TransformGizmo>();
+    private static _sharedEventMap: { [key: string]: () => void } | null = null;
+
     constructor(target: Component | null) {
         super(target);
         const toolName = getService()?.Gizmo?.transformToolData?.toolName ?? 'position';
@@ -80,24 +83,30 @@ class TransformGizmo extends GizmoBase<Component> {
         this._gizmo.show();
     }
 
-    private _eventMap: { [key: string]: () => void } = {};
-
-    private _initEventMap() {
-        if ('toolNameChanged' in this._eventMap) return;
-        this._eventMap.toolNameChanged = () => {
-            const tn = getService()?.Gizmo?.transformToolData?.toolName ?? 'position';
-            this.changeTool(tn as TransformToolDataToolNameType);
-        };
-        this._eventMap.viewModeChanged = () => {
-            repaintEngine();
-        };
-        this._eventMap.pivotChanged = () => {
-            (this._gizmo as any).updateControllerTransform?.();
-            repaintEngine();
-        };
-        this._eventMap.coordinateChanged = () => {
-            (this._gizmo as any).updateControllerTransform?.();
-            repaintEngine();
+    private static _ensureSharedEventMap() {
+        if (TransformGizmo._sharedEventMap) return;
+        TransformGizmo._sharedEventMap = {
+            toolNameChanged: () => {
+                const tn = getService()?.Gizmo?.transformToolData?.toolName ?? 'position';
+                for (const inst of TransformGizmo._activeInstances) {
+                    inst.changeTool(tn as TransformToolDataToolNameType);
+                }
+            },
+            viewModeChanged: () => {
+                repaintEngine();
+            },
+            pivotChanged: () => {
+                const toolName = getService()?.Gizmo?.transformToolData?.toolName ?? 'position';
+                const gizmo = gizmoMap[toolName as TransformToolDataToolNameType];
+                (gizmo as any)?.updateControllerTransform?.();
+                repaintEngine();
+            },
+            coordinateChanged: () => {
+                const toolName = getService()?.Gizmo?.transformToolData?.toolName ?? 'position';
+                const gizmo = gizmoMap[toolName as TransformToolDataToolNameType];
+                (gizmo as any)?.updateControllerTransform?.();
+                repaintEngine();
+            },
         };
     }
 
@@ -120,23 +129,22 @@ class TransformGizmo extends GizmoBase<Component> {
             super.onShow();
         }
 
-        this._initEventMap();
-
         const svc = getService();
         const toolName = svc?.Gizmo?.transformToolData?.toolName ?? 'position';
         this.changeTool(toolName as TransformToolDataToolNameType);
 
-        const ttd = svc?.Gizmo?.transformToolData;
-        // 先移除旧监听，防止重复 onShow 导致监听器累积
-        ttd?.removeListener?.('tool-name-changed', this._eventMap.toolNameChanged);
-        ttd?.removeListener?.('view-mode-changed', this._eventMap.viewModeChanged);
-        ttd?.removeListener?.('pivot-changed', this._eventMap.pivotChanged);
-        ttd?.removeListener?.('coordinate-changed', this._eventMap.coordinateChanged);
+        const wasEmpty = TransformGizmo._activeInstances.size === 0;
+        TransformGizmo._activeInstances.add(this);
 
-        ttd?.addListener?.('tool-name-changed', this._eventMap.toolNameChanged);
-        ttd?.addListener?.('view-mode-changed', this._eventMap.viewModeChanged);
-        ttd?.addListener?.('pivot-changed', this._eventMap.pivotChanged);
-        ttd?.addListener?.('coordinate-changed', this._eventMap.coordinateChanged);
+        if (wasEmpty) {
+            TransformGizmo._ensureSharedEventMap();
+            const ttd = svc?.Gizmo?.transformToolData;
+            const em = TransformGizmo._sharedEventMap!;
+            ttd?.addListener?.('tool-name-changed', em.toolNameChanged);
+            ttd?.addListener?.('view-mode-changed', em.viewModeChanged);
+            ttd?.addListener?.('pivot-changed', em.pivotChanged);
+            ttd?.addListener?.('coordinate-changed', em.coordinateChanged);
+        }
 
         this._gizmo.onShow?.();
     }
@@ -146,12 +154,19 @@ class TransformGizmo extends GizmoBase<Component> {
             super.onHide();
         }
 
-        const svc = getService();
-        const ttd = svc?.Gizmo?.transformToolData;
-        ttd?.removeListener?.('tool-name-changed', this._eventMap.toolNameChanged);
-        ttd?.removeListener?.('view-mode-changed', this._eventMap.viewModeChanged);
-        ttd?.removeListener?.('pivot-changed', this._eventMap.pivotChanged);
-        ttd?.removeListener?.('coordinate-changed', this._eventMap.coordinateChanged);
+        TransformGizmo._activeInstances.delete(this);
+
+        if (TransformGizmo._activeInstances.size === 0) {
+            const svc = getService();
+            const ttd = svc?.Gizmo?.transformToolData;
+            const em = TransformGizmo._sharedEventMap;
+            if (em) {
+                ttd?.removeListener?.('tool-name-changed', em.toolNameChanged);
+                ttd?.removeListener?.('view-mode-changed', em.viewModeChanged);
+                ttd?.removeListener?.('pivot-changed', em.pivotChanged);
+                ttd?.removeListener?.('coordinate-changed', em.coordinateChanged);
+            }
+        }
 
         this._gizmo.onHide?.();
     }

--- a/src/core/scene/scene-process/service/gizmo/node/transform.ts
+++ b/src/core/scene/scene-process/service/gizmo/node/transform.ts
@@ -166,6 +166,7 @@ class TransformGizmo extends GizmoBase<Component> {
                 ttd?.removeListener?.('pivot-changed', em.pivotChanged);
                 ttd?.removeListener?.('coordinate-changed', em.coordinateChanged);
             }
+            TransformGizmo._sharedEventMap = null;
         }
 
         this._gizmo.onHide?.();
@@ -176,6 +177,21 @@ class TransformGizmo extends GizmoBase<Component> {
     }
 
     public onDestroy(): void {
+        if (TransformGizmo._activeInstances.has(this)) {
+            TransformGizmo._activeInstances.delete(this);
+            if (TransformGizmo._activeInstances.size === 0) {
+                const svc = getService();
+                const ttd = svc?.Gizmo?.transformToolData;
+                const em = TransformGizmo._sharedEventMap;
+                if (em) {
+                    ttd?.removeListener?.('tool-name-changed', em.toolNameChanged);
+                    ttd?.removeListener?.('view-mode-changed', em.viewModeChanged);
+                    ttd?.removeListener?.('pivot-changed', em.pivotChanged);
+                    ttd?.removeListener?.('coordinate-changed', em.coordinateChanged);
+                }
+                TransformGizmo._sharedEventMap = null;
+            }
+        }
         this._gizmo.onDestroy?.();
     }
 


### PR DESCRIPTION
修复 TransformGizmo 的 MaxListenersExceededWarning 内存泄漏问题。

  问题

  框选多个节点时，每个被选中的节点都会创建一个 TransformGizmo 实例，每个实例在 onShow
  中向共享的 transformToolData EventEmitter 注册 4 个事件监听（tool-name-changed、view
  -mode-changed、pivot-changed、coordinate-changed）。虽然每个实例在注册前会先移除自身
  的旧监听，但不同实例的回调是不同的函数引用，removeListener 无法互相清理，导致选中
  11+ 个节点时触发 MaxListenersExceededWarning。

  复现路径：打开场景 → 框选 11 个以上节点 → 控制台出现 Possible EventEmitter memory
  leak detected. 11 "view-mode-changed" listeners added。

  修复思路

  将事件监听从逐实例注册改为共享监听 + 引用计数：

  - 使用静态 _activeInstances: Set<TransformGizmo> 跟踪当前活跃实例
  - 使用静态 _sharedEventMap 持有共享的事件回调（所有实例共用同一组 listener）
  - 第一个实例 onShow 时注册监听，最后一个实例 onHide 时移除并置空
  - onDestroy 中同样做清理，防止未经 onHide 直接销毁导致泄漏
  - toolNameChanged 回调遍历所有活跃实例调用 changeTool
  - pivotChanged/coordinateChanged 直接操作 gizmoMap 单例（行为等价，因为所有实例的
  _gizmo 都指向 gizmoMap 中的同一对象，避免了多实例重复调用）