### PR TITLE
[break] feat(scene): init custom layers in engine service

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -3958,8 +3958,8 @@ export declare interface ParticleAssetUserData {
 export declare type Physics = 'cannon' | 'ammo' | 'builtin';
 export declare type Platform = InternalPlatform | string;
 export declare interface PlatformBuildSchema {
-    common: Record<string, ICocosConfigurationPropertySchema>;
-    platformOptions: Record<string, ICocosConfigurationPropertySchema>;
+    common: ICocosConfigurationPropertySchema;
+    platformOptions: ICocosConfigurationPropertySchema;
 }
 export declare interface PlatformBundleConfig {
     platformName: string;
@@ -5497,6 +5497,10 @@ export declare interface ICreatePrefabFromNodeParams {
     overwrite?: boolean;
 }
 export declare type ICreateType = typeof CREATE_TYPES[number];
+export declare interface ICustomLayerConfig {
+    name: string;
+    value: number;
+}
 export declare interface ICutParams {
     paths: string[];
 }
@@ -5526,6 +5530,7 @@ export declare interface IEditorService extends IServiceEvents {
 export declare interface IEngineService extends IServiceEvents {
     init(): Promise<void>;
     repaintInEditMode(): Promise<void>;
+    initCustomLayer(layers?: ICustomLayerConfig[]): Promise<void>;
 }
 export declare interface IExecuteComponentMethodOptions {
     path: string;
@@ -7558,6 +7563,10 @@ export declare interface ICustomJointTextureLayout {
     textureLength: number;
     contents: IChunkContent[];
 }
+export declare interface ICustomLayerConfig {
+    name: string;
+    value: number;
+}
 export declare interface ICutParams {
     paths: string[];
 }
@@ -7642,6 +7651,7 @@ export declare interface IEngineProjectConfig extends Exclude<IEngineConfig, 'in
 export declare interface IEngineService extends IServiceEvents {
     init(): Promise<void>;
     repaintInEditMode(): Promise<void>;
+    initCustomLayer(layers?: ICustomLayerConfig[]): Promise<void>;
 }
 export declare interface IExecuteComponentMethodOptions {
     path: string;

--- a/src/core/scene/common/engine.ts
+++ b/src/core/scene/common/engine.ts
@@ -1,11 +1,16 @@
 import { IServiceEvents } from '../scene-process/service/core';
 
+export interface ICustomLayerConfig {
+    name: string;
+    value: number;
+}
+
 export interface IEngineEvents {
     'engine:update': [];
     'engine:ticked': [];
 }
 
-export interface IPublicEngineService extends Omit<IEngineService, keyof IServiceEvents> {}
+export interface IPublicEngineService extends Omit<IEngineService, 'initCustomLayer' | keyof IServiceEvents> {}
 
 export interface IEngineService extends IServiceEvents {
     /**
@@ -17,4 +22,9 @@ export interface IEngineService extends IServiceEvents {
      * 让引擎执行一帧
      */
     repaintInEditMode(): Promise<void>;
+
+    /**
+     * 初始化自定义 Layer 配置
+     */
+    initCustomLayer(layers?: ICustomLayerConfig[]): Promise<void>;
 }

--- a/src/core/scene/common/engine.ts
+++ b/src/core/scene/common/engine.ts
@@ -1,4 +1,4 @@
-import { IServiceEvents } from '../scene-process/service/core';
+import type { IServiceEvents } from '../scene-process/service/core';
 
 export interface ICustomLayerConfig {
     name: string;

--- a/src/core/scene/scene-process/service/engine.ts
+++ b/src/core/scene/scene-process/service/engine.ts
@@ -5,13 +5,16 @@ import { Component, director, GeometryRenderer as CCGeometryRenderer, Node } fro
 import { GeometryRenderer, methods as GeometryMethods } from './engine/geometry_renderer';
 import { BaseService, register } from './core';
 import { Service } from './core/decorator';
-import { IEngineEvents, IEngineService } from '../../common';
+import { ICustomLayerConfig, IEngineEvents, IEngineService } from '../../common';
 import { NodeEventType } from '../../common';
 import { Rpc } from '../rpc';
 
 const tickTime = 1000 / 60;
+// Engine Layers reserves bits 20-31 for built-ins; user custom layers live in bit positions 0-19.
+const USER_LAYER_MIN_BIT = 0;
+const USER_LAYER_MAX_BIT = 19;
 const layerMask: number[] = [];
-for (let i = 0; i <= 19; i++) {
+for (let i = USER_LAYER_MIN_BIT; i <= USER_LAYER_MAX_BIT; i++) {
     layerMask[i] = 1 << i;
 }
 
@@ -84,12 +87,12 @@ export class EngineService extends BaseService<IEngineEvents> implements IEngine
         }
     }
 
-    public async initCustomLayer(layers?: { name: string; value: number }[]) {
+    public async initCustomLayer(layers?: ICustomLayerConfig[]) {
         if (!Array.isArray(layers)) {
             return;
         }
 
-        for (let i = 0; i <= 19; i++) {
+        for (let i = USER_LAYER_MIN_BIT; i <= USER_LAYER_MAX_BIT; i++) {
             cc.Layers.deleteLayer(i);
         }
 

--- a/src/core/scene/scene-process/service/engine.ts
+++ b/src/core/scene/scene-process/service/engine.ts
@@ -10,6 +10,10 @@ import { NodeEventType } from '../../common';
 import { Rpc } from '../rpc';
 
 const tickTime = 1000 / 60;
+const layerMask: number[] = [];
+for (let i = 0; i <= 19; i++) {
+    layerMask[i] = 1 << i;
+}
 
 // 与 cocos-editor 一致：控制连续 tick 的状态枚举
 enum NeedAnimState {
@@ -78,6 +82,23 @@ export class EngineService extends BaseService<IEngineEvents> implements IEngine
         if (this._tickedFrameInEM !== director.getTotalFrames()) {
             this._shouldRepaintInEM = true;
         }
+    }
+
+    public async initCustomLayer(layers?: { name: string; value: number }[]) {
+        if (!Array.isArray(layers)) {
+            return;
+        }
+
+        for (let i = 0; i <= 19; i++) {
+            cc.Layers.deleteLayer(i);
+        }
+
+        layers.forEach((layer) => {
+            const index = layerMask.findIndex((num) => layer.value === num);
+            if (index !== -1) {
+                cc.Layers.addLayer(layer.name, index);
+            }
+        });
     }
 
     public setFrameRate(fps: number) {

--- a/src/core/scene/scene-process/service/engine.ts
+++ b/src/core/scene/scene-process/service/engine.ts
@@ -5,7 +5,7 @@ import { Component, director, GeometryRenderer as CCGeometryRenderer, Node } fro
 import { GeometryRenderer, methods as GeometryMethods } from './engine/geometry_renderer';
 import { BaseService, register } from './core';
 import { Service } from './core/decorator';
-import { ICustomLayerConfig, IEngineEvents, IEngineService } from '../../common';
+import type { ICustomLayerConfig, IEngineEvents, IEngineService } from '../../common';
 import { NodeEventType } from '../../common';
 import { Rpc } from '../rpc';
 

--- a/src/core/scene/test/engine-custom-layer.test.ts
+++ b/src/core/scene/test/engine-custom-layer.test.ts
@@ -1,0 +1,61 @@
+jest.mock('cc', () => ({
+    Component: class Component {},
+    Node: class Node {},
+    GeometryRenderer: class GeometryRenderer {},
+    director: {
+        getTotalFrames: jest.fn(() => 0),
+        tick: jest.fn(),
+    },
+}));
+
+type CustomLayer = { name: string; value: number };
+
+const layers = {
+    deleteLayer: jest.fn(),
+    addLayer: jest.fn(),
+};
+
+(globalThis as any).cc = {
+    Layers: layers,
+};
+
+import { EngineService } from '../scene-process/service/engine';
+
+describe('Engine custom layer', () => {
+    beforeEach(() => {
+        layers.deleteLayer.mockClear();
+        layers.addLayer.mockClear();
+    });
+
+    it('resets custom layer slots and adds valid layer masks', async () => {
+        const service = new EngineService() as unknown as {
+            initCustomLayer(layers?: CustomLayer[]): Promise<void>;
+        };
+
+        await service.initCustomLayer([
+            { name: 'Gameplay', value: 1 << 3 },
+            { name: 'InvalidBit', value: 1 << 23 },
+            { name: 'UIOverride', value: 1 << 0 },
+        ]);
+
+        expect(layers.deleteLayer).toHaveBeenCalledTimes(20);
+        expect(layers.deleteLayer.mock.calls.map(([index]) => index)).toEqual([
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+            10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+        ]);
+        expect(layers.addLayer).toHaveBeenCalledTimes(2);
+        expect(layers.addLayer).toHaveBeenNthCalledWith(1, 'Gameplay', 3);
+        expect(layers.addLayer).toHaveBeenNthCalledWith(2, 'UIOverride', 0);
+    });
+
+    it('ignores missing layer config', async () => {
+        const service = new EngineService() as unknown as {
+            initCustomLayer(layers?: CustomLayer[]): Promise<void>;
+        };
+
+        await service.initCustomLayer();
+
+        expect(layers.deleteLayer).not.toHaveBeenCalled();
+        expect(layers.addLayer).not.toHaveBeenCalled();
+    });
+});

--- a/src/core/scene/test/engine-service-interface.test.ts
+++ b/src/core/scene/test/engine-service-interface.test.ts
@@ -1,0 +1,19 @@
+import type { IEngineService, IPublicEngineService } from '../common/engine';
+
+describe('Engine service interface', () => {
+    it('exposes custom layer initialization only on the internal engine service', () => {
+        const assertInternal = (service: IEngineService) => {
+            const result: Promise<void> = service.initCustomLayer([{ name: 'Gameplay', value: 1 << 3 }]);
+
+            expect(result).toBeDefined();
+        };
+
+        const assertPublic = (service: IPublicEngineService) => {
+            // @ts-expect-error custom layer initialization is scene-process internal.
+            service.initCustomLayer([{ name: 'Gameplay', value: 1 << 3 }]);
+        };
+
+        expect(assertInternal).toBeDefined();
+        expect(assertPublic).toBeDefined();
+    });
+});


### PR DESCRIPTION
## 变更说明
- 在 scene-process `EngineService` 中新增 `initCustomLayer`，按 Creator startup 语义重置 0-19 号自定义 layer 槽位并应用合法 layer mask。
- 将 `initCustomLayer` 保持为内部 `IEngineService` 能力，不暴露到主进程 `EngineProxy` / `IPublicEngineService`。
- 补充单测和 DTS 快照，覆盖自定义 layer 初始化行为与 internal/public 接口边界。

## QA 手测步骤
1. 在 PinK 中打开一个走 cocos-cli `scene-process/engine-bootstrap.ts` 的场景 Webview。
2. 打开该 Scene Webview 的 DevTools Console，执行：`await globalThis.cli.Scene.Engine.initCustomLayer([{ name: "Gameplay", value: 1 << 3 }])`。
3. 在同一 Console 中检查 `cc.Layers.Enum.Gameplay`，应为 `8`，并且节点 layer 下拉/相关 dump 能看到该自定义 layer。
4. 再执行：`await globalThis.cli.Scene.Engine.initCustomLayer([{ name: "FX", value: 1 << 4 }, { name: "Ignored", value: 1 << 23 }])`。
5. 检查 `cc.Layers.Enum.FX` 应为 `16`，`Ignored` 不应被加入；此前的 `Gameplay` 自定义 layer 应已从自定义 layer 槽位中清理。
6. 确认整个流程不依赖主进程 `Scene.Engine` / `EngineProxy` 调用，只通过 scene-process 内部 `globalThis.cli.Scene.Engine` 生效。

## 补充验证
- [x] `rtk npm test -- --runTestsByPath src/core/scene/test/engine-custom-layer.test.ts src/core/scene/test/engine-service-interface.test.ts --runInBand`
- [x] `rtk npm run build`
- [x] `rtk npm run generate:dts`
- [x] `rtk git diff --check`