### PR TITLE
fix(prefab): add _prefab null guards and use sceneUtils

### DIFF
--- a/src/core/engine/editor-extends/missing-reporter/missing-object-reporter.ts
+++ b/src/core/engine/editor-extends/missing-reporter/missing-object-reporter.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import { MissingReporter } from './missing-reporter';
-import * as _ from 'lodash';
+import findLast from 'lodash/findLast';
 import * as ps from 'path';
 import * as ObjectWalker from './object-walker';
 import * as assetdb from '@cocos/asset-db';
@@ -13,7 +13,7 @@ export class MissingObjectReporter extends MissingReporter {
         if (obj instanceof cc.Component || obj instanceof cc.Asset) {
             parsingOwner = obj;
         } else {
-            parsingOwner = _.findLast(parsedObjects, (x: any) => (x instanceof cc.Component || x instanceof cc.Asset));
+            parsingOwner = findLast(parsedObjects, (x: any) => (x instanceof cc.Component || x instanceof cc.Asset));
         }
 
         let byOwner = '';
@@ -21,7 +21,7 @@ export class MissingObjectReporter extends MissingReporter {
             const ownerType = MissingReporter.getObjectType(parsingOwner);
             byOwner = ` by ${ownerType} "${cc.js.getClassName(parsingOwner)}"`;
         } else {
-            parsingOwner = _.findLast(parsedObjects, (x: any) => (x instanceof cc.Node));
+            parsingOwner = findLast(parsedObjects, (x: any) => (x instanceof cc.Node));
             if (parsingOwner) {
                 byOwner = ` by node "${parsingOwner.name}"`;
             }

--- a/src/core/scene/scene-process/service/prefab/node.ts
+++ b/src/core/scene/scene-process/service/prefab/node.ts
@@ -17,12 +17,12 @@ import {
 } from 'cc';
 import { prefabUtils } from './utils';
 import { componentOperation } from './component';
-import { promisify } from 'util';
 import { isEditorNode, isPartOfNode } from '../node/node-utils';
 import { Service } from '../core';
 import { IChangeNodeOptions, NodeEventType } from '../../../common';
 import { Rpc } from '../../rpc';
 import { TimerUtil } from './timer-util';
+import { sceneUtils } from '../scene/utils';
 
 const nodeMgr = EditorExtends.Node;
 const compMgr = EditorExtends.Component;
@@ -1419,12 +1419,12 @@ class NodeOperation {
         if (parent) {
             prefabUtils.fireBeforeChangeMsg(parent);
             const index = node.getSiblingIndex();
-            const prefab = await promisify(assetManager.loadAny)(prefabAsset);
+            const prefab = await sceneUtils.loadAny<Prefab>(prefabAsset);
             const assetRootNode = instantiate(prefab);
-            if (!assetRootNode['_prefab'].instance) {
+            if (assetRootNode['_prefab'] && !assetRootNode['_prefab'].instance) {
                 assetRootNode['_prefab'].instance = prefabUtils.createPrefabInstance();
             }
-            if (node['_prefab'] && node['_prefab'].instance) {
+            if (node['_prefab'] && node['_prefab'].instance && assetRootNode['_prefab'] && assetRootNode['_prefab'].instance) {
                 assetRootNode['_prefab'].instance.fileId = node['_prefab'].instance.fileId;
             }
             this.createReservedPropertyOverrides(assetRootNode);
@@ -1438,6 +1438,7 @@ class NodeOperation {
             prefabUtils.fireChangeMsg(parent);
             return assetRootNode;
         }
+        return null;
     }
 
     /**
@@ -1460,7 +1461,7 @@ class NodeOperation {
         let asset: any = assetUuid;
         if (typeof assetUuid === 'string') {
             // asset = cce.prefabUtil.serialize.asAsset(assetUuid);
-            asset = await promisify(assetManager.loadAny)(assetUuid);
+            asset = await sceneUtils.loadAny(assetUuid);
         }
 
         if (!asset) {


### PR DESCRIPTION
- Replace `promisify(assetManager.loadAny)` with `sceneUtils.loadAny` for consistency. And `import { promisify } from 'util';` will cause runtime error when running in PinK Scene Webview. It's a node environment only deps.
- Add null check for `assetRootNode['_prefab']` before accessing `.instance` in `replacePrefabAsset`
- Extend conditional to also guard `assetRootNode['_prefab'].instance` when copying fileId
- Add missing `return null` for the no-parent path in `replacePrefabAsset`
- Switch to tree-shakeable `lodash/findLast` import in missing-object-reporter
