### PR TITLE
[break] Expose internal node asset query APIs

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -5580,6 +5580,8 @@ export declare interface INodeService extends IServiceEvents {
     delete(params: IDeleteNodeParams): Promise<IDeleteNodeResult | null>;
     query(params?: IQueryNodeParams): Promise<INode | IScene | null>;
     queryNodeTree(params: IQueryNodeTreeParams): Promise<INodeTreeItem | null>;
+    queryNodesByAssetUuid(uuid: string): string[];
+    queryNodesMissAsset(): Promise<string[]>;
     previewSetProperty(options: ISetPropertyOptions): Promise<boolean>;
     cancelPreviewSetProperty(options: ISetPropertyOptions): Promise<boolean>;
     setProperty(options: ISetPropertyOptions): Promise<boolean>;
@@ -7705,6 +7707,8 @@ export declare interface INodeService extends IServiceEvents {
     delete(params: IDeleteNodeParams): Promise<IDeleteNodeResult | null>;
     query(params?: IQueryNodeParams): Promise<INode | IScene | null>;
     queryNodeTree(params: IQueryNodeTreeParams): Promise<INodeTreeItem | null>;
+    queryNodesByAssetUuid(uuid: string): string[];
+    queryNodesMissAsset(): Promise<string[]>;
     previewSetProperty(options: ISetPropertyOptions): Promise<boolean>;
     cancelPreviewSetProperty(options: ISetPropertyOptions): Promise<boolean>;
     setProperty(options: ISetPropertyOptions): Promise<boolean>;

--- a/src/core/engine/editor-extends/manager/node-path-manager.ts
+++ b/src/core/engine/editor-extends/manager/node-path-manager.ts
@@ -35,7 +35,7 @@ export class NodePathManager {
         return finalPath;
     }
 
-    add(uuid: string, path: string) {
+    private _addPathMapping(uuid: string, path: string) {
         this._uuidToPath.set(uuid, path);
         this._pathToUuid.set(path, uuid);
         const lowerPath = path.toLowerCase();
@@ -45,19 +45,28 @@ export class NodePathManager {
         this._lowerPathToUuids.get(lowerPath)!.add(uuid);
     }
 
-    remove(uuid: string) {
-        const path = this._uuidToPath.get(uuid);
-        if (path) {
-            this._pathToUuid.delete(path);
-            const lowerPath = path.toLowerCase();
-            const uuids = this._lowerPathToUuids.get(lowerPath);
-            if (uuids) {
-                uuids.delete(uuid);
-                if (uuids.size === 0) {
-                    this._lowerPathToUuids.delete(lowerPath);
-                }
+    private _removePathMapping(uuid: string, path: string | undefined) {
+        if (!path) {
+            return;
+        }
+        this._pathToUuid.delete(path);
+        const lowerPath = path.toLowerCase();
+        const uuids = this._lowerPathToUuids.get(lowerPath);
+        if (uuids) {
+            uuids.delete(uuid);
+            if (uuids.size === 0) {
+                this._lowerPathToUuids.delete(lowerPath);
             }
         }
+    }
+
+    add(uuid: string, path: string) {
+        this._addPathMapping(uuid, path);
+    }
+
+    remove(uuid: string) {
+        const path = this._uuidToPath.get(uuid);
+        this._removePathMapping(uuid, path);
         this._uuidToPath.delete(uuid);
         this._nodeNames.delete(uuid);
         const parentUuid = this._getParentUuid(path);
@@ -173,6 +182,40 @@ export class NodePathManager {
     getNodePath(uuid: string): string {
         return this._uuidToPath.get(uuid) || '';
     }
+    move(uuid: string, name: string, newParentUuid: string | undefined, oldParentUuid?: string): string {
+        const oldPath = this._uuidToPath.get(uuid);
+        if (!oldPath) {
+            return '';
+        }
+
+        const parentPath = newParentUuid ? (this._uuidToPath.get(newParentUuid) || '') : '';
+        const oldName = oldPath.split('/').pop();
+        const cleanName = this._sanitizeName(name);
+        const subtreeEntries = Array.from(this._uuidToPath.entries())
+            .filter(([, path]) => path === oldPath || path.startsWith(`${oldPath}/`));
+
+        for (const [entryUuid, path] of subtreeEntries) {
+            this._removePathMapping(entryUuid, path);
+        }
+
+        if (oldParentUuid) {
+            const oldNameSet = this._nodeNames.get(oldParentUuid);
+            if (oldNameSet && oldName) {
+                oldNameSet.delete(oldName);
+            }
+        }
+
+        const finalName = this.ensureUniqueName(newParentUuid, cleanName);
+        const newPath = parentPath ? `${parentPath}/${finalName}` : finalName;
+
+        for (const [entryUuid, path] of subtreeEntries) {
+            const suffix = path === oldPath ? '' : path.slice(oldPath.length);
+            this._addPathMapping(entryUuid, `${newPath}${suffix}`);
+        }
+
+        return newPath;
+    }
+
 
     updateUuid(uuid: string, newName: string, parentUuid?: string) {
         const oldPath = this._uuidToPath.get(uuid);

--- a/src/core/engine/editor-extends/manager/node.ts
+++ b/src/core/engine/editor-extends/manager/node.ts
@@ -114,6 +114,44 @@ export default class NodeManager extends EventEmitter {
     }
 
     /**
+     * 更新节点父级关系，并同步该节点及其后代的路径索引。
+     */
+    updateNodeParent(uuid: string, newParentUuid?: string): string {
+        const node = this._map[uuid];
+        if (!node) {
+            return '';
+        }
+
+        const oldParentUuid = this._getParentUuid(uuid);
+        if (oldParentUuid === newParentUuid) {
+            return pathManager.getNodePath(uuid);
+        }
+
+        const newPath = pathManager.move(uuid, node.name, newParentUuid, oldParentUuid);
+        if (!newPath) {
+            return '';
+        }
+
+        if (oldParentUuid) {
+            const oldChildren = this._parentChildren.get(oldParentUuid);
+            oldChildren?.delete(uuid);
+        }
+        if (newParentUuid) {
+            if (!this._parentChildren.has(newParentUuid)) {
+                this._parentChildren.set(newParentUuid, new Set());
+            }
+            this._parentChildren.get(newParentUuid)!.add(uuid);
+        }
+
+        const finalName = newPath.split('/').pop();
+        if (finalName && node.name !== finalName) {
+            node.name = finalName;
+        }
+
+        return newPath;
+    }
+
+    /**
      * 获取一个节点数据，查的范围包括被删除的节点
      * @param uuid
      */

--- a/src/core/engine/test/node-path-manager.test.ts
+++ b/src/core/engine/test/node-path-manager.test.ts
@@ -1,0 +1,39 @@
+import { NodePathManager } from '../editor-extends/manager/node-path-manager';
+
+describe('NodePathManager parent updates', () => {
+    let manager: NodePathManager;
+
+    beforeEach(() => {
+        manager = new NodePathManager();
+    });
+
+    it('updates the moved node and descendant paths when the parent changes', () => {
+        expect(manager.generateUniquePath('parent', 'A', 'scene')).toBe('A');
+        expect(manager.generateUniquePath('child', 'B', 'scene')).toBe('B');
+        expect(manager.generateUniquePath('grandchild', 'C', 'child')).toBe('B/C');
+
+        const movedPath = manager.move('child', 'B', 'parent', 'scene');
+
+        expect(movedPath).toBe('A/B');
+        expect(manager.getNodePath('child')).toBe('A/B');
+        expect(manager.getNodePath('grandchild')).toBe('A/B/C');
+        expect(manager.getNodeUuid('A/B')).toBe('child');
+        expect(manager.getNodeUuid('A/B/C')).toBe('grandchild');
+        expect(manager.getNodeResult('B').error).toBe('Not found');
+    });
+
+    it('frees the old parent name and uniquifies collisions under the new parent', () => {
+        expect(manager.generateUniquePath('parent', 'A', 'scene')).toBe('A');
+        expect(manager.generateUniquePath('existing', 'B', 'parent')).toBe('A/B');
+        expect(manager.generateUniquePath('moving', 'B', 'scene')).toBe('B');
+
+        const movedPath = manager.move('moving', 'B', 'parent', 'scene');
+
+        expect(movedPath).toBe('A/B_001');
+        expect(manager.getNodePath('moving')).toBe('A/B_001');
+        expect(manager.getNodeUuid('A/B_001')).toBe('moving');
+        expect(manager.getNodeResult('B').error).toBe('Not found');
+
+        expect(manager.generateUniquePath('newRootChild', 'B', 'scene')).toBe('B');
+    });
+});

--- a/src/core/scene/common/node.ts
+++ b/src/core/scene/common/node.ts
@@ -277,7 +277,9 @@ export type IPublicNodeService = Omit<INodeService, keyof IServiceEvents |
     'queryClipboardState' |
     'moveArrayElement' |
     'removeArrayElement' |
-    'changeNodeLock'
+    'changeNodeLock' |
+    'queryNodesByAssetUuid' |
+    'queryNodesMissAsset'
 >;
 
 /**
@@ -312,6 +314,16 @@ export interface INodeService extends IServiceEvents {
      * 查询节点树（层级管理器格式）
      */
     queryNodeTree(params: IQueryNodeTreeParams): Promise<INodeTreeItem | null>;
+
+    /**
+     * 查询当前场景中使用指定资源的节点 uuid 列表
+     */
+    queryNodesByAssetUuid(uuid: string): string[];
+
+    /**
+     * 查询当前场景中资源丢失的节点 uuid 列表
+     */
+    queryNodesMissAsset(): Promise<string[]>;
 
     // ---- 编辑器相关接口 ----
 

--- a/src/core/scene/scene-process/engine-bootstrap.ts
+++ b/src/core/scene/scene-process/engine-bootstrap.ts
@@ -116,13 +116,15 @@ export async function startup(options: {
     const dr = config?.overrideSettings?.screen?.designResolution;
     const drWidth = dr?.width ?? 1280;
     const drHeight = dr?.height ?? 720;
-    let drPolicy = cc.ResolutionPolicy.SHOW_ALL;
-    if (dr) {
-        const fw = dr.fitWidth !== false;
-        const fh = dr.fitHeight === true;
-        if (fw && !fh) drPolicy = cc.ResolutionPolicy.FIXED_WIDTH;
-        else if (!fw && fh) drPolicy = cc.ResolutionPolicy.FIXED_HEIGHT;
-    }
+    const drPolicy = cc.ResolutionPolicy.SHOW_ALL;
+    // FIXED_WIDTH / FIXED_HEIGHT should only be used by preview.
+    // There is no preview flow in scene process yet, so keep SHOW_ALL by default.
+    // if (dr) {
+    //     const fw = dr.fitWidth !== false;
+    //     const fh = dr.fitHeight === true;
+    //     if (fw && !fh) drPolicy = cc.ResolutionPolicy.FIXED_WIDTH;
+    //     else if (!fw && fh) drPolicy = cc.ResolutionPolicy.FIXED_HEIGHT;
+    // }
     cc.view.setDesignResolutionSize(drWidth, drHeight, drPolicy);
 
     await cc.game.run();

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -352,6 +352,14 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         }
     }
 
+    queryNodesByAssetUuid(uuid: string): string[] {
+        return nodeMgr.queryNodesByAssetUuid(uuid);
+    }
+
+    async queryNodesMissAsset(): Promise<string[]> {
+        return await nodeMgr.queryNodesMissAsset();
+    }
+
     /**
      * 检查并根据需要创建 canvas节点或为父级添加UITransform组件，返回父级节点，如果需要canvas节点，则父级节点会是canvas节点
      * @param workMode
@@ -743,4 +751,3 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         }
     }
 }
-

--- a/src/core/scene/scene-process/service/node/index.ts
+++ b/src/core/scene/scene-process/service/node/index.ts
@@ -88,6 +88,7 @@ export class NodeManager {
     _onAnchorChanged?: (...args: any[]) => void;
     _onParentChanged?: (...args: any[]) => void;
     _onLightProbeChanged?: (...args: any[]) => void;
+    private _sceneRoot: Node | null = null;
 
     emit<K extends keyof INodeEvents>(event: K, ...args: INodeEvents[K]): void;
     emit(event: string, ...args: any[]): void;
@@ -111,6 +112,8 @@ export class NodeManager {
             return;
         }
 
+        this._sceneRoot = scene as Node;
+        this.registerEventListeners(this._sceneRoot);
         const nodeMap = NodeMgr.getNodesInScene();
 
         // 场景载入后要将现有节点监听所需事件
@@ -191,8 +194,12 @@ export class NodeManager {
         // 遍历事件映射表，统一注册事件
         Object.entries(this.NodeHandlers).forEach(([eventType, handlerName]) => {
             const boundHandler = (this as any)[handlerName].bind(this, node);
+            const key = `${eventType}_${node.uuid}`;
+            if (this.nodeHandlers.has(key)) {
+                return;
+            }
             node.on(eventType, boundHandler, this);
-            this.nodeHandlers.set(`${eventType}_${node.uuid}`, boundHandler);
+            this.nodeHandlers.set(key, boundHandler);
         });
     }
 
@@ -264,10 +271,15 @@ export class NodeManager {
             return;
         }
 
+        const childAdded = child.parent === parent;
+        if (childAdded) {
+            NodeMgr.updateNodeParent(child.uuid, parent.uuid);
+        }
+
         this.emit('node:change', parent, { type: NodeEventType.CHILD_CHANGED });
 
-        // 自身 parent = null 为删除，最后会有 deleted 消息，所以不需要再发 changed 消息
-        if (child.parent) {
+        // 只有挂入新父节点后，子节点路径索引才稳定；移出旧父节点时只通知旧父节点 children 变化。
+        if (childAdded) {
             this.emit('node:change', child, { type: NodeEventType.PARENT_CHANGED });
         }
     }
@@ -284,6 +296,10 @@ export class NodeManager {
      * 清空当前管理的节点
      */
     clear() {
+        if (this._sceneRoot) {
+            this.unregisterEventListeners(this._sceneRoot);
+            this._sceneRoot = null;
+        }
         const nodeMap = NodeMgr.getNodes();
         Object.keys(nodeMap).forEach((key) => {
             this.unregisterEventListeners(nodeMap[key]);
@@ -950,25 +966,40 @@ export class NodeManager {
             uuids = [uuids];
         }
 
-        uuids = uuids.filter((uuid: string) => {
-            const node = this.query(uuid);
-            if (!node || !node.parent) {
-                return false;
-            }
-            return true;
-        });
         let parentNode: Node | null;
         if (parent) {
             parentNode = this.query(parent);
         }
         parentNode ||= director.getScene();
 
-        for (const uuid of uuids) {
-            const node = this.query(uuid);
-            node?.setParent(parentNode, keepWorldTransform);
+        if (!parentNode) {
+            return [];
         }
 
-        return uuids;
+        const movedUuids: string[] = [];
+        for (const uuid of uuids) {
+            const node = this.query(uuid);
+            if (!node || !node.parent) {
+                continue;
+            }
+
+            const oldParent = node.parent;
+            const parentChanged = oldParent !== parentNode;
+
+            if (oldParent) {
+                this.emit('node:before-change', oldParent);
+            }
+            if (parentChanged) {
+                this.emit('node:before-change', parentNode);
+            }
+            this.emit('node:before-change', node);
+
+            node.setParent(parentNode, keepWorldTransform);
+
+            movedUuids.push(uuid);
+        }
+
+        return movedUuids;
     }
 
     /**

--- a/src/core/scene/scene-process/service/node/index.ts
+++ b/src/core/scene/scene-process/service/node/index.ts
@@ -1460,7 +1460,7 @@ export class NodeManager {
                 console.error(error);
             }
 
-            this.emit('node:change', node);
+            this.emit('node:change', node, { type: NodeOperationType.SET_PROPERTY, propPath: 'locked' });
 
             // 处理内循环的情况
             if (loop === true && node.children && node.children.length > 0) {

--- a/src/core/scene/scene-process/service/node/index.ts
+++ b/src/core/scene/scene-process/service/node/index.ts
@@ -11,6 +11,7 @@ const NodeMgr = EditorExtends.Node;
 
 import get from 'lodash/get';
 import set from 'lodash/set';
+import findLast from 'lodash/findLast';
 import { isEditorNode, getNodeName, setLayer } from './node-utils';
 import { prefabUtils } from '../prefab/utils';
 import { ServiceEvents } from '../core/global-events';
@@ -43,6 +44,7 @@ import { type IScene } from '../../../common/editor/scene';
 
 import { loadAny } from './node-create';
 import compMgr from '../component/index';
+import { Rpc } from '../../rpc';
 
 const creatableAssetTypes = [
     'cc.AnimationClip',
@@ -386,73 +388,77 @@ export class NodeManager {
         return dumpUtil.dumpNode(node);
     }
 
-    // /**
-    //  * 查询当前场景的节点树信息
-    //  * @param uuid asset uuid
-    //  */
-    // queryNodesByAssetUuid(uuid: string) {
-    //     if (!uuid) {
-    //         return [];
-    //     }
+    /**
+     * 查询当前场景的节点树信息
+     * @param uuid asset uuid
+     */
+    queryNodesByAssetUuid(uuid: string) {
+        if (!uuid) {
+            return [];
+        }
 
-    //     return NodeMgr.getNodesByAsset(uuid);
-    // }
+        return NodeMgr.getNodesByAsset(uuid);
+    }
 
-    // /**
-    //  * 获取丢失资源的节点
-    //  * @returns uuids[] 节点数组
-    //  */
-    // async queryNodesMissAsset() {
-    //     const nodesUuid: string[] = [];
+    /**
+     * 获取丢失资源的节点
+     * @returns uuids[] 节点数组
+     */
+    async queryNodesMissAsset() {
+        const scene = director.getScene();
+        if (!scene?.children?.length) return [];
 
-    //     // 搜集 MissingScript
-    //     const missScripts: { nodeUuid: string, scriptUuid: string }[] = [];
-    //     EditorExtends.walkProperties(
-    //         director.getScene()?.children,
-    //         (obj: any, key: any, value: any, parsedObjects: any) => {
-    //             // 搜集资源丢失的节点
-    //             if (value._uuid) {
-    //                 const isAssetMiss = !(cc.assetManager.assets.get(value._uuid) || cc.assetManager.assets.get(Editor.Utils.UUID.compressUUID(value._uuid, true)));
-    //                 if (isAssetMiss) {
-    //                     const node = findLast(parsedObjects, (item: any) => item instanceof cc.Node);
-    //                     if (node && !nodesUuid.includes(node.uuid)) {
-    //                         nodesUuid.push(node.uuid);
-    //                     }
-    //                 }
-    //             }
-    //             // 搜集 MissingScript（脚本丢失或者是编译不通过的脚本）
-    //             if (value instanceof MissingScript) {
-    //                 // @ts-ignore __type__: 存储编译不通过或丢失的脚本 id
-    //                 const id = value._$erialized?.__type__;
-    //                 missScripts.push({
-    //                     nodeUuid: value.node.uuid,
-    //                     scriptUuid: EditorExtends.UuidUtils.decompressUuid(id),
-    //                 });
-    //             }
-    //         },
-    //         {
-    //             dontSkipNull: false,
-    //             ignoreSubPrefabHelper: true,
-    //         },
-    //     );
+        const nodesUuid = new Set<string>();
+        const missScripts: { nodeUuid: string, scriptUuid: string }[] = [];
 
-    //     // 检测 MissingScript 的脚本是否真的丢失
-    //     const existingScriptResult = await Editor.Message.request('asset-db', 'batch-message-handler', missScripts.map((item: { nodeUuid: string, scriptUuid: string }) => {
-    //         return {
-    //             name: 'query-asset-info',
-    //             args: [item.scriptUuid],
-    //         };
-    //     }));
-    //     const existingScriptUUIDs = existingScriptResult.map((info: IAssetInfo | null) => info && info.uuid);
-    //     missScripts.forEach((item: { nodeUuid: string, scriptUuid: string }) => {
-    //         if (!existingScriptUUIDs.includes(item.scriptUuid) &&
-    //             !nodesUuid.includes(item.nodeUuid)) {
-    //             nodesUuid.push(item.nodeUuid);
-    //         }
-    //     });
+        EditorExtends.walkProperties(
+            scene.children,
+            (obj: any, key: any, value: any, parsedObjects: any) => {
+                // 处理资源丢失
+                if (value?._uuid) {
+                    const compressed = EditorExtends.UuidUtils.compressUUID(value._uuid, true);
+                    const assetExists = cc.assetManager.assets.get(value._uuid) ||
+                        cc.assetManager.assets.get(compressed);
+                    if (!assetExists) {
+                        const node = findLast(parsedObjects, (item: any) => item instanceof cc.Node);
+                        if (node) nodesUuid.add(node.uuid);
+                    }
+                }
 
-    //     return nodesUuid;
-    // }
+                // 处理 MissingScript
+                if (value instanceof MissingScript) {
+                    // @ts-ignore __type__: 存储编译不通过或丢失的脚本 id
+                    const scriptId = value._$erialized?.__type__;
+                    if (scriptId) {
+                        missScripts.push({
+                            nodeUuid: value.node.uuid,
+                            scriptUuid: EditorExtends.UuidUtils.decompressUUID(scriptId),
+                        });
+                    }
+                }
+            },
+            { dontSkipNull: false, ignoreSubPrefabHelper: true }
+        );
+
+        // 批量查询并添加真正丢失的脚本节点
+        if (missScripts.length) {
+            const existingScripts = new Set(
+                (await Promise.all(missScripts.map(({ scriptUuid }) =>
+                    Rpc.getInstance().request('assetManager', 'queryAssetInfo', [scriptUuid])
+                )))
+                    .map((info: any | null) => info?.uuid)
+                    .filter(Boolean)
+            );
+
+            for (const { nodeUuid, scriptUuid } of missScripts) {
+                if (!existingScripts.has(scriptUuid)) {
+                    nodesUuid.add(nodeUuid);
+                }
+            }
+        }
+
+        return Array.from(nodesUuid);
+    }
 
     /**
      * 预览设置属性后的效果，不进入undo堆栈

--- a/src/core/scene/scene-process/service/selection.ts
+++ b/src/core/scene/scene-process/service/selection.ts
@@ -31,10 +31,10 @@ interface SelectionEntry {
 @register('Selection')
 export class SelectionService extends BaseService<ISelectionEvents> implements ISelectionService {
     private _selections: SelectionEntry[] = [];
-    private _onNodeChangedHandler?: (node: Node, opts: IChangeNodeOptions) => void;
+    private _onNodeChangedHandler?: (node: Node, opts?: IChangeNodeOptions) => void;
 
     init() {
-        this._onNodeChangedHandler = (node: Node, opts: IChangeNodeOptions) => {
+        this._onNodeChangedHandler = (node: Node, opts: IChangeNodeOptions = {}) => {
             if (opts.type === NodeEventType.SET_PROPERTY && opts.propPath === 'name') {
                 this._onNodePathChanged(node);
             } else if (opts.type === NodeEventType.PARENT_CHANGED) {

--- a/src/core/scene/test/node-hierarchy.testcase.ts
+++ b/src/core/scene/test/node-hierarchy.testcase.ts
@@ -279,6 +279,31 @@ describe('Node 层级操作测试', () => {
             expect(sourceChildren).not.toContain('CutChild');
         });
 
+        it('cut 同层级节点后 paste as child 会移动到目标节点下', async () => {
+            const suffix = Date.now().toString(36);
+            const parentName = `CutSiblingTarget_${suffix}`;
+            const childName = `CutSiblingChild_${suffix}`;
+            const siblingTarget = await NodeProxy.createByType({ path: '/', name: parentName, nodeType: NodeType.EMPTY });
+            const siblingChild = await NodeProxy.createByType({ path: '/', name: childName, nodeType: NodeType.EMPTY });
+
+            try {
+                await cut({ paths: [siblingChild!.path] });
+                const result = await paste({ parentPath: siblingTarget!.path });
+                expect(result).toContain(`${siblingTarget!.path}/${childName}`);
+
+                const targetChildren = await getChildNames(siblingTarget!.path);
+                expect(targetChildren).toContain(childName);
+
+                const rootChildren = await getChildNames('/');
+                expect(rootChildren).toContain(parentName);
+                expect(rootChildren).not.toContain(childName);
+            } finally {
+                await NodeProxy.delete({ path: siblingTarget!.path, keepWorldTransform: false }).catch(() => {});
+                await NodeProxy.delete({ path: siblingChild!.path, keepWorldTransform: false }).catch(() => {});
+                await NodeProxy.delete({ path: `${siblingTarget!.path}/${childName}`, keepWorldTransform: false }).catch(() => {});
+            }
+        });
+
         it('cut 多个节点并 paste', async () => {
             const c1 = await NodeProxy.createByType({ path: parent!.path, name: 'CutMulti1', nodeType: NodeType.EMPTY });
             const c2 = await NodeProxy.createByType({ path: parent!.path, name: 'CutMulti2', nodeType: NodeType.EMPTY });

--- a/src/core/scene/test/node-service-interface.test.ts
+++ b/src/core/scene/test/node-service-interface.test.ts
@@ -1,0 +1,23 @@
+import type { INodeService, IPublicNodeService } from '../common/node';
+
+describe('Node service interface', () => {
+    it('exposes asset query APIs only on the internal node service', () => {
+        const assertInternal = (service: INodeService) => {
+            const nodesByAsset: string[] = service.queryNodesByAssetUuid('asset-uuid');
+            const nodesMissAsset: Promise<string[]> = service.queryNodesMissAsset();
+
+            expect(nodesByAsset).toBeDefined();
+            expect(nodesMissAsset).toBeDefined();
+        };
+
+        const assertPublic = (service: IPublicNodeService) => {
+            // @ts-expect-error asset query APIs are internal-only.
+            service.queryNodesByAssetUuid('asset-uuid');
+            // @ts-expect-error asset query APIs are internal-only.
+            service.queryNodesMissAsset();
+        };
+
+        expect(assertInternal).toBeDefined();
+        expect(assertPublic).toBeDefined();
+    });
+});


### PR DESCRIPTION
## Summary
- Expose `queryNodesByAssetUuid` and `queryNodesMissAsset` on `INodeService` while keeping them out of `IPublicNodeService`.
- Add `NodeService` wrappers and restore the scene-process node manager asset query implementations.
- Emit a typed `node:change` payload when node lock state changes, and make selection change handling tolerate legacy events without options.
- Keep the scene-process design resolution policy at `SHOW_ALL` until preview-specific policy handling exists.
- Add a type contract test and update DTS snapshots for the internal/public node service boundary.
- Synchronize node path indexes when nodes move between parents, including cut/paste-as-child, and add regression coverage for subtree path updates.
