### PR TITLE
[feat] IProperty 添加 __component_path__ 字段用于标识组件数据路径

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -5706,6 +5706,7 @@ export declare interface IProperty {
     multiline?: boolean; 
     optionalTypes?: string[]; 
     userData?: { [key: string]: any }; 
+    __component_path__?: string; 
 }
 export declare interface IPropertyGroupOptions {
     id: string 
@@ -7873,6 +7874,7 @@ export declare interface IProperty {
     multiline?: boolean; 
     optionalTypes?: string[]; 
     userData?: { [key: string]: any }; 
+    __component_path__?: string; 
 }
 export declare interface IPropertyGroupOptions {
     id: string 

--- a/packages/cocos-cli-types/package.json
+++ b/packages/cocos-cli-types/package.json
@@ -2,7 +2,7 @@
     "name": "@cocos/cocos-cli-types",
     "description": "types for cocos cli",
     "author": "cocos cli",
-    "version": "0.0.1-alpha.28.1",
+    "version": "0.0.1-alpha.29.1",
     "main": "index.d.ts",
     "types": "index.d.ts",
     "exports": {

--- a/src/core/scene/@types/public.d.ts
+++ b/src/core/scene/@types/public.d.ts
@@ -109,4 +109,6 @@ export interface IProperty {
     optionalTypes?: string[]; // 对属性是 object 且是可变类型的数据的支持，比如 render-pipeline
 
     userData?: { [key: string]: any }; // 用户透传的数据
+
+    __component_path__?: string; // 该属性用于标识这是组件数据，值为组件路径，如 'Canvas/cc.Label_1'
 }


### PR DESCRIPTION
## 变更摘要

- `IProperty` 接口新增 `__component_path__?: string` 字段，用于标识组件数据及其路径（如 `Canvas/cc.Label_1`）
- `cocos-cli-types` 版本升级至 `0.0.1-alpha.29.1`
- 同步更新 snapshot 测试