### PR TITLE
Fix engine config updates

### DIFF
--- a/src/core/engine/index.ts
+++ b/src/core/engine/index.ts
@@ -4,7 +4,7 @@ import { EngineInfo } from './@types/public';
 import { IEngineConfig, IEngineProjectConfig, IInitEngineInfo } from './@types/config';
 import { IModuleConfig, ModuleRenderConfig } from './@types/modules';
 import { join } from 'path';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, merge } from 'lodash';
 import { configurationRegistry, IBaseConfiguration } from '../configuration';
 import { assetManager } from '../assets';
 import { getEngineDynamicConfigContribution, getEngineRenderConfig, getLocalizedEngineRenderConfig } from './dynamic-metadata';
@@ -236,6 +236,14 @@ class EngineManager implements IEngine {
         };
     }
 
+    private getSelectedModuleProjectConfig(projectConfig: IEngineProjectConfig) {
+        if (!projectConfig.configs || Object.keys(projectConfig.configs).length === 0) {
+            return undefined;
+        }
+        const globalConfigKey = projectConfig.globalConfigKey || Object.keys(projectConfig.configs)[0];
+        return projectConfig.configs[globalConfigKey];
+    }
+
     /**
      * TODO init data in register project modules
      */
@@ -290,7 +298,6 @@ class EngineManager implements IEngine {
         this._info.tmpDir = join(enginePath, '.temp');
         this._loadEngineI18n(enginePath);
         this._defaultConfig = this.resolveDefaultConfig(this._info.typescript.path);
-        this._config = this.defaultConfig;
         const configInstance = await configurationRegistry.register('engine', {
             defaults: this.defaultConfig,
             nodes: () => createEngineMetadataNodes({
@@ -299,21 +306,31 @@ class EngineManager implements IEngine {
             }),
         });
         this._configInstance = configInstance;
-        this._init = true;
-        await this.updateConfig();
-        return this;
-    }
+        const syncConfig = () => {
+            const projectConfig = configInstance.getAll() || {};
+            const mergedConfig = merge(
+                cloneDeep(configInstance.getDefaultConfig() || {}),
+                projectConfig,
+            ) as IEngineConfig & IEngineProjectConfig;
+            const moduleConfig = this.getSelectedModuleProjectConfig(mergedConfig);
 
-    async updateConfig() {
-        const projectConfig = await this._configInstance.get<IEngineProjectConfig>();
-        this._config = projectConfig;
-        if (!projectConfig.configs || Object.keys(projectConfig.configs).length === 0) {
-            return this;
-        }
-        const globalConfigKey = projectConfig.globalConfigKey || Object.keys(projectConfig.configs)[0];
-        this._config.includeModules = projectConfig.configs[globalConfigKey].includeModules;
-        this._config.flags = projectConfig.configs[globalConfigKey].flags;
-        this._config.noDeprecatedFeatures = projectConfig.configs[globalConfigKey].noDeprecatedFeatures;
+            if (moduleConfig) {
+                if (!Object.prototype.hasOwnProperty.call(projectConfig, 'includeModules')) {
+                    mergedConfig.includeModules = moduleConfig.includeModules;
+                }
+                if (!Object.prototype.hasOwnProperty.call(projectConfig, 'flags')) {
+                    mergedConfig.flags = moduleConfig.flags;
+                }
+                if (!Object.prototype.hasOwnProperty.call(projectConfig, 'noDeprecatedFeatures')) {
+                    mergedConfig.noDeprecatedFeatures = moduleConfig.noDeprecatedFeatures;
+                }
+            }
+            this._config = mergedConfig;
+        };
+        syncConfig();
+        configInstance.on('configuration:save', syncConfig);
+        this._init = true;
+        return this;
     }
 
     async importEditorExtensions() {

--- a/src/core/engine/test/engine.test.ts
+++ b/src/core/engine/test/engine.test.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { EngineLoader } from 'cc/loader.js';
 import { TestGlobalEnv } from '../../../tests/global-env';
 import type { IEngineProjectConfig } from '../@types/config';
+import { configurationManager } from '../../configuration';
 
 [
     'cc',
@@ -35,6 +36,7 @@ describe('Engine', () => {
     let engine: IEngine;
 
     beforeEach(async () => {
+        await configurationManager.initialize(TestGlobalEnv.projectRoot);
         // 在每个测试用例之前初始化 engine
         engine = await Engine.init(TestGlobalEnv.engineRoot);
     });
@@ -63,13 +65,25 @@ describe('Engine', () => {
     });
 
     it('getConfig should return updated config after _configInstance.set()', async () => {
-        const originalModules = Engine.getConfig().includeModules;
-        const newModules = [...originalModules, '__test_config_sync__'];
+        const configInstance = Engine['_configInstance'];
+        const projectConfig = configInstance.getAll() as Partial<IEngineProjectConfig> | undefined;
+        const originalDesignResolution = projectConfig?.designResolution
+            ? { ...projectConfig.designResolution }
+            : undefined;
+        const nextWidth = (Engine.getConfig().designResolution?.width || 0) + 1;
 
-        // @ts-ignore - accessing private for test
-        await Engine['_configInstance'].set('includeModules', newModules);
+        try {
+            await configInstance.set('designResolution.width', nextWidth);
 
-        // Save 事件同步更新 _config 缓存，getConfig 应返回新值
-        expect(Engine.getConfig().includeModules).toEqual(newModules);
+            // Save 事件同步更新 _config 缓存，getConfig 应返回新值
+            expect(Engine.getConfig().designResolution.width).toBe(nextWidth);
+        } finally {
+            if (originalDesignResolution) {
+                await configInstance.set('designResolution', originalDesignResolution);
+            } else {
+                await configInstance.remove('designResolution');
+            }
+            await configurationManager.save(true);
+        }
     }, 30000);
 });

--- a/src/core/engine/test/engine.test.ts
+++ b/src/core/engine/test/engine.test.ts
@@ -2,6 +2,7 @@ import { Engine, IEngine } from '../index';
 import { join } from 'path';
 import { EngineLoader } from 'cc/loader.js';
 import { TestGlobalEnv } from '../../../tests/global-env';
+import type { IEngineProjectConfig } from '../@types/config';
 
 [
     'cc',
@@ -49,4 +50,26 @@ describe('Engine', () => {
         // @ts-ignore
         expect(ccm).toBeDefined();
     }, 1000 * 60 * 50);
+
+    it('getConfig should expose the selected module config at top level', () => {
+        const config = Engine.getConfig() as ReturnType<typeof Engine.getConfig> & IEngineProjectConfig;
+        const selectedConfigKey = config.globalConfigKey || Object.keys(config.configs || {})[0];
+
+        expect(selectedConfigKey).toBeDefined();
+        expect(config.configs?.[selectedConfigKey]).toBeDefined();
+        expect(config.includeModules).toEqual(config.configs![selectedConfigKey].includeModules);
+        expect(config.flags).toEqual(config.configs![selectedConfigKey].flags);
+        expect(config.noDeprecatedFeatures).toEqual(config.configs![selectedConfigKey].noDeprecatedFeatures);
+    });
+
+    it('getConfig should return updated config after _configInstance.set()', async () => {
+        const originalModules = Engine.getConfig().includeModules;
+        const newModules = [...originalModules, '__test_config_sync__'];
+
+        // @ts-ignore - accessing private for test
+        await Engine['_configInstance'].set('includeModules', newModules);
+
+        // Save 事件同步更新 _config 缓存，getConfig 应返回新值
+        expect(Engine.getConfig().includeModules).toEqual(newModules);
+    }, 30000);
 });


### PR DESCRIPTION
## Summary
- Keep the cached engine config in sync with the registered engine configuration instance.
- Merge project-level engine config updates with the resolved default config before returning `Engine.getConfig()`.
- Add a regression test for `_configInstance.set()` updating `Engine.getConfig()`.

## Test Plan
- npm test -- --runTestsByPath src/core/engine/test/engine.test.ts
- npx tsc -b --pretty false