### PR TITLE
fix(scene): gate non-scene node component dump with queryComponent flag

### DIFF
--- a/src/core/scene/scene-process/service/scene/utils.ts
+++ b/src/core/scene/scene-process/service/scene/utils.ts
@@ -181,12 +181,14 @@ class SceneUtil {
         if (dump.__prefab__) {
             this.enrichPrefabDump(dump.__prefab__, node['_prefab']);
         }
-        if (dump.__comps__) {
+        if (queryComponent && dump.__comps__) {
             for (let i = 0; i < dump.__comps__.length && i < node.components.length; i++) {
                 const comp = node.components[i];
                 (dump.__comps__[i] as any).__component_path__ = compMgr.getPathFromUuid(comp.uuid) ?? '';
                 (dump.__comps__[i] as any).__compPrefab__ = (comp as any).__prefab || null;
             }
+        } else {
+            d.__comps__ = [];
         }
 
         d.__childNodes__ = [];


### PR DESCRIPTION
## Summary
- 为非 scene 节点加回 `queryComponent` 条件判断，`queryComponent: false` 时将 `__comps__` 置为空数组，与 scene 节点行为一致
- 是 #568 的遗漏修复

## Test plan
- [ ] CI unit tests 通过
- [ ] CI E2E tests 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)