### PR TITLE
fix(scene): adapt UIService to path-based Selection.query

### DIFF
--- a/src/core/scene/scene-process/service/ui.ts
+++ b/src/core/scene/scene-process/service/ui.ts
@@ -57,13 +57,13 @@ function filterTopLevelNodes(nodes: Node[]): Node[] {
 @register('UI')
 export class UIService extends BaseService<IUIEvents> implements IUIService {
     public alignSelection(type: UIAlignType) {
-        const curSelectPaths = Service.Selection.query();
+        const selectPaths = Service.Selection.query();
 
-        if (curSelectPaths.length <= 1) {
+        if (selectPaths.length <= 1) {
             return;
         }
 
-        let selectedNodes: Node[] = curSelectPaths.map((path: string) => {
+        let selectedNodes: Node[] = selectPaths.map((path: string) => {
             return getNodeByPath(path);
         }).filter(Boolean) as Node[];
 
@@ -127,13 +127,13 @@ export class UIService extends BaseService<IUIEvents> implements IUIService {
     }
 
     public distributeSelection(type: UIAlignType) {
-        const curSelectPaths = Service.Selection.query();
+        const selectPaths = Service.Selection.query();
 
-        if (curSelectPaths.length <= 1) {
+        if (selectPaths.length <= 1) {
             return;
         }
 
-        let selectedNodes = curSelectPaths.map((path: string) => {
+        let selectedNodes = selectPaths.map((path: string) => {
             return getNodeByPath(path);
         }).filter(Boolean) as Node[];
 

--- a/src/core/scene/scene-process/service/ui.ts
+++ b/src/core/scene/scene-process/service/ui.ts
@@ -12,9 +12,9 @@ interface Item {
     bounds: Rect;
 }
 
-function getNodeByUuid(uuid: string): Node | null {
+function getNodeByPath(path: string): Node | null {
     const EditorExtends = (cc as any).EditorExtends || (globalThis as any).EditorExtends;
-    return EditorExtends?.Node?.getNode?.(uuid) ?? null;
+    return EditorExtends?.Node?.getNodeByPath?.(path) ?? null;
 }
 
 function getWorldBounds(node: Node): Rect {
@@ -57,14 +57,14 @@ function filterTopLevelNodes(nodes: Node[]): Node[] {
 @register('UI')
 export class UIService extends BaseService<IUIEvents> implements IUIService {
     public alignSelection(type: UIAlignType) {
-        const curSelectUuids = Service.Selection.query();
+        const curSelectPaths = Service.Selection.query();
 
-        if (curSelectUuids.length <= 1) {
+        if (curSelectPaths.length <= 1) {
             return;
         }
 
-        let selectedNodes: Node[] = curSelectUuids.map((id: string) => {
-            return getNodeByUuid(id);
+        let selectedNodes: Node[] = curSelectPaths.map((path: string) => {
+            return getNodeByPath(path);
         }).filter(Boolean) as Node[];
 
         selectedNodes = filterTopLevelNodes(selectedNodes);
@@ -127,14 +127,14 @@ export class UIService extends BaseService<IUIEvents> implements IUIService {
     }
 
     public distributeSelection(type: UIAlignType) {
-        const curSelectUuids = Service.Selection.query();
+        const curSelectPaths = Service.Selection.query();
 
-        if (curSelectUuids.length <= 1) {
+        if (curSelectPaths.length <= 1) {
             return;
         }
 
-        let selectedNodes = curSelectUuids.map((id: string) => {
-            return getNodeByUuid(id);
+        let selectedNodes = curSelectPaths.map((path: string) => {
+            return getNodeByPath(path);
         }).filter(Boolean) as Node[];
 
         selectedNodes = filterTopLevelNodes(selectedNodes);


### PR DESCRIPTION
## Summary
- `Service.Selection.query()` now returns node paths instead of uuids after the SelectionService interface refactor (#575), but `UIService` was still treating the result as uuids and calling `getNodeByUuid`, which produced an empty selection for align/distribute actions.
- Switch `alignSelection` and `distributeSelection` in `src/core/scene/scene-process/service/ui.ts` to resolve nodes via `getNodeByPath`, and rename the local variable to reflect the new semantics.

## Test plan
- [ ] Multi-select two or more nodes in the scene and trigger each UI align action (top / v-center / bottom / left / h-center / right) — nodes align as expected.
- [ ] Multi-select three or more nodes and trigger each UI distribute action — nodes distribute evenly.
- [ ] Undo restores original positions for both flows.