### PR TITLE
fix: allow closing editors without saving

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -5443,6 +5443,7 @@ export declare interface IClipboardState {
 }
 export declare interface ICloseOptions {
     urlOrUUID?: string;
+    save?: boolean;
 }
 export declare interface IComponent extends IProperty {
     value: {
@@ -7449,6 +7450,7 @@ export declare interface IClipboardState {
 }
 export declare interface ICloseOptions {
     urlOrUUID?: string;
+    save?: boolean;
 }
 export declare interface ICocosConfigurationNode {
     id: string;

--- a/src/core/scene/common/editor/options.ts
+++ b/src/core/scene/common/editor/options.ts
@@ -39,4 +39,6 @@ export interface IReloadOptions {
  */
 export interface ICloseOptions {
     urlOrUUID?: string;
+    /** Whether to save before closing. Defaults to true for backward compatibility. */
+    save?: boolean;
 }

--- a/src/core/scene/scene-process/service/editor.ts
+++ b/src/core/scene/scene-process/service/editor.ts
@@ -191,7 +191,7 @@ export class EditorService extends BaseService<IEditorEvents> implements IEditor
             const editor = this.editorMap.get(uuid);
             if (!editor) return true;
 
-            const result = await editor.close();
+            const result = await editor.close({ save: params.save ?? true });
 
             // 如果关闭的是当前打开的编辑器，清除当前状态
             if (uuid === this.currentEditorUuid) {

--- a/src/core/scene/scene-process/service/editors/base-editor.ts
+++ b/src/core/scene/scene-process/service/editors/base-editor.ts
@@ -107,7 +107,7 @@ export abstract class BaseEditor {
     // 抽象方法，子类必须实现
     abstract encode(entity?: IEditorTarget): Promise<TEditorEntity>;
     abstract open(asset: IAssetInfo): Promise<TEditorEntity>;
-    abstract close(): Promise<boolean>;
+    abstract close(options?: { save?: boolean }): Promise<boolean>;
     abstract save(): Promise<IAssetInfo>;
     /**
      * 执行实际的重载操作，子类需要实现具体的重载逻辑

--- a/src/core/scene/scene-process/service/editors/prefab-editor.ts
+++ b/src/core/scene/scene-process/service/editors/prefab-editor.ts
@@ -43,11 +43,13 @@ export class PrefabEditor extends BaseEditor {
         return this.encode();
     }
 
-    async close(): Promise<boolean> {
+    async close(options?: { save?: boolean }): Promise<boolean> {
         if (!this.entity) {
             throw new Error('没有打开预制体');
         }
-        await this.save();
+        if (options?.save !== false) {
+            await this.save();
+        }
         await sceneUtils.runScene(new Scene(''));
         this.setCurrentOpen(null);
         return true;

--- a/src/core/scene/scene-process/service/editors/scene-editor.ts
+++ b/src/core/scene/scene-process/service/editors/scene-editor.ts
@@ -42,11 +42,13 @@ export class SceneEditor extends BaseEditor {
         return this.encode();
     }
 
-    async close(): Promise<boolean> {
+    async close(options?: { save?: boolean }): Promise<boolean> {
         if (!this.entity) {
             throw new Error('[close] 没有打开场景');
         }
-        await this.save();
+        if (options?.save !== false) {
+            await this.save();
+        }
         await sceneUtils.runScene(new Scene(''));
         this.setCurrentOpen(null);
         return true;

--- a/src/core/scene/test/editor-close-options.test.ts
+++ b/src/core/scene/test/editor-close-options.test.ts
@@ -1,0 +1,73 @@
+jest.mock('cc', () => ({
+    Scene: class Scene {
+        name: string;
+        constructor(name = '') {
+            this.name = name;
+        }
+    },
+    SceneAsset: class SceneAsset { },
+    Component: class Component { },
+    Node: class Node { },
+    Prefab: class Prefab {
+        static _utils: { applyTargetOverrides: jest.Mock } = { applyTargetOverrides: jest.fn() };
+    },
+    find: jest.fn(),
+    instantiate: jest.fn(),
+}));
+
+jest.mock('../scene-process/service/scene/utils', () => ({
+    sceneUtils: {
+        generateNodeDump: jest.fn(),
+        loadAny: jest.fn(),
+        runScene: jest.fn(async () => undefined),
+        serialize: jest.fn(),
+    },
+}));
+
+jest.mock('../scene-process/service/prefab/prefab-editor-utils', () => ({
+    editorPrefabUtils: {
+        serialize: jest.fn(),
+        storePrefabUUID: jest.fn(),
+        restorePrefabUUID: jest.fn(),
+        generateSceneAsset: jest.fn(),
+        removePrefabInstanceRoots: jest.fn(),
+    },
+}));
+
+import { SceneEditor } from '../scene-process/service/editors/scene-editor';
+import { PrefabEditor } from '../scene-process/service/editors/prefab-editor';
+
+type CloseableEditor = SceneEditor | PrefabEditor;
+
+function setOpen(editor: CloseableEditor): void {
+    editor.setCurrentOpen({
+        instance: {},
+        identifier: {
+            assetType: 'scene',
+            assetName: 'asset',
+            assetUuid: 'asset-uuid',
+            assetUrl: 'db://assets/asset.scene',
+        },
+    } as never);
+}
+
+async function expectCloseSaveCalls(editor: CloseableEditor, options: { save?: boolean } | undefined, expectedCalls: number): Promise<void> {
+    setOpen(editor);
+    const save = jest.spyOn(editor, 'save').mockResolvedValue({} as never);
+
+    await editor.close(options);
+
+    expect(save).toHaveBeenCalledTimes(expectedCalls);
+}
+
+describe('Editor close options', () => {
+    it('scene close saves by default and can skip save', async () => {
+        await expectCloseSaveCalls(new SceneEditor(), undefined, 1);
+        await expectCloseSaveCalls(new SceneEditor(), { save: false }, 0);
+    });
+
+    it('prefab close saves by default and can skip save', async () => {
+        await expectCloseSaveCalls(new PrefabEditor(), undefined, 1);
+        await expectCloseSaveCalls(new PrefabEditor(), { save: false }, 0);
+    });
+});

--- a/src/core/scene/test/editor-proxy-prefab.testcase.ts
+++ b/src/core/scene/test/editor-proxy-prefab.testcase.ts
@@ -11,6 +11,7 @@ describe('EditorProxy Prefab 测试', () => {
         let identifier: IBaseIdentifier | null = null;
         let instanceAssetURL = '';
         let entity: INodeInfo | null = null;
+        let currentPrefabFile = '';
 
         it('create - 创建新预制体', async () => {
             identifier = await EditorProxy.create({
@@ -188,6 +189,7 @@ describe('EditorProxy Prefab 测试', () => {
             const result = await EditorProxy.save({});
 
             expect(result).not.toBeNull();
+            currentPrefabFile = result.file;
 
             const content = readFileSync(result.file, 'utf-8');
 
@@ -206,6 +208,23 @@ describe('EditorProxy Prefab 测试', () => {
 
             expect(result).not.toBeNull();
             expect(JSON.stringify(result)).toContain('current-prefab-test-node');
+        });
+
+        it('close - 不保存地关闭当前预制体', async () => {
+            await NodeProxy.createByType({
+                path: '',
+                nodeType: NodeType.EMPTY,
+                name: 'discard-current-prefab-test-node',
+            });
+
+            const result = await EditorProxy.close({
+                save: false,
+            });
+
+            expect(result).toBe(true);
+
+            const content = readFileSync(currentPrefabFile, 'utf-8');
+            expect(content).not.toContain('discard-current-prefab-test-node');
         });
 
         it('close - 关闭当前预制体', async () => {

--- a/src/core/scene/test/editor-proxy-scene.testcase.ts
+++ b/src/core/scene/test/editor-proxy-scene.testcase.ts
@@ -9,6 +9,7 @@ describe('EditorProxy Scene 测试', () => {
     describe('场景操作', () => {
         let identifier: IBaseIdentifier | null = null;
         let entity: ISceneInfo | INodeInfo | null = null;
+        let currentSceneFile = '';
 
         it('create - 创建新场景', async () => {
             identifier = await EditorProxy.create({
@@ -146,6 +147,7 @@ describe('EditorProxy Scene 测试', () => {
             });
             const result = await EditorProxy.save({});
             expect(result).not.toBeNull();
+            currentSceneFile = result.file;
             const content = readFileSync(result.file, 'utf-8');
             expect(content).toContain('current-scene-test-node');
         });
@@ -159,6 +161,22 @@ describe('EditorProxy Scene 测试', () => {
             const result = await EditorProxy.queryCurrent();
             expect(result).not.toBeNull();
             expect(JSON.stringify(result)).toContain('current-scene-test-node');
+        });
+
+        it('close - 不保存地关闭当前场景', async () => {
+            await NodeProxy.createByType({
+                path: '',
+                nodeType: NodeType.EMPTY,
+                name: 'discard-current-scene-test-node',
+            });
+
+            const result = await EditorProxy.close({
+                save: false,
+            });
+
+            expect(result).toBe(true);
+            const content = readFileSync(currentSceneFile, 'utf-8');
+            expect(content).not.toContain('discard-current-scene-test-node');
         });
 
         it('close - 关闭当前场景', async () => {


### PR DESCRIPTION
## 变更说明
- 为 editor close 增加 save 选项，允许调用方显式跳过保存并关闭场景/预制体。
- 保持兼容默认行为：未传 save 时仍按原逻辑保存后关闭。
- 补充 scene/prefab 关闭不保存的单测、接口测试用例，并更新 DTS 快照。

## 验证
- [x] rtk npm test -- --runTestsByPath src/core/scene/test/editor-close-options.test.ts --runInBand
- [x] rtk npm run generate:dts
- [x] rtk ./node_modules/.bin/tsc -b --pretty false
- [x] rtk git diff --check