### PR TITLE
feat(scene): add queryComponents to ComponentService

### DIFF
--- a/src/core/scene/common/component.ts
+++ b/src/core/scene/common/component.ts
@@ -92,6 +92,7 @@ export type IPublicComponentService = Omit<IComponentService, keyof IServiceEven
     'reset' |
     'queryClasses' |
     'queryFunctionOfNode' |
+    'queryComponents' |
     'executeMethod' |
     'hasScript'
 >;
@@ -206,6 +207,12 @@ export interface IComponentService extends IServiceEvents {
      * @returns 节点上组件的函数信息，节点不存在时返回空对象
      */
     queryFunctionOfNode(path: string): Promise<any>;
+
+    /**
+     * 查询所有已注册的组件菜单项
+     * @returns 组件菜单项数组，包含类名、类 ID 和菜单路径
+     */
+    queryComponents(): Promise<Array<{ name: string; cid: string; path: string }>>;
 
     /**
      * 执行组件上的指定方法

--- a/src/core/scene/scene-process/service/component.ts
+++ b/src/core/scene/scene-process/service/component.ts
@@ -466,6 +466,26 @@ export class ComponentService extends BaseService<IComponentEvents> implements I
         return getComponentFunctionOfNode(node);
     }
 
+    async queryComponents(): Promise<Array<{ name: string; cid: string; path: string }>> {
+        // TODO: 需要根据 cocos.config.json 的 include modules 是否包含 3d 做过滤
+        // 参考 app/builtin/scene/source/script/3d/manager/scene/scene-manager.ts
+        const menus = EditorExtends.Component.getMenus();
+        if (menus.length > 0) {
+            return menus.map((item: any) => ({
+                name: cc.js.getClassName(item.component),
+                cid: cc.js.getClassId(item.component),
+                path: item.menuPath,
+            }));
+        }
+        // TODO: 这个是兜底的，等 EditorExtends.Component.getMenus() 完全实现了之后就可以删除了
+        const classes = await this.queryClasses({ extends: 'cc.Component', excludeSelf: true });
+        return classes.map(cls => ({
+            name: cls.name,
+            cid: '',
+            path: cls.name,
+        }));
+    }
+
     public init() {
         this.registerCompMgrEvents();
     }


### PR DESCRIPTION
## Summary
- 为 `IComponentService` 接口新增 `queryComponents` 方法，查询所有已注册的组件菜单项
- 实现优先使用 `EditorExtends.Component.getMenus()` 获取组件信息，并提供基于 `queryClasses` 的兜底方案
- 将 `queryComponents` 暴露到 `IPublicComponentService` 公共接口

## Test plan
- [ ] 验证 `queryComponents` 能正确返回组件菜单列表（name、cid、path）
- [ ] 验证当 `getMenus()` 返回空数组时，兜底逻辑能正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)