### PR TITLE
[fix] scene worker exits when parent disconnects

### DIFF
--- a/src/core/scene/scene-process/main.ts
+++ b/src/core/scene/scene-process/main.ts
@@ -15,6 +15,12 @@ async function startup() {
         }
     });
 
+    // 父进程死亡时 IPC 通道断开，立即退出避免被 launchd 收养成为孤儿进程
+    process.on('disconnect', () => {
+        console.log('[Scene] Parent disconnected, exiting');
+        process.exit(0);
+    });
+
     console.log(`[Scene] startup worker pid: ${process.pid}`);
 
     console.log(`[Scene] parse args ${process.argv}`);


### PR DESCRIPTION
## Summary
- Fix Scene Worker child process being left as an orphan after its parent dies unexpectedly
- Scene Worker loads heavy native modules (sharp/libvips/rollup) and consumes hundreds of MB when leaked
- Listen on the `disconnect` event so the worker exits the moment the IPC channel breaks (i.e. parent gone)

## Changes
- `src/core/scene/scene-process/main.ts`: register `process.on('disconnect', ...)` inside `startup()` to exit immediately when the parent's IPC channel closes

## Root Cause
Scene Worker is forked via `child_process.fork()` (`scene-worker.ts:74`) and previously only exited on receiving the `'scene-process:exit'` IPC message. When the parent process (cocos utility / cocos host) dies unexpectedly:
1. That message is never sent
2. macOS does NOT automatically deliver SIGTERM/SIGHUP to children when the parent dies
3. The worker is reparented to launchd and keeps running — sharp/libvips worker threads keep the event loop alive

Node.js `child_process.fork()` always emits a `disconnect` event on the child when the parent's IPC channel closes — that's the most reliable signal for "parent is gone."

## Test plan
- [ ] Open a Cocos project in PinK, wait for Scene Ready
- [ ] Quit PinK
- [ ] Verify via Activity Monitor (search "pink") or `ps aux | grep scene-process` that the Scene Worker process disappears immediately