### PR TITLE
fix(builder): normalize bundle config metadata path

### DIFF
--- a/src/core/builder/share/metadata.ts
+++ b/src/core/builder/share/metadata.ts
@@ -2,6 +2,7 @@ import lodash from 'lodash';
 import type { IBuildCacheUseConfig } from '../@types';
 import type { BuildConfiguration } from '../@types/config-export';
 import type { ICocosConfigurationNode, IConfigurationItem } from '../../configuration/script/metadata';
+import { DefaultBundleConfig } from './bundle-utils';
 import {
     convertConfigItem,
     createNode,
@@ -133,9 +134,14 @@ function createBuilderBundleConfigNode(
     defaults: BuildConfiguration['bundleConfig'],
     order: number
 ): ICocosConfigurationNode {
+    const customDefaults = {
+        default: DefaultBundleConfig,
+        ...defaults.custom,
+    };
+
     return createNode('builder.bundleConfig', 'i18n:configuration.builder.bundleConfig.title', 'builder', {
-        'builder.bundleConfig': objectSchema(undefined, {
-            default: defaults,
+        'builder.bundleConfig.custom': objectSchema(undefined, {
+            default: customDefaults,
             title: 'i18n:configuration.builder.bundleConfig.title',
             description: 'i18n:configuration.builder.bundleConfig.description',
         }),

--- a/src/core/configuration/test/metadata.test.ts
+++ b/src/core/configuration/test/metadata.test.ts
@@ -7,6 +7,7 @@ interface IMetadataRuntime {
     project: typeof import('../../project').default;
     Engine: typeof import('../../engine').Engine;
     builderConfig: typeof import('../../builder/share/builder-config').default;
+    DefaultBundleConfig: typeof import('../../builder/share/bundle-utils').DefaultBundleConfig;
     pluginManager: typeof import('../../builder/manager/plugin').pluginManager;
     assetConfig: typeof import('../../assets/asset-config').default;
     scriptConfig: typeof import('../../scripting/shared/query-shared-settings').scriptConfig;
@@ -43,6 +44,7 @@ async function loadFreshRuntime(): Promise<IMetadataRuntime> {
         const project = (require('../../project') as typeof import('../../project')).default;
         const { Engine } = require('../../engine') as typeof import('../../engine');
         const builderConfig = (require('../../builder/share/builder-config') as typeof import('../../builder/share/builder-config')).default;
+        const { DefaultBundleConfig } = require('../../builder/share/bundle-utils') as typeof import('../../builder/share/bundle-utils');
         const { pluginManager } = require('../../builder/manager/plugin') as typeof import('../../builder/manager/plugin');
         const assetConfig = (require('../../assets/asset-config') as typeof import('../../assets/asset-config')).default;
         const { scriptConfig } = require('../../scripting/shared/query-shared-settings') as typeof import('../../scripting/shared/query-shared-settings');
@@ -53,6 +55,7 @@ async function loadFreshRuntime(): Promise<IMetadataRuntime> {
             project,
             Engine,
             builderConfig,
+            DefaultBundleConfig,
             pluginManager,
             assetConfig,
             scriptConfig,
@@ -141,15 +144,19 @@ describe('configuration metadata', () => {
         const textureCompressNode = findNode(beforePlatformRegister, 'builder.textureCompressConfig');
         const bundleConfigNode = findNode(beforePlatformRegister, 'builder.bundleConfig');
         const textureCompressProperty = findProperty(textureCompressNode, 'builder.textureCompressConfig');
-        const bundleConfigProperty = findProperty(bundleConfigNode, 'builder.bundleConfig');
+        const bundleConfigProperty = findProperty(bundleConfigNode, 'builder.bundleConfig.custom');
 
         expect(findNode(beforePlatformRegister, 'builder.common')).toBeDefined();
         expect(findNode(beforePlatformRegister, 'builder.useCacheConfig')).toBeDefined();
         expect(textureCompressProperty.type).toBe('object');
         expect(textureCompressProperty.default).toEqual(runtime.builderConfig.getDefaultConfig().textureCompressConfig);
         expect(textureCompressProperty.properties).toBeUndefined();
+        expect(bundleConfigNode.properties['builder.bundleConfig']).toBeUndefined();
         expect(bundleConfigProperty.type).toBe('object');
-        expect(bundleConfigProperty.default).toEqual(runtime.builderConfig.getDefaultConfig().bundleConfig);
+        expect(bundleConfigProperty.default).toEqual({
+            default: runtime.DefaultBundleConfig,
+            ...runtime.builderConfig.getDefaultConfig().bundleConfig.custom,
+        });
         expect(bundleConfigProperty.properties).toBeUndefined();
         expect(tryFindNode(beforePlatformRegister, 'builder.platforms.web-mobile')).toBeUndefined();
 


### PR DESCRIPTION
## 修复内容

修复 Bundle Settings 配置元数据与 `cocos.config.json` schema 不一致的问题。

- Bundle Settings 的 metadata 改为暴露 `builder.bundleConfig.custom`，避免配置写回到错误的 `builder.bundleConfig.default`
- 补齐常驻 `default` bundle 预设，保证 UI 默认配置有完整值
- 修正 `cocos.config.json` 类型定义，允许 `$schema`、`scene` 等配置文件已有字段
- 将 `builder.bundleConfig.custom` 的 schema 对齐实际的 `CustomBundleConfig` 结构
- 支持动态 bundle 名和动态平台 key，避免 `native`、`web`、`minigame` 等平台覆盖配置被 schema 判定为非法属性
- 增加 schema 回归测试，覆盖顶层字段、bundle custom 配置结构和平台覆盖 key