### PR TITLE
[fix] support visible attribute in encodeObject & i18n help text

### DIFF
--- a/src/core/scene/scene-process/service/dump/encode.ts
+++ b/src/core/scene/scene-process/service/dump/encode.ts
@@ -80,8 +80,8 @@ export function encodeNode(node: Node): INode {
 
     const data: INode = {
         path: EditorExtends.Node.getNodePath(node),
-        active: encodeObject(node.active, { displayName: 'Active', default: null }, node),
-        locked: encodeObject(Boolean(node.objFlags & cc.Object.Flags.LockedInEditor), { displayName: 'Locked', default: false, animatable: false }, node),
+        active: encodeObject(node.active, { displayName: 'Active', default: null , visible: false }, node),
+        locked: encodeObject(Boolean(node.objFlags & cc.Object.Flags.LockedInEditor), { displayName: 'Locked', default: false, animatable: false, visible: false }, node),
         name: encodeObject(node.name, { displayName: 'Name', default: null, animatable: false }, node),
         position: encodeObject(
             node.position,
@@ -334,7 +334,7 @@ export function encodeComponent(component: any): IComponent {
     data.editor = {
         inspector: ctor._inspector || '',
         icon: ctor._icon || '',
-        help: ctor._help || '',
+        help: i18n.transI18nName(`${ctor._help}`.replace('i18n:cc', 'i18n:ENGINE.help.cc')) || '',
         _showTick:
             typeof component.start === 'function' ||
             typeof component.update === 'function' ||
@@ -609,7 +609,7 @@ export function encodeObject(object: any, attributes: any, owner: any = null, ob
         type: type,
         path: '',
         readonly: !!attributes.readonly,
-        visible: true,
+        visible: attributes.visible ?? true,
         animatable: attributes.animatable === undefined ? true : !!attributes.animatable, // 如果没有定义默认是 true，否则根据定义取布尔值
     };
 

--- a/src/core/scene/test/node-for-editor.testcase.ts
+++ b/src/core/scene/test/node-for-editor.testcase.ts
@@ -603,7 +603,7 @@ describe('Node ForEditor 接口测试', () => {
             const active = dump.active;
 
             expect(typeof active.value).toBe('boolean');
-            expect(active.visible).toBe(true);
+            expect(active.visible).toBe(false);
             expect(active.displayName).toBe('Active');
         });
 


### PR DESCRIPTION
## Summary
- `encodeObject`: 支持从 `attributes.visible` 读取 visible 属性，默认 `true`
- `encodeNode`: 给 `active` 和 `locked` 属性设置 `visible: false`，在检查器中隐藏
- `encodeComponent`: 组件 help 字段使用 i18n 翻译

## Test plan
- [ ] 验证场景节点的 active/locked 属性在检查器中不可见
- [ ] 验证组件 help 文本正确显示 i18n 翻译内容
- [ ] 验证其他属性的 visible 行为不受影响（默认仍为 true）