### PR TITLE
[break] fix(assets): support texture cube creation

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -724,7 +724,7 @@ export declare interface SpriteFrameVertices {
     maxPos: number[];
 }
 export declare function start(): Promise<void>;
-export declare const SUPPORT_CREATE_TYPES: readonly ["animation-clip", "typescript", "auto-atlas", "effect", "scene", "prefab", "material", "terrain", "physics-material", "label-atlas", "render-texture", "directory", "effect-header"];
+export declare const SUPPORT_CREATE_TYPES: readonly ["animation-clip", "typescript", "auto-atlas", "effect", "scene", "prefab", "material", "texture-cube", "terrain", "physics-material", "label-atlas", "render-texture", "directory", "effect-header"];
 export declare enum TangentImportSetting {
     exclude = 0,
     optional = 1,
@@ -4696,7 +4696,7 @@ export declare interface StoreInfo {
     uuid: string;
     mtime: number;
 }
-export declare const SUPPORT_CREATE_TYPES: readonly ["animation-clip", "typescript", "auto-atlas", "effect", "scene", "prefab", "material", "terrain", "physics-material", "label-atlas", "render-texture", "directory", "effect-header"];
+export declare const SUPPORT_CREATE_TYPES: readonly ["animation-clip", "typescript", "auto-atlas", "effect", "scene", "prefab", "material", "texture-cube", "terrain", "physics-material", "label-atlas", "render-texture", "directory", "effect-header"];
 export declare type SyncPluginHooks =
 	| 'augmentChunkHash'
 	| 'outputOptions'
@@ -6168,7 +6168,7 @@ export declare interface SpriteFrameVertices {
     minPos: number[];
     maxPos: number[];
 }
-export declare const SUPPORT_CREATE_TYPES: readonly ["animation-clip", "typescript", "auto-atlas", "effect", "scene", "prefab", "material", "terrain", "physics-material", "label-atlas", "render-texture", "directory", "effect-header"];
+export declare const SUPPORT_CREATE_TYPES: readonly ["animation-clip", "typescript", "auto-atlas", "effect", "scene", "prefab", "material", "texture-cube", "terrain", "physics-material", "label-atlas", "render-texture", "directory", "effect-header"];
 export declare enum TangentImportSetting {
     exclude = 0,
     optional = 1,
@@ -8562,7 +8562,7 @@ export declare function startCompileScript(assetChanges?: AssetChangeInfo[]): Pr
 export declare function startEngineCompilation(force?: boolean): Promise<void>;
 export declare function startupWorker(projectPath: string): Promise<void>;
 export declare function stop_2(): Promise<void>;
-export declare const SUPPORT_CREATE_TYPES: readonly ["animation-clip", "typescript", "auto-atlas", "effect", "scene", "prefab", "material", "terrain", "physics-material", "label-atlas", "render-texture", "directory", "effect-header"];
+export declare const SUPPORT_CREATE_TYPES: readonly ["animation-clip", "typescript", "auto-atlas", "effect", "scene", "prefab", "material", "texture-cube", "terrain", "physics-material", "label-atlas", "render-texture", "directory", "effect-header"];
 export declare enum TangentImportSetting {
     exclude = 0,
     optional = 1,

--- a/packages/cocos-cli-types/package.json
+++ b/packages/cocos-cli-types/package.json
@@ -2,7 +2,7 @@
     "name": "@cocos/cocos-cli-types",
     "description": "types for cocos cli",
     "author": "cocos cli",
-    "version": "0.0.1-alpha.27.1",
+    "version": "0.0.1-alpha.28.1",
     "main": "index.d.ts",
     "types": "index.d.ts",
     "exports": {

--- a/repo.json
+++ b/repo.json
@@ -2,7 +2,7 @@
     "engine": {
         "repo": "https://github.com/cocos/cocos4.git",
         "dist": "packages/engine",
-        "tag": "4.0.0-alpha.20"
+        "tag": "4.0.0-alpha.21"
     },
     "external": {
         "repo": "https://github.com/cocos/cocos-engine-external.git",

--- a/src/core/assets/@types/interface.ts
+++ b/src/core/assets/@types/interface.ts
@@ -69,7 +69,7 @@ export const SUPPORT_CREATE_TYPES = [
     'scene',                   // 场景
     'prefab',                  // 预制体
     'material',                // 材质
-    // 'texture-cube',            // 立方体贴图
+    'texture-cube',            // 立方体贴图
     'terrain',                 // 地形
     'physics-material',        // 物理材质
     'label-atlas',             // 标签图集

--- a/src/core/assets/asset-handler/assets/texture-cube.ts
+++ b/src/core/assets/asset-handler/assets/texture-cube.ts
@@ -26,7 +26,7 @@ export const TextureCubeHandler: AssetHandler = {
                 {
                     label: 'i18n:ENGINE.assets.newCubeMap',
                     fullFileName: 'cubemap.cubemap',
-                    content: '',
+                    template: 'db://internal/default_file_content/texture-cube/default.cubemap',
                     name: 'default',
                 },
             ];

--- a/src/core/assets/test/operation.test.ts
+++ b/src/core/assets/test/operation.test.ts
@@ -526,6 +526,22 @@ describe('测试 db 的操作接口', function () {
             const content = readFileSync(assetInfo!.file, 'utf8');
             expect(content).toEqual('console.log("Hello, World!");');
         });
+
+        it('创建 texture-cube 时生成 .cubemap 文件而不是目录', async () => {
+            const assetInfo = await assetManager.createAssetByType(
+                'texture-cube' as any,
+                databasePath,
+                'texture-cube-file-check',
+                { overwrite: true }
+            );
+
+            expect(assetInfo).not.toBeNull();
+            expect(assetInfo!.type).toEqual('cc.TextureCube');
+            expect(assetInfo!.isDirectory).toBe(false);
+            expect(assetInfo!.file.endsWith('.cubemap')).toBe(true);
+            expect(statSync(assetInfo!.file).isFile()).toBe(true);
+            expect(statSync(assetInfo!.file).isDirectory()).toBe(false);
+        });
     });
 
     describe('concurrent-create-asset', () => {

--- a/tests/shared/asset-test-data.ts
+++ b/tests/shared/asset-test-data.ts
@@ -16,6 +16,7 @@ export const CREATE_ASSET_TYPE_TEST_CASES = [
     { type: 'scene', ext: 'scene', ccType: 'cc.SceneAsset', description: 'quality 场景', templateName: 'quality' },
     { type: 'prefab', ext: 'prefab', ccType: 'cc.Prefab', description: '预制体' },
     { type: 'material', ext: 'mtl', ccType: 'cc.Material', description: '材质' },
+    { type: 'texture-cube', ext: 'cubemap', ccType: 'cc.TextureCube', description: '立方体贴图' },
     { type: 'terrain', ext: 'terrain', ccType: 'cc.TerrainAsset', description: '地形' },
     { type: 'physics-material', ext: 'pmtl', ccType: 'cc.PhysicsMaterial', description: '物理材质' },
     { type: 'label-atlas', ext: 'labelatlas', ccType: 'cc.LabelAtlas', description: '标签图集' },


### PR DESCRIPTION
### 变更概述

- 修复 `texture-cube` 通过 `createAssetByType` 新建时返回普通资源的问题，改为使用内置 `.cubemap` 模板。
- 将 `texture-cube` 加入 `SUPPORT_CREATE_TYPES`，让 MCP schema 和公开类型支持创建立方体贴图。
- 更新默认 cubemap 六面图，并新增对应的内置模板资源。
- 补充单元测试与 MCP e2e 覆盖，确保创建结果是 `.cubemap` 文件且类型为 `cc.TextureCube`。

<img width="486" height="368" alt="企业微信截图_17804723707230" src="https://github.com/user-attachments/assets/6abda6ff-bef6-4841-ab53-6f2ac4bef4ec" />

后续可能会加入默认贴图
<img width="284" height="221" alt="企业微信截图_1780473076792" src="https://github.com/user-attachments/assets/744c8150-1163-49bf-8715-3a80a202fcf2" />
