### PR TITLE
Fix/cli 500

### DIFF
--- a/src/api/assets/assets.ts
+++ b/src/api/assets/assets.ts
@@ -77,7 +77,7 @@ import {
 } from './schema';
 import { z } from 'zod';
 import { description, param, result, title, tool } from '../decorator/decorator.js';
-import { COMMON_STATUS, CommonResultType, HttpStatusCode } from '../base/schema-base';
+import { COMMON_STATUS, CommonResultType, getCommonErrorStatus, HttpStatusCode } from '../base/schema-base';
 import { assetDBManager, assetManager } from '../../core/assets';
 import { IAssetInfo } from '../../core/assets/@types/public';
 import { SchemaUrlOrPath, SchemaUrlOrUUID, SchemaUUIDOrPath } from '../base/schema-identifier';
@@ -126,7 +126,7 @@ export class AssetsApi {
         try {
             await assetManager.refreshAsset(dir);
         } catch (e) {
-            ret.code = COMMON_STATUS.FAIL;
+            ret.code = getCommonErrorStatus(e);
             console.error('refresh dir fail:', e);
             ret.reason = e instanceof Error ? e.message : String(e);
         }
@@ -154,11 +154,11 @@ export class AssetsApi {
         try {
             ret.data = await assetManager.queryAssetInfo(urlOrUUIDOrPath, dataKeys as (keyof IAssetInfo)[] | undefined);
             if (!ret.data) {
-                ret.code = COMMON_STATUS.FAIL;
+                ret.code = COMMON_STATUS.NOT_FOUND;
                 ret.reason = `❌Asset can not be found: ${urlOrUUIDOrPath}. Please refresh asset db and try again.`;
             }
         } catch (e) {
-            ret.code = COMMON_STATUS.FAIL;
+            ret.code = getCommonErrorStatus(e);
             console.error('query asset info fail:', e instanceof Error ? e.message : String(e));
             ret.reason = e instanceof Error ? e.message : String(e);
         }
@@ -183,11 +183,11 @@ export class AssetsApi {
         try {
             ret.data = await assetManager.queryAssetMeta(urlOrUUIDOrPath);
             if (!ret.data) {
-                ret.code = COMMON_STATUS.FAIL;
+                ret.code = COMMON_STATUS.NOT_FOUND;
                 ret.reason = `Asset not found: ${urlOrUUIDOrPath}`;
             }
         } catch (e) {
-            ret.code = COMMON_STATUS.FAIL;
+            ret.code = getCommonErrorStatus(e);
             console.error('query asset meta fail:', e instanceof Error ? e.message : String(e));
             ret.reason = e instanceof Error ? e.message : String(e);
         }
@@ -316,9 +316,9 @@ export class AssetsApi {
         try {
             ret.data = await assetManager.createAsset(options);
         } catch (e) {
-            ret.code = COMMON_STATUS.FAIL;
+            ret.code = getCommonErrorStatus(e);
             console.error(e);
-            ret.reason = e instanceof Error ? e.message + e.stack : String(e);
+            ret.reason = e instanceof Error ? e.message : String(e);
         }
         return ret;
     }
@@ -344,7 +344,7 @@ export class AssetsApi {
         try {
             ret.data = await assetManager.importAsset(source, target, options);
         } catch (e) {
-            ret.code = COMMON_STATUS.FAIL;
+            ret.code = getCommonErrorStatus(e);
             console.error('import asset fail:', e instanceof Error ? e.message : String(e));
             ret.reason = e instanceof Error ? e.message : String(e);
         }
@@ -672,11 +672,11 @@ export class AssetsApi {
             if (asset) {
                 ret.data = await assetManager.queryAssetUserDataConfig(asset);
             } else {
-                ret.code = COMMON_STATUS.FAIL;
+                ret.code = COMMON_STATUS.NOT_FOUND;
                 ret.reason = `❌Asset can not be found: ${urlOrUuidOrPath}`;
             }
         } catch (e) {
-            ret.code = COMMON_STATUS.FAIL;
+            ret.code = getCommonErrorStatus(e);
             console.error('query asset user data config fail:', e instanceof Error ? e.message : String(e));
             ret.reason = e instanceof Error ? e.message : String(e);
         }
@@ -705,11 +705,11 @@ export class AssetsApi {
         try {
             ret.data = await assetManager.updateUserData(urlOrUuidOrPath, path, value);
             if (!ret.data) {
-                ret.code = COMMON_STATUS.FAIL;
+                ret.code = COMMON_STATUS.NOT_FOUND;
                 ret.reason = `❌Asset can not be found: ${urlOrUuidOrPath}. Please refresh asset db and try again.`;
             }
         } catch (e) {
-            ret.code = COMMON_STATUS.FAIL;
+            ret.code = getCommonErrorStatus(e);
             console.error('update asset user data fail:', e instanceof Error ? e.message : String(e));
             ret.reason = e instanceof Error ? e.message : String(e);
         }

--- a/src/api/base/schema-base.ts
+++ b/src/api/base/schema-base.ts
@@ -33,6 +33,8 @@ export const HTTP_STATUS = {
 
 export const COMMON_STATUS = {
     SUCCESS: HTTP_STATUS.OK,
+    BAD_REQUEST: HTTP_STATUS.BAD_REQUEST,
+    NOT_FOUND: HTTP_STATUS.NOT_FOUND,
     FAIL: HTTP_STATUS.INTERNAL_SERVER_ERROR,
 } as const;
 
@@ -47,10 +49,10 @@ export const HttpStatusCodeSchema = z.union([
     // z.literal(HTTP_STATUS.ACCEPTED),
     // z.literal(HTTP_STATUS.NO_CONTENT),
     // z.literal(HTTP_STATUS.NOT_MODIFIED),
-    // z.literal(HTTP_STATUS.BAD_REQUEST),
+    z.literal(HTTP_STATUS.BAD_REQUEST),
     // z.literal(HTTP_STATUS.UNAUTHORIZED),
     // z.literal(HTTP_STATUS.FORBIDDEN),
-    // z.literal(HTTP_STATUS.NOT_FOUND),
+    z.literal(HTTP_STATUS.NOT_FOUND),
     // z.literal(HTTP_STATUS.METHOD_NOT_ALLOWED),
     // z.literal(HTTP_STATUS.CONFLICT),
     // z.literal(HTTP_STATUS.UNPROCESSABLE_ENTITY),
@@ -61,6 +63,23 @@ export const HttpStatusCodeSchema = z.union([
     // z.literal(HTTP_STATUS.SERVICE_UNAVAILABLE),
     // z.literal(HTTP_STATUS.GATEWAY_TIMEOUT),
 ]);
+
+export function getCommonErrorStatus(error: unknown): CommonStatus {
+    const code = typeof error === 'object' && error !== null && 'code' in error
+        ? String((error as { code?: unknown }).code)
+        : '';
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (code === 'ENOENT' || /ENOENT|no such file or directory|not found|not exist|cannot find|can not find|can not be found/i.test(message)) {
+        return COMMON_STATUS.NOT_FOUND;
+    }
+
+    if (/parameter error|filename cannot be empty|invalid url|unsafe file path|extension mismatch|cannot resolve/i.test(message)) {
+        return COMMON_STATUS.BAD_REQUEST;
+    }
+
+    return COMMON_STATUS.FAIL;
+}
 
 // ===== CommonResult Definition ===== // CommonResult 定义
 

--- a/src/api/scene/component.ts
+++ b/src/api/scene/component.ts
@@ -16,7 +16,7 @@ import {
 } from './component-schema';
 
 import { description, param, result, title, tool } from '../decorator/decorator.js';
-import { COMMON_STATUS, CommonResultType } from '../base/schema-base';
+import { COMMON_STATUS, CommonResultType, getCommonErrorStatus } from '../base/schema-base';
 import { Scene, IComponentInfo } from '../../core/scene';
 import { ISetPropertyOptionsInfo } from '../../core/scene/common/cli/component';
 
@@ -38,7 +38,7 @@ export class ComponentApi {
             };
         } catch (e) {
             return {
-                code: COMMON_STATUS.FAIL,
+                code: getCommonErrorStatus(e),
                 reason: e instanceof Error ? e.message : String(e)
             };
         }
@@ -60,7 +60,7 @@ export class ComponentApi {
             };
         } catch (e) {
             return {
-                code: COMMON_STATUS.FAIL,
+                code: getCommonErrorStatus(e),
                 reason: e instanceof Error ? e.message : String(e)
             };
         }
@@ -85,7 +85,7 @@ export class ComponentApi {
             };
         } catch (e) {
             return {
-                code: COMMON_STATUS.FAIL,
+                code: getCommonErrorStatus(e),
                 reason: e instanceof Error ? e.message : String(e)
             };
         }
@@ -107,7 +107,7 @@ export class ComponentApi {
             };
         } catch (e) {
             return {
-                code: COMMON_STATUS.FAIL,
+                code: getCommonErrorStatus(e),
                 reason: e instanceof Error ? e.message : String(e)
             };
         }
@@ -129,7 +129,7 @@ export class ComponentApi {
             };
         } catch (e) {
             return {
-                code: COMMON_STATUS.FAIL,
+                code: getCommonErrorStatus(e),
                 reason: e instanceof Error ? e.message : String(e)
             };
         }

--- a/src/api/scene/node.ts
+++ b/src/api/scene/node.ts
@@ -17,7 +17,7 @@ import {
     SchemaNodeUpdateResult,
 } from './node-schema';
 import { description, param, result, title, tool } from '../decorator/decorator.js';
-import { COMMON_STATUS, CommonResultType } from '../base/schema-base';
+import { COMMON_STATUS, CommonResultType, getCommonErrorStatus } from '../base/schema-base';
 import { ICreateByNodeTypeParams, INodeInfo, Scene } from '../../core/scene';
 
 export class NodeApi {
@@ -40,7 +40,7 @@ export class NodeApi {
                 ret.data = resultNode;
             }
         } catch (e) {
-            ret.code = COMMON_STATUS.FAIL;
+            ret.code = getCommonErrorStatus(e);
             console.error('Failed to create node:', e); // 创建节点失败:
             ret.reason = e instanceof Error ? e.message : String(e);
         }
@@ -67,7 +67,7 @@ export class NodeApi {
                 ret.data = resultNode;
             }
         } catch (e) {
-            ret.code = COMMON_STATUS.FAIL;
+            ret.code = getCommonErrorStatus(e);
             console.error('Failed to create node:', e); // 创建节点失败:
             ret.reason = e instanceof Error ? e.message : String(e);
         }
@@ -96,7 +96,7 @@ export class NodeApi {
                 path: result.path,
             };
         } catch (e) {
-            ret.code = COMMON_STATUS.FAIL;
+            ret.code = getCommonErrorStatus(e);
             console.error('Failed to delete node:', e); // 删除节点失败:
             ret.reason = e instanceof Error ? e.message : String(e);
             delete ret.data;
@@ -122,7 +122,7 @@ export class NodeApi {
         } catch (e) {
             console.error('Failed to update node:', e); // 更新节点失败:
             return {
-                code: COMMON_STATUS.FAIL,
+                code: getCommonErrorStatus(e),
                 reason: e instanceof Error ? e.message : String(e),
             };
         }
@@ -146,7 +146,7 @@ export class NodeApi {
             if (!result) throw new Error(`node not found at path: ${options.path}`);
             ret.data = result;
         } catch (e) {
-            ret.code = COMMON_STATUS.FAIL;
+            ret.code = getCommonErrorStatus(e);
             console.error('Failed to query node:', e); // 查询节点失败:
             ret.reason = e instanceof Error ? e.message : String(e);
         }

--- a/src/api/system/file-editor.ts
+++ b/src/api/system/file-editor.ts
@@ -16,7 +16,7 @@ import {
 } from './file-editor-schema';
 
 import { description, param, result, title, tool } from '../decorator/decorator.js';
-import { COMMON_STATUS, CommonResultType } from '../base/schema-base';
+import { COMMON_STATUS, CommonResultType, getCommonErrorStatus } from '../base/schema-base';
 import { insertTextAtLine, eraseLinesInRange, replaceTextInFile, queryLinesInFile } from '../../core/filesystem/file-edit';
 
 export class FileEditorApi {
@@ -33,7 +33,7 @@ export class FileEditorApi {
             };
         } catch (e) {
             return {
-                code: COMMON_STATUS.FAIL,
+                code: getCommonErrorStatus(e),
                 reason: e instanceof Error ? e.message : String(e)
             };
         }
@@ -52,7 +52,7 @@ export class FileEditorApi {
             };
         } catch (e) {
             return {
-                code: COMMON_STATUS.FAIL,
+                code: getCommonErrorStatus(e),
                 reason: e instanceof Error ? e.message : String(e)
             };
         }
@@ -71,7 +71,7 @@ export class FileEditorApi {
             };
         } catch (e) {
             return {
-                code: COMMON_STATUS.FAIL,
+                code: getCommonErrorStatus(e),
                 reason: e instanceof Error ? e.message : String(e)
             };
         }
