### PR TITLE
Fix(scene): Resolve gizmo scaling calculation using outdated dimension state when switching between 2D and 3D.

### DIFF
--- a/src/core/scene/scene-process/service/camera.ts
+++ b/src/core/scene/scene-process/service/camera.ts
@@ -35,15 +35,15 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
             this._controller.active = false;
         }
         this._controller = value ? this._controller2D : this._controller3D;
+        // 先同步 ttd.is2D 再激活控制器，确保 gizmo adjustControllerSize 使用正确的维度状态
+        const ttd = Service.Gizmo?.transformToolData;
+        if (ttd && ttd.is2D !== value) {
+            ttd.is2D = value;
+        }
         this._controller.active = true;
         if (!this._controllerFirstChange && this._currentUuid) {
             this.defaultFocus(this._currentUuid);
             this._controllerFirstChange = true;
-        }
-        // 同步 transformToolData.is2D，触发 dimension-changed 事件
-        const ttd = Service.Gizmo?.transformToolData;
-        if (ttd && ttd.is2D !== value) {
-            ttd.is2D = value;
         }
         Service.Engine.repaintInEditMode();
     }


### PR DESCRIPTION
Related issue: https://zentao.sud.tech/index.php?m=bug&f=view&bugID=386

 描述:
  - 问题: 选中方向光后，3D→2D→3D 切换会导致灯光 gizmo 显示异常（灯光穿透），因为 CameraService.is2D setter
  中先激活了相机控制器（触发 gizmo adjustControllerSize），再更新 transformToolData.is2D，导致 gizmo 的 getDistScalar
  使用过期的 2D 缩放公式
  - 修复: 将 ttd.is2D 赋值移到控制器激活之前，确保 gizmo 重新计算尺寸时读取到正确的维度状态
  - 无递归风险：this._controller 已切换，is2D getter 返回新值，dimension-changed 回调中的 Service.Camera.is2D = is2D
  会被 early return 拦截