### PR TITLE
Fix configuration event typing and engine config sync

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -6225,13 +6225,23 @@ export { }
 `;
 
 exports[`DTS API compatibility configuration.d.ts should match snapshot 1`] = `
-"import { EventEmitter } from 'events';
+"export declare type AnyArgs = any[];
+export declare type BaseConfigurationEvents = {
+    [ConfigurationEventName.Save]: [instance: IBaseConfiguration];
+};
+export declare const ConfigurationEventName: {
+    readonly Save: "configuration:save";
+    readonly Registry: "configuration:registry";
+    readonly UnRegistry: "configuration:unregistry";
+    readonly Reload: "configuration:reload";
+    readonly Update: "configuration:update";
+    readonly Remove: "configuration:remove";
+};
 export declare type ConfigurationScope = 'default' | 'project';
-export declare type EventEmitterMethods = Pick<EventEmitter, 'on' | 'off' | 'once' | 'emit'>;
 export declare function get<T>(key: string, scope?: ConfigurationScope): Promise<T>;
 export declare function getConfigPath(): Promise<string>;
 export declare function getMetadata(): Promise<ICocosConfigurationNode[]>;
-export declare interface IBaseConfiguration extends EventEmitterMethods {
+export declare interface IBaseConfiguration extends TypedEventEmitter<BaseConfigurationEvents> {
     moduleName: string;
     getDefaultConfig(): Record<string, any> | undefined;
     mergeDefaultConfig(defaultConfig?: Record<string, any>): void;
@@ -6275,6 +6285,12 @@ export declare function reload(): Promise<void>;
 export declare function remove(key: string, scope?: ConfigurationScope): Promise<boolean>;
 export declare function save(force?: boolean): Promise<void>;
 export declare function set<T>(key: string, value: T, scope?: ConfigurationScope): Promise<boolean>;
+export declare interface TypedEventEmitter<T extends Record<string, AnyArgs>> {
+    on<K extends keyof T>(eventName: K, listener: (...args: T[K]) => void): this;
+    off<K extends keyof T>(eventName: K, listener: (...args: T[K]) => void): this;
+    once<K extends keyof T>(eventName: K, listener: (...args: T[K]) => void): this;
+    emit<K extends keyof T>(eventName: K, ...args: T[K]): boolean;
+}
 export { }
 "
 `;
@@ -6522,7 +6538,6 @@ exports[`DTS API compatibility index.d.ts should match snapshot 1`] = `
 "import { __private } from 'cc';
 import { ChunkInfo } from '@cocos/creator-programming-quick-pack/lib/loader';
 import type { Component } from 'cc';
-import { EventEmitter } from 'events';
 import { default as i18n_2 } from 'i18next';
 import { NextFunction } from 'express';
 import type { Node as Node_2 } from 'cc';
@@ -6557,6 +6572,7 @@ export declare interface AnimationImportSetting {
         };
     }>;
 }
+export declare type AnyArgs = any[];
 export declare const ASSET_HANDLER_TYPES: string[];
 export declare enum AssetActionEnum {
     'add' = 0,
@@ -6762,6 +6778,9 @@ export declare namespace Base {
         init_2 as init
     }
 }
+export declare type BaseConfigurationEvents = {
+    [ConfigurationEventName.Save]: [instance: IBaseConfiguration];
+};
 export declare interface BaseItem {
     label?: string;
     description?: string;
@@ -6817,6 +6836,14 @@ export declare namespace Configuration {
         ICocosConfigurationPropertySchema
     }
 }
+export declare const ConfigurationEventName: {
+    readonly Save: "configuration:save";
+    readonly Registry: "configuration:registry";
+    readonly UnRegistry: "configuration:unregistry";
+    readonly Reload: "configuration:reload";
+    readonly Update: "configuration:update";
+    readonly Remove: "configuration:remove";
+};
 export declare type ConfigurationScope = 'default' | 'project';
 export declare const CREATE_TYPES: readonly ["scene", "prefab"];
 export declare function createAsset(options: CreateAssetOptions): Promise<IAssetInfo>;
@@ -6913,7 +6940,6 @@ export declare interface EngineInfo {
     tmpDir: string;
     version: string;
 }