@@ -90,7 +90,7 @@ export class FileEditorApi {
             };
         } catch (e) {
             return {
-                code: COMMON_STATUS.FAIL,
+                code: getCommonErrorStatus(e),
                 reason: e instanceof Error ? e.message : String(e)
             };
         }

--- a/src/core/assets/manager/operation.ts
+++ b/src/core/assets/manager/operation.ts
@@ -9,7 +9,7 @@ import { IMoveOptions } from '../@types/private';
 import { IAsset, CreateAssetOptions, IExportOptions, IExportData, CreateAssetByTypeOptions, ICreateMenuInfo } from '../@types/protected';
 import { AssetOperationOption, AssetUserDataMap, DeleteAssetOptions, IAssetInfo, IAssetMeta, ISupportCreateType } from '../@types/public';
 import assetConfig from '../asset-config';
-import { url2path, ensureOutputData, url2uuid } from '../utils';
+import { url2path, ensureOutputData, url2uuid, pathToDbUrlIfAssetDBPath, dirnameForDbUrlOrPath } from '../utils';
 import assetDBManager from './asset-db';
 import assetHandlerManager from './asset-handler';
 import { copyPath, moveAssetSource, removeAssetSource, renamePath } from './filesystem';
@@ -205,12 +205,14 @@ class AssetOperation extends EventEmitter {
      * @param options 
      */
     async importAsset(source: string, target: string, options?: AssetOperationOption): Promise<IAssetInfo[]> {
-        if (target.startsWith('db://')) {
-            target = url2path(target);
+        const targetPath = target.startsWith('db://') ? url2path(target) : target;
+        const assetTarget = this._pathToDbUrlIfInsideAssetDB(target);
+
+        if (!this._isSameFilesystemPath(source, targetPath)) {
+            await copyPath(source, targetPath, options);
         }
-        await copyPath(source, target, options);
-        await this.refreshAsset(target);
-        const assetInfo = assetQuery.queryAssetInfo(target);
+        await this.refreshAsset(assetTarget);
+        const assetInfo = assetQuery.queryAssetInfo(assetTarget);
         if (!assetInfo) {
             return [];
         }
@@ -297,18 +299,43 @@ class AssetOperation extends EventEmitter {
     }
 
     private async _refreshAsset(pathOrUrlOrUUID: string, autoRefreshDir = true): Promise<number> {
-        const result = await refresh(pathOrUrlOrUUID);
+        const refreshTarget = this._pathToDbUrlIfInsideAssetDB(pathOrUrlOrUUID);
+        const refreshDir = this._dirnameForRefresh(refreshTarget);
+        const result = await refresh(refreshTarget);
         if (result === undefined) {
             throw new Error(`can not find asset ${pathOrUrlOrUUID}`);
         }
         if (autoRefreshDir) {
             // HACK 某些情况下导入原始资源后，文件夹的 mtime 会发生变化，导致资源量大的情况下下次获得焦点自动刷新时会有第二次的文件夹大批量刷新
             // 用进入队列的方式才能保障 pause 等机制不会被影响
-            await assetDBManager.addTask(assetDBManager.autoRefreshAssetLazy.bind(assetDBManager), [dirname(pathOrUrlOrUUID)]);
+            await assetDBManager.addTask(assetDBManager.autoRefreshAssetLazy.bind(assetDBManager), [refreshDir]);
         }
         // this.autoRefreshAssetLazy(dirname(pathOrUrlOrUUID));
-        console.debug(`refresh asset ${dirname(pathOrUrlOrUUID)} success`);
+        console.debug(`refresh asset ${refreshDir} success`);
         return result;
+    }
+
+    private _pathToDbUrlIfInsideAssetDB(pathOrUrlOrUUID: string) {
+        return pathToDbUrlIfAssetDBPath(pathOrUrlOrUUID, assetDBManager.assetDBInfo);
+    }
+
+    private _isSameFilesystemPath(source: string, target: string) {
+        if (!isAbsolute(source) || !isAbsolute(target)) {
+            return source === target;
+        }
+
+        let normalizedSource = utils.Path.normalize(source);
+        let normalizedTarget = utils.Path.normalize(target);
+        if (process.platform === 'win32') {
+            normalizedSource = normalizedSource.toLowerCase();
+            normalizedTarget = normalizedTarget.toLowerCase();
+        }
+
+        return normalizedSource === normalizedTarget;
+    }
+
+    private _dirnameForRefresh(pathOrUrlOrUUID: string) {
+        return dirnameForDbUrlOrPath(pathOrUrlOrUUID);
     }
 
     /**

--- a/src/core/assets/manager/query.ts
+++ b/src/core/assets/manager/query.ts
@@ -3,7 +3,7 @@ import { isAbsolute, basename, extname } from 'path';
 import { QueryAssetType, IAsset } from '../@types/protected';
 import { AssetHandlerType, IAssetInfo, IAssetMeta, QueryAssetsOption } from '../@types/public';
 import { FilterPluginOptions, IPluginScriptInfo } from '../../scripting/interface';
-import { url2uuid, libArr2Obj, getExtendsFromCCType, url2path } from '../utils';
+import { url2uuid, libArr2Obj, getExtendsFromCCType, url2path, pathToDbUrlIfAssetDBPath } from '../utils';
 import assetDBManager from './asset-db';
 import assetHandlerManager from './asset-handler';
 import script from '../../scripting';
@@ -141,6 +141,7 @@ class AssetQueryManager {
         if (!urlOrUUIDOrPath || typeof urlOrUUIDOrPath !== 'string') {
             throw new Error('parameter error');
         }
+        urlOrUUIDOrPath = pathToDbUrlIfAssetDBPath(urlOrUUIDOrPath, assetDBManager.assetDBInfo);
         let uuid = '';
 
         if (urlOrUUIDOrPath.startsWith('db://')) {
@@ -649,6 +650,7 @@ class AssetQueryManager {
         if (!urlOrPath || typeof urlOrPath !== 'string') {
             return null;
         }
+        urlOrPath = pathToDbUrlIfAssetDBPath(urlOrPath, assetDBManager.assetDBInfo);
 
         if (urlOrPath.startsWith('db://')) {
             const name = urlOrPath.substr(5);

--- a/src/core/assets/test/operation-filesystem-bridge.test.ts
+++ b/src/core/assets/test/operation-filesystem-bridge.test.ts
@@ -9,6 +9,7 @@ const mockQueryAsset = jest.fn();
 const mockQueryAssetInfo = jest.fn();
 const mockQueryAssetInfos = jest.fn();
 const mockQueryUrl = jest.fn();
+const mockRefresh = jest.fn(async (_pathOrUrlOrUUID: string) => 0);
 const mockAddTask = jest.fn(async (func: Function, args: any[]) => await func(...args));
 const { dirname, join } = require('path') as typeof import('path');
 
@@ -21,7 +22,7 @@ jest.mock('fs-extra', () => ({
 }));
 
 jest.mock('@cocos/asset-db', () => ({
-    refresh: jest.fn(async () => 0),
+    refresh: (pathOrUrlOrUUID: string) => mockRefresh(pathOrUrlOrUUID),
     reimport: jest.fn(),
     queryUrl: (...args: any[]) => mockQueryUrl(...args),
     Asset: class {},
@@ -31,6 +32,25 @@ jest.mock('../utils', () => ({
     url2path: jest.fn((value) => value),
     ensureOutputData: jest.fn(),
     url2uuid: jest.fn((value) => value),
+    pathToDbUrlIfAssetDBPath: jest.fn((value: string, assetDBInfo: Record<string, { name: string; target: string }>) => {
+        if (!value || value.startsWith('db://')) {
+            return value;
+        }
+        if (value === 'D:/project/assets/resources/Image' || value === 'assets/resources/Image') {
+            return 'db://assets/resources/Image';
+        }
+        if (value === 'D:/project/assets/resources/Image/snake_head.png') {
+            return 'db://assets/resources/Image/snake_head.png';
+        }
+        return assetDBInfo.assets && value === assetDBInfo.assets.target ? 'db://assets' : value;
+    }),
+    dirnameForDbUrlOrPath: jest.fn((value: string) => {
+        if (value.startsWith('db://')) {
+            const index = value.lastIndexOf('/');
+            return index <= 'db://assets'.length ? 'db://assets' : value.slice(0, index);
+        }
+        return value.replace(/[\\/][^\\/]*$/, '');
+    }),
 }));
 
 jest.mock('../manager/filesystem', () => ({
@@ -90,8 +110,31 @@ jest.mock('../../base/i18n', () => ({
 }));
 
 describe('asset operation filesystem bridge', () => {
+    function setAssetDBInfo(target = 'D:/project/assets') {
+        const assetDBManager = require('../manager/asset-db').default as typeof import('../manager/asset-db').default;
+        assetDBManager.assetDBInfo.assets = {
+            name: 'assets',
+            target,
+            readonly: false,
+            temp: 'D:/project/temp/assets',
+            library: 'D:/project/library',
+            level: 0,
+            globList: [],
+            ignoreFiles: [],
+            visible: true,
+            state: 'none',
+            preImportExtList: [],
+        };
+    }
+
     beforeEach(() => {
         jest.clearAllMocks();
+        const assetDBManager = require('../manager/asset-db').default as typeof import('../manager/asset-db').default;
+        Object.keys(assetDBManager.assetDBInfo).forEach((key) => delete assetDBManager.assetDBInfo[key]);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
     });
 
     it('renameAsset should delegate rename steps to filesystem bridge', async () => {
@@ -169,6 +212,64 @@ describe('asset operation filesystem bridge', () => {
 
         expect(mockCopyPath).toHaveBeenCalledWith(source, target, { overwrite: true });
         expect(mockCopy).not.toHaveBeenCalled();
+        expect(result).toEqual([assetInfo]);
+    });
+
+    it('refreshAsset should normalize an absolute asset-db path before refreshing', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        setAssetDBInfo();
+
+        await assetOperation.refreshAsset('D:/project/assets/resources/Image');
+
+        expect(mockRefresh).toHaveBeenCalledWith('db://assets/resources/Image');
+    });
+
+    it('refreshAsset should normalize a database-name relative asset path before refreshing', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        setAssetDBInfo();
+
+        await assetOperation.refreshAsset('assets/resources/Image');
+
+        expect(mockRefresh).toHaveBeenCalledWith('db://assets/resources/Image');
+    });
+
+    it('importAsset should refresh an existing file in the asset DB when source and target are the same path', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const target = 'D:/project/assets/resources/Image/snake_head.png';
+        const assetInfo = {
+            isDirectory: false,
+            url: 'db://assets/resources/Image/snake_head.png',
+        };
+
+        setAssetDBInfo();
+        mockQueryAssetInfo.mockReturnValue(assetInfo);
+
+        const result = await assetOperation.importAsset(target, target, { overwrite: true });
+
+        expect(mockCopyPath).not.toHaveBeenCalled();
+        expect(mockRefresh).toHaveBeenCalledWith('db://assets/resources/Image/snake_head.png');
+        expect(mockQueryAssetInfo).toHaveBeenCalledWith('db://assets/resources/Image/snake_head.png');
+        expect(result).toEqual([assetInfo]);
+    });
+
+    it('importAsset should copy external files to the physical target and refresh the db url', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const source = 'D:/outside/snake_head.png';
+        const target = 'D:/project/assets/resources/Image/snake_head.png';
+        const assetInfo = {
+            isDirectory: false,
+            url: 'db://assets/resources/Image/snake_head.png',
+        };
+
+        setAssetDBInfo();
+        mockCopyPath.mockResolvedValue(undefined);
+        mockQueryAssetInfo.mockReturnValue(assetInfo);
+
+        const result = await assetOperation.importAsset(source, target, { overwrite: true });
+
+        expect(mockCopyPath).toHaveBeenCalledWith(source, target, { overwrite: true });
+        expect(mockRefresh).toHaveBeenCalledWith('db://assets/resources/Image/snake_head.png');
+        expect(mockQueryAssetInfo).toHaveBeenCalledWith('db://assets/resources/Image/snake_head.png');
         expect(result).toEqual([assetInfo]);
     });
 });

--- a/src/core/assets/test/query-path-normalization.test.ts
+++ b/src/core/assets/test/query-path-normalization.test.ts
@@ -1,0 +1,109 @@
+export {};
+
+const mockQueryUUID = jest.fn();
+const mockQueryAsset = jest.fn();
+
+jest.mock('@cocos/asset-db', () => ({
+    queryUUID: (...args: any[]) => mockQueryUUID(...args),
+    queryAsset: (...args: any[]) => mockQueryAsset(...args),
+    VirtualAsset: class {},
+    AssetDB: class {},
+    Asset: class {},
+    forEach: jest.fn(),
+    queryPath: jest.fn(),
+    queryUrl: jest.fn(),
+}));
+
+jest.mock('@cocos/asset-db/index', () => ({
+    queryUUID: (...args: any[]) => mockQueryUUID(...args),
+    queryAsset: (...args: any[]) => mockQueryAsset(...args),
+    Utils: {
+        nameToId: (value: string) => value,
+    },
+    queryPath: jest.fn(),
+    Asset: class {},
+    VirtualAsset: class {},
+}));
+
+jest.mock('../manager/asset-db', () => ({
+    __esModule: true,
+    default: {
+        assetDBInfo: {
+            assets: {
+                name: 'assets',
+                target: 'D:/project/assets',
+                readonly: false,
+                temp: 'D:/project/temp/assets',
+                library: 'D:/project/library',
+                level: 0,
+                globList: [],
+                ignoreFiles: [],
+                visible: true,
+                state: 'none',
+                preImportExtList: [],
+            },
+        },
+        assetDBMap: {},
+        path2url: jest.fn(),
+    },
+}));
+
+jest.mock('../manager/asset-handler', () => ({
+    __esModule: true,
+    default: {},
+}));
+
+jest.mock('../manager/filesystem', () => ({
+    removeAssetSource: jest.fn(),
+}));
+
+jest.mock('../asset-config', () => ({
+    __esModule: true,
+    default: {
+        data: {
+            root: 'D:/project',
+        },
+    },
+}));
+
+jest.mock('../../scripting', () => ({
+    __esModule: true,
+    default: {},
+}));
+
+jest.mock('../../base/i18n', () => ({
+    __esModule: true,
+    default: {
+        t: (key: string) => key,
+    },
+}));
+
+describe('asset query path normalization', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('queryAssetInfo should normalize a database-name relative asset path', () => {
+        const assetQuery = require('../manager/query').default as typeof import('../manager/query').default;
+        const assetInfo = {
+            url: 'db://assets/resources/Image/snake_head.png',
+        };
+
+        mockQueryUUID.mockReturnValue('snake-head-uuid');
+        mockQueryAsset.mockReturnValue({
+            uuid: 'snake-head-uuid',
+            isDirectory: () => false,
+        });
+        const queryByUUID = jest.spyOn(assetQuery, 'queryAssetInfoByUUID').mockReturnValue(assetInfo as any);
+
+        const result = assetQuery.queryAssetInfo('assets/resources/Image/snake_head.png');
+
+        expect(mockQueryUUID).toHaveBeenCalledWith('db://assets/resources/Image/snake_head.png');
+        expect(queryByUUID).toHaveBeenCalledWith('snake-head-uuid', undefined);
+        expect(result).toBe(assetInfo);
+    });
+});

--- a/src/core/assets/utils.ts
+++ b/src/core/assets/utils.ts
@@ -24,6 +24,56 @@ export function url2path(url: string) {
     return Utils.Path.resolveToRaw(url);
 }
 
+export function pathToDbUrlIfAssetDBPath(pathOrUrlOrUUID: string, assetDBInfo: Record<string, { name: string; target: string }>) {
+    if (!pathOrUrlOrUUID || pathOrUrlOrUUID.startsWith('db://')) {
+        return pathOrUrlOrUUID;
+    }
+
+    if (!isAbsolute(pathOrUrlOrUUID)) {
+        const normalizedRelativePath = pathOrUrlOrUUID
+            .replace(/\\/g, '/')
+            .replace(/^\.\/+/, '')
+            .replace(/\/+$/, '');
+        const [dbName, ...relativeParts] = normalizedRelativePath.split('/').filter(Boolean);
+        const dbInfo = dbName && assetDBInfo[dbName];
+
+        if (dbInfo) {
+            return relativeParts.length ? `db://${dbInfo.name}/${relativeParts.join('/')}` : `db://${dbInfo.name}`;
+        }
+
+        return pathOrUrlOrUUID;
+    }
+
+    const matchedDBInfo = Object.values(assetDBInfo)
+        .filter((info) => info?.target && Utils.Path.contains(info.target, pathOrUrlOrUUID))
+        .sort((a, b) => Utils.Path.normalize(b.target).length - Utils.Path.normalize(a.target).length)[0];
+
+    if (!matchedDBInfo) {
+        return pathOrUrlOrUUID;
+    }
+
+    const relativePath = relative(
+        Utils.Path.normalize(matchedDBInfo.target),
+        Utils.Path.normalize(pathOrUrlOrUUID),
+    ).replace(/\\/g, '/');
+
+    return relativePath ? `db://${matchedDBInfo.name}/${relativePath}` : `db://${matchedDBInfo.name}`;
+}
+
+export function dirnameForDbUrlOrPath(pathOrUrlOrUUID: string) {
+    if (!pathOrUrlOrUUID.startsWith('db://')) {
+        return Utils.Path.dirname(pathOrUrlOrUUID);
+    }
+
+    const root = /^db:\/\/[^/]+/.exec(pathOrUrlOrUUID)?.[0];
+    if (!root || pathOrUrlOrUUID === root) {
+        return pathOrUrlOrUUID;
+    }
+
+    const index = pathOrUrlOrUUID.lastIndexOf('/');
+    return index <= root.length ? root : pathOrUrlOrUUID.slice(0, index);
+}
+
 /**
 * 将时间戳转为可阅读的时间信息
 */

--- a/src/mcp/mcp.middleware.ts
+++ b/src/mcp/mcp.middleware.ts
@@ -14,6 +14,11 @@ import stripAnsi from 'strip-ansi';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { assetManager } from '../core/assets';
+
+export function isToolErrorCode(code: unknown): boolean {
+    return typeof code === 'number' && code >= 500 && code < 600;
+}
+
 export class McpMiddleware {
     private server: McpServer;
     private resourceManager: ResourceManager;
@@ -167,7 +172,7 @@ export class McpMiddleware {
                              return {
                                 content: [{ type: 'text' as const, text: formattedResult }],
                                 structuredContent: structuredContent,
-                                isError: result.code == 500
+                                isError: isToolErrorCode(result?.code)
                              };
 
                         } catch (error) {

--- a/tests/bug-497-api-error-status.test.ts
+++ b/tests/bug-497-api-error-status.test.ts
@@ -1,0 +1,219 @@
+const mockQueryAssetInfo = jest.fn();
+const mockQueryAssetMeta = jest.fn();
+const mockRefreshAsset = jest.fn();
+const mockCreateAsset = jest.fn();
+const mockImportAsset = jest.fn();
+const mockQueryLinesInFile = jest.fn();
+const mockNodeQuery = jest.fn();
+const mockNodeDelete = jest.fn();
+const mockComponentQuery = jest.fn();
+
+jest.mock('../src/api/decorator/decorator.js', () => ({
+    description: () => jest.fn(),
+    param: () => jest.fn(),
+    result: () => jest.fn(),
+    title: () => jest.fn(),
+    tool: () => jest.fn(),
+}), { virtual: true });
+
+jest.mock('../src/core/assets', () => ({
+    assetDBManager: {},
+    assetManager: {
+        queryAssetInfo: (...args: unknown[]) => mockQueryAssetInfo(...args),
+        queryAssetMeta: (...args: unknown[]) => mockQueryAssetMeta(...args),
+        refreshAsset: (...args: unknown[]) => mockRefreshAsset(...args),
+        createAsset: (...args: unknown[]) => mockCreateAsset(...args),
+        importAsset: (...args: unknown[]) => mockImportAsset(...args),
+    },
+}));
+
+jest.mock('../src/core/filesystem/file-edit', () => ({
+    insertTextAtLine: jest.fn(),
+    eraseLinesInRange: jest.fn(),
+    replaceTextInFile: jest.fn(),
+    queryLinesInFile: (...args: unknown[]) => mockQueryLinesInFile(...args),
+}));
+
+jest.mock('../src/core/scene', () => ({
+    NodeType: {
+        EMPTY: 'Node',
+    },
+    Scene: {
+        Node: {
+            query: (...args: unknown[]) => mockNodeQuery(...args),
+            delete: (...args: unknown[]) => mockNodeDelete(...args),
+        },
+        Component: {
+            query: (...args: unknown[]) => mockComponentQuery(...args),
+        },
+    },
+}));
+
+import { AssetsApi } from '../src/api/assets/assets';
+import { FileEditorApi } from '../src/api/system/file-editor';
+import { NodeApi } from '../src/api/scene/node';
+import { ComponentApi } from '../src/api/scene/component';
+import { COMMON_STATUS, HTTP_STATUS, HttpStatusCodeSchema, getCommonErrorStatus } from '../src/api/base/schema-base';
+
+describe('Bug #497 common API error status codes', () => {
+    let consoleErrorSpy: jest.SpyInstance;
+
+    beforeAll(() => {
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    });
+
+    afterAll(() => {
+        consoleErrorSpy.mockRestore();
+    });
+
+    beforeEach(() => {
+        mockQueryAssetInfo.mockReset();
+        mockQueryAssetMeta.mockReset();
+        mockRefreshAsset.mockReset();
+        mockCreateAsset.mockReset();
+        mockImportAsset.mockReset();
+        mockQueryLinesInFile.mockReset();
+        mockNodeQuery.mockReset();
+        mockNodeDelete.mockReset();
+        mockComponentQuery.mockReset();
+    });
+
+    it('allows client-side business error codes in common results', () => {
+        expect(HttpStatusCodeSchema.parse(HTTP_STATUS.BAD_REQUEST)).toBe(HTTP_STATUS.BAD_REQUEST);
+        expect(HttpStatusCodeSchema.parse(HTTP_STATUS.NOT_FOUND)).toBe(HTTP_STATUS.NOT_FOUND);
+    });
+
+    it('classifies common not-found and bad-request errors without using 500', () => {
+        expect(getCommonErrorStatus(new Error('ENOENT: no such file or directory'))).toBe(COMMON_STATUS.NOT_FOUND);
+        expect(getCommonErrorStatus(new Error('Asset can not be found: db://assets/missing.scene'))).toBe(COMMON_STATUS.NOT_FOUND);
+        expect(getCommonErrorStatus(new Error('can not find asset d:\\cocos\\program\\snake2\\assets\\resources\\Image'))).toBe(COMMON_STATUS.NOT_FOUND);
+        expect(getCommonErrorStatus(new Error('Filename cannot be empty.'))).toBe(COMMON_STATUS.BAD_REQUEST);
+        expect(getCommonErrorStatus(new Error('parameter error'))).toBe(COMMON_STATUS.BAD_REQUEST);
+        expect(getCommonErrorStatus(new Error('unexpected internal crash'))).toBe(COMMON_STATUS.FAIL);
+    });
+
+    it('returns 404 when detailed asset info is not found', async () => {
+        mockQueryAssetInfo.mockReturnValue(null);
+
+        const result = await new AssetsApi().queryAssetInfo('db://assets/missing.scene');
+
+        expect(result.code).toBe(HTTP_STATUS.NOT_FOUND);
+        expect(result.data).toBeNull();
+        expect(result.reason).toContain('Asset can not be found');
+    });
+
+    it('returns 404 when asset metadata is not found', async () => {
+        mockQueryAssetMeta.mockReturnValue(null);
+
+        const result = await new AssetsApi().queryAssetMeta('db://assets/missing.scene');
+
+        expect(result.code).toBe(HTTP_STATUS.NOT_FOUND);
+        expect(result.data).toBeNull();
+        expect(result.reason).toContain('Asset not found');
+    });
+
+    it('returns 400 for asset query parameter errors', async () => {
+        mockQueryAssetInfo.mockImplementation(() => {
+            throw new Error('parameter error');
+        });
+
+        const result = await new AssetsApi().queryAssetInfo('bad');
+
+        expect(result.code).toBe(HTTP_STATUS.BAD_REQUEST);
+        expect(result.reason).toBe('parameter error');
+    });
+
+    it('returns 404 when refreshing a missing asset directory', async () => {
+        mockRefreshAsset.mockRejectedValue(new Error('can not find asset d:\\cocos\\program\\snake2\\assets\\resources\\Image'));
+
+        const result = await new AssetsApi().refresh('d:\\cocos\\program\\snake2\\assets\\resources\\Image');
+
+        expect(result.code).toBe(HTTP_STATUS.NOT_FOUND);
+        expect(result.data).toBeNull();
+        expect(result.reason).toContain('can not find asset');
+    });
+
+    it('returns 400 when asset creation receives an invalid target URL', async () => {
+        mockCreateAsset.mockRejectedValue(new Error('Invalid URL: input URL must be a string and start with db:// \n  url:'));
+
+        const result = await new AssetsApi().createAsset({
+            target: 'd:\\cocos\\program\\snake2\\assets\\resources',
+        });
+
+        expect(result.code).toBe(HTTP_STATUS.BAD_REQUEST);
+        expect(result.data).toBeNull();
+        expect(result.reason).toContain('Invalid URL');
+    });
+
+    it('returns 404 when importing from a missing asset path', async () => {
+        mockImportAsset.mockRejectedValue(new Error('can not find asset d:\\cocos\\program\\snake2\\assets\\resources\\Image\\food.png'));
+
+        const result = await new AssetsApi().importAsset(
+            'd:\\cocos\\program\\snake2\\assets\\resources\\Image\\food.png',
+            'd:\\cocos\\program\\snake2\\assets\\resources\\Image\\food.png'
+        );
+
+        expect(result.code).toBe(HTTP_STATUS.NOT_FOUND);
+        expect(result.data).toEqual([]);
+        expect(result.reason).toContain('can not find asset');
+    });
+
+    it('returns 404 when queried file does not exist', async () => {
+        mockQueryLinesInFile.mockRejectedValue(new Error("ENOENT: no such file or directory, open 'D:/project/assets/package.json'"));
+
+        const result = await new FileEditorApi().queryFileText({
+            dbURL: 'db://assets/package.json',
+            fileType: 'json',
+            startLine: 1,
+            lineCount: 40,
+        });
+
+        expect(result.code).toBe(HTTP_STATUS.NOT_FOUND);
+        expect(result.reason).toContain('ENOENT');
+    });
+
+    it('returns 400 when the db URL cannot resolve to a file path', async () => {
+        mockQueryLinesInFile.mockRejectedValue(new Error('Filename cannot be empty.'));
+
+        const result = await new FileEditorApi().queryFileText({
+            dbURL: 'db://project.json',
+            fileType: 'json',
+            startLine: 1,
+            lineCount: 40,
+        });
+
+        expect(result.code).toBe(HTTP_STATUS.BAD_REQUEST);
+        expect(result.reason).toBe('Filename cannot be empty.');
+    });
+
+    it('returns 404 when a queried node is not found', async () => {
+        mockNodeQuery.mockResolvedValue(null);
+
+        const result = await new NodeApi().queryNode({
+            path: 'Canvas/Missing',
+            queryChildren: false,
+            queryComponent: false,
+        });
+
+        expect(result.code).toBe(HTTP_STATUS.NOT_FOUND);
+        expect(result.reason).toBe('node not found at path: Canvas/Missing');
+    });
+
+    it('returns 404 when a deleted node is not found', async () => {
+        mockNodeDelete.mockResolvedValue(null);
+
+        const result = await new NodeApi().deleteNode({ path: 'Canvas/Missing' });
+
+        expect(result.code).toBe(HTTP_STATUS.NOT_FOUND);
+        expect(result.reason).toBe('node not found at path: Canvas/Missing');
+    });
+
+    it('returns 404 when a queried component is not found', async () => {
+        mockComponentQuery.mockResolvedValue(null);
+
+        const result = await new ComponentApi().queryComponent({ path: 'Canvas/Missing/cc.Label' });
+
+        expect(result.code).toBe(HTTP_STATUS.NOT_FOUND);
+        expect(result.reason).toBe('component not found: Canvas/Missing/cc.Label');
+    });
+});

--- a/tests/bug-497-mcp-error-status.test.ts
+++ b/tests/bug-497-mcp-error-status.test.ts
@@ -1,0 +1,16 @@
+jest.mock('../src/core/assets', () => ({
+    assetManager: {
+        queryAssetInfos: jest.fn(),
+    },
+}));
+
+import { HTTP_STATUS } from '../src/api/base/schema-base';
+import { isToolErrorCode } from '../src/mcp/mcp.middleware';
+
+describe('Bug #497 MCP tool error flagging', () => {
+    it('treats only 5xx result codes as MCP tool errors', () => {
+        expect(isToolErrorCode(HTTP_STATUS.BAD_REQUEST)).toBe(false);
+        expect(isToolErrorCode(HTTP_STATUS.NOT_FOUND)).toBe(false);
+        expect(isToolErrorCode(HTTP_STATUS.INTERNAL_SERVER_ERROR)).toBe(true);
+    });
+});


### PR DESCRIPTION
修复 [#497](https://zentao.sud.center/index.php?m=bug&f=view&bugID=497)：CLI/MCP 调用中业务错误被误标为 500，以及资源路径兼容导致的图片资源查找失败问题。

主要修改：
- 统一 CLI CommonResult 的错误分类，Not Found / 参数错误等业务错误返回 404/400，不再默认落到 500。
- MCP `isError` 仅对 5xx 生效，避免 4xx 业务错误被 MCP Inspector 标记为工具调用失败。
- 修复资源刷新/导入/查询的路径归一化：
  - 支持项目 assets 下绝对路径转换为 `db://assets/...`
  - 支持 `assets/resources/Image` 这类数据库名相对路径转换为 `db://assets/resources/Image`
  - 避免 `source === target` 时自拷贝，改为直接刷新入库