### PR TITLE
[break] Improve configuration event typing

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -6225,13 +6225,25 @@ export { }
 `;
 
 exports[`DTS API compatibility configuration.d.ts should match snapshot 1`] = `
-"import { EventEmitter } from 'events';
+"import type { EventEmitter } from 'events';
+export declare type AnyArgs = any[];
+export declare type BaseConfigurationEvents = {
+    [ConfigurationEventName.Save]: [instance: IBaseConfiguration];
+};
+export declare const ConfigurationEventName: {
+    readonly Save: "configuration:save";
+    readonly Registry: "configuration:registry";
+    readonly UnRegistry: "configuration:unregistry";
+    readonly Reload: "configuration:reload";
+    readonly Update: "configuration:update";
+    readonly Remove: "configuration:remove";
+};
 export declare type ConfigurationScope = 'default' | 'project';
 export declare type EventEmitterMethods = Pick<EventEmitter, 'on' | 'off' | 'once' | 'emit'>;
 export declare function get<T>(key: string, scope?: ConfigurationScope): Promise<T>;
 export declare function getConfigPath(): Promise<string>;
 export declare function getMetadata(): Promise<ICocosConfigurationNode[]>;
-export declare interface IBaseConfiguration extends EventEmitterMethods {
+export declare interface IBaseConfiguration extends TypedEventEmitter<BaseConfigurationEvents> {
     moduleName: string;
     getDefaultConfig(): Record<string, any> | undefined;
     mergeDefaultConfig(defaultConfig?: Record<string, any>): void;
@@ -6268,6 +6280,14 @@ export declare interface IConfiguration {
     [key: string]: any;
 }
 export declare function init(projectPath: string): Promise<void>;
+export declare const MessageType: {
+    readonly Save: "configuration:save";
+    readonly Registry: "configuration:registry";
+    readonly UnRegistry: "configuration:unregistry";
+    readonly Reload: "configuration:reload";
+    readonly Update: "configuration:update";
+    readonly Remove: "configuration:remove";
+};
 export declare function migrate(): Promise<void>;
 export declare function migrateFromProject(): Promise<IConfiguration>;
 export declare function onDidSave(callback: () => void): () => void;
@@ -6275,6 +6295,16 @@ export declare function reload(): Promise<void>;
 export declare function remove(key: string, scope?: ConfigurationScope): Promise<boolean>;
 export declare function save(force?: boolean): Promise<void>;
 export declare function set<T>(key: string, value: T, scope?: ConfigurationScope): Promise<boolean>;
+export declare interface TypedEventEmitter<T extends Record<string, AnyArgs>> extends EventEmitterMethods {
+    on<K extends keyof T>(eventName: K, listener: (...args: T[K]) => void): EventEmitter;
+    on(eventName: string | symbol, listener: (...args: any[]) => void): EventEmitter;
+    off<K extends keyof T>(eventName: K, listener: (...args: T[K]) => void): EventEmitter;
+    off(eventName: string | symbol, listener: (...args: any[]) => void): EventEmitter;
+    once<K extends keyof T>(eventName: K, listener: (...args: T[K]) => void): EventEmitter;
+    once(eventName: string | symbol, listener: (...args: any[]) => void): EventEmitter;
+    emit<K extends keyof T>(eventName: K, ...args: T[K]): boolean;
+    emit(eventName: string | symbol, ...args: any[]): boolean;
+}
 export { }
 "
 `;
@@ -6522,7 +6552,7 @@ exports[`DTS API compatibility index.d.ts should match snapshot 1`] = `
 "import { __private } from 'cc';
 import { ChunkInfo } from '@cocos/creator-programming-quick-pack/lib/loader';
 import type { Component } from 'cc';
-import { EventEmitter } from 'events';
+import type { EventEmitter } from 'events';
 import { default as i18n_2 } from 'i18next';
 import { NextFunction } from 'express';
 import type { Node as Node_2 } from 'cc';
@@ -6557,6 +6587,7 @@ export declare interface AnimationImportSetting {
         };
     }>;
 }
+export declare type AnyArgs = any[];
 export declare const ASSET_HANDLER_TYPES: string[];
 export declare enum AssetActionEnum {
     'add' = 0,
@@ -6762,6 +6793,9 @@ export declare namespace Base {
         init_2 as init
     }
 }