-export declare type EventEmitterMethods = Pick<EventEmitter, 'on' | 'off' | 'once' | 'emit'>;
 export declare interface ExecuteAssetDBScriptMethodOptions {
     name: string;
     method: string;
@@ -7190,7 +7216,7 @@ export declare interface IAssetWriteFileOptions extends IAssetOperationOptionsBa
     create?: boolean;
     overwrite?: boolean;
 }
-export declare interface IBaseConfiguration extends EventEmitterMethods {
+export declare interface IBaseConfiguration extends TypedEventEmitter<BaseConfigurationEvents> {
     moduleName: string;
     getDefaultConfig(): Record<string, any> | undefined;
     mergeDefaultConfig(defaultConfig?: Record<string, any>): void;
@@ -8602,6 +8628,12 @@ export declare interface ThumbnailInfo {
 }
 export declare type ThumbnailSize = 'large' | 'small' | 'middle' | 'origin';
 export declare type TSceneTemplateType = typeof SCENE_TEMPLATE_TYPE[number];
+export declare interface TypedEventEmitter<T extends Record<string, AnyArgs>> {
+    on<K extends keyof T>(eventName: K, listener: (...args: T[K]) => void): this;
+    off<K extends keyof T>(eventName: K, listener: (...args: T[K]) => void): this;
+    once<K extends keyof T>(eventName: K, listener: (...args: T[K]) => void): this;
+    emit<K extends keyof T>(eventName: K, ...args: T[K]): boolean;
+}
 export declare type UIAlignType = 'top' | 'v-center' | 'bottom' | 'left' | 'h-center' | 'right';
 export declare function unregister(): Promise<void>;
 export declare function updateAssetUserData(urlOrUuidOrPath: string, path: string, value: any): Promise<any>;

--- a/src/core/configuration/index.ts
+++ b/src/core/configuration/index.ts
@@ -1,15 +1,17 @@
 import { IBaseConfiguration } from './script/config';
-import { ConfigurationScope } from './script/interface';
+import { ConfigurationEventName, ConfigurationScope } from './script/interface';
 import { configurationRegistry } from './script/registry';
 import { configurationManager } from './script/manager';
 
 export * from './migration';
 
 export {
+    ConfigurationEventName,
     ConfigurationScope,
     IBaseConfiguration,
     configurationRegistry,
     configurationManager,
 };
 
+export type { AnyArgs, IConfiguration, TypedEventEmitter } from './script/interface';
 export { ICocosConfigurationNode, ICocosConfigurationPropertySchema } from './script/metadata';

--- a/src/core/configuration/script/config.ts
+++ b/src/core/configuration/script/config.ts
@@ -1,13 +1,15 @@
 import * as utils from './utils';
-import { ConfigurationScope, MessageType } from './interface';
+import { ConfigurationEventName, ConfigurationScope, TypedEventEmitter } from './interface';
 import { EventEmitter } from 'events';
 
-type EventEmitterMethods = Pick<EventEmitter, 'on' | 'off' | 'once' | 'emit'>;
+export type BaseConfigurationEvents = {
+    [ConfigurationEventName.Save]: [instance: IBaseConfiguration];
+};
 
 /**
  * 配置基类接口
  */
-export interface IBaseConfiguration extends EventEmitterMethods {
+export interface IBaseConfiguration extends TypedEventEmitter<BaseConfigurationEvents> {
     /**
      * 模块名
      */
@@ -58,6 +60,26 @@ export interface IBaseConfiguration extends EventEmitterMethods {
  */
 export class BaseConfiguration extends EventEmitter implements IBaseConfiguration {
     protected configs: Record<string, any> = {};
+
+    public on<K extends keyof BaseConfigurationEvents>(eventName: K, listener: (...args: BaseConfigurationEvents[K]) => void): this;
+    public on(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        return super.on(eventName, listener);
+    }
+
+    public off<K extends keyof BaseConfigurationEvents>(eventName: K, listener: (...args: BaseConfigurationEvents[K]) => void): this;
+    public off(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        return super.off(eventName, listener);
+    }
+
+    public once<K extends keyof BaseConfigurationEvents>(eventName: K, listener: (...args: BaseConfigurationEvents[K]) => void): this;
+    public once(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        return super.once(eventName, listener);
+    }
+
+    public emit<K extends keyof BaseConfigurationEvents>(eventName: K, ...args: BaseConfigurationEvents[K]): boolean;
+    public emit(eventName: string | symbol, ...args: any[]): boolean {
+        return super.emit(eventName, ...args);
+    }
 
     constructor(
         public readonly moduleName: string,
@@ -150,7 +172,7 @@ export class BaseConfiguration extends EventEmitter implements IBaseConfiguratio
     }
 
     public async save() {
-        this.emit(MessageType.Save, this);
+        this.emit(ConfigurationEventName.Save, this);
         return true;
     }
 }

--- a/src/core/configuration/script/interface.ts
+++ b/src/core/configuration/script/interface.ts
@@ -4,7 +4,7 @@
  */
 export type ConfigurationScope = 'default' | 'project';
 
-export const MessageType = {
+export const ConfigurationEventName = {
     Save: 'configuration:save',
     Registry: 'configuration:registry',
     UnRegistry: 'configuration:unregistry',
@@ -12,6 +12,19 @@ export const MessageType = {
     Update: 'configuration:update',
     Remove: 'configuration:remove',
 } as const;
+
+export type AnyArgs = any[];
+
+/**
+ * 类型化的事件发射器接口
+ * 替代 Pick<EventEmitter, 'on' | 'off' | 'once' | 'emit'>
+ */
+export interface TypedEventEmitter<T extends Record<string, AnyArgs>> {
+    on<K extends keyof T>(eventName: K, listener: (...args: T[K]) => void): this;
+    off<K extends keyof T>(eventName: K, listener: (...args: T[K]) => void): this;
+    once<K extends keyof T>(eventName: K, listener: (...args: T[K]) => void): this;
+    emit<K extends keyof T>(eventName: K, ...args: T[K]): boolean;
+}
 
 /**
  * 配置的格式

--- a/src/core/configuration/script/manager.ts
+++ b/src/core/configuration/script/manager.ts
@@ -1,15 +1,22 @@
 import { gt } from 'semver';
-import path, { join, relative } from 'path';
+import path, { join } from 'path';
 import fse from 'fs-extra';
 import { newConsole } from '../../base/console';
 import * as utils from './utils';
-import { IConfiguration, ConfigurationScope, MessageType } from './interface';
+import { IConfiguration, ConfigurationEventName, ConfigurationScope, TypedEventEmitter } from './interface';
 import { CocosMigrationManager } from '../migration';
 import { configurationRegistry } from './registry';
 import { IBaseConfiguration } from './config';
 import EventEmitter from 'events';
 
-export interface IConfigurationManager {
+export type ConfigurationManagerEvents = {
+    [ConfigurationEventName.Reload]: [config: IConfiguration];
+    [ConfigurationEventName.Update]: [key: string, value: any, scope: ConfigurationScope];
+    [ConfigurationEventName.Remove]: [key: string, scope: ConfigurationScope];
+    [ConfigurationEventName.Save]: [config: IConfiguration];
+};
+
+export interface IConfigurationManager extends TypedEventEmitter<ConfigurationManagerEvents> {
     /**
      * 初始化配置管理器
      */
@@ -70,6 +77,26 @@ export class ConfigurationManager extends EventEmitter implements IConfiguration
     static SchemaPathSource = join(__dirname, '../../../../dist/cocos.config.schema.json');
     static relativeSchemaPath = `./temp/cli/${path.basename(ConfigurationManager.SchemaPathSource)}`;
 
+    public on<K extends keyof ConfigurationManagerEvents>(eventName: K, listener: (...args: ConfigurationManagerEvents[K]) => void): this;
+    public on(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        return super.on(eventName, listener);
+    }
+
+    public off<K extends keyof ConfigurationManagerEvents>(eventName: K, listener: (...args: ConfigurationManagerEvents[K]) => void): this;
+    public off(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        return super.off(eventName, listener);
+    }
+
+    public once<K extends keyof ConfigurationManagerEvents>(eventName: K, listener: (...args: ConfigurationManagerEvents[K]) => void): this;
+    public once(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        return super.once(eventName, listener);
+    }
+
+    public emit<K extends keyof ConfigurationManagerEvents>(eventName: K, ...args: ConfigurationManagerEvents[K]): boolean;
+    public emit(eventName: string | symbol, ...args: any[]): boolean {
+        return super.emit(eventName, ...args);
+    }
+
     private initialized: boolean = false;
     private projectPath: string = '';
     private configPath: string = '';
@@ -96,8 +123,8 @@ export class ConfigurationManager extends EventEmitter implements IConfiguration
             return;
         }
 
-        configurationRegistry.on(MessageType.Registry, this.onRegistryConfigurationBind);
-        configurationRegistry.on(MessageType.UnRegistry, this.onUnRegistryConfigurationBind);
+        configurationRegistry.on(ConfigurationEventName.Registry, this.onRegistryConfigurationBind);
+        configurationRegistry.on(ConfigurationEventName.UnRegistry, this.onUnRegistryConfigurationBind);
 
         this.projectPath = projectPath;
         this.configPath = path.join(projectPath, ConfigurationManager.name);
@@ -118,33 +145,33 @@ export class ConfigurationManager extends EventEmitter implements IConfiguration
      */
     public async reload(): Promise<void> {
         await this.load();
-        this.emit(MessageType.Reload, this.projectConfig);
+        this.emit(ConfigurationEventName.Reload, this.projectConfig);
     }
 
-    private onRegistryConfiguration(instance: IBaseConfiguration): void {
-        if (!this.configurationMap.has(instance.moduleName)) {
+    private onRegistryConfiguration(configInstance: IBaseConfiguration): void {
+        if (!this.configurationMap.has(configInstance.moduleName)) {
             // 从 projectConfig 中获取现有配置并初始化到配置实例中
-            const existingConfig = this.projectConfig[instance.moduleName];
+            const existingConfig = this.projectConfig[configInstance.moduleName];
             if (existingConfig && typeof existingConfig === 'object') {
                 // 将现有配置设置到配置实例的 configs 中
-                this.initializeConfigFromProject(instance, existingConfig);
+                this.initializeConfigFromProject(configInstance, existingConfig);
             }
 
             const bind = async (configInstance: IBaseConfiguration) => {
                 this.projectConfig[configInstance.moduleName] = configInstance.getAll();
                 await this.save();
             };
-            instance.on(MessageType.Save, bind);
-            this.configurationMap.set(instance.moduleName, bind);
+            configInstance.on(ConfigurationEventName.Save, bind);
+            this.configurationMap.set(configInstance.moduleName, bind);
         }
     }
 
-    private onUnRegistryConfiguration(instances: IBaseConfiguration): void {
-        const bind = this.configurationMap.get(instances.moduleName);
+    private onUnRegistryConfiguration(configInstance: IBaseConfiguration): void {
+        const bind = this.configurationMap.get(configInstance.moduleName);
         if (bind) {
             // TODO 是否需要删除
-            instances.off(MessageType.Save, bind);
-            this.configurationMap.delete(instances.moduleName);
+            configInstance.off(ConfigurationEventName.Save, bind);
+            this.configurationMap.delete(configInstance.moduleName);
         }
     }
 
@@ -255,7 +282,7 @@ export class ConfigurationManager extends EventEmitter implements IConfiguration
             await this.ensureInitialized();
             const { moduleName, actualKey } = this.parseKey(key);
             await this.getInstance(moduleName).set(actualKey, value, scope);
-            this.emit(MessageType.Update, key, value, scope);
+            this.emit(ConfigurationEventName.Update, key, value, scope);
             return true;
         } catch (error) {
             throw new Error(`[Configuration] 更新配置失败：${error}`);
@@ -271,7 +298,7 @@ export class ConfigurationManager extends EventEmitter implements IConfiguration
         try {
             await this.ensureInitialized();
             const { moduleName, actualKey } = this.parseKey(key);
-            this.emit(MessageType.Remove, key, scope);
+            this.emit(ConfigurationEventName.Remove, key, scope);
             return await this.getInstance(moduleName).remove(actualKey, scope);
         } catch (error) {
             throw new Error(`[Configuration] 移除配置失败：${error}`);
@@ -294,7 +321,9 @@ export class ConfigurationManager extends EventEmitter implements IConfiguration
         try {
             if (await fse.pathExists(this.configPath)) {
                 this.projectConfig = await fse.readJSON(this.configPath);
-                this.projectConfig.version && (this.version = this.projectConfig.version);
+                if (this.projectConfig.version) {
+                    this.version = this.projectConfig.version;
+                }
                 newConsole.debug(`[Configuration] 已加载项目配置: ${this.configPath}`, this.projectConfig);
             } else {
                 newConsole.debug(`[Configuration] 项目配置文件不存在，将创建新文件: ${this.configPath}`);
@@ -324,7 +353,7 @@ export class ConfigurationManager extends EventEmitter implements IConfiguration
                     this.projectConfig.$schema = ConfigurationManager.relativeSchemaPath;
                     // 保存配置文件
                     await fse.writeJSON(this.configPath, this.projectConfig, { spaces: 4 });
-                    this.emit(MessageType.Save, this.projectConfig);
+                    this.emit(ConfigurationEventName.Save, this.projectConfig);
                     newConsole.debug(`[Configuration] 已保存项目配置: ${this.configPath}`);
                 } catch (error) {
                     newConsole.error(`[Configuration] 保存项目配置失败: ${this.configPath} - ${error}`);

--- a/src/core/configuration/script/registry.ts
+++ b/src/core/configuration/script/registry.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import { newConsole } from '../../base/console';
 import { BaseConfiguration, IBaseConfiguration } from './config';
-import { MessageType } from './interface';
+import { ConfigurationEventName, TypedEventEmitter } from './interface';
 import type {
     ICocosConfigurationMetadataRegistration,
     ICocosConfigurationNode,
@@ -14,7 +14,12 @@ export interface IConfigurationRegistration {
     nodes?: ICocosConfigurationMetadataRegistration;
 }
 
-export interface IConfigurationRegistry {
+export type ConfigurationRegistryEvents = {
+    [ConfigurationEventName.Registry]: [instance: IBaseConfiguration];
+    [ConfigurationEventName.UnRegistry]: [instance: IBaseConfiguration];
+};
+
+export interface IConfigurationRegistry extends TypedEventEmitter<ConfigurationRegistryEvents> {
     getInstances(): Record<string, IBaseConfiguration>;
     getInstance(moduleName: string): IBaseConfiguration | undefined;
 
@@ -179,6 +184,26 @@ export class ConfigurationRegistry extends EventEmitter implements IConfiguratio
     private instances: Record<string, IBaseConfiguration> = {};
     private registrations: Record<string, IConfigurationRegistration> = {};
 
+    public on<K extends keyof ConfigurationRegistryEvents>(eventName: K, listener: (...args: ConfigurationRegistryEvents[K]) => void): this;
+    public on(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        return super.on(eventName, listener);
+    }
+
+    public off<K extends keyof ConfigurationRegistryEvents>(eventName: K, listener: (...args: ConfigurationRegistryEvents[K]) => void): this;
+    public off(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        return super.off(eventName, listener);
+    }
+
+    public once<K extends keyof ConfigurationRegistryEvents>(eventName: K, listener: (...args: ConfigurationRegistryEvents[K]) => void): this;
+    public once(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        return super.once(eventName, listener);
+    }
+
+    public emit<K extends keyof ConfigurationRegistryEvents>(eventName: K, ...args: ConfigurationRegistryEvents[K]): boolean;
+    public emit(eventName: string | symbol, ...args: any[]): boolean {
+        return super.emit(eventName, ...args);
+    }
+
     public getInstances(): Record<string, IBaseConfiguration> {
         return this.instances;
     }
@@ -242,13 +267,13 @@ export class ConfigurationRegistry extends EventEmitter implements IConfiguratio
         }
 
         this.instances[moduleName] = nextInstance;
-        this.emit(MessageType.Registry, nextInstance);
+        this.emit(ConfigurationEventName.Registry, nextInstance);
         return nextInstance as IBaseConfiguration | T;
     }
 
     public async unregister(moduleName: string): Promise<void> {
         const instance = this.instances[moduleName];
-        this.emit(MessageType.UnRegistry, instance);
+        this.emit(ConfigurationEventName.UnRegistry, instance);
         delete this.instances[moduleName];
         delete this.registrations[moduleName];
     }

--- a/src/core/configuration/test/config.test.ts
+++ b/src/core/configuration/test/config.test.ts
@@ -1,5 +1,4 @@
 import { BaseConfiguration } from '../script/config';
-import { MessageType } from '../script/interface';
 
 describe('BaseConfiguration', () => {
     let config: BaseConfiguration;
@@ -136,23 +135,23 @@ describe('BaseConfiguration', () => {
             const emitSpy = jest.spyOn(config, 'emit');
             const result = await config.save();
             expect(result).toBe(true);
-            expect(emitSpy).toHaveBeenCalledWith(MessageType.Save, config);
+            expect(emitSpy).toHaveBeenCalledWith('configuration:save', config);
         });
 
         it('should handle event listeners', () => {
             const listener = jest.fn();
-            config.on(MessageType.Save, listener);
-            config.emit(MessageType.Save, config);
+            config.on('configuration:save', listener);
+            config.emit('configuration:save', config);
             expect(listener).toHaveBeenCalledWith(config);
 
-            config.off(MessageType.Save, listener);
-            config.emit(MessageType.Save, config);
+            config.off('configuration:save', listener);
+            config.emit('configuration:save', config);
             expect(listener).toHaveBeenCalledTimes(1);
 
             const onceListener = jest.fn();
-            config.once(MessageType.Save, onceListener);
-            config.emit(MessageType.Save, config);
-            config.emit(MessageType.Save, config);
+            config.once('configuration:save', onceListener);
+            config.emit('configuration:save', config);
+            config.emit('configuration:save', config);
             expect(onceListener).toHaveBeenCalledTimes(1);
         });
     });

--- a/src/core/configuration/test/manager.test.ts
+++ b/src/core/configuration/test/manager.test.ts
@@ -1,6 +1,5 @@
 import { ConfigurationManager } from '../script/manager';
 import { configurationRegistry } from '../script/registry';
-import { MessageType } from '../script/interface';
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import { CocosMigrationManager } from '../migration';
@@ -64,8 +63,8 @@ describe('ConfigurationManager', () => {
             await manager.initialize(projectPath);
             expect(manager['initialized']).toBe(true);
             expect(manager['configPath']).toBe(configPath);
-            expect(mockRegistry.on).toHaveBeenCalledWith(MessageType.Registry, expect.any(Function));
-            expect(mockRegistry.on).toHaveBeenCalledWith(MessageType.UnRegistry, expect.any(Function));
+            expect(mockRegistry.on).toHaveBeenCalledWith('configuration:registry', expect.any(Function));
+            expect(mockRegistry.on).toHaveBeenCalledWith('configuration:unregistry', expect.any(Function));
             // 由于 projectConfig 初始为空，save 方法会直接返回，所以不会调用 writeJSON 或 ensureDir
             // 这是正确的行为，因为空的配置不需要保存
 
@@ -271,12 +270,12 @@ describe('ConfigurationManager', () => {
             };
 
             const onRegistryHandler = mockRegistry.on.mock.calls.find(
-                call => call[0] === MessageType.Registry
+                call => call[0] === 'configuration:registry'
             )?.[1] as Function;
 
             expect(onRegistryHandler).toBeDefined();
             await onRegistryHandler(mockInstance);
-            expect(mockInstance.on).toHaveBeenCalledWith(MessageType.Save, expect.any(Function));
+            expect(mockInstance.on).toHaveBeenCalledWith('configuration:save', expect.any(Function));
             expect(manager['configurationMap'].has('testModule')).toBe(true);
 
             // Unregistry event
@@ -286,7 +285,7 @@ describe('ConfigurationManager', () => {
             };
 
             const onUnRegistryHandler = mockRegistry.on.mock.calls.find(
-                call => call[0] === MessageType.UnRegistry
+                call => call[0] === 'configuration:unregistry'
             )?.[1] as Function;
 
             expect(onUnRegistryHandler).toBeDefined();
@@ -485,7 +484,7 @@ describe('ConfigurationManager', () => {
 
             // 获取注册事件处理器
             const onRegistryHandler = mockRegistry.on.mock.calls.find(
-                call => call[0] === MessageType.Registry
+                call => call[0] === 'configuration:registry'
             )?.[1] as Function;
 
             expect(onRegistryHandler).toBeDefined();
@@ -504,7 +503,7 @@ describe('ConfigurationManager', () => {
 
             // 模拟 Save 事件触发（当配置被修改时）
             const saveHandler = mockInstance.on.mock.calls.find(
-                call => call[0] === MessageType.Save
+                call => call[0] === 'configuration:save'
             )?.[1] as Function;
 
             expect(saveHandler).toBeDefined();
@@ -551,7 +550,7 @@ describe('ConfigurationManager', () => {
 
             // 获取注册事件处理器
             const onRegistryHandler = mockRegistry.on.mock.calls.find(
-                call => call[0] === MessageType.Registry
+                call => call[0] === 'configuration:registry'
             )?.[1] as Function;
 
             expect(onRegistryHandler).toBeDefined();

--- a/src/core/configuration/test/registry.test.ts
+++ b/src/core/configuration/test/registry.test.ts
@@ -1,7 +1,6 @@
 import { ConfigurationRegistry } from '../script/registry';
 import { BaseConfiguration } from '../script/config';
 import { IBaseConfiguration } from '../script/config';
-import { MessageType } from '../script/interface';
 import type { ICocosConfigurationNode } from '../script/metadata';
 import i18n from '../../base/i18n';
 
@@ -69,7 +68,7 @@ describe('ConfigurationRegistry', () => {
             expect(instance).toBeInstanceOf(BaseConfiguration);
             expect(instance.moduleName).toBe(moduleName);
             expect(registry.getInstance(moduleName)).toBe(instance);
-            expect(emitSpy).toHaveBeenCalledWith(MessageType.Registry, expect.any(BaseConfiguration));
+            expect(emitSpy).toHaveBeenCalledWith('configuration:registry', expect.any(BaseConfiguration));
             
             // Register with default config
             const instanceWithConfig = await registry.register('module2', defaultConfig);
@@ -108,7 +107,7 @@ describe('ConfigurationRegistry', () => {
             
             await registry.unregister(moduleName);
             expect(registry.getInstance(moduleName)).toBeUndefined();
-            expect(emitSpy).toHaveBeenCalledWith(MessageType.UnRegistry, instance);
+            expect(emitSpy).toHaveBeenCalledWith('configuration:unregistry', instance);
         });
 
         it('should handle multiple unregistrations and non-existent modules', async () => {
@@ -134,8 +133,8 @@ describe('ConfigurationRegistry', () => {
             const registryListener = jest.fn();
             const unregistryListener = jest.fn();
             
-            registry.on(MessageType.Registry, registryListener);
-            registry.on(MessageType.UnRegistry, unregistryListener);
+            registry.on('configuration:registry', registryListener);
+            registry.on('configuration:unregistry', unregistryListener);
             
             await registry.register(moduleName);
             expect(registryListener).toHaveBeenCalledWith(expect.any(BaseConfiguration));
@@ -144,13 +143,13 @@ describe('ConfigurationRegistry', () => {
             expect(unregistryListener).toHaveBeenCalledWith(expect.any(BaseConfiguration));
             
             // Test listener removal
-            registry.off(MessageType.Registry, registryListener);
+            registry.off('configuration:registry', registryListener);
             await registry.register('module2');
             expect(registryListener).toHaveBeenCalledTimes(1); // Only called once before removal
             
             // Test once listener
             const onceListener = jest.fn();
-            registry.once(MessageType.Registry, onceListener);
+            registry.once('configuration:registry', onceListener);
             await registry.register('module3');
             await registry.register('module4');
             expect(onceListener).toHaveBeenCalledTimes(1);
@@ -222,7 +221,7 @@ describe('ConfigurationRegistry', () => {
             const errorListener = jest.fn().mockImplementation(() => {
                 throw new Error('Listener error');
             });
-            registry.on(MessageType.Registry, errorListener);
+            registry.on('configuration:registry', errorListener);
             
             try {
                 await registry.register('error-module');
@@ -295,7 +294,7 @@ describe('ConfigurationRegistry', () => {
             const customInstance = new BaseConfiguration('eventModule', { key: 'value' });
             const eventSpy = jest.fn();
             
-            registry.on(MessageType.Registry, eventSpy);
+            registry.on('configuration:registry', eventSpy);
             await registry.register('eventModule', customInstance);
 
             expect(eventSpy).toHaveBeenCalledWith(customInstance);

--- a/src/core/engine/index.ts
+++ b/src/core/engine/index.ts
@@ -1,11 +1,11 @@
 import fse from 'fs-extra';
 import { existsSync, readdirSync, statSync } from 'fs';
 import { EngineInfo } from './@types/public';
-import { IEngineConfig, IEngineProjectConfig, IInitEngineInfo } from './@types/config';
+import { IEngineConfig, IInitEngineInfo } from './@types/config';
 import { IModuleConfig, ModuleRenderConfig } from './@types/modules';
 import { join } from 'path';
-import { cloneDeep } from 'lodash';
-import { configurationRegistry, IBaseConfiguration } from '../configuration';
+import { cloneDeep, merge } from 'lodash';
+import { ConfigurationEventName, configurationRegistry, IBaseConfiguration } from '../configuration';
 import { assetManager } from '../assets';
 import { getEngineDynamicConfigContribution, getEngineRenderConfig, getLocalizedEngineRenderConfig } from './dynamic-metadata';
 import { createEngineMetadataNodes } from './metadata';
@@ -290,7 +290,6 @@ class EngineManager implements IEngine {
         this._info.tmpDir = join(enginePath, '.temp');
         this._loadEngineI18n(enginePath);
         this._defaultConfig = this.resolveDefaultConfig(this._info.typescript.path);
-        this._config = this.defaultConfig;
         const configInstance = await configurationRegistry.register('engine', {
             defaults: this.defaultConfig,
             nodes: () => createEngineMetadataNodes({
@@ -299,21 +298,16 @@ class EngineManager implements IEngine {
             }),
         });
         this._configInstance = configInstance;
+        const syncConfig = () => {
+            this._config = merge(
+                cloneDeep(configInstance.getDefaultConfig() || {}),
+                configInstance.getAll() || {},
+            ) as IEngineConfig;
+        };
+        syncConfig();
+        configInstance.on(ConfigurationEventName.Save, syncConfig);
         this._init = true;
-        await this.updateConfig();
         return this;
-    }
-
-    async updateConfig() {
-        const projectConfig = await this._configInstance.get<IEngineProjectConfig>();
-        this._config = projectConfig;
-        if (!projectConfig.configs || Object.keys(projectConfig.configs).length === 0) {
-            return this;
-        }
-        const globalConfigKey = projectConfig.globalConfigKey || Object.keys(projectConfig.configs)[0];
-        this._config.includeModules = projectConfig.configs[globalConfigKey].includeModules;
-        this._config.flags = projectConfig.configs[globalConfigKey].flags;
-        this._config.noDeprecatedFeatures = projectConfig.configs[globalConfigKey].noDeprecatedFeatures;
     }
 
     async importEditorExtensions() {

--- a/src/core/engine/test/engine.test.ts
+++ b/src/core/engine/test/engine.test.ts
@@ -49,4 +49,15 @@ describe('Engine', () => {
         // @ts-ignore
         expect(ccm).toBeDefined();
     }, 1000 * 60 * 50);
+
+    it('getConfig should return updated config after _configInstance.set()', async () => {
+        const originalModules = Engine.getConfig().includeModules;
+        const newModules = [...originalModules, '__test_config_sync__'];
+
+        // @ts-ignore - accessing private for test
+        await Engine['_configInstance'].set('includeModules', newModules);
+
+        // Save 事件同步更新 _config 缓存，getConfig 应返回新值
+        expect(Engine.getConfig().includeModules).toEqual(newModules);
+    }, 30000);
 });

--- a/src/lib/configuration/configuration.ts
+++ b/src/lib/configuration/configuration.ts
@@ -1,7 +1,9 @@
 import type { IConfiguration, ConfigurationScope } from '../../core/configuration/script/interface';
+import { ConfigurationEventName } from '../../core/configuration/script/interface';
 import type { ICocosConfigurationNode } from '../../core/configuration/script/metadata';
 
-export { IConfiguration, ConfigurationScope } from '../../core/configuration/script/interface';
+export { ConfigurationEventName };
+export type { AnyArgs, IConfiguration, ConfigurationScope, TypedEventEmitter } from '../../core/configuration/script/interface';
 export { IBaseConfiguration } from '../../core/configuration/script/config';
 
 export async function init(projectPath: string): Promise<void> {
@@ -59,8 +61,8 @@ export function onDidSave(callback: () => void): () => void {
     // 同步引入：调用时 configurationManager 必定已初始化
     const { configurationManager } = require('../../core/configuration/index');
     const handler = () => callback();
-    configurationManager.on('configuration:save', handler);
-    return () => configurationManager.off('configuration:save', handler);
+    configurationManager.on(ConfigurationEventName.Save, handler);
+    return () => configurationManager.off(ConfigurationEventName.Save, handler);
 }
 
 // ==================== Metadata ====================


### PR DESCRIPTION
## Summary
- Add typed configuration event names and event emitter signatures to improve configuration API completions.
- Export the configuration event names through the core and public configuration entry points.
- Keep the engine config cache synced when the engine configuration instance is updated.

## Test Plan
- npm run generate:dts
- npx tsc -b --pretty false
- npm test