### PR TITLE
[break] Surface required build options in getPlatformBuildSchema

### DIFF
--- a/src/core/builder/@types/protected/build-plugin.ts
+++ b/src/core/builder/@types/protected/build-plugin.ts
@@ -45,12 +45,14 @@ export type IBuilderRegisterInfo = IPlatformRegisterInfo | IPluginRegisterInfo;
 
 /**
  * 构建面板渲染用的平台配置 schema。
+ * common / platformOptions 各为一个对象节点({ type:'object', properties, required }),
  * 字段与配置系统 schema(ICocosConfigurationPropertySchema)对齐,由 convertConfigItem 从
  * IBuilderConfigItem 转换而来(label->title、type:'enum'->string|number+enum 等),hidden 项已在源头过滤。
+ * 必填项(源端 verifyRules:['required'])收进对象节点的 required 数组(JSON Schema 对象级)。
  */
 export interface PlatformBuildSchema {
-    common: Record<string, ICocosConfigurationPropertySchema>;
-    platformOptions: Record<string, ICocosConfigurationPropertySchema>;
+    common: ICocosConfigurationPropertySchema;
+    platformOptions: ICocosConfigurationPropertySchema;
 }
 
 export interface PlatformConfigItem {

--- a/src/core/builder/manager/plugin.ts
+++ b/src/core/builder/manager/plugin.ts
@@ -893,15 +893,24 @@ export class PluginManager extends EventEmitter {
      * 复用配置系统的 convertConfigItem(label->title、type:'enum'->string|number+enum、对象/数组递归、i18n 翻译)。
      * hidden 项直接过滤(配置系统 schema 无 hidden 字段;如 md5CacheOptions 不渲染,其值仍随构建参数透传)。
      */
-    private toRenderSchema(items: Record<string, IBuilderConfigItem>): Record<string, ICocosConfigurationPropertySchema> {
-        const result: Record<string, ICocosConfigurationPropertySchema> = {};
+    private toRenderSchema(items: Record<string, IBuilderConfigItem>): ICocosConfigurationPropertySchema {
+        const properties: Record<string, ICocosConfigurationPropertySchema> = {};
+        const required: string[] = [];
         for (const [key, item] of Object.entries(items)) {
             if (!item || item.hidden) {
                 continue;
             }
-            result[key] = convertConfigItem(item as unknown as ICocosConfigurationPropertySchema, key);
+            properties[key] = convertConfigItem(item as unknown as ICocosConfigurationPropertySchema, key);
+            // 必填:从 verifyRules:['required'] 派生,收进父对象节点的 required(JSON Schema 对象级);拦构建仍由 checkBuildOption 负责
+            if (item.verifyRules?.includes('required')) {
+                required.push(key);
+            }
         }
-        return result;
+        const node: ICocosConfigurationPropertySchema = { type: 'object', properties };
+        if (required.length) {
+            node.required = required;
+        }
+        return node;
     }
 
     public getPlatformBuildSchema(platform: Platform | string): PlatformBuildSchema {

--- a/src/core/builder/test/query-platform-build-schema.spec.ts
+++ b/src/core/builder/test/query-platform-build-schema.spec.ts
@@ -187,19 +187,23 @@ describe('PluginManager platform config schema queries', () => {
         const result = pm.getPlatformBuildSchema('test');
 
         // name 标记为 hidden -> 在源头过滤(配置系统 schema 无 hidden 字段)
-        expect(result.common.name).toBeUndefined();
-        expect(result.common.mainBundleCompressionType).toMatchObject({
+        expect(result.common.properties!.name).toBeUndefined();
+        expect(result.common.properties!.mainBundleCompressionType).toMatchObject({
             title: 'Main Bundle Compression',
             type: 'string',
             enum: ['none', 'merge_dep', 'zip'],
             enumDescriptions: ['None', 'Merge Dependencies', 'Zip'],
         });
-        expect(result.platformOptions.mode).toMatchObject({
+        expect(result.platformOptions.properties!.mode).toMatchObject({
             title: 'Mode',
             type: 'string',
             enum: ['auto'],
             enumDescriptions: ['Auto'],
         });
+        // 必填(verifyRules:['required'])-> hoist 进对象节点的 required(JSON Schema 对象级);
+        // name 被 hidden 过滤,故 common 无 required
+        expect(result.platformOptions.required).toEqual(['mode']);
+        expect(result.common.required).toBeUndefined();
     });
 
     it('getPlatformBuildSchema derives compression items from platform supportedCompressionTypes', async () => {
@@ -230,12 +234,12 @@ describe('PluginManager platform config schema queries', () => {
 
         const result = pm.getPlatformBuildSchema('asset-source');
 
-        expect(result.common.mainBundleCompressionType).toMatchObject({
+        expect(result.common.properties!.mainBundleCompressionType).toMatchObject({
             type: 'string',
             enum: ['none', 'zip'],
             enumDescriptions: ['None', 'Zip'],
         });
-        expect(result.platformOptions.quality).toMatchObject({
+        expect(result.platformOptions.properties!.quality).toMatchObject({
             title: 'Quality',
             type: 'number',
             default: 80,
@@ -478,13 +482,13 @@ describe('PluginManager platform config schema queries', () => {
 
         expect(platforms[0].displayName).toBe('测试平台');
         expect(platforms[0].createTemplateLabel).toBe('测试平台');
-        expect(schema.common.name).toBeUndefined();
-        expect(schema.common.mainBundleCompressionType).toMatchObject({
+        expect(schema.common.properties!.name).toBeUndefined();
+        expect(schema.common.properties!.mainBundleCompressionType).toMatchObject({
             enum: ['none', 'merge_dep', 'zip'],
             enumDescriptions: ['无', '合并依赖', 'Zip'],
         });
-        expect(schema.platformOptions.mode.title).toBe('模式');
-        expect(schema.platformOptions.mode.description).toBeUndefined();
+        expect(schema.platformOptions.properties!.mode.title).toBe('模式');
+        expect(schema.platformOptions.properties!.mode.description).toBeUndefined();
         expect(stage.displayName).toBe('制作');
         expect(stage.description).toBe('制作描述');
         expect(template.displayName).toBe('测试模板');
@@ -504,8 +508,8 @@ describe('PluginManager platform config schema queries', () => {
 
         expect(platforms[0].displayName).toBe('Stored Platform Value');
         // metadata.ts 中展示字段优先使用已物化的展示值, i18n key 仅作为缺省回退与刷新依据。
-        expect(schema.platformOptions.mode.title).toBe('Stored Mode Value');
-        expect(schema.platformOptions.mode).toMatchObject({ enum: ['auto'], enumDescriptions: ['Stored Auto Value'] });
+        expect(schema.platformOptions.properties!.mode.title).toBe('Stored Mode Value');
+        expect(schema.platformOptions.properties!.mode).toMatchObject({ enum: ['auto'], enumDescriptions: ['Stored Auto Value'] });
         // 源 option 对象不被 getPlatformBuildSchema 修改(克隆后再转换)
         expect(option.label).toBe('Stored Mode Value');
         expect(option.labelI18nKey).toBe('i18n:test.option.mode');


### PR DESCRIPTION
## What

`getPlatformBuildSchema` now returns `common` / `platformOptions` as object schema nodes (`{ type: 'object', properties, required }`) instead of flat property maps.

Build options declared with `verifyRules: ['required']` are collected into the node's `required` array (JSON Schema object-level), so the build panel can flag required fields. Runtime enforcement still goes through the `required` validation rule; the schema `required` is for UI marking only.

## Changes

- `PlatformBuildSchema.common` / `platformOptions`: `Record<string, schema>` -> `ICocosConfigurationPropertySchema` (object node).
- `toRenderSchema`: builds `properties` and collects `required` from `verifyRules: ['required']`.
- Spec updated for the object-node shape and `required` assertions.
