### PR TITLE
Fix/assets create asset

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -17,7 +17,8 @@ jobs:
     
     strategy:
       matrix:
-        os: [windows-latest, macos-latest]
+        # Windows native build still uses the bundled CMake 3.24.3 and VS2022 generator.
+        os: [windows-2022, macos-latest]
 
     runs-on: ${{matrix.os}}
 

--- a/e2e/cli/build.e2e.test.ts
+++ b/e2e/cli/build.e2e.test.ts
@@ -10,6 +10,23 @@ import { TestProject } from '../helpers/project-manager';
 import { resolve, join } from 'path';
 import { platform } from 'os';
 
+function logCliFailure(context: string, result: { exitCode: number | null; stdout?: string; stderr?: string; error?: Error }) {
+    if (result.exitCode === 0 && !result.error) {
+        return;
+    }
+
+    console.error(`[${context}] exitCode=${result.exitCode}`);
+    if (result.error) {
+        console.error(`[${context}] error=${result.error.stack || result.error.message}`);
+    }
+    if (result.stdout) {
+        console.error(`[${context}] stdout:\n${result.stdout}`);
+    }
+    if (result.stderr) {
+        console.error(`[${context}] stderr:\n${result.stderr}`);
+    }
+}
+
 describe('cocos build command', () => {
     let testProject: TestProject;
 
@@ -28,6 +45,7 @@ describe('cocos build command', () => {
                 project: testProject.path,
                 platform: 'web-desktop',
             });
+            logCliFailure('build web-desktop', result);
 
             // 验证构建成功
             expect(result.exitCode).toBe(0);
@@ -100,6 +118,7 @@ describe('cocos build command', () => {
                     project: testProject.path,
                     platform: 'windows',
                 });
+                logCliFailure('build windows', result);
     
                 expect(result.error).toBe(undefined);
                 expect(result.exitCode).toBe(0);

--- a/src/api/assets/assets.ts
+++ b/src/api/assets/assets.ts
@@ -385,7 +385,7 @@ export class AssetsApi {
      */
     @tool('assets-save-asset')
     @title('Save Asset Data') // 保存资源数据
-    @description('Save complete content to an existing asset file. Required arguments: pathOrUrlOrUUID (existing asset URL, UUID, or file path) and data (complete file content). Do not call this tool with empty arguments. This tool does not create new assets or temporary files; create the asset first with assets-create-asset-by-type or assets-create-asset, then call save. For scripts, pass complete syntactically valid content.')
+    @description('Save complete content to an existing asset file. Required arguments: pathOrUrlOrUUID (existing asset URL, UUID, or file path) and data (complete file content). Do not call this tool with empty arguments. This tool does not create new assets or temporary files; create the asset first with assets-create-asset-by-type or assets-create-asset, then call save. For scripts, pass complete syntactically valid content. For scene and prefab assets, pass complete valid Cocos serialized JSON; prefer scene-* tools and scene-save for scene graph edits.')
     @result(SchemaSaveAssetResult)
     async saveAsset(
         @param(SchemaSaveAssetPath) pathOrUrlOrUUID: TSaveAssetPath,

--- a/src/api/assets/assets.ts
+++ b/src/api/assets/assets.ts
@@ -292,9 +292,9 @@ export class AssetsApi {
         try {
             ret.data = await assetManager.createAssetByType(ccType, dirOrUrl, baseName, options);
         } catch (e) {
-            ret.code = COMMON_STATUS.FAIL;
+            ret.code = getCommonErrorStatus(e);
             console.error(e);
-            ret.reason = e instanceof Error ? e.message + e.stack : String(e);
+            ret.reason = e instanceof Error ? e.message : String(e);
         }
 
         return ret;

--- a/src/api/assets/assets.ts
+++ b/src/api/assets/assets.ts
@@ -385,7 +385,7 @@ export class AssetsApi {
      */
     @tool('assets-save-asset')
     @title('Save Asset Data') // 保存资源数据
-    @description('Save complete content to an existing asset file. Required arguments: pathOrUrlOrUUID (existing asset URL, UUID, or file path) and data (complete file content). Do not call this tool with empty arguments. This tool does not create new assets; create the asset first with assets-create-asset-by-type or assets-create-asset, then call save. For scripts, pass complete syntactically valid content.')
+    @description('Save complete content to an existing asset file. Required arguments: pathOrUrlOrUUID (existing asset URL, UUID, or file path) and data (complete file content). Do not call this tool with empty arguments. This tool does not create new assets or temporary files; create the asset first with assets-create-asset-by-type or assets-create-asset, then call save. For scripts, pass complete syntactically valid content.')
     @result(SchemaSaveAssetResult)
     async saveAsset(
         @param(SchemaSaveAssetPath) pathOrUrlOrUUID: TSaveAssetPath,
@@ -400,7 +400,7 @@ export class AssetsApi {
         try {
             ret.data = await assetManager.saveAsset(pathOrUrlOrUUID, data);
         } catch (e) {
-            ret.code = COMMON_STATUS.FAIL;
+            ret.code = getCommonErrorStatus(e);
             console.error('save asset fail:', e instanceof Error ? e.message : String(e));
             ret.reason = e instanceof Error ? e.message : String(e);
         }

--- a/src/api/assets/assets.ts
+++ b/src/api/assets/assets.ts
@@ -10,8 +10,10 @@ import {
     SchemaTargetPath,
     SchemaAssetOperationOption,
     SchemaSourcePath,
+    SchemaSaveAssetPath,
     SchemaAssetData,
     TUrlOrUUIDOrPath,
+    TSaveAssetPath,
     TDataKeys,
     TQueryAssetsOption,
     TSupportCreateType,
@@ -383,10 +385,10 @@ export class AssetsApi {
      */
     @tool('assets-save-asset')
     @title('Save Asset Data') // 保存资源数据
-    @description('Save the content of asset files. Used to modify the content of text-based assets (such as scripts, configuration files, scenes, etc.) and write to disk. Supports both string and Buffer data formats.') // 保存资源文件的内容。用于修改文本类资源（如脚本、配置文件、场景等）的内容并写入磁盘。支持字符串和 Buffer 两种数据格式。
+    @description('Save complete content to an existing asset file. Required arguments: pathOrUrlOrUUID (existing asset URL, UUID, or file path) and data (complete file content). Do not call this tool with empty arguments. This tool does not create new assets; create the asset first with assets-create-asset-by-type or assets-create-asset, then call save. For scripts, pass complete syntactically valid content.')
     @result(SchemaSaveAssetResult)
     async saveAsset(
-        @param(SchemaUrlOrUUIDOrPath) pathOrUrlOrUUID: TUrlOrUUIDOrPath,
+        @param(SchemaSaveAssetPath) pathOrUrlOrUUID: TSaveAssetPath,
         @param(SchemaAssetData) data: TAssetData
     ): Promise<CommonResultType<TSaveAssetResult>> {
         const code: HttpStatusCode = COMMON_STATUS.SUCCESS;

--- a/src/api/assets/schema.ts
+++ b/src/api/assets/schema.ts
@@ -158,7 +158,8 @@ export const SchemaCreateAssetOptions = z.object({
 export const SchemaSourcePath = z.string().min(1).describe('Source file path, location of asset file to import'); // 源文件路径，要导入的资源文件位置
 
 // Asset save related // 资源保存相关
-export const SchemaAssetData = z.string().min(1).describe('Asset data to save, can be string or Buffer'); // 要保存的资源数据，可以是字符串或 Buffer
+export const SchemaSaveAssetPath = SchemaUrlOrUUIDOrPath.describe('Required existing asset URL, UUID, or file path to save. This must refer to an asset that already exists in the asset database.'); // 保存已有资源时使用的 URL、UUID 或文件路径
+export const SchemaAssetData = z.string().min(1).describe('Required complete file content to save. Do not omit this field, pass an empty string, or pass partial/truncated script content.'); // 要保存的完整资源数据
 
 // Return value Schema // 返回值 Schema
 export const SchemaAssetInfoResult = SchemaAssetInfo.nullable().describe('Asset detailed information object, including name, type, path, UUID, etc.'); // 资源详细信息对象，包含名称、类型、路径、UUID 等字段
@@ -213,6 +214,7 @@ export type TDirOrDbPath = z.infer<typeof SchemaDirOrDbPath>;
 export type TBaseName = z.infer<typeof SchemaBaseName>;
 export type TDbDirResult = z.infer<typeof SchemaDbDirResult>;
 export type TUrlOrUUIDOrPath = z.infer<typeof SchemaUrlOrUUIDOrPath>;
+export type TSaveAssetPath = z.infer<typeof SchemaSaveAssetPath>;
 export type TUUIDOrPath = z.infer<typeof SchemaUUIDOrPath>;
 export type TUrlOrUUID = z.infer<typeof SchemaUrlOrUUID>;
 export type TUrlOrPath = z.infer<typeof SchemaUrlOrPath>;

--- a/src/api/base/schema-base.ts
+++ b/src/api/base/schema-base.ts
@@ -74,7 +74,7 @@ export function getCommonErrorStatus(error: unknown): CommonStatus {
         return COMMON_STATUS.NOT_FOUND;
     }
 
-    if (/parameter error|filename cannot be empty|invalid url|unsafe file path|extension mismatch|cannot resolve/i.test(message)) {
+    if (/parameter error|filename cannot be empty|invalid url|invalid .*content|unsafe file path|extension mismatch|cannot resolve/i.test(message)) {
         return COMMON_STATUS.BAD_REQUEST;
     }
 

--- a/src/core/assets/manager/operation.ts
+++ b/src/core/assets/manager/operation.ts
@@ -27,6 +27,22 @@ function isScriptAsset(asset: IAsset) {
         || /\.(?:[cm]?js|[cm]?ts|jsx|tsx)$/i.test(asset.source || '');
 }
 
+function getSceneOrPrefabAssetKind(asset: IAsset): 'scene' | 'prefab' | null {
+    const importer = asset.meta?.importer;
+    const source = asset.source || '';
+    if (importer === 'scene' || /\.scene$/i.test(source)) {
+        return 'scene';
+    }
+    if (importer === 'prefab' || /\.prefab$/i.test(source)) {
+        return 'prefab';
+    }
+    return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 function getTypeScriptSyntaxError(fileName: string, content: string): string | null {
     let ts: typeof import('typescript') | null = null;
     try {
@@ -140,6 +156,60 @@ function getScriptStructureError(content: string): string | null {
     return null;
 }
 
+function getSceneOrPrefabJsonError(asset: IAsset, content: string | Buffer): string | null {
+    const kind = getSceneOrPrefabAssetKind(asset);
+    if (!kind) {
+        return null;
+    }
+
+    const text = typeof content === 'string'
+        ? content
+        : Buffer.isBuffer(content)
+            ? content.toString('utf8')
+            : null;
+    if (text === null) {
+        return 'content must be JSON text';
+    }
+
+    let data: unknown;
+    try {
+        data = JSON.parse(text);
+    } catch (error) {
+        return `invalid JSON: ${error instanceof Error ? error.message : String(error)}`;
+    }
+
+    if (!Array.isArray(data)) {
+        return `expected ${kind} JSON array`;
+    }
+    if (data.length < 2) {
+        return `expected ${kind} JSON array with asset and root entries`;
+    }
+
+    const assetEntry = data[0];
+    const rootEntry = data[1];
+    if (!isRecord(assetEntry) || !isRecord(rootEntry)) {
+        return `expected ${kind} asset and root entries to be objects`;
+    }
+
+    if (kind === 'scene') {
+        if (assetEntry.__type__ !== 'cc.SceneAsset') {
+            return 'expected first entry __type__ to be cc.SceneAsset';
+        }
+        if (rootEntry.__type__ !== 'cc.Scene') {
+            return 'expected second entry __type__ to be cc.Scene';
+        }
+        return null;
+    }
+
+    if (assetEntry.__type__ !== 'cc.Prefab') {
+        return 'expected first entry __type__ to be cc.Prefab';
+    }
+    if (rootEntry.__type__ !== 'cc.Node') {
+        return 'expected second entry __type__ to be cc.Node';
+    }
+    return null;
+}
+
 class AssetOperation extends EventEmitter {
 
     /**
@@ -231,7 +301,7 @@ class AssetOperation extends EventEmitter {
             throw new Error(`${i18n.t('assets.save_asset.fail.uuid')}`);
         }
 
-        this._validateScriptContentBeforeSave(asset, content);
+        this._validateAssetContentBeforeSave(asset, content);
         const res = await assetHandlerManager.saveAsset(asset, content);
         if (res) {
             await asset._assetDB.reimport(asset.uuid);
@@ -240,6 +310,11 @@ class AssetOperation extends EventEmitter {
             throw asset.importError || new Error(`Save asset ${asset.source} failed`);
         }
         return assetQuery.encodeAsset(asset);
+    }
+
+    private _validateAssetContentBeforeSave(asset: IAsset, content: string | Buffer) {
+        this._validateScriptContentBeforeSave(asset, content);
+        this._validateSceneOrPrefabContentBeforeSave(asset, content);
     }
 
     private _validateScriptContentBeforeSave(asset: IAsset, content: string | Buffer) {
@@ -251,6 +326,13 @@ class AssetOperation extends EventEmitter {
         const error = syntaxError || structureError;
         if (error) {
             throw new Error(`Invalid script content: ${error}`);
+        }
+    }
+
+    private _validateSceneOrPrefabContentBeforeSave(asset: IAsset, content: string | Buffer) {
+        const error = getSceneOrPrefabJsonError(asset, content);
+        if (error) {
+            throw new Error(`Invalid scene/prefab asset content: ${error}`);
         }
     }
 

--- a/src/core/assets/manager/operation.ts
+++ b/src/core/assets/manager/operation.ts
@@ -174,10 +174,7 @@ class AssetOperation extends EventEmitter {
         if (!createMenus.length) {
             throw new Error(`Can not support create type: ${type}`);
         }
-        let dir = dirOrUrl;
-        if (dirOrUrl.startsWith('db://')) {
-            dir = url2path(dirOrUrl);
-        }
+        const dir = this._resolveCreateAssetDir(dirOrUrl);
         let createInfo: undefined | ICreateMenuInfo = createMenus[0];
         if (createMenus.length > 1 && options?.templateName) {
             createInfo = createMenus.find((menu) => menu.name === options.templateName);
@@ -186,7 +183,8 @@ class AssetOperation extends EventEmitter {
             }
         }
         const extName = extname(createInfo.fullFileName);
-        const target = join(dir, baseName + extName);
+        const fileName = extName && baseName.endsWith(extName) ? baseName : baseName + extName;
+        const target = join(dir, fileName);
 
         return await this.createAsset({
             handler: createInfo.handler,
@@ -196,6 +194,14 @@ class AssetOperation extends EventEmitter {
             template: createInfo.template,
             content: options?.content,
         });
+    }
+
+    private _resolveCreateAssetDir(dirOrUrl: string) {
+        const normalizedDirOrUrl = this._pathToDbUrlIfInsideAssetDB(dirOrUrl);
+        if (normalizedDirOrUrl.startsWith('db://')) {
+            return url2path(normalizedDirOrUrl);
+        }
+        return normalizedDirOrUrl;
     }
 
     /**

--- a/src/core/assets/manager/operation.ts
+++ b/src/core/assets/manager/operation.ts
@@ -20,6 +20,126 @@ import EventEmitter from 'events';
 import { mergeMeta } from '../asset-handler/utils';
 import * as lodash from 'lodash';
 
+function isScriptAsset(asset: IAsset) {
+    const importer = asset.meta?.importer;
+    return importer === 'typescript'
+        || importer === 'javascript'
+        || /\.(?:[cm]?js|[cm]?ts|jsx|tsx)$/i.test(asset.source || '');
+}
+
+function getTypeScriptSyntaxError(fileName: string, content: string): string | null {
+    let ts: typeof import('typescript') | null = null;
+    try {
+        ts = require('typescript') as typeof import('typescript');
+    } catch {
+        return null;
+    }
+
+    const result = ts.transpileModule(content, {
+        fileName,
+        reportDiagnostics: true,
+        compilerOptions: {
+            target: ts.ScriptTarget.ESNext,
+            experimentalDecorators: true,
+        },
+    });
+    const diagnostic = result.diagnostics?.find((item) => item.category === ts.DiagnosticCategory.Error);
+    if (!diagnostic) {
+        return null;
+    }
+
+    const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
+    if (diagnostic.file && typeof diagnostic.start === 'number') {
+        const position = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+        return `${message} (${position.line + 1}:${position.character + 1})`;
+    }
+    return message;
+}
+
+function getScriptStructureError(content: string): string | null {
+    const stack: { char: string; line: number; column: number }[] = [];
+    let line = 1;
+    let column = 0;
+    let state: 'normal' | 'singleQuote' | 'doubleQuote' | 'template' | 'lineComment' | 'blockComment' = 'normal';
+    let escaped = false;
+    const opening = new Set(['(', '[', '{']);
+    const closing: Record<string, string> = {
+        ')': '(',
+        ']': '[',
+        '}': '{',
+    };
+
+    for (let index = 0; index < content.length; index++) {
+        const char = content[index];
+        const next = content[index + 1];
+        column++;
+
+        if (state === 'lineComment') {
+            if (char === '\n') {
+                state = 'normal';
+            }
+        } else if (state === 'blockComment') {
+            if (char === '*' && next === '/') {
+                state = 'normal';
+                index++;
+                column++;
+            }
+        } else if (state === 'singleQuote' || state === 'doubleQuote' || state === 'template') {
+            const quote = state === 'singleQuote' ? '\'' : state === 'doubleQuote' ? '"' : '`';
+            if (escaped) {
+                escaped = false;
+            } else if (char === '\\') {
+                escaped = true;
+            } else if (char === quote) {
+                state = 'normal';
+            }
+        } else {
+            if (char === '/' && next === '/') {
+                state = 'lineComment';
+                index++;
+                column++;
+            } else if (char === '/' && next === '*') {
+                state = 'blockComment';
+                index++;
+                column++;
+            } else if (char === '\'') {
+                state = 'singleQuote';
+            } else if (char === '"') {
+                state = 'doubleQuote';
+            } else if (char === '`') {
+                state = 'template';
+            } else if (opening.has(char)) {
+                stack.push({ char, line, column });
+            } else if (closing[char]) {
+                const last = stack.pop();
+                if (!last || last.char !== closing[char]) {
+                    return `unexpected "${char}" at ${line}:${column}`;
+                }
+            }
+        }
+
+        if (char === '\n') {
+            line++;
+            column = 0;
+            if (state === 'lineComment') {
+                state = 'normal';
+            }
+        }
+    }
+
+    if (state === 'singleQuote' || state === 'doubleQuote' || state === 'template') {
+        return `unterminated ${state === 'template' ? 'template string' : 'string literal'}`;
+    }
+    if (state === 'blockComment') {
+        return 'unterminated block comment';
+    }
+    const last = stack.pop();
+    if (last) {
+        return `unclosed "${last.char}" at ${last.line}:${last.column}`;
+    }
+    return null;
+}
+
 class AssetOperation extends EventEmitter {
 
     /**
@@ -111,6 +231,7 @@ class AssetOperation extends EventEmitter {
             throw new Error(`${i18n.t('assets.save_asset.fail.uuid')}`);
         }
 
+        this._validateScriptContentBeforeSave(asset, content);
         const res = await assetHandlerManager.saveAsset(asset, content);
         if (res) {
             await asset._assetDB.reimport(asset.uuid);
@@ -119,6 +240,18 @@ class AssetOperation extends EventEmitter {
             throw asset.importError || new Error(`Save asset ${asset.source} failed`);
         }
         return assetQuery.encodeAsset(asset);
+    }
+
+    private _validateScriptContentBeforeSave(asset: IAsset, content: string | Buffer) {
+        if (!isScriptAsset(asset) || typeof content !== 'string') {
+            return;
+        }
+        const structureError = getScriptStructureError(content);
+        const syntaxError = getTypeScriptSyntaxError(asset.source, content);
+        const error = syntaxError || structureError;
+        if (error) {
+            throw new Error(`Invalid script content: ${error}`);
+        }
     }
 
     checkValidUrl(urlOrPath: string) {

--- a/src/core/assets/test/operation-filesystem-bridge.test.ts
+++ b/src/core/assets/test/operation-filesystem-bridge.test.ts
@@ -409,4 +409,123 @@ describe('asset operation filesystem bridge', () => {
         expect(mockSaveAssetByHandler).toHaveBeenCalledWith(asset, content);
         expect(reimport).toHaveBeenCalledWith('script-uuid');
     });
+
+    it('saveAsset should reject invalid scene JSON before writing', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const reimport = jest.fn();
+        const asset = {
+            source: 'D:/project/assets/scenes/GameScene.scene',
+            uuid: 'scene-uuid',
+            imported: true,
+            invalid: false,
+            meta: {
+                importer: 'scene',
+            },
+            _assetDB: {
+                options: {
+                    readonly: false,
+                },
+                reimport,
+            },
+        };
+        mockQueryAsset.mockReturnValue(asset);
+
+        await expect(assetOperation.saveAsset(
+            'db://assets/scenes/GameScene.scene',
+            'test content'
+        )).rejects.toThrow('Invalid scene/prefab asset content');
+
+        expect(mockSaveAssetByHandler).not.toHaveBeenCalled();
+        expect(reimport).not.toHaveBeenCalled();
+    });
+
+    it('saveAsset should reject incomplete prefab JSON before writing', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const reimport = jest.fn();
+        const asset = {
+            source: 'D:/project/assets/prefabs/Hero.prefab',
+            uuid: 'prefab-uuid',
+            imported: true,
+            invalid: false,
+            meta: {
+                importer: 'prefab',
+            },
+            _assetDB: {
+                options: {
+                    readonly: false,
+                },
+                reimport,
+            },
+        };
+        mockQueryAsset.mockReturnValue(asset);
+
+        await expect(assetOperation.saveAsset(
+            'db://assets/prefabs/Hero.prefab',
+            '[{"__type__":"cc.Prefab"'
+        )).rejects.toThrow('Invalid scene/prefab asset content');
+
+        expect(mockSaveAssetByHandler).not.toHaveBeenCalled();
+        expect(reimport).not.toHaveBeenCalled();
+    });
+
+    it('saveAsset should keep valid scene and prefab JSON writable', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const reimport = jest.fn();
+        const sceneAsset = {
+            source: 'D:/project/assets/scenes/GameScene.scene',
+            uuid: 'scene-uuid',
+            imported: true,
+            invalid: false,
+            meta: {
+                importer: 'scene',
+            },
+            _assetDB: {
+                options: {
+                    readonly: false,
+                },
+                reimport,
+            },
+        };
+        const sceneContent = JSON.stringify([
+            { __type__: 'cc.SceneAsset', _name: 'GameScene', scene: { __id__: 1 } },
+            { __type__: 'cc.Scene', _name: 'GameScene', _id: 'scene-uuid' },
+        ]);
+        mockQueryAsset.mockReturnValue(sceneAsset);
+        mockSaveAssetByHandler.mockResolvedValue(true);
+
+        await assetOperation.saveAsset('db://assets/scenes/GameScene.scene', sceneContent);
+
+        expect(mockSaveAssetByHandler).toHaveBeenCalledWith(sceneAsset, sceneContent);
+        expect(reimport).toHaveBeenCalledWith('scene-uuid');
+
+        jest.clearAllMocks();
+
+        const prefabReimport = jest.fn();
+        const prefabAsset = {
+            source: 'D:/project/assets/prefabs/Hero.prefab',
+            uuid: 'prefab-uuid',
+            imported: true,
+            invalid: false,
+            meta: {
+                importer: 'prefab',
+            },
+            _assetDB: {
+                options: {
+                    readonly: false,
+                },
+                reimport: prefabReimport,
+            },
+        };
+        const prefabContent = JSON.stringify([
+            { __type__: 'cc.Prefab', _name: 'Hero', data: { __id__: 1 } },
+            { __type__: 'cc.Node', _name: 'Hero' },
+        ]);
+        mockQueryAsset.mockReturnValue(prefabAsset);
+        mockSaveAssetByHandler.mockResolvedValue(true);
+
+        await assetOperation.saveAsset('db://assets/prefabs/Hero.prefab', prefabContent);
+
+        expect(mockSaveAssetByHandler).toHaveBeenCalledWith(prefabAsset, prefabContent);
+        expect(prefabReimport).toHaveBeenCalledWith('prefab-uuid');
+    });
 });

--- a/src/core/assets/test/operation-filesystem-bridge.test.ts
+++ b/src/core/assets/test/operation-filesystem-bridge.test.ts
@@ -9,8 +9,11 @@ const mockQueryAsset = jest.fn();
 const mockQueryAssetInfo = jest.fn();
 const mockQueryAssetInfos = jest.fn();
 const mockQueryUrl = jest.fn();
+const mockAssetQueryUrl = jest.fn();
 const mockRefresh = jest.fn(async (_pathOrUrlOrUUID: string) => 0);
 const mockAddTask = jest.fn(async (func: Function, args: any[]) => await func(...args));
+const mockGetCreateMenuByName = jest.fn();
+const mockCreateAssetByHandler = jest.fn();
 const { dirname, join } = require('path') as typeof import('path');
 
 jest.mock('fs-extra', () => ({
@@ -29,12 +32,23 @@ jest.mock('@cocos/asset-db', () => ({
 }));
 
 jest.mock('../utils', () => ({
-    url2path: jest.fn((value) => value),
+    url2path: jest.fn((value) => {
+        if (value === 'db://assets') {
+            return 'D:/project/assets';
+        }
+        if (value.startsWith('db://assets/')) {
+            return `D:/project/assets/${value.slice('db://assets/'.length)}`;
+        }
+        return value;
+    }),
     ensureOutputData: jest.fn(),
     url2uuid: jest.fn((value) => value),
     pathToDbUrlIfAssetDBPath: jest.fn((value: string, assetDBInfo: Record<string, { name: string; target: string }>) => {
         if (!value || value.startsWith('db://')) {
             return value;
+        }
+        if (value.startsWith('assets/') || value === 'assets') {
+            return value === 'assets' ? 'db://assets' : `db://assets/${value.slice('assets/'.length)}`;
         }
         if (value === 'D:/project/assets/resources/Image' || value === 'assets/resources/Image') {
             return 'db://assets/resources/Image';
@@ -74,7 +88,10 @@ jest.mock('../manager/asset-db', () => ({
 
 jest.mock('../manager/asset-handler', () => ({
     __esModule: true,
-    default: {},
+    default: {
+        getCreateMenuByName: (...args: any[]) => mockGetCreateMenuByName(...args),
+        createAsset: (...args: any[]) => mockCreateAssetByHandler(...args),
+    },
 }));
 
 jest.mock('../asset-config', () => ({
@@ -92,7 +109,7 @@ jest.mock('../manager/query', () => ({
     default: {
         queryAsset: (...args: any[]) => mockQueryAsset(...args),
         encodeAsset: jest.fn((asset) => ({ source: asset.source })),
-        queryUrl: jest.fn(),
+        queryUrl: (...args: any[]) => mockAssetQueryUrl(...args),
         queryAssetInfo: (...args: any[]) => mockQueryAssetInfo(...args),
         queryAssetInfos: (...args: any[]) => mockQueryAssetInfos(...args),
     },
@@ -131,6 +148,16 @@ describe('asset operation filesystem bridge', () => {
         jest.clearAllMocks();
         const assetDBManager = require('../manager/asset-db').default as typeof import('../manager/asset-db').default;
         Object.keys(assetDBManager.assetDBInfo).forEach((key) => delete assetDBManager.assetDBInfo[key]);
+        mockAssetQueryUrl.mockImplementation((value: string) => {
+            const normalized = value.replace(/\\/g, '/');
+            if (normalized.startsWith('D:/project/assets/')) {
+                return `db://assets/${normalized.slice('D:/project/assets/'.length)}`;
+            }
+            if (normalized === 'D:/project/assets') {
+                return 'db://assets';
+            }
+            return '';
+        });
     });
 
     afterEach(() => {
@@ -271,5 +298,56 @@ describe('asset operation filesystem bridge', () => {
         expect(mockRefresh).toHaveBeenCalledWith('db://assets/resources/Image/snake_head.png');
         expect(mockQueryAssetInfo).toHaveBeenCalledWith('db://assets/resources/Image/snake_head.png');
         expect(result).toEqual([assetInfo]);
+    });
+
+    it('createAssetByType should resolve a database-name relative directory before creating', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        setAssetDBInfo();
+        mockGetCreateMenuByName.mockResolvedValue([{
+            name: 'default',
+            label: 'TypeScript',
+            fullFileName: 'NewComponent.ts',
+            handler: 'typescript',
+            template: 'typescript-template',
+        }]);
+        const target = join('D:/project/assets/Script', 'Food.ts');
+        mockCreateAssetByHandler.mockResolvedValue(target);
+        mockQueryAsset.mockReturnValue({
+            source: target,
+            imported: true,
+            invalid: false,
+        });
+
+        await assetOperation.createAssetByType('typescript', 'assets/Script', 'Food');
+
+        expect(mockCreateAssetByHandler).toHaveBeenCalledWith(expect.objectContaining({
+            handler: 'typescript',
+            target,
+            template: 'typescript-template',
+        }));
+    });
+
+    it('createAssetByType should not duplicate the extension when baseName already includes it', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        setAssetDBInfo();
+        mockGetCreateMenuByName.mockResolvedValue([{
+            name: 'default',
+            label: 'TypeScript',
+            fullFileName: 'NewComponent.ts',
+            handler: 'typescript',
+        }]);
+        const target = join('D:/project/assets/Script', 'Food.ts');
+        mockCreateAssetByHandler.mockResolvedValue(target);
+        mockQueryAsset.mockReturnValue({
+            source: target,
+            imported: true,
+            invalid: false,
+        });
+
+        await assetOperation.createAssetByType('typescript', 'assets/Script', 'Food.ts');
+
+        expect(mockCreateAssetByHandler).toHaveBeenCalledWith(expect.objectContaining({
+            target,
+        }));
     });
 });

--- a/src/core/assets/test/operation-filesystem-bridge.test.ts
+++ b/src/core/assets/test/operation-filesystem-bridge.test.ts
@@ -14,6 +14,7 @@ const mockRefresh = jest.fn(async (_pathOrUrlOrUUID: string) => 0);
 const mockAddTask = jest.fn(async (func: Function, args: any[]) => await func(...args));
 const mockGetCreateMenuByName = jest.fn();
 const mockCreateAssetByHandler = jest.fn();
+const mockSaveAssetByHandler = jest.fn();
 const { dirname, join } = require('path') as typeof import('path');
 
 jest.mock('fs-extra', () => ({
@@ -91,6 +92,7 @@ jest.mock('../manager/asset-handler', () => ({
     default: {
         getCreateMenuByName: (...args: any[]) => mockGetCreateMenuByName(...args),
         createAsset: (...args: any[]) => mockCreateAssetByHandler(...args),
+        saveAsset: (...args: any[]) => mockSaveAssetByHandler(...args),
     },
 }));
 
@@ -349,5 +351,62 @@ describe('asset operation filesystem bridge', () => {
         expect(mockCreateAssetByHandler).toHaveBeenCalledWith(expect.objectContaining({
             target,
         }));
+    });
+
+    it('saveAsset should reject incomplete TypeScript content before writing', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const reimport = jest.fn();
+        const asset = {
+            source: 'D:/project/assets/scripts/Board.ts',
+            uuid: 'script-uuid',
+            imported: true,
+            invalid: false,
+            meta: {
+                importer: 'typescript',
+            },
+            _assetDB: {
+                options: {
+                    readonly: false,
+                },
+                reimport,
+            },
+        };
+        mockQueryAsset.mockReturnValue(asset);
+
+        await expect(assetOperation.saveAsset(
+            'db://assets/scripts/Board.ts',
+            "import { _decorator } from 'cc';\nexport class Board {\n"
+        )).rejects.toThrow('Invalid script content');
+
+        expect(mockSaveAssetByHandler).not.toHaveBeenCalled();
+        expect(reimport).not.toHaveBeenCalled();
+    });
+
+    it('saveAsset should keep valid TypeScript content writable', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const reimport = jest.fn();
+        const asset = {
+            source: 'D:/project/assets/scripts/Board.ts',
+            uuid: 'script-uuid',
+            imported: true,
+            invalid: false,
+            meta: {
+                importer: 'typescript',
+            },
+            _assetDB: {
+                options: {
+                    readonly: false,
+                },
+                reimport,
+            },
+        };
+        const content = "import { _decorator } from 'cc';\nexport class Board {}\n";
+        mockQueryAsset.mockReturnValue(asset);
+        mockSaveAssetByHandler.mockResolvedValue(true);
+
+        await assetOperation.saveAsset('db://assets/scripts/Board.ts', content);
+
+        expect(mockSaveAssetByHandler).toHaveBeenCalledWith(asset, content);
+        expect(reimport).toHaveBeenCalledWith('script-uuid');
     });
 });

--- a/tests/assets-save-asset-tool-description.test.ts
+++ b/tests/assets-save-asset-tool-description.test.ts
@@ -26,6 +26,7 @@ describe('assets-save-asset tool guidance', () => {
         expect(description).toContain('pathOrUrlOrUUID');
         expect(description).toContain('data');
         expect(description).toContain('complete file content');
+        expect(description).toContain('temporary files');
     });
 
     it('describes save parameters as required existing asset content', () => {

--- a/tests/assets-save-asset-tool-description.test.ts
+++ b/tests/assets-save-asset-tool-description.test.ts
@@ -27,6 +27,7 @@ describe('assets-save-asset tool guidance', () => {
         expect(description).toContain('data');
         expect(description).toContain('complete file content');
         expect(description).toContain('temporary files');
+        expect(description).toContain('scene and prefab');
     });
 
     it('describes save parameters as required existing asset content', () => {

--- a/tests/assets-save-asset-tool-description.test.ts
+++ b/tests/assets-save-asset-tool-description.test.ts
@@ -1,0 +1,36 @@
+import 'reflect-metadata';
+
+jest.mock('../src/core/assets', () => ({
+    assetDBManager: {},
+    assetManager: {},
+}));
+
+jest.mock('../src/api/decorator/decorator.js', () => ({
+    description: (desc: string) => (target: object, propertyKey: string | symbol) => {
+        Reflect.defineMetadata(`tool:description:${propertyKey.toString()}`, desc, target);
+    },
+    param: () => jest.fn(),
+    result: () => jest.fn(),
+    title: () => jest.fn(),
+    tool: () => jest.fn(),
+}), { virtual: true });
+
+import { AssetsApi } from '../src/api/assets/assets';
+import { SchemaAssetData, SchemaSaveAssetPath } from '../src/api/assets/schema';
+
+describe('assets-save-asset tool guidance', () => {
+    it('documents required save target and complete asset data', () => {
+        const description = Reflect.getOwnMetadata('tool:description:saveAsset', AssetsApi.prototype);
+
+        expect(description).toContain('Do not call this tool with empty arguments');
+        expect(description).toContain('pathOrUrlOrUUID');
+        expect(description).toContain('data');
+        expect(description).toContain('complete file content');
+    });
+
+    it('describes save parameters as required existing asset content', () => {
+        expect(SchemaSaveAssetPath.description).toContain('existing asset');
+        expect(SchemaAssetData.description).toContain('complete file content');
+        expect(SchemaAssetData.description).toMatch(/required/i);
+    });
+});

--- a/tests/bug-497-api-error-status.test.ts
+++ b/tests/bug-497-api-error-status.test.ts
@@ -4,6 +4,7 @@ const mockRefreshAsset = jest.fn();
 const mockCreateAsset = jest.fn();
 const mockCreateAssetByType = jest.fn();
 const mockImportAsset = jest.fn();
+const mockSaveAsset = jest.fn();
 const mockQueryLinesInFile = jest.fn();
 const mockNodeQuery = jest.fn();
 const mockNodeDelete = jest.fn();
@@ -26,6 +27,7 @@ jest.mock('../src/core/assets', () => ({
         createAsset: (...args: unknown[]) => mockCreateAsset(...args),
         createAssetByType: (...args: unknown[]) => mockCreateAssetByType(...args),
         importAsset: (...args: unknown[]) => mockImportAsset(...args),
+        saveAsset: (...args: unknown[]) => mockSaveAsset(...args),
     },
 }));
 
@@ -75,6 +77,7 @@ describe('Bug #497 common API error status codes', () => {
         mockCreateAsset.mockReset();
         mockCreateAssetByType.mockReset();
         mockImportAsset.mockReset();
+        mockSaveAsset.mockReset();
         mockQueryLinesInFile.mockReset();
         mockNodeQuery.mockReset();
         mockNodeDelete.mockReset();
@@ -170,6 +173,23 @@ describe('Bug #497 common API error status codes', () => {
         expect(result.code).toBe(HTTP_STATUS.NOT_FOUND);
         expect(result.data).toEqual([]);
         expect(result.reason).toContain('can not find asset');
+    });
+
+    it('returns 404 when saving a missing existing asset', async () => {
+        mockSaveAsset.mockRejectedValue(new Error('Failed to save asset: cannot find asset e:\\pink\\test12\\assets\\scripts\\Board.ts.tmp'));
+
+        const result = await new AssetsApi().saveAsset(
+            'e:\\pink\\test12\\assets\\scripts\\Board.ts.tmp',
+            '// temp file for fix'
+        );
+
+        expect(mockSaveAsset).toHaveBeenCalledWith(
+            'e:\\pink\\test12\\assets\\scripts\\Board.ts.tmp',
+            '// temp file for fix'
+        );
+        expect(result.code).toBe(HTTP_STATUS.NOT_FOUND);
+        expect(result.data).toBeNull();
+        expect(result.reason).toContain('cannot find asset');
     });
 
     it('returns 404 when queried file does not exist', async () => {

--- a/tests/bug-497-api-error-status.test.ts
+++ b/tests/bug-497-api-error-status.test.ts
@@ -93,6 +93,7 @@ describe('Bug #497 common API error status codes', () => {
         expect(getCommonErrorStatus(new Error('ENOENT: no such file or directory'))).toBe(COMMON_STATUS.NOT_FOUND);
         expect(getCommonErrorStatus(new Error('Asset can not be found: db://assets/missing.scene'))).toBe(COMMON_STATUS.NOT_FOUND);
         expect(getCommonErrorStatus(new Error('can not find asset d:\\cocos\\program\\snake2\\assets\\resources\\Image'))).toBe(COMMON_STATUS.NOT_FOUND);
+        expect(getCommonErrorStatus(new Error('Invalid scene/prefab asset content: invalid JSON'))).toBe(COMMON_STATUS.BAD_REQUEST);
         expect(getCommonErrorStatus(new Error('Filename cannot be empty.'))).toBe(COMMON_STATUS.BAD_REQUEST);
         expect(getCommonErrorStatus(new Error('parameter error'))).toBe(COMMON_STATUS.BAD_REQUEST);
         expect(getCommonErrorStatus(new Error('unexpected internal crash'))).toBe(COMMON_STATUS.FAIL);
@@ -190,6 +191,19 @@ describe('Bug #497 common API error status codes', () => {
         expect(result.code).toBe(HTTP_STATUS.NOT_FOUND);
         expect(result.data).toBeNull();
         expect(result.reason).toContain('cannot find asset');
+    });
+
+    it('returns 400 when saving invalid scene or prefab content', async () => {
+        mockSaveAsset.mockRejectedValue(new Error('Invalid scene/prefab asset content: invalid JSON: Unexpected token'));
+
+        const result = await new AssetsApi().saveAsset(
+            'db://assets/scenes/GameScene.scene',
+            'test content'
+        );
+
+        expect(result.code).toBe(HTTP_STATUS.BAD_REQUEST);
+        expect(result.data).toBeNull();
+        expect(result.reason).toContain('Invalid scene/prefab asset content');
     });
 
     it('returns 404 when queried file does not exist', async () => {

--- a/tests/bug-497-api-error-status.test.ts
+++ b/tests/bug-497-api-error-status.test.ts
@@ -2,6 +2,7 @@ const mockQueryAssetInfo = jest.fn();
 const mockQueryAssetMeta = jest.fn();
 const mockRefreshAsset = jest.fn();
 const mockCreateAsset = jest.fn();
+const mockCreateAssetByType = jest.fn();
 const mockImportAsset = jest.fn();
 const mockQueryLinesInFile = jest.fn();
 const mockNodeQuery = jest.fn();
@@ -23,6 +24,7 @@ jest.mock('../src/core/assets', () => ({
         queryAssetMeta: (...args: unknown[]) => mockQueryAssetMeta(...args),
         refreshAsset: (...args: unknown[]) => mockRefreshAsset(...args),
         createAsset: (...args: unknown[]) => mockCreateAsset(...args),
+        createAssetByType: (...args: unknown[]) => mockCreateAssetByType(...args),
         importAsset: (...args: unknown[]) => mockImportAsset(...args),
     },
 }));
@@ -71,6 +73,7 @@ describe('Bug #497 common API error status codes', () => {
         mockQueryAssetMeta.mockReset();
         mockRefreshAsset.mockReset();
         mockCreateAsset.mockReset();
+        mockCreateAssetByType.mockReset();
         mockImportAsset.mockReset();
         mockQueryLinesInFile.mockReset();
         mockNodeQuery.mockReset();
@@ -143,6 +146,17 @@ describe('Bug #497 common API error status codes', () => {
         expect(result.code).toBe(HTTP_STATUS.BAD_REQUEST);
         expect(result.data).toBeNull();
         expect(result.reason).toContain('Invalid URL');
+    });
+
+    it('returns 400 when createAssetByType receives an invalid target URL', async () => {
+        mockCreateAssetByType.mockRejectedValue(new Error('Invalid URL: input URL must be a string and start with db:// \n  url:'));
+
+        const result = await new AssetsApi().createAssetByType('typescript', 'assets/Script', 'Food');
+
+        expect(result.code).toBe(HTTP_STATUS.BAD_REQUEST);
+        expect(result.data).toBeNull();
+        expect(result.reason).toContain('Invalid URL');
+        expect(result.reason).not.toContain('Error: Invalid URL');
     });
 
     it('returns 404 when importing from a missing asset path', async () => {


### PR DESCRIPTION
## 变更说明

本 PR 针对创建游戏流程中弱模型更容易触发的 5 类 asset 工具问题做防御性修复，目标是减少无效工具调用导致的 500，并让错误更可诊断、可恢复。

### 修复点

1. `assets-create-asset-by-type` 兼容 `dirOrUrl` 传入相对 asset-db 路径，如 `assets/Script`。
2. 强化 `assets-save-asset` 工具描述，明确必须传入已存在资产路径和完整内容，避免模型传 `{}` 或误当作创建工具使用。
3. 保存脚本资产前校验 TypeScript/JavaScript 内容完整性，避免半截脚本写入后污染资源。
4. 保存不存在的资产或 `.tmp` 临时文件时返回 `404`，不再归类为 `500`。
5. 保存 `.scene` / `.prefab` 这类 JSON-backed asset 前校验基础 Cocos 序列化结构，避免未生成完整的 JSON 被写入。