### PR TITLE
[break] fix: add asset meta user data update API

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -170,6 +170,9 @@ export declare function deleteAsset(dbPath: string, options?: DeleteAssetOptions
 export declare interface DeleteAssetOptions {
     useTrash?: boolean;
 }
+export declare interface UpdateAssetMetaUserDataOptions {
+    reimport?: boolean;
+}
 export declare interface DirectoryAssetUserData {
     isBundle?: boolean;
     bundleConfigID?: string;
@@ -658,7 +661,6 @@ export declare interface RtSpriteFrameAssetUserData {
     height?: number;
 }
 export declare function saveAsset(pathOrUrlOrUUID: string, data: string | Buffer): Promise<IAssetInfo>;
-export declare function saveAssetMeta(uuid: string, meta: IAssetMeta): Promise<void>;
 export declare interface ScriptModuleUserData {
     isPlugin: false;
 }
@@ -762,6 +764,7 @@ export declare interface ThumbnailInfo {
 }
 export declare type ThumbnailSize = 'large' | 'small' | 'middle' | 'origin';
 export declare function updateAssetUserData(urlOrUuidOrPath: string, path: string, value: any): Promise<any>;
+export declare function updateAssetMetaUserData(parentUuid: string, subMetaId: string | null | undefined, path: string, value: any, options?: UpdateAssetMetaUserDataOptions): Promise<any>;
 export declare function updateDefaultUserData(handler: string, path: string, value: any): Promise<void>;
 export declare type WrapMode = 'repeat' | 'clamp-to-edge' | 'mirrored-repeat';
 export { }
@@ -6817,7 +6820,6 @@ export declare namespace Assets {
         refresh,
         queryAssetInfo,
         queryAssetMeta,
-        saveAssetMeta,
         queryCreateMap,
         queryAssetInfos,
         queryAssetDBInfos,
@@ -6837,6 +6839,7 @@ export declare namespace Assets {
         updateDefaultUserData,
         queryAssetUserDataConfig,
         updateAssetUserData,
+        updateAssetMetaUserData,
         queryAssetConfigMap,
         queryThumbnailHandlers,
         generateThumbnail,
@@ -6862,6 +6865,7 @@ export declare namespace Assets {
         IAssetInfo,
         AssetOperationOption,
         DeleteAssetOptions,
+        UpdateAssetMetaUserDataOptions,
         AssetInfo,
         IRedirectInfo,
         QueryAssetsOption,
@@ -7015,6 +7019,9 @@ export declare interface CreateAssetOptions {
 export declare function deleteAsset(dbPath: string, options?: DeleteAssetOptions): Promise<IAssetInfo | null>;
 export declare interface DeleteAssetOptions {
     useTrash?: boolean;
+}
+export declare interface UpdateAssetMetaUserDataOptions {
+    reimport?: boolean;
 }
 export declare interface DirectoryAssetUserData {
     isBundle?: boolean;
@@ -8733,7 +8740,6 @@ export declare interface RtSpriteFrameAssetUserData {
 }
 export declare function save(force?: boolean): Promise<void>;
 export declare function saveAsset(pathOrUrlOrUUID: string, data: string | Buffer): Promise<IAssetInfo>;
-export declare function saveAssetMeta(uuid: string, meta: IAssetMeta): Promise<void>;
 export declare namespace Scene {
     export {
         init_6 as init,
@@ -8897,6 +8903,7 @@ export declare type TSceneTemplateType = typeof SCENE_TEMPLATE_TYPE[number];
 export declare type UIAlignType = 'top' | 'v-center' | 'bottom' | 'left' | 'h-center' | 'right';
 export declare function unregister(): Promise<void>;
 export declare function updateAssetUserData(urlOrUuidOrPath: string, path: string, value: any): Promise<any>;
+export declare function updateAssetMetaUserData(parentUuid: string, subMetaId: string | null | undefined, path: string, value: any, options?: UpdateAssetMetaUserDataOptions): Promise<any>;
 export declare function updateDefaultUserData(handler: string, path: string, value: any): Promise<void>;
 export declare interface Vec2 {
     x: number;

--- a/src/api/assets/assets.ts
+++ b/src/api/assets/assets.ts
@@ -71,6 +71,12 @@ import {
     TUpdateAssetUserDataPath,
     TUpdateAssetUserDataValue,
     TUpdateAssetUserDataResult,
+    SchemaUpdateAssetMetaUserDataParentUuid,
+    SchemaUpdateAssetMetaUserDataSubMetaId,
+    SchemaUpdateAssetMetaUserDataOptions,
+    TUpdateAssetMetaUserDataParentUuid,
+    TUpdateAssetMetaUserDataSubMetaId,
+    TUpdateAssetMetaUserDataOptions,
     SchemaAssetConfigMapResult,
     TAssetConfigMapResult,
     TUUIDOrPath,
@@ -725,7 +731,42 @@ export class AssetsApi {
     }
 
     /**
-     * Query Asset Config Map // 查询资源配置映射表
+     * Update Asset Meta User Data
+     */
+    @tool('assets-update-asset-meta-user-data')
+    @title('Update Asset Meta User Data')
+    @description('Update only the userData field in an asset .meta file. Pass parentUuid and optional subMetaId; subMetaId targets parentUuid@subMetaId, while null or omitted subMetaId updates the parent asset. By default this only saves the .meta file. Set options.reimport to true when the imported library data must be regenerated.')
+    @result(SchemaUpdateAssetUserDataResult)
+    async updateAssetMetaUserData(
+        @param(SchemaUpdateAssetMetaUserDataParentUuid) parentUuid: TUpdateAssetMetaUserDataParentUuid,
+        @param(SchemaUpdateAssetMetaUserDataSubMetaId) subMetaId: TUpdateAssetMetaUserDataSubMetaId,
+        @param(SchemaUpdateAssetUserDataPath) path: TUpdateAssetUserDataPath,
+        @param(SchemaUpdateAssetUserDataValue) value: TUpdateAssetUserDataValue,
+        @param(SchemaUpdateAssetMetaUserDataOptions) options?: TUpdateAssetMetaUserDataOptions
+    ): Promise<CommonResultType<TUpdateAssetUserDataResult>> {
+        const ret: CommonResultType<TUpdateAssetUserDataResult> = {
+            code: COMMON_STATUS.SUCCESS,
+            data: null,
+        };
+
+        try {
+            ret.data = await assetManager.updateMetaUserData(parentUuid, subMetaId, path, value, options);
+            if (!ret.data) {
+                const uuid = subMetaId ? `${parentUuid}@${subMetaId}` : parentUuid;
+                ret.code = COMMON_STATUS.NOT_FOUND;
+                ret.reason = `Asset can not be found: ${uuid}. Please refresh asset db and try again.`;
+            }
+        } catch (e) {
+            ret.code = getCommonErrorStatus(e);
+            console.error('update asset meta user data fail:', e instanceof Error ? e.message : String(e));
+            ret.reason = e instanceof Error ? e.message : String(e);
+        }
+
+        return ret;
+    }
+
+    /**
+     * Query Asset Config Map
      */
     // @tool('assets-query-asset-config-map')
     @title('Query Asset Config Map') // 查询资源配置映射表

--- a/src/api/assets/schema.ts
+++ b/src/api/assets/schema.ts
@@ -259,6 +259,17 @@ export type TUpdateAssetUserDataValue = z.infer<typeof SchemaUpdateAssetUserData
 export const SchemaUpdateAssetUserDataResult = z.any().describe('Updated user data object'); // 更新后的用户数据对象
 export type TUpdateAssetUserDataResult = z.infer<typeof SchemaUpdateAssetUserDataResult>;
 
+export const SchemaUpdateAssetMetaUserDataParentUuid = z.string().min(1).describe('Parent asset UUID. Use subMetaId to target a sub asset meta.');
+export type TUpdateAssetMetaUserDataParentUuid = z.infer<typeof SchemaUpdateAssetMetaUserDataParentUuid>;
+
+export const SchemaUpdateAssetMetaUserDataSubMetaId = z.string().min(1).nullable().optional().describe('Sub meta id. Pass null or omit it to update the parent asset meta userData.');
+export type TUpdateAssetMetaUserDataSubMetaId = z.infer<typeof SchemaUpdateAssetMetaUserDataSubMetaId>;
+
+export const SchemaUpdateAssetMetaUserDataOptions = z.object({
+    reimport: z.boolean().optional().describe('Whether to reimport the asset after saving .meta. Default false.'),
+}).optional().describe('Options for updating asset meta userData');
+export type TUpdateAssetMetaUserDataOptions = z.infer<typeof SchemaUpdateAssetMetaUserDataOptions>;
+
 // Recursively defined user data configuration item // 递归定义用户数据配置项
 const SchemaUserDataConfigItem: z.ZodType<any> = z.lazy(() => z.object({
     key: z.string().optional().describe('Unique identifier'), // 唯一标识符

--- a/src/api/decorator/decorator.ts
+++ b/src/api/decorator/decorator.ts
@@ -30,8 +30,9 @@ export function tool(toolName?: string) {
       throw new Error(`Tool name "${name}" is already registered`);
     }
 
-    const paramSchemas: ParamSchema[] =
-        Reflect.getOwnMetadata(`tool:paramSchemas:${propertyKey.toString()}`, proto) || [];
+    const paramSchemas: ParamSchema[] = [
+      ...(Reflect.getOwnMetadata(`tool:paramSchemas:${propertyKey.toString()}`, proto) || []),
+    ].sort((a, b) => a.index - b.index);
 
     const returnSchema: ZodType<any> | undefined =
         Reflect.getOwnMetadata(`tool:returnSchema:${propertyKey.toString()}`, proto);

--- a/src/core/assets/@types/public.d.ts
+++ b/src/core/assets/@types/public.d.ts
@@ -72,6 +72,10 @@ export interface DeleteAssetOptions {
     useTrash?: boolean;
 }
 
+export interface UpdateAssetMetaUserDataOptions {
+    reimport?: boolean;
+}
+
 // Basic information about the resource
 // 资源的基础信息
 export interface AssetInfo extends IAssetInfo {

--- a/src/core/assets/manager/asset.ts
+++ b/src/core/assets/manager/asset.ts
@@ -45,6 +45,7 @@ class AssetManager extends EventEmitter {
     outputExportData = assetOperation.outputExportData.bind(assetOperation);
     createAssetByType = assetOperation.createAssetByType.bind(assetOperation);
     updateUserData = assetOperation.updateUserData.bind(assetOperation);
+    updateMetaUserData = assetOperation.updateMetaUserData.bind(assetOperation);
 
     // ----------- assetHandlerManager ------------
     queryAssetConfigMap = assetHandlerManager.queryAssetConfigMap.bind(assetHandlerManager);
@@ -350,6 +351,7 @@ export interface TypedAssetManager extends EventEmitter {
     outputExportData: typeof assetOperation.outputExportData;
     createAssetByType: typeof assetOperation.createAssetByType;
     updateUserData: typeof assetOperation.updateUserData;
+    updateMetaUserData: typeof assetOperation.updateMetaUserData;
 
     queryAssetConfigMap: typeof assetHandlerManager.queryAssetConfigMap;
     updateDefaultUserData: typeof assetHandlerManager.updateDefaultUserData;

--- a/src/core/assets/manager/operation.ts
+++ b/src/core/assets/manager/operation.ts
@@ -7,7 +7,7 @@ import { copy as fsCopy, move, remove, existsSync } from 'fs-extra';
 import { isAbsolute, dirname, join, relative, extname } from 'path';
 import { IMoveOptions } from '../@types/private';
 import { IAsset, CreateAssetOptions, IExportOptions, IExportData, CreateAssetByTypeOptions, ICreateMenuInfo } from '../@types/protected';
-import { AssetOperationOption, AssetUserDataMap, DeleteAssetOptions, IAssetInfo, IAssetMeta, ISupportCreateType } from '../@types/public';
+import { AssetOperationOption, AssetUserDataMap, DeleteAssetOptions, IAssetInfo, IAssetMeta, ISupportCreateType, UpdateAssetMetaUserDataOptions } from '../@types/public';
 import assetConfig from '../asset-config';
 import { url2path, ensureOutputData, url2uuid, pathToDbUrlIfAssetDBPath, dirnameForDbUrlOrPath } from '../utils';
 import assetDBManager from './asset-db';
@@ -283,6 +283,28 @@ class AssetOperation extends EventEmitter {
         lodash.set(asset?.meta.userData, path, value);
         await asset.save();
         return asset?.meta.userData;
+    }
+
+    async updateMetaUserData<T extends keyof AssetUserDataMap = 'unknown'>(
+        parentUuid: string,
+        subMetaId: string | null | undefined,
+        path: string,
+        value: any,
+        options: UpdateAssetMetaUserDataOptions = {},
+    ): Promise<AssetUserDataMap[T]> {
+        const uuid = subMetaId ? `${parentUuid}@${subMetaId}` : parentUuid;
+        const asset = assetQuery.queryAsset(uuid);
+        if (!asset) {
+            console.error(`can not find asset ${uuid}`);
+            return;
+        }
+        const userData = asset.meta.userData || (asset.meta.userData = {} as AssetUserDataMap[T]);
+        lodash.set(userData, path, value);
+        await asset.save();
+        if (options.reimport) {
+            await asset._assetDB.reimport(asset.uuid);
+        }
+        return userData;
     }
 
     async saveAsset(uuidOrURLOrPath: string, content: string | Buffer) {

--- a/src/core/assets/test/operation-filesystem-bridge.test.ts
+++ b/src/core/assets/test/operation-filesystem-bridge.test.ts
@@ -166,6 +166,62 @@ describe('asset operation filesystem bridge', () => {
         jest.restoreAllMocks();
     });
 
+    it('updateMetaUserData updates parent asset userData without reimport by default', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const reimport = jest.fn();
+        const asset = {
+            uuid: 'parent-uuid',
+            meta: {
+                userData: {},
+            },
+            save: jest.fn().mockResolvedValue(true),
+            _assetDB: {
+                reimport,
+            },
+        };
+        mockQueryAsset.mockReturnValue(asset);
+
+        const result = await assetOperation.updateMetaUserData('parent-uuid', null, 'custom.enabled', true);
+
+        expect(mockQueryAsset).toHaveBeenCalledWith('parent-uuid');
+        expect(asset.meta.userData).toEqual({
+            custom: {
+                enabled: true,
+            },
+        });
+        expect(asset.save).toHaveBeenCalledTimes(1);
+        expect(reimport).not.toHaveBeenCalled();
+        expect(result).toBe(asset.meta.userData);
+    });
+
+    it('updateMetaUserData updates sub asset userData and reimports when requested', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const reimport = jest.fn();
+        const subAsset = {
+            uuid: 'parent-uuid@6c48a',
+            meta: {
+                userData: {
+                    minfilter: 'linear',
+                },
+            },
+            save: jest.fn().mockResolvedValue(true),
+            _assetDB: {
+                reimport,
+            },
+        };
+        mockQueryAsset.mockReturnValue(subAsset);
+
+        const result = await assetOperation.updateMetaUserData('parent-uuid', '6c48a', 'minfilter', 'nearest', { reimport: true });
+
+        expect(mockQueryAsset).toHaveBeenCalledWith('parent-uuid@6c48a');
+        expect(subAsset.meta.userData).toEqual({
+            minfilter: 'nearest',
+        });
+        expect(subAsset.save).toHaveBeenCalledTimes(1);
+        expect(reimport).toHaveBeenCalledWith('parent-uuid@6c48a');
+        expect(result).toBe(subAsset.meta.userData);
+    });
+
     it('renameAsset should delegate rename steps to filesystem bridge', async () => {
         const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
         const source = 'D:/project/assets/source.txt';

--- a/src/lib/assets/assets.ts
+++ b/src/lib/assets/assets.ts
@@ -1,4 +1,4 @@
-import type { AssetOperationOption, CreateAssetByTypeOptions, DeleteAssetOptions, IAssetFileSystemProvider, IAssetInfo, IAssetMeta, ISupportCreateType, QueryAssetsOption } from '../../core/assets/@types/public';
+import type { AssetOperationOption, CreateAssetByTypeOptions, DeleteAssetOptions, IAssetFileSystemProvider, IAssetInfo, IAssetMeta, ISupportCreateType, QueryAssetsOption, UpdateAssetMetaUserDataOptions } from '../../core/assets/@types/public';
 import type { CreateAssetOptions, IAssetConfig, IAssetDBInfo, ICreateMenuInfo, IUerDataConfigItem, QueryAssetType, ThumbnailInfo, ThumbnailSize } from '../../core/assets/@types/protected';
 import type { FilterPluginOptions, IPluginScriptInfo } from '../../core/scripting/interface';
 import { assetDBManager, assetManager } from '../../core/assets';
@@ -106,13 +106,6 @@ export async function queryAssetInfo(
  */
 export async function queryAssetMeta(urlOrUUIDOrPath: string): Promise<IAssetMeta<'unknown'> | null> {
     return await assetManager.queryAssetMeta(urlOrUUIDOrPath);
-}
-
-/**
- * Save Asset Metadata // 保存资源元数据
- */
-export async function saveAssetMeta(uuid: string, meta: IAssetMeta): Promise<void> {
-    return await assetManager.saveAssetMeta(uuid, meta);
 }
 
 /**
@@ -291,6 +284,19 @@ export async function updateAssetUserData(
     value: any
 ): Promise<any> {
     return await assetManager.updateUserData(urlOrUuidOrPath, path, value);
+}
+
+/**
+ * Update Asset Meta User Data // 更新资源 meta 中的用户数据
+ */
+export async function updateAssetMetaUserData(
+    parentUuid: string,
+    subMetaId: string | null | undefined,
+    path: string,
+    value: any,
+    options?: UpdateAssetMetaUserDataOptions
+): Promise<any> {
+    return await assetManager.updateMetaUserData(parentUuid, subMetaId, path, value, options);
 }
 
 /**

--- a/tests/assets-update-meta-user-data-api.test.ts
+++ b/tests/assets-update-meta-user-data-api.test.ts
@@ -1,0 +1,58 @@
+const mockUpdateMetaUserData = jest.fn();
+
+jest.mock('../src/core/assets', () => ({
+    assetDBManager: {},
+    assetManager: {
+        updateMetaUserData: (...args: unknown[]) => mockUpdateMetaUserData(...args),
+    },
+}));
+
+jest.mock('../src/api/decorator/decorator.js', () => jest.requireActual('../src/api/decorator/decorator'), { virtual: true });
+
+import { toolRegistry } from '../src/api/decorator/decorator.js';
+import { COMMON_STATUS } from '../src/api/base/schema-base';
+import { AssetsApi } from '../src/api/assets/assets';
+
+describe('assets-update-asset-meta-user-data api', () => {
+    beforeEach(() => {
+        mockUpdateMetaUserData.mockReset();
+    });
+
+    it('registers a tool with parentUuid, subMetaId, path, value, and options parameters', () => {
+        const tool = toolRegistry.get('assets-update-asset-meta-user-data');
+
+        expect(tool).toBeDefined();
+        expect(tool?.meta.paramSchemas.map((param) => param.name)).toEqual([
+            'parentUuid',
+            'subMetaId',
+            'path',
+            'value',
+            'options',
+        ]);
+    });
+
+    it('delegates to assetManager.updateMetaUserData and returns updated userData', async () => {
+        const updatedUserData = { minfilter: 'nearest' };
+        mockUpdateMetaUserData.mockResolvedValue(updatedUserData);
+
+        const result = await (new AssetsApi() as any).updateAssetMetaUserData(
+            'parent-uuid',
+            '6c48a',
+            'minfilter',
+            'nearest',
+            { reimport: true },
+        );
+
+        expect(result).toEqual({
+            code: COMMON_STATUS.SUCCESS,
+            data: updatedUserData,
+        });
+        expect(mockUpdateMetaUserData).toHaveBeenCalledWith(
+            'parent-uuid',
+            '6c48a',
+            'minfilter',
+            'nearest',
+            { reimport: true },
+        );
+    });
+});

--- a/tests/lib/assets-api.test.ts
+++ b/tests/lib/assets-api.test.ts
@@ -1,4 +1,3 @@
-import type { IAssetMeta } from '../../src/core/assets/@types/public';
 import { assetManager } from '../../src/core/assets';
 import * as Assets from '../../src/lib/assets/assets';
 
@@ -7,26 +6,30 @@ describe('lib assets api', () => {
         jest.restoreAllMocks();
     });
 
-    it('exposes saveAssetMeta and delegates to assetManager', async () => {
-        const meta = {
-            ver: 'ver',
-            importer: 'database',
-            imported: true,
-            uuid: 'test-uuid',
-            files: [],
-            subMetas: {},
-            userData: {},
-        } as IAssetMeta;
-        const spy = jest.spyOn(assetManager, 'saveAssetMeta').mockResolvedValue(undefined);
-        const saveAssetMeta = (Assets as { saveAssetMeta?: typeof assetManager.saveAssetMeta }).saveAssetMeta;
+    it('does not expose saveAssetMeta from the public lib API', () => {
+        expect((Assets as { saveAssetMeta?: unknown }).saveAssetMeta).toBeUndefined();
+    });
 
-        expect(saveAssetMeta).toEqual(expect.any(Function));
+    it('exposes updateAssetMetaUserData and delegates to assetManager', async () => {
+        const result = { minfilter: 'nearest' };
+        const spy = jest.spyOn(assetManager as any, 'updateMetaUserData').mockResolvedValue(result);
+        const updateAssetMetaUserData = (Assets as {
+            updateAssetMetaUserData?: (
+                parentUuid: string,
+                subMetaId: string | null,
+                path: string,
+                value: unknown,
+                options?: { reimport?: boolean }
+            ) => Promise<unknown>;
+        }).updateAssetMetaUserData;
 
-        if (!saveAssetMeta) {
-            throw new Error('saveAssetMeta is not exposed from lib/assets/assets');
+        expect(updateAssetMetaUserData).toEqual(expect.any(Function));
+
+        if (!updateAssetMetaUserData) {
+            throw new Error('updateAssetMetaUserData is not exposed from lib/assets/assets');
         }
 
-        await expect(saveAssetMeta('test-uuid', meta)).resolves.toBeUndefined();
-        expect(spy).toHaveBeenCalledWith('test-uuid', meta);
+        await expect(updateAssetMetaUserData('parent-uuid', '6c48a', 'minfilter', 'nearest', { reimport: true })).resolves.toBe(result);
+        expect(spy).toHaveBeenCalledWith('parent-uuid', '6c48a', 'minfilter', 'nearest', { reimport: true });
     });
 });


### PR DESCRIPTION
### 变更说明

- 移除 public lib API 中的 `saveAssetMeta` 暴露, 避免修改meta一些不能修改的数据。
- 新增 `updateAssetMetaUserData(parentUuid, subMetaId, path, value, options?)`，支持父资源和子资源 meta.userData 更新。
- 默认只保存 `.meta`，仅在 `options.reimport === true` 时触发 reimport。
- 新增 Pink API Lab 工具：`assets-update-asset-meta-user-data`。
- 修正 tool 参数 schema 顺序，保证 API Lab 参数按声明顺序展示。