+export declare type BaseConfigurationEvents = {
+    [ConfigurationEventName.Save]: [instance: IBaseConfiguration];
+};
 export declare interface BaseItem {
     label?: string;
     description?: string;
@@ -6810,13 +6844,26 @@ export declare namespace Configuration {
         getConfigPath,
         onDidSave,
         getMetadata,
+        ConfigurationEventName,
+        MessageType,
+        AnyArgs,
+        EventEmitterMethods,
         IConfiguration,
         ConfigurationScope,
+        TypedEventEmitter,
         IBaseConfiguration,
         ICocosConfigurationNode,
         ICocosConfigurationPropertySchema
     }
 }
+export declare const ConfigurationEventName: {
+    readonly Save: "configuration:save";
+    readonly Registry: "configuration:registry";
+    readonly UnRegistry: "configuration:unregistry";
+    readonly Reload: "configuration:reload";
+    readonly Update: "configuration:update";
+    readonly Remove: "configuration:remove";
+};
 export declare type ConfigurationScope = 'default' | 'project';
 export declare const CREATE_TYPES: readonly ["scene", "prefab"];
 export declare function createAsset(options: CreateAssetOptions): Promise<IAssetInfo>;
@@ -7190,7 +7237,7 @@ export declare interface IAssetWriteFileOptions extends IAssetOperationOptionsBa
     create?: boolean;
     overwrite?: boolean;
 }
