### PR TITLE
[break] fix(scene): preview UI prefabs without Canvas

### DIFF
--- a/src/core/scene/common/engine.ts
+++ b/src/core/scene/common/engine.ts
@@ -5,6 +5,11 @@ export interface ICustomLayerConfig {
     value: number;
 }
 
+export interface ICustomLayerConfig {
+    name: string;
+    value: number;
+}
+
 export interface IEngineEvents {
     'engine:update': [];
     'engine:ticked': [];

--- a/src/core/scene/scene-process/service/editors/prefab-editor.ts
+++ b/src/core/scene/scene-process/service/editors/prefab-editor.ts
@@ -1,9 +1,10 @@
-import { find, instantiate, Node, Prefab, Scene } from 'cc';
+import { Canvas, find, instantiate, Node, Prefab, Scene, UITransform } from 'cc';
 import { type IBaseIdentifier, ICreateOptions, IEditorTarget, INode } from '../../../common';
 import { Rpc } from '../../rpc';
 import { editorPrefabUtils } from '../prefab/prefab-editor-utils';
 import { BaseEditor } from './base-editor';
 import { sceneUtils } from '../scene/utils';
+import { createShouldHideInHierarchyCanvasNode } from '../node/node-create';
 
 import type { IAssetInfo } from '../../../../assets/@types/public';
 
@@ -33,6 +34,7 @@ export class PrefabEditor extends BaseEditor {
         // 实例化预制体
         const instance = instantiate(prefabAsset);
         this.virtualScene.addChild(instance);
+        await this.ensurePreviewCanvasForUI(instance);
 
         // 设置当前打开的预制体
         this.setCurrentOpen({
@@ -71,15 +73,39 @@ export class PrefabEditor extends BaseEditor {
         }
 
         const prefabName = this.entity.instance.name;
+        const prefabUuid = this.entity.instance.uuid;
         const prefabUUIDMap = editorPrefabUtils.storePrefabUUID(this.virtualScene);
         const sceneAsset = editorPrefabUtils.generateSceneAsset(this.virtualScene, this.getRootNode());
         const json = EditorExtends.serialize(sceneAsset);
         this.virtualScene = await sceneUtils.runSceneImmediateByJson(json);
         editorPrefabUtils.removePrefabInstanceRoots(this.virtualScene);
         editorPrefabUtils.restorePrefabUUID(this.virtualScene, prefabUUIDMap);
-        this.entity.instance = find(prefabName) as Node;
+        const instance = EditorExtends.Node.getNode(prefabUuid) as Node | null || find(prefabName) as Node | null;
+        if (!instance) {
+            throw new Error(`reload 失败，找不到预制体根节点: ${prefabName}`);
+        }
+        this.entity.instance = instance;
         Prefab._utils.applyTargetOverrides(this.entity.instance);
+        await this.ensurePreviewCanvasForUI(this.entity.instance);
         return this.encode();
+    }
+
+    private async ensurePreviewCanvasForUI(instance: Node): Promise<void> {
+        if (!this.virtualScene || !this.shouldUsePreviewCanvas(instance)) {
+            return;
+        }
+
+        const canvasNode = await createShouldHideInHierarchyCanvasNode(this.virtualScene);
+        instance.parent = canvasNode;
+    }
+
+    private shouldUsePreviewCanvas(instance: Node): boolean {
+        const hasCanvas = Boolean(instance.getComponentInChildren(Canvas));
+        if (hasCanvas) {
+            return false;
+        }
+
+        return instance.getComponentsInChildren(UITransform).length > 0;
     }
 
     async create(params: ICreateOptions): Promise<IBaseIdentifier> {

--- a/src/core/scene/test/prefab-editor-preview-canvas.test.ts
+++ b/src/core/scene/test/prefab-editor-preview-canvas.test.ts
@@ -1,0 +1,124 @@
+const createShouldHideInHierarchyCanvasNode = jest.fn();
+
+class MockCanvas { }
+class MockUITransform { }
+
+class MockScene {
+    name: string;
+    children: any[] = [];
+
+    constructor(name = '') {
+        this.name = name;
+    }
+
+    addChild(node: any): void {
+        this.children.push(node);
+        node.parent = this;
+    }
+}
+
+jest.mock('cc', () => ({
+    Canvas: MockCanvas,
+    UITransform: MockUITransform,
+    Scene: MockScene,
+    Node: class Node { },
+    Prefab: class Prefab {
+        static _utils: { applyTargetOverrides: jest.Mock } = { applyTargetOverrides: jest.fn() };
+    },
+    find: jest.fn(),
+    instantiate: jest.fn(),
+}));
+
+jest.mock('../scene-process/service/scene/utils', () => ({
+    sceneUtils: {
+        generateNodeDump: jest.fn(async () => ({})),
+        loadAny: jest.fn(),
+        runScene: jest.fn(),
+        runSceneImmediateByJson: jest.fn(),
+    },
+}));
+
+jest.mock('../scene-process/service/node/node-create', () => ({
+    createShouldHideInHierarchyCanvasNode,
+}));
+
+jest.mock('../scene-process/service/prefab/prefab-editor-utils', () => ({
+    editorPrefabUtils: {
+        serialize: jest.fn(),
+        storePrefabUUID: jest.fn(),
+        restorePrefabUUID: jest.fn(),
+        generateSceneAsset: jest.fn(),
+        removePrefabInstanceRoots: jest.fn(),
+    },
+}));
+
+import { instantiate } from 'cc';
+import { sceneUtils } from '../scene-process/service/scene/utils';
+import { PrefabEditor } from '../scene-process/service/editors/prefab-editor';
+
+async function openPrefabWith(prefabRoot: any, scene = new MockScene('virtual-scene')): Promise<MockScene> {
+    (sceneUtils.runScene as jest.Mock).mockResolvedValue(scene);
+    (sceneUtils.loadAny as jest.Mock).mockResolvedValue({});
+    (instantiate as unknown as jest.Mock).mockReturnValue(prefabRoot);
+
+    await new PrefabEditor().open({
+        uuid: 'prefab-uuid',
+        name: 'LabelPrefab',
+        type: 'prefab',
+        url: 'db://assets/LabelPrefab.prefab',
+    } as never);
+
+    return scene;
+}
+
+describe('PrefabEditor preview Canvas', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('hosts a UI prefab without its own Canvas under an editor-only Canvas when opened', async () => {
+        const scene = new MockScene('virtual-scene');
+        const previewCanvas = { name: 'should_hide_in_hierarchy' };
+        const prefabRoot = {
+            name: 'LabelPrefab',
+            parent: null,
+            getComponentInChildren: jest.fn((type: unknown) => type === MockCanvas ? null : null),
+            getComponentsInChildren: jest.fn((type: unknown) => type === MockUITransform ? [{}] : []),
+        };
+
+        createShouldHideInHierarchyCanvasNode.mockResolvedValue(previewCanvas);
+
+        await openPrefabWith(prefabRoot, scene);
+
+        expect(createShouldHideInHierarchyCanvasNode).toHaveBeenCalledWith(scene);
+        expect(prefabRoot.parent).toBe(previewCanvas);
+    });
+
+    it('does not create a preview Canvas when the prefab already owns one', async () => {
+        const prefabRoot = {
+            name: 'CanvasPrefab',
+            parent: null,
+            getComponentInChildren: jest.fn((type: unknown) => type === MockCanvas ? {} : null),
+            getComponentsInChildren: jest.fn((type: unknown) => type === MockUITransform ? [{}] : []),
+        };
+
+        const scene = await openPrefabWith(prefabRoot);
+
+        expect(createShouldHideInHierarchyCanvasNode).not.toHaveBeenCalled();
+        expect(prefabRoot.parent).toBe(scene);
+    });
+
+    it('does not create a preview Canvas for prefabs without UI components', async () => {
+        const prefabRoot = {
+            name: 'MeshPrefab',
+            parent: null,
+            getComponentInChildren: jest.fn(() => null),
+            getComponentsInChildren: jest.fn(() => []),
+        };
+
+        const scene = await openPrefabWith(prefabRoot);
+
+        expect(createShouldHideInHierarchyCanvasNode).not.toHaveBeenCalled();
+        expect(prefabRoot.parent).toBe(scene);
+    });
+});


### PR DESCRIPTION
## 变更说明
- Prefab 编辑器打开或 reload UI Prefab 时，如果 Prefab 自身没有 Canvas，会挂到隐藏的编辑器预览 Canvas 下显示。
- 保持真实 Prefab root 作为保存对象，避免把预览 Canvas 写入资产。
- 补充 Prefab 编辑器单测，覆盖无 Canvas UI、已有 Canvas UI、非 UI Prefab 三种场景。

## QA 手测步骤
- 准备一个包含 Label / Sprite 等 2D UI 节点、但 Prefab 自身没有 Canvas 的 Prefab。
- 在 Prefab 编辑模式打开该 Prefab，确认 Scene 视图中 UI 内容可见。
- 查看 Hierarchy，确认没有可见的额外 Canvas 节点污染用户层级。
- 保存并重新打开该 Prefab，确认 Prefab 资产本身没有新增 Canvas，且 UI 内容仍可见。
- 再打开一个自身已有 Canvas 的 UI Prefab，确认显示正常且没有重复 Canvas 行为。
- 再打开一个纯 3D / 非 UI Prefab，确认其挂载和显示行为不变。

## 开发验证
- [x] `rtk npm test -- --runTestsByPath src/core/scene/test/prefab-editor-preview-canvas.test.ts src/core/scene/test/editor-close-options.test.ts --runInBand`
- [x] `rtk git diff --check -- src/core/scene/scene-process/service/editors/prefab-editor.ts src/core/scene/test/prefab-editor-preview-canvas.test.ts`
- [x] `rtk ./node_modules/.bin/tsc -b --pretty false`