-export declare interface IBaseConfiguration extends EventEmitterMethods {
+export declare interface IBaseConfiguration extends TypedEventEmitter<BaseConfigurationEvents> {
     moduleName: string;
     getDefaultConfig(): Record<string, any> | undefined;
     mergeDefaultConfig(defaultConfig?: Record<string, any>): void;
@@ -8133,6 +8180,14 @@ export declare interface MeshSimplifyOptions {
     errorRate?: number;
     lockBoundary?: boolean;
 }
+export declare const MessageType: {
+    readonly Save: "configuration:save";
+    readonly Registry: "configuration:registry";
+    readonly UnRegistry: "configuration:unregistry";
+    readonly Reload: "configuration:reload";
+    readonly Update: "configuration:update";
+    readonly Remove: "configuration:remove";
+};
 export declare function migrate(): Promise<void>;
 export declare function migrateFromProject(): Promise<IConfiguration>;
 export declare interface Migration {
@@ -8602,6 +8657,16 @@ export declare interface ThumbnailInfo {
 }
 export declare type ThumbnailSize = 'large' | 'small' | 'middle' | 'origin';
 export declare type TSceneTemplateType = typeof SCENE_TEMPLATE_TYPE[number];
+export declare interface TypedEventEmitter<T extends Record<string, AnyArgs>> extends EventEmitterMethods {
+    on<K extends keyof T>(eventName: K, listener: (...args: T[K]) => void): EventEmitter;
+    on(eventName: string | symbol, listener: (...args: any[]) => void): EventEmitter;
+    off<K extends keyof T>(eventName: K, listener: (...args: T[K]) => void): EventEmitter;
+    off(eventName: string | symbol, listener: (...args: any[]) => void): EventEmitter;
+    once<K extends keyof T>(eventName: K, listener: (...args: T[K]) => void): EventEmitter;
+    once(eventName: string | symbol, listener: (...args: any[]) => void): EventEmitter;
+    emit<K extends keyof T>(eventName: K, ...args: T[K]): boolean;
+    emit(eventName: string | symbol, ...args: any[]): boolean;
+}
 export declare type UIAlignType = 'top' | 'v-center' | 'bottom' | 'left' | 'h-center' | 'right';
 export declare function unregister(): Promise<void>;
 export declare function updateAssetUserData(urlOrUuidOrPath: string, path: string, value: any): Promise<any>;

--- a/src/core/configuration/index.ts
+++ b/src/core/configuration/index.ts
@@ -1,15 +1,18 @@
 import { IBaseConfiguration } from './script/config';
-import { ConfigurationScope } from './script/interface';
+import { ConfigurationEventName, ConfigurationScope, MessageType } from './script/interface';
 import { configurationRegistry } from './script/registry';
 import { configurationManager } from './script/manager';
 
 export * from './migration';
 
 export {
+    ConfigurationEventName,
+    MessageType,
     ConfigurationScope,
     IBaseConfiguration,
     configurationRegistry,
     configurationManager,
 };
 
+export type { AnyArgs, EventEmitterMethods, IConfiguration, TypedEventEmitter } from './script/interface';
 export { ICocosConfigurationNode, ICocosConfigurationPropertySchema } from './script/metadata';

--- a/src/core/configuration/script/config.ts
+++ b/src/core/configuration/script/config.ts
@@ -1,13 +1,15 @@
 import * as utils from './utils';
-import { ConfigurationScope, MessageType } from './interface';
+import { ConfigurationEventName, ConfigurationScope, TypedEventEmitter } from './interface';
 import { EventEmitter } from 'events';
 
-type EventEmitterMethods = Pick<EventEmitter, 'on' | 'off' | 'once' | 'emit'>;
+export type BaseConfigurationEvents = {
+    [ConfigurationEventName.Save]: [instance: IBaseConfiguration];
+};
 
 /**
  * 配置基类接口
  */
-export interface IBaseConfiguration extends EventEmitterMethods {
+export interface IBaseConfiguration extends TypedEventEmitter<BaseConfigurationEvents> {
     /**
      * 模块名
      */
@@ -58,6 +60,30 @@ export interface IBaseConfiguration extends EventEmitterMethods {
  */
 export class BaseConfiguration extends EventEmitter implements IBaseConfiguration {
     protected configs: Record<string, any> = {};
+
+    public on<K extends keyof BaseConfigurationEvents>(eventName: K, listener: (...args: BaseConfigurationEvents[K]) => void): this;
+    public on(eventName: string | symbol, listener: (...args: any[]) => void): this;
+    public on(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        return super.on(eventName, listener);
+    }
+
+    public off<K extends keyof BaseConfigurationEvents>(eventName: K, listener: (...args: BaseConfigurationEvents[K]) => void): this;
+    public off(eventName: string | symbol, listener: (...args: any[]) => void): this;
+    public off(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        return super.off(eventName, listener);
+    }
+
+    public once<K extends keyof BaseConfigurationEvents>(eventName: K, listener: (...args: BaseConfigurationEvents[K]) => void): this;
+    public once(eventName: string | symbol, listener: (...args: any[]) => void): this;
+    public once(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        return super.once(eventName, listener);
+    }
+
+    public emit<K extends keyof BaseConfigurationEvents>(eventName: K, ...args: BaseConfigurationEvents[K]): boolean;
+    public emit(eventName: string | symbol, ...args: any[]): boolean;
+    public emit(eventName: string | symbol, ...args: any[]): boolean {
+        return super.emit(eventName, ...args);
+    }
 
     constructor(
         public readonly moduleName: string,
@@ -150,7 +176,7 @@ export class BaseConfiguration extends EventEmitter implements IBaseConfiguratio
     }
 
     public async save() {
-        this.emit(MessageType.Save, this);
+        this.emit(ConfigurationEventName.Save, this);
         return true;
     }
 }

--- a/src/core/configuration/script/interface.ts
+++ b/src/core/configuration/script/interface.ts
@@ -1,10 +1,11 @@
+import type { EventEmitter } from 'events';
 
 /**
  * 配置范围
  */
 export type ConfigurationScope = 'default' | 'project';
 
-export const MessageType = {
+export const ConfigurationEventName = {
     Save: 'configuration:save',
     Registry: 'configuration:registry',
     UnRegistry: 'configuration:unregistry',
@@ -12,6 +13,29 @@ export const MessageType = {
     Update: 'configuration:update',
     Remove: 'configuration:remove',
 } as const;
+
+/**
+ * @deprecated Use ConfigurationEventName instead.
+ */
+export const MessageType = ConfigurationEventName;
+
+export type AnyArgs = any[];
+export type EventEmitterMethods = Pick<EventEmitter, 'on' | 'off' | 'once' | 'emit'>;
+
+/**
+ * 类型化的事件发射器接口
+ * 在 EventEmitterMethods 基础上补充已知事件的参数类型
+ */
+export interface TypedEventEmitter<T extends Record<string, AnyArgs>> extends EventEmitterMethods {
+    on<K extends keyof T>(eventName: K, listener: (...args: T[K]) => void): EventEmitter;
+    on(eventName: string | symbol, listener: (...args: any[]) => void): EventEmitter;
+    off<K extends keyof T>(eventName: K, listener: (...args: T[K]) => void): EventEmitter;
+    off(eventName: string | symbol, listener: (...args: any[]) => void): EventEmitter;
+    once<K extends keyof T>(eventName: K, listener: (...args: T[K]) => void): EventEmitter;
+    once(eventName: string | symbol, listener: (...args: any[]) => void): EventEmitter;
+    emit<K extends keyof T>(eventName: K, ...args: T[K]): boolean;
+    emit(eventName: string | symbol, ...args: any[]): boolean;
+}
 
 /**
  * 配置的格式

--- a/src/core/configuration/script/manager.ts
+++ b/src/core/configuration/script/manager.ts
@@ -1,15 +1,22 @@
 import { gt } from 'semver';
-import path, { join, relative } from 'path';
+import path, { join } from 'path';
 import fse from 'fs-extra';
 import { newConsole } from '../../base/console';
 import * as utils from './utils';
-import { IConfiguration, ConfigurationScope, MessageType } from './interface';
+import { IConfiguration, ConfigurationEventName, ConfigurationScope, TypedEventEmitter } from './interface';
 import { CocosMigrationManager } from '../migration';
 import { configurationRegistry } from './registry';
 import { IBaseConfiguration } from './config';
 import EventEmitter from 'events';
 
-export interface IConfigurationManager {
+export type ConfigurationManagerEvents = {
+    [ConfigurationEventName.Reload]: [config: IConfiguration];
+    [ConfigurationEventName.Update]: [key: string, value: any, scope: ConfigurationScope];
+    [ConfigurationEventName.Remove]: [key: string, scope: ConfigurationScope];
+    [ConfigurationEventName.Save]: [config: IConfiguration];
+};
+
+export interface IConfigurationManager extends TypedEventEmitter<ConfigurationManagerEvents> {
     /**
      * 初始化配置管理器
      */
@@ -70,6 +77,30 @@ export class ConfigurationManager extends EventEmitter implements IConfiguration
     static SchemaPathSource = join(__dirname, '../../../../dist/cocos.config.schema.json');
     static relativeSchemaPath = `./temp/cli/${path.basename(ConfigurationManager.SchemaPathSource)}`;
 
+    public on<K extends keyof ConfigurationManagerEvents>(eventName: K, listener: (...args: ConfigurationManagerEvents[K]) => void): this;
+    public on(eventName: string | symbol, listener: (...args: any[]) => void): this;
+    public on(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        return super.on(eventName, listener);
+    }
+
+    public off<K extends keyof ConfigurationManagerEvents>(eventName: K, listener: (...args: ConfigurationManagerEvents[K]) => void): this;
+    public off(eventName: string | symbol, listener: (...args: any[]) => void): this;
+    public off(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        return super.off(eventName, listener);
+    }
+
+    public once<K extends keyof ConfigurationManagerEvents>(eventName: K, listener: (...args: ConfigurationManagerEvents[K]) => void): this;
+    public once(eventName: string | symbol, listener: (...args: any[]) => void): this;
+    public once(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        return super.once(eventName, listener);
+    }
+
+    public emit<K extends keyof ConfigurationManagerEvents>(eventName: K, ...args: ConfigurationManagerEvents[K]): boolean;
+    public emit(eventName: string | symbol, ...args: any[]): boolean;
+    public emit(eventName: string | symbol, ...args: any[]): boolean {
+        return super.emit(eventName, ...args);
+    }
+
     private initialized: boolean = false;
     private projectPath: string = '';
     private configPath: string = '';
@@ -96,8 +127,8 @@ export class ConfigurationManager extends EventEmitter implements IConfiguration
             return;
         }
 
-        configurationRegistry.on(MessageType.Registry, this.onRegistryConfigurationBind);
-        configurationRegistry.on(MessageType.UnRegistry, this.onUnRegistryConfigurationBind);
+        configurationRegistry.on(ConfigurationEventName.Registry, this.onRegistryConfigurationBind);
+        configurationRegistry.on(ConfigurationEventName.UnRegistry, this.onUnRegistryConfigurationBind);
 
         this.projectPath = projectPath;
         this.configPath = path.join(projectPath, ConfigurationManager.name);
@@ -118,33 +149,33 @@ export class ConfigurationManager extends EventEmitter implements IConfiguration
      */
     public async reload(): Promise<void> {
         await this.load();
-        this.emit(MessageType.Reload, this.projectConfig);
+        this.emit(ConfigurationEventName.Reload, this.projectConfig);
     }
 
-    private onRegistryConfiguration(instance: IBaseConfiguration): void {
-        if (!this.configurationMap.has(instance.moduleName)) {
+    private onRegistryConfiguration(configInstance: IBaseConfiguration): void {
+        if (!this.configurationMap.has(configInstance.moduleName)) {
             // 从 projectConfig 中获取现有配置并初始化到配置实例中
-            const existingConfig = this.projectConfig[instance.moduleName];
+            const existingConfig = this.projectConfig[configInstance.moduleName];
             if (existingConfig && typeof existingConfig === 'object') {
                 // 将现有配置设置到配置实例的 configs 中
-                this.initializeConfigFromProject(instance, existingConfig);
+                this.initializeConfigFromProject(configInstance, existingConfig);
             }
 
             const bind = async (configInstance: IBaseConfiguration) => {
                 this.projectConfig[configInstance.moduleName] = configInstance.getAll();
                 await this.save();
             };
-            instance.on(MessageType.Save, bind);
-            this.configurationMap.set(instance.moduleName, bind);
+            configInstance.on(ConfigurationEventName.Save, bind);
+            this.configurationMap.set(configInstance.moduleName, bind);
         }
     }
 
-    private onUnRegistryConfiguration(instances: IBaseConfiguration): void {
-        const bind = this.configurationMap.get(instances.moduleName);
+    private onUnRegistryConfiguration(configInstance: IBaseConfiguration): void {
+        const bind = this.configurationMap.get(configInstance.moduleName);
         if (bind) {
             // TODO 是否需要删除
-            instances.off(MessageType.Save, bind);
-            this.configurationMap.delete(instances.moduleName);
+            configInstance.off(ConfigurationEventName.Save, bind);
+            this.configurationMap.delete(configInstance.moduleName);
         }
     }
 
@@ -255,7 +286,7 @@ export class ConfigurationManager extends EventEmitter implements IConfiguration
             await this.ensureInitialized();
             const { moduleName, actualKey } = this.parseKey(key);
             await this.getInstance(moduleName).set(actualKey, value, scope);
-            this.emit(MessageType.Update, key, value, scope);
+            this.emit(ConfigurationEventName.Update, key, value, scope);
             return true;
         } catch (error) {
             throw new Error(`[Configuration] 更新配置失败：${error}`);
@@ -271,7 +302,7 @@ export class ConfigurationManager extends EventEmitter implements IConfiguration
         try {
             await this.ensureInitialized();
             const { moduleName, actualKey } = this.parseKey(key);
-            this.emit(MessageType.Remove, key, scope);
+            this.emit(ConfigurationEventName.Remove, key, scope);
             return await this.getInstance(moduleName).remove(actualKey, scope);
         } catch (error) {
             throw new Error(`[Configuration] 移除配置失败：${error}`);
@@ -294,7 +325,9 @@ export class ConfigurationManager extends EventEmitter implements IConfiguration
         try {
             if (await fse.pathExists(this.configPath)) {
                 this.projectConfig = await fse.readJSON(this.configPath);
-                this.projectConfig.version && (this.version = this.projectConfig.version);
+                if (this.projectConfig.version) {
+                    this.version = this.projectConfig.version;
+                }
                 newConsole.debug(`[Configuration] 已加载项目配置: ${this.configPath}`, this.projectConfig);
             } else {
                 newConsole.debug(`[Configuration] 项目配置文件不存在，将创建新文件: ${this.configPath}`);
@@ -324,7 +357,7 @@ export class ConfigurationManager extends EventEmitter implements IConfiguration
                     this.projectConfig.$schema = ConfigurationManager.relativeSchemaPath;
                     // 保存配置文件
                     await fse.writeJSON(this.configPath, this.projectConfig, { spaces: 4 });
-                    this.emit(MessageType.Save, this.projectConfig);
+                    this.emit(ConfigurationEventName.Save, this.projectConfig);
                     newConsole.debug(`[Configuration] 已保存项目配置: ${this.configPath}`);
                 } catch (error) {
                     newConsole.error(`[Configuration] 保存项目配置失败: ${this.configPath} - ${error}`);

--- a/src/core/configuration/script/registry.ts
+++ b/src/core/configuration/script/registry.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import { newConsole } from '../../base/console';
 import { BaseConfiguration, IBaseConfiguration } from './config';
-import { MessageType } from './interface';
+import { ConfigurationEventName, TypedEventEmitter } from './interface';
 import type {
     ICocosConfigurationMetadataRegistration,
     ICocosConfigurationNode,
@@ -14,7 +14,12 @@ export interface IConfigurationRegistration {
     nodes?: ICocosConfigurationMetadataRegistration;
 }
 
-export interface IConfigurationRegistry {
+export type ConfigurationRegistryEvents = {
+    [ConfigurationEventName.Registry]: [instance: IBaseConfiguration];
+    [ConfigurationEventName.UnRegistry]: [instance: IBaseConfiguration];
+};
+
+export interface IConfigurationRegistry extends TypedEventEmitter<ConfigurationRegistryEvents> {
     getInstances(): Record<string, IBaseConfiguration>;
     getInstance(moduleName: string): IBaseConfiguration | undefined;
 
@@ -179,6 +184,30 @@ export class ConfigurationRegistry extends EventEmitter implements IConfiguratio
     private instances: Record<string, IBaseConfiguration> = {};
     private registrations: Record<string, IConfigurationRegistration> = {};
 
+    public on<K extends keyof ConfigurationRegistryEvents>(eventName: K, listener: (...args: ConfigurationRegistryEvents[K]) => void): this;
+    public on(eventName: string | symbol, listener: (...args: any[]) => void): this;
+    public on(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        return super.on(eventName, listener);
+    }
+
+    public off<K extends keyof ConfigurationRegistryEvents>(eventName: K, listener: (...args: ConfigurationRegistryEvents[K]) => void): this;
+    public off(eventName: string | symbol, listener: (...args: any[]) => void): this;
+    public off(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        return super.off(eventName, listener);
+    }
+
+    public once<K extends keyof ConfigurationRegistryEvents>(eventName: K, listener: (...args: ConfigurationRegistryEvents[K]) => void): this;
+    public once(eventName: string | symbol, listener: (...args: any[]) => void): this;
+    public once(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        return super.once(eventName, listener);
+    }
+
+    public emit<K extends keyof ConfigurationRegistryEvents>(eventName: K, ...args: ConfigurationRegistryEvents[K]): boolean;
+    public emit(eventName: string | symbol, ...args: any[]): boolean;
+    public emit(eventName: string | symbol, ...args: any[]): boolean {
+        return super.emit(eventName, ...args);
+    }
+
     public getInstances(): Record<string, IBaseConfiguration> {
         return this.instances;
     }
@@ -242,13 +271,13 @@ export class ConfigurationRegistry extends EventEmitter implements IConfiguratio
         }
 
         this.instances[moduleName] = nextInstance;
-        this.emit(MessageType.Registry, nextInstance);
+        this.emit(ConfigurationEventName.Registry, nextInstance);
         return nextInstance as IBaseConfiguration | T;
     }
 
     public async unregister(moduleName: string): Promise<void> {
         const instance = this.instances[moduleName];
-        this.emit(MessageType.UnRegistry, instance);
+        this.emit(ConfigurationEventName.UnRegistry, instance);
         delete this.instances[moduleName];
         delete this.registrations[moduleName];
     }

--- a/src/lib/configuration/configuration.ts
+++ b/src/lib/configuration/configuration.ts
@@ -1,7 +1,9 @@
 import type { IConfiguration, ConfigurationScope } from '../../core/configuration/script/interface';
+import { ConfigurationEventName, MessageType } from '../../core/configuration/script/interface';
 import type { ICocosConfigurationNode } from '../../core/configuration/script/metadata';
 
-export { IConfiguration, ConfigurationScope } from '../../core/configuration/script/interface';
+export { ConfigurationEventName, MessageType };
+export type { AnyArgs, EventEmitterMethods, IConfiguration, ConfigurationScope, TypedEventEmitter } from '../../core/configuration/script/interface';
 export { IBaseConfiguration } from '../../core/configuration/script/config';
 
 export async function init(projectPath: string): Promise<void> {
@@ -59,8 +61,8 @@ export function onDidSave(callback: () => void): () => void {
     // 同步引入：调用时 configurationManager 必定已初始化
     const { configurationManager } = require('../../core/configuration/index');
     const handler = () => callback();
-    configurationManager.on('configuration:save', handler);
-    return () => configurationManager.off('configuration:save', handler);
+    configurationManager.on(ConfigurationEventName.Save, handler);
+    return () => configurationManager.off(ConfigurationEventName.Save, handler);
 }
 
 // ==================== Metadata ====================


### PR DESCRIPTION
## Summary
- Add typed configuration event names and emitter signatures for better configuration API completions.
- Preserve the legacy MessageType and EventEmitterMethods exports, including string/symbol fallback overloads for existing event listener code.
- Update DTS snapshots for the typed event API while keeping compatibility aliases available.

## Test Plan
- npm run generate:dts
- npm test -- --runTestsByPath src/core/configuration/test/config.test.ts src/core/configuration/test/manager.test.ts src/core/configuration/test/registry.test.ts
- npx tsc -b --pretty false
- git diff --check
- git diff --cached --check