### PR TITLE
[break] chore(types): refresh cocos-cli-types snapshot

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -299,7 +299,7 @@ export declare interface IAssetConfig {
     userDataConfig?: Record<string, IUerDataConfigItem>;
 }
 export declare interface IAssetDBInfo extends AssetDBOptions_2 {
-    state: 'none' | 'start' | 'startup' | 'refresh'; 
+    state: 'none' | 'start' | 'startup' | 'refresh';
     visible: boolean;
     preImportExtList: string[];
 }
@@ -316,36 +316,36 @@ export declare interface IAssetFileSystemProvider {
     copy?(sourcePath: string, destinationPath: string, options?: IAssetRenameOptions): Promise<void> | void;
 }
 export declare interface IAssetInfo {
-    name: string; 
-    source: string; 
-    loadUrl: string; 
-    url: string; 
-    file: string; 
-    uuid: string; 
-    importer: AssetHandlerType; 
-    imported: boolean; 
-    invalid: boolean; 
-    type: IAssetType; 
-    isDirectory: boolean; 
-    library: { [key: string]: string }; 
-    isBundle?: boolean; 
-    displayName?: string; 
-    readonly?: boolean; 
-    visible?: boolean; 
-    subAssets?: { [key: string]: IAssetInfo }; 
+    name: string;
+    source: string;
+    loadUrl: string;
+    url: string;
+    file: string;
+    uuid: string;
+    importer: AssetHandlerType;
+    imported: boolean;
+    invalid: boolean;
+    type: IAssetType;
+    isDirectory: boolean;
+    library: { [key: string]: string };
+    isBundle?: boolean;
+    displayName?: string;
+    readonly?: boolean;
+    visible?: boolean;
+    subAssets?: { [key: string]: IAssetInfo };
     instantiation?: string;
-    redirect?: IRedirectInfo; 
+    redirect?: IRedirectInfo;
     meta?: IAssetMeta,
     parent?: {
         source: string;
         library: { [key: string]: string };
         uuid: string;
     };
-    extends?: string[]; 
-    mtime?: number; 
-    depends?: string[]; 
-    dependeds?: string[]; 
-    temp?: string; 
+    extends?: string[];
+    mtime?: number;
+    depends?: string[];
+    dependeds?: string[];
+    temp?: string;
 }
 export declare interface IAssetMeta<T extends ISupportCreateType | 'unknown' = 'unknown'> {
     ver: string;
@@ -379,28 +379,28 @@ export declare interface IAssetRenameOptions extends IAssetOperationOptionsBase 
 }
 export declare type IAssetType =
 | ISupportCreateCCType
-| 'cc.Asset'               
-| 'cce.Database'           
-| 'cce.EffectHeader'       
-| 'cc.VideoClip'           
-| 'cc.TiledMapAsset'       
-| 'cc.TTFFont'             
-| 'cc.Texture2D'           
-| 'cc.SpriteFrame'         
-| 'cc.ImageAsset'          
-| 'cc.TextAsset'           
-| 'cc.JsonAsset'           
-| 'cc.AudioClip'           
-| 'cc.BitmapFont'          
-| 'cc.BufferAsset'         
-| 'cc.ParticleAsset'       
-| 'cc.RenderPipeline'     
-| 'cc.Skeleton'            
-| 'cc.Mesh'                
-| 'sp.SkeletonData'        
-| 'dragonBones.DragonBonesAsset'      
-| 'dragonBones.DragonBonesAtlasAsset' 
-| 'RenderStage'            
+| 'cc.Asset'
+| 'cce.Database'
+| 'cce.EffectHeader'
+| 'cc.VideoClip'
+| 'cc.TiledMapAsset'
+| 'cc.TTFFont'
+| 'cc.Texture2D'
+| 'cc.SpriteFrame'
+| 'cc.ImageAsset'
+| 'cc.TextAsset'
+| 'cc.JsonAsset'
+| 'cc.AudioClip'
+| 'cc.BitmapFont'
+| 'cc.BufferAsset'
+| 'cc.ParticleAsset'
+| 'cc.RenderPipeline'
+| 'cc.Skeleton'
+| 'cc.Mesh'
+| 'sp.SkeletonData'
+| 'dragonBones.DragonBonesAsset'
+| 'dragonBones.DragonBonesAtlasAsset'
+| 'RenderStage'
 | 'RenderFlow';
 export declare interface IAssetWriteFileOptions extends IAssetOperationOptionsBase {
     create?: boolean;
@@ -451,24 +451,24 @@ export declare interface IRedirectInfo {
     uuid: string;
 }
 export declare type ISupportCreateCCType =
-| 'cc.AnimationClip'        
-| 'cc.Script'               
-| 'cc.SpriteAtlas'          
-| 'cc.EffectAsset'          
-| 'cc.SceneAsset'           
-| 'cc.Prefab'               
-| 'cc.Material'             
-| 'cc.TextureCube'          
-| 'cc.TerrainAsset'         
-| 'cc.PhysicsMaterial'      
-| 'cc.LabelAtlas'           
-| 'cc.RenderTexture'        
-| 'cc.AnimationGraph'       
-| 'cc.AnimationMask'        
+| 'cc.AnimationClip'
+| 'cc.Script'
+| 'cc.SpriteAtlas'
+| 'cc.EffectAsset'
+| 'cc.SceneAsset'
+| 'cc.Prefab'
+| 'cc.Material'
+| 'cc.TextureCube'
+| 'cc.TerrainAsset'
+| 'cc.PhysicsMaterial'
+| 'cc.LabelAtlas'
+| 'cc.RenderTexture'
+| 'cc.AnimationGraph'
+| 'cc.AnimationMask'
 | 'cc.AnimationGraphVariant';
 export declare type ISupportCreateType = typeof SUPPORT_CREATE_TYPES[number];
 export declare interface IUerDataConfigItem {
-    key?: string; 
+    key?: string;
     label?: string;
     description?: string;
     default?: any;
@@ -628,11 +628,11 @@ export declare function queryAssetInfo(urlOrUUIDOrPath: string, dataKeys?: strin
 export declare function queryAssetInfos(options?: QueryAssetsOption): Promise<IAssetInfo[]>;
 export declare function queryAssetMeta(urlOrUUIDOrPath: string): Promise<IAssetMeta<'unknown'> | null>;
 export declare interface QueryAssetsOption {
-    ccType?: string | string[], 
-    isBundle?: boolean, 
-    importer?: string | string[], 
-    pattern?: string, 
-    extname?: string | string[], 
+    ccType?: string | string[],
+    isBundle?: boolean,
+    importer?: string | string[],
+    pattern?: string,
+    extname?: string | string[],
     userData?: Record<string, boolean | string | number>;
     type?: string;
 }
@@ -758,7 +758,7 @@ export declare interface TextureCubeAssetUserData extends TextureBaseAssetUserDa
 }
 export declare interface ThumbnailInfo {
     type: 'icon' | 'image',
-    value: string; 
+    value: string;
 }
 export declare type ThumbnailSize = 'large' | 'small' | 'middle' | 'origin';
 export declare function updateAssetUserData(urlOrUuidOrPath: string, path: string, value: any): Promise<any>;
@@ -1572,14 +1572,14 @@ export declare interface EmittedChunk {
 export declare type EmittedFile = EmittedAsset | EmittedChunk;
 export declare interface EngineInfo {
     typescript: {
-        type: 'builtin' | 'custom'; 
-        builtin: string, 
-        path: string; 
+        type: 'builtin' | 'custom';
+        builtin: string,
+        path: string;
     },
     native: {
-        type: 'builtin' | 'custom'; 
-        builtin: string, 
-        path: string; 
+        type: 'builtin' | 'custom';
+        builtin: string,
+        path: string;
     },
     tmpDir: string;
     version: string;
@@ -1818,36 +1818,36 @@ export declare interface IAssetInfo extends IAssetInfo_2 {
     mtime: number;
 }
 export declare interface IAssetInfo_2 {
-    name: string; 
-    source: string; 
-    loadUrl: string; 
-    url: string; 
-    file: string; 
-    uuid: string; 
-    importer: AssetHandlerType; 
-    imported: boolean; 
-    invalid: boolean; 
-    type: IAssetType; 
-    isDirectory: boolean; 
-    library: { [key: string]: string }; 
-    isBundle?: boolean; 
-    displayName?: string; 
-    readonly?: boolean; 
-    visible?: boolean; 
-    subAssets?: { [key: string]: IAssetInfo_2 }; 
+    name: string;
+    source: string;
+    loadUrl: string;
+    url: string;
+    file: string;
+    uuid: string;
+    importer: AssetHandlerType;
+    imported: boolean;
+    invalid: boolean;
+    type: IAssetType;
+    isDirectory: boolean;
+    library: { [key: string]: string };
+    isBundle?: boolean;
+    displayName?: string;
+    readonly?: boolean;
+    visible?: boolean;
+    subAssets?: { [key: string]: IAssetInfo_2 };
     instantiation?: string;
-    redirect?: IRedirectInfo; 
+    redirect?: IRedirectInfo;
     meta?: IAssetMeta,
     parent?: {
         source: string;
         library: { [key: string]: string };
         uuid: string;
     };
-    extends?: string[]; 
-    mtime?: number; 
-    depends?: string[]; 
-    dependeds?: string[]; 
-    temp?: string; 
+    extends?: string[];
+    mtime?: number;
+    depends?: string[];
+    dependeds?: string[];
+    temp?: string;
 }
 export declare type IAssetInfoMap = Record<UUID, IAssetInfo>;
 export declare interface IAssetMeta<T extends ISupportCreateType | 'unknown' = 'unknown'> {
@@ -1877,28 +1877,28 @@ export declare interface IAssetPathInfo extends IAssetPathBase {
 }
 export declare type IAssetType =
 | ISupportCreateCCType
-| 'cc.Asset'               
-| 'cce.Database'           
-| 'cce.EffectHeader'       
-| 'cc.VideoClip'           
-| 'cc.TiledMapAsset'       
-| 'cc.TTFFont'             
-| 'cc.Texture2D'           
-| 'cc.SpriteFrame'         
-| 'cc.ImageAsset'          
-| 'cc.TextAsset'           
-| 'cc.JsonAsset'           
-| 'cc.AudioClip'           
-| 'cc.BitmapFont'          
-| 'cc.BufferAsset'         
-| 'cc.ParticleAsset'       
-| 'cc.RenderPipeline'     
-| 'cc.Skeleton'            
-| 'cc.Mesh'                
-| 'sp.SkeletonData'        
-| 'dragonBones.DragonBonesAsset'      
-| 'dragonBones.DragonBonesAtlasAsset' 
-| 'RenderStage'            
+| 'cc.Asset'
+| 'cce.Database'
+| 'cce.EffectHeader'
+| 'cc.VideoClip'
+| 'cc.TiledMapAsset'
+| 'cc.TTFFont'
+| 'cc.Texture2D'
+| 'cc.SpriteFrame'
+| 'cc.ImageAsset'
+| 'cc.TextAsset'
+| 'cc.JsonAsset'
+| 'cc.AudioClip'
+| 'cc.BitmapFont'
+| 'cc.BufferAsset'
+| 'cc.ParticleAsset'
+| 'cc.RenderPipeline'
+| 'cc.Skeleton'
+| 'cc.Mesh'
+| 'sp.SkeletonData'
+| 'dragonBones.DragonBonesAsset'
+| 'dragonBones.DragonBonesAtlasAsset'
+| 'RenderStage'
 | 'RenderFlow';
 export declare type IASTCQuality = 'veryfast' | 'fast' | 'medium' | 'thorough' | 'exhaustive';
 export declare interface IAtlasInfo {
@@ -3062,14 +3062,14 @@ export declare interface IPhysicsConfig {
     };
 }
 export declare interface IPhysicsConfig_2 {
-    gravity: IVec3Like_2; 
-    allowSleep: boolean; 
-    sleepThreshold: number; 
-    autoSimulation: boolean; 
-    fixedTimeStep: number; 
-    maxSubSteps: number; 
-    defaultMaterial?: string; 
-    useNodeChains: boolean; 
+    gravity: IVec3Like_2;
+    allowSleep: boolean;
+    sleepThreshold: number;
+    autoSimulation: boolean;
+    fixedTimeStep: number;
+    maxSubSteps: number;
+    defaultMaterial?: string;
+    useNodeChains: boolean;
     collisionMatrix: ICollisionMatrix_2;
     physicsEngine: string;
     physX?: {
@@ -3340,20 +3340,20 @@ export declare interface ISuffixMap {
     import: Record<string, string[]>;
 }
 export declare type ISupportCreateCCType =
-| 'cc.AnimationClip'        
-| 'cc.Script'               
-| 'cc.SpriteAtlas'          
-| 'cc.EffectAsset'          
-| 'cc.SceneAsset'           
-| 'cc.Prefab'               
-| 'cc.Material'             
-| 'cc.TextureCube'          
-| 'cc.TerrainAsset'         
-| 'cc.PhysicsMaterial'      
-| 'cc.LabelAtlas'           
-| 'cc.RenderTexture'        
-| 'cc.AnimationGraph'       
-| 'cc.AnimationMask'        
+| 'cc.AnimationClip'
+| 'cc.Script'
+| 'cc.SpriteAtlas'
+| 'cc.EffectAsset'
+| 'cc.SceneAsset'
+| 'cc.Prefab'
+| 'cc.Material'
+| 'cc.TextureCube'
+| 'cc.TerrainAsset'
+| 'cc.PhysicsMaterial'
+| 'cc.LabelAtlas'
+| 'cc.RenderTexture'
+| 'cc.AnimationGraph'
+| 'cc.AnimationMask'
 | 'cc.AnimationGraphVariant';
 export declare type ISupportCreateType = typeof SUPPORT_CREATE_TYPES[number];
 export declare interface ISupportFormat {
@@ -5294,36 +5294,36 @@ export declare interface IApplyPrefabChangesParams {
     nodePath: string;
 }
 export declare interface IAssetInfo {
-    name: string; 
-    source: string; 
-    loadUrl: string; 
-    url: string; 
-    file: string; 
-    uuid: string; 
-    importer: AssetHandlerType; 
-    imported: boolean; 
-    invalid: boolean; 
-    type: IAssetType; 
-    isDirectory: boolean; 
-    library: { [key: string]: string }; 
-    isBundle?: boolean; 
-    displayName?: string; 
-    readonly?: boolean; 
-    visible?: boolean; 
-    subAssets?: { [key: string]: IAssetInfo }; 
+    name: string;
+    source: string;
+    loadUrl: string;
+    url: string;
+    file: string;
+    uuid: string;
+    importer: AssetHandlerType;
+    imported: boolean;
+    invalid: boolean;
+    type: IAssetType;
+    isDirectory: boolean;
+    library: { [key: string]: string };
+    isBundle?: boolean;
+    displayName?: string;
+    readonly?: boolean;
+    visible?: boolean;
+    subAssets?: { [key: string]: IAssetInfo };
     instantiation?: string;
-    redirect?: IRedirectInfo; 
+    redirect?: IRedirectInfo;
     meta?: IAssetMeta,
     parent?: {
         source: string;
         library: { [key: string]: string };
         uuid: string;
     };
-    extends?: string[]; 
-    mtime?: number; 
-    depends?: string[]; 
-    dependeds?: string[]; 
-    temp?: string; 
+    extends?: string[];
+    mtime?: number;
+    depends?: string[];
+    dependeds?: string[];
+    temp?: string;
 }
 export declare interface IAssetMeta<T extends ISupportCreateType | 'unknown' = 'unknown'> {
     ver: string;
@@ -5345,28 +5345,28 @@ export declare interface IAssetService extends IServiceEvents {
 }
 export declare type IAssetType =
 | ISupportCreateCCType
-| 'cc.Asset'               
-| 'cce.Database'           
-| 'cce.EffectHeader'       
-| 'cc.VideoClip'           
-| 'cc.TiledMapAsset'       
-| 'cc.TTFFont'             
-| 'cc.Texture2D'           
-| 'cc.SpriteFrame'         
-| 'cc.ImageAsset'          
-| 'cc.TextAsset'           
-| 'cc.JsonAsset'           
-| 'cc.AudioClip'           
-| 'cc.BitmapFont'          
-| 'cc.BufferAsset'         
-| 'cc.ParticleAsset'       
-| 'cc.RenderPipeline'     
-| 'cc.Skeleton'            
-| 'cc.Mesh'                
-| 'sp.SkeletonData'        
-| 'dragonBones.DragonBonesAsset'      
-| 'dragonBones.DragonBonesAtlasAsset' 
-| 'RenderStage'            
+| 'cc.Asset'
+| 'cce.Database'
+| 'cce.EffectHeader'
+| 'cc.VideoClip'
+| 'cc.TiledMapAsset'
+| 'cc.TTFFont'
+| 'cc.Texture2D'
+| 'cc.SpriteFrame'
+| 'cc.ImageAsset'
+| 'cc.TextAsset'
+| 'cc.JsonAsset'
+| 'cc.AudioClip'
+| 'cc.BitmapFont'
+| 'cc.BufferAsset'
+| 'cc.ParticleAsset'
+| 'cc.RenderPipeline'
+| 'cc.Skeleton'
+| 'cc.Mesh'
+| 'sp.SkeletonData'
+| 'dragonBones.DragonBonesAsset'
+| 'dragonBones.DragonBonesAtlasAsset'
+| 'RenderStage'
 | 'RenderFlow';
 export declare interface IBaseCreateNodeParams {
     path: string;
@@ -5497,10 +5497,6 @@ export declare interface ICreatePrefabFromNodeParams {
     overwrite?: boolean;
 }
 export declare type ICreateType = typeof CREATE_TYPES[number];
-export declare interface ICustomLayerConfig {
-    name: string;
-    value: number;
-}
 export declare interface ICustomLayerConfig {
     name: string;
     value: number;
@@ -5745,49 +5741,49 @@ export declare interface IPrefabStateInfo {
 }
 export declare interface IProperty {
     value: { [key: string]: IPropertyValueType } | IPropertyValueType;
-    default?: any; 
+    default?: any;
     values?: ({ [key: string]: IPropertyValueType } | IPropertyValueType)[];
     lock?: { [key in keyof Vec4]?: IPropertyLock };
     cid?: string;
     type?: string;
-    ui?: { name: string; data?: any }; 
+    ui?: { name: string; data?: any };
     readonly?: boolean;
     visible?: boolean;
     name?: string;
-    elementTypeData?: IProperty; 
-    path: string; 
+    elementTypeData?: IProperty;
+    path: string;
     isArray?: boolean;
     invalid?: boolean;
-    extends?: string[]; 
-    displayName?: string; 
-    displayOrder?: number; 
-    help?: string; 
-    group?: IPropertyGroupOptions; 
-    tooltip?: string; 
-    editor?: any; 
-    animatable?: boolean; 
-    radioGroup?: boolean; 
-    enumList?: any[]; 
+    extends?: string[];
+    displayName?: string;
+    displayOrder?: number;
+    help?: string;
+    group?: IPropertyGroupOptions;
+    tooltip?: string;
+    editor?: any;
+    animatable?: boolean;
+    radioGroup?: boolean;
+    enumList?: any[];
     bitmaskList?: any[];
-    min?: number; 
-    max?: number; 
-    step?: number; 
-    slide?: boolean; 
-    unit?: string; 
-    radian?: boolean; 
-    multiline?: boolean; 
-    optionalTypes?: string[]; 
-    userData?: { [key: string]: any }; 
+    min?: number;
+    max?: number;
+    step?: number;
+    slide?: boolean;
+    unit?: string;
+    radian?: boolean;
+    multiline?: boolean;
+    optionalTypes?: string[];
+    userData?: { [key: string]: any };
 }
 export declare interface IPropertyGroupOptions {
-    id: string 
+    id: string
     name: string,
-    displayOrder: number, 
-    style: string 
+    displayOrder: number,
+    style: string
 }
-export declare type IPropertyLock = { 
-    default: number; 
-    message: string 
+export declare type IPropertyLock = {
+    default: number;
+    message: string
 };
 export declare type IPropertyValueType = IProperty | IProperty[] | null | undefined | number | boolean | string | Vec4 | Vec3 | Vec2 | Mat4 | any | Array<unknown>
 export declare interface IQueryClassesOptions {
@@ -5970,20 +5966,20 @@ export declare interface ISetPropertyOptions {
     record?: boolean;
 }
 export declare type ISupportCreateCCType =
-| 'cc.AnimationClip'        
-| 'cc.Script'               
-| 'cc.SpriteAtlas'          
-| 'cc.EffectAsset'          
-| 'cc.SceneAsset'           
-| 'cc.Prefab'               
-| 'cc.Material'             
-| 'cc.TextureCube'          
-| 'cc.TerrainAsset'         
-| 'cc.PhysicsMaterial'      
-| 'cc.LabelAtlas'           
-| 'cc.RenderTexture'        
-| 'cc.AnimationGraph'       
-| 'cc.AnimationMask'        
+| 'cc.AnimationClip'
+| 'cc.Script'
+| 'cc.SpriteAtlas'
+| 'cc.EffectAsset'
+| 'cc.SceneAsset'
+| 'cc.Prefab'
+| 'cc.Material'
+| 'cc.TextureCube'
+| 'cc.TerrainAsset'
+| 'cc.PhysicsMaterial'
+| 'cc.LabelAtlas'
+| 'cc.RenderTexture'
+| 'cc.AnimationGraph'
+| 'cc.AnimationMask'
 | 'cc.AnimationGraphVariant';
 export declare type ISupportCreateType = typeof SUPPORT_CREATE_TYPES[number];
 export declare interface ITargetOverrideInfo {
@@ -6493,14 +6489,14 @@ export declare type CCEModuleMap = {
 };
 export declare interface EngineInfo {
     typescript: {
-        type: 'builtin' | 'custom'; 
-        builtin: string, 
-        path: string; 
+        type: 'builtin' | 'custom';
+        builtin: string,
+        path: string;
     },
     native: {
-        type: 'builtin' | 'custom'; 
-        builtin: string, 
-        path: string; 
+        type: 'builtin' | 'custom';
+        builtin: string,
+        path: string;
     },
     tmpDir: string;
     version: string;
@@ -6548,8 +6544,8 @@ export declare interface IDesignResolution {
 }
 export declare interface IDisplayModuleCache {
     _value: boolean;
-    _option?: string; 
-    _flags?: IFlags_2; 
+    _option?: string;
+    _flags?: IFlags_2;
 }
 export declare interface IDisplayModuleItem extends IFeatureItem {
     _value: boolean;
@@ -6622,14 +6618,14 @@ export declare type IModules = Record<string, IModuleItem>;
 export declare function init(projectPath: string): Promise<void>;
 export declare function initEngine(enginePath: string, projectPath: string, serverURL?: string): Promise<void>;
 export declare interface IPhysicsConfig {
-    gravity: IVec3Like; 
-    allowSleep: boolean; 
-    sleepThreshold: number; 
-    autoSimulation: boolean; 
-    fixedTimeStep: number; 
-    maxSubSteps: number; 
-    defaultMaterial?: string; 
-    useNodeChains: boolean; 
+    gravity: IVec3Like;
+    allowSleep: boolean;
+    sleepThreshold: number;
+    autoSimulation: boolean;
+    fixedTimeStep: number;
+    maxSubSteps: number;
+    defaultMaterial?: string;
+    useNodeChains: boolean;
     collisionMatrix: ICollisionMatrix;
     physicsEngine: string;
     physX?: {
@@ -6640,10 +6636,10 @@ export declare interface IPhysicsConfig {
     };
 }
 export declare interface IPhysicsMaterial {
-    friction: number; 
-    rollingFriction: number; 
-    spinningFriction: number; 
-    restitution: number; 
+    friction: number;
+    rollingFriction: number;
+    spinningFriction: number;
+    restitution: number;
 }
 export declare interface ISplashBackgroundColor {
     x: number;
@@ -6702,15 +6698,11 @@ export { }
 exports[`DTS API compatibility index.d.ts should match snapshot 1`] = `
 "import { __private } from 'cc';
 import { ChunkInfo } from '@cocos/creator-programming-quick-pack/lib/loader';
-import type { Component } from 'cc';
 import { EventEmitter } from 'events';
 import { default as i18n_2 } from 'i18next';
 import { NextFunction } from 'express';
-import type { Node as Node_2 } from 'cc';
 import { Request as Request_2 } from 'express';
 import { Response as Response_2 } from 'express';
-import type { Scene as Scene_2 } from 'cc';
-import type { Vec3 as Vec3_2 } from 'cc';
 export declare interface AnimationClipAssetUserData {
     name: string;
 }
@@ -6999,7 +6991,6 @@ export declare namespace Configuration {
     }
 }
 export declare type ConfigurationScope = 'default' | 'project';
-export declare const CREATE_TYPES: readonly ["scene", "prefab"];
 export declare function createAsset(options: CreateAssetOptions): Promise<IAssetInfo>;
 export declare function createAssetByType(ccType: ISupportCreateType, dirOrUrl: string, baseName: string, options?: CreateAssetByTypeOptions): Promise<IAssetInfo>;
 export declare interface CreateAssetByTypeOptions extends AssetOperationOption {
@@ -7082,14 +7073,14 @@ export declare namespace Engine {
 }
 export declare interface EngineInfo {
     typescript: {
-        type: 'builtin' | 'custom'; 
-        builtin: string, 
-        path: string; 
+        type: 'builtin' | 'custom';
+        builtin: string,
+        path: string;
     },
     native: {
-        type: 'builtin' | 'custom'; 
-        builtin: string, 
-        path: string; 
+        type: 'builtin' | 'custom';
+        builtin: string,
+        path: string;
     },
     tmpDir: string;
     version: string;
@@ -7155,19 +7146,6 @@ export declare function getStatus_2(): {
     url?: string;
 };
 export declare function getUrl(): string | undefined;
-export declare class GlobalEventManager {
-    on<TEvents extends Record<string, any>>(event: keyof TEvents, listener: TEvents[keyof TEvents] extends void ? () => void : (payload: TEvents[keyof TEvents]) => void): void;
-    on(event: string, listener: (...args: any[]) => void): void;
-    once<TEvents extends Record<string, any>>(event: keyof TEvents, listener: TEvents[keyof TEvents] extends void ? () => void : (payload: TEvents[keyof TEvents]) => void): void;
-    once(event: string, listener: (...args: any[]) => void): void;
-    off<TEvents extends Record<string, any>>(event: keyof TEvents, listener: TEvents[keyof TEvents] extends void ? () => void : (payload: TEvents[keyof TEvents]) => void): void;
-    off(event: string, listener: (...args: any[]) => void): void;
-    emit<TEvents extends Record<string, any>>(event: keyof TEvents, ...args: TEvents[keyof TEvents]): void;
-    emit(event: string, ...args: any[]): void;
-    broadcast<TEvents extends Record<string, any>>(event: keyof TEvents, ...args: TEvents[keyof TEvents]): void;
-    broadcast(event: string, ...args: any[]): void;
-    clear(event?: string): void;
-}
 export declare interface GltfAnimationAssetUserData {
     gltfIndex: number;
     events: Array<{
@@ -7246,13 +7224,6 @@ export declare namespace i18n {
         i18n_2 as default
     }
 }
-export declare interface IAddComponentOptions {
-    nodePath: string;
-    component: string;
-}
-export declare interface IApplyPrefabChangesParams {
-    nodePath: string;
-}
 export declare interface IAssetConfig {
     displayName?: string;
     description?: string;
@@ -7260,7 +7231,7 @@ export declare interface IAssetConfig {
     userDataConfig?: Record<string, IUerDataConfigItem>;
 }
 export declare interface IAssetDBInfo extends AssetDBOptions {
-    state: 'none' | 'start' | 'startup' | 'refresh'; 
+    state: 'none' | 'start' | 'startup' | 'refresh';
     visible: boolean;
     preImportExtList: string[];
 }
@@ -7277,36 +7248,36 @@ export declare interface IAssetFileSystemProvider {
     copy?(sourcePath: string, destinationPath: string, options?: IAssetRenameOptions): Promise<void> | void;
 }
 export declare interface IAssetInfo {
-    name: string; 
-    source: string; 
-    loadUrl: string; 
-    url: string; 
-    file: string; 
-    uuid: string; 
-    importer: AssetHandlerType; 
-    imported: boolean; 
-    invalid: boolean; 
-    type: IAssetType; 
-    isDirectory: boolean; 
-    library: { [key: string]: string }; 
-    isBundle?: boolean; 
-    displayName?: string; 
-    readonly?: boolean; 
-    visible?: boolean; 
-    subAssets?: { [key: string]: IAssetInfo }; 
+    name: string;
+    source: string;
+    loadUrl: string;
+    url: string;
+    file: string;
+    uuid: string;
+    importer: AssetHandlerType;
+    imported: boolean;
+    invalid: boolean;
+    type: IAssetType;
+    isDirectory: boolean;
+    library: { [key: string]: string };
+    isBundle?: boolean;
+    displayName?: string;
+    readonly?: boolean;
+    visible?: boolean;
+    subAssets?: { [key: string]: IAssetInfo };
     instantiation?: string;
-    redirect?: IRedirectInfo; 
+    redirect?: IRedirectInfo;
     meta?: IAssetMeta,
     parent?: {
         source: string;
         library: { [key: string]: string };
         uuid: string;
     };
-    extends?: string[]; 
-    mtime?: number; 
-    depends?: string[]; 
-    dependeds?: string[]; 
-    temp?: string; 
+    extends?: string[];
+    mtime?: number;
+    depends?: string[];
+    dependeds?: string[];
+    temp?: string;
 }
 export declare interface IAssetMeta<T extends ISupportCreateType | 'unknown' = 'unknown'> {
     ver: string;
@@ -7338,34 +7309,30 @@ export declare type IAssetOperationOrigin = 'direct-op' | 'watcher';
 export declare interface IAssetRenameOptions extends IAssetOperationOptionsBase {
     overwrite?: boolean;
 }
-export declare interface IAssetService extends IServiceEvents {
-    assetChanged(uuid: string): Promise<void>;
-    assetDeleted(uuid: string): Promise<void>;
-}
 export declare type IAssetType =
 | ISupportCreateCCType
-| 'cc.Asset'               
-| 'cce.Database'           
-| 'cce.EffectHeader'       
-| 'cc.VideoClip'           
-| 'cc.TiledMapAsset'       
-| 'cc.TTFFont'             
-| 'cc.Texture2D'           
-| 'cc.SpriteFrame'         
-| 'cc.ImageAsset'          
-| 'cc.TextAsset'           
-| 'cc.JsonAsset'           
-| 'cc.AudioClip'           
-| 'cc.BitmapFont'          
-| 'cc.BufferAsset'         
-| 'cc.ParticleAsset'       
-| 'cc.RenderPipeline'     
-| 'cc.Skeleton'            
-| 'cc.Mesh'                
-| 'sp.SkeletonData'        
-| 'dragonBones.DragonBonesAsset'      
-| 'dragonBones.DragonBonesAtlasAsset' 
-| 'RenderStage'            
+| 'cc.Asset'
+| 'cce.Database'
+| 'cce.EffectHeader'
+| 'cc.VideoClip'
+| 'cc.TiledMapAsset'
+| 'cc.TTFFont'
+| 'cc.Texture2D'
+| 'cc.SpriteFrame'
+| 'cc.ImageAsset'
+| 'cc.TextAsset'
+| 'cc.JsonAsset'
+| 'cc.AudioClip'
+| 'cc.BitmapFont'
+| 'cc.BufferAsset'
+| 'cc.ParticleAsset'
+| 'cc.RenderPipeline'
+| 'cc.Skeleton'
+| 'cc.Mesh'
+| 'sp.SkeletonData'
+| 'dragonBones.DragonBonesAsset'
+| 'dragonBones.DragonBonesAtlasAsset'
+| 'RenderStage'
 | 'RenderFlow';
 export declare interface IAssetWriteFileOptions extends IAssetOperationOptionsBase {
     create?: boolean;
@@ -7381,86 +7348,9 @@ export declare interface IBaseConfiguration extends EventEmitterMethods {
     remove(key: string, scope?: ConfigurationScope): Promise<boolean>;
     save(): Promise<boolean>;
 }
-export declare interface IBaseCreateNodeParams {
-    path: string;
-    name?: string;
-    workMode?: '2d' | '3d';
-    position?: IVec3;
-    keepWorldTransform?: boolean;
-    canvasRequired?: boolean;
-    unlinkPrefab?: boolean;
-}
-export declare interface IBaseIdentifier {
-    assetName: string;
-    assetUuid: string;
-    assetUrl: string;
-    assetType: string;
-}
-export declare interface ICameraConfig {
-    color: number[];
-    fov: number;
-    far: number;
-    near: number;
-    wheelSpeed: number;
-    wanderSpeed: number;
-    enableAcceleration: boolean;
-    aperture: number;
-    shutter: number;
-    iso: number;
-}
-export declare interface ICameraService {
-    init(): void;
-    initFromConfig(): Promise<void>;
-    is2D: boolean;
-    focus(nodes?: string[] | null, editorCameraInfo?: any, immediate?: boolean): void;
-    defaultFocus(uuid: string): void;
-    rotateCameraToDir(dir: Vec3_2, rotateByViewDist: boolean): void;
-    changeProjection(): void;
-    setGridVisible(value: boolean): void;
-    isGridVisible(): boolean;
-    setCameraProperty(options: any): void;
-    resetCameraProperty(): void;
-    queryConfig(): ICameraConfig;
-    updateConfig(config: Partial<ICameraConfig>): void;
-    getCameraFov(): number;
-    zoomUp(): void;
-    zoomDown(): void;
-    zoomReset(): void;
-    alignNodeToSceneView(nodes: string[]): void;
-    alignSceneViewToNode(nodes: string[]): void;
-    setGridColor(color: number[]): void;
-    setOriginAxes2D(config: IOriginAxesConfig): void;
-    setOriginAxes3D(config: IOriginAxesConfig): void;
-    onUpdate(deltaTime: number): void;
-}
-export declare interface IChangeNodeLockParams {
-    paths: string[];
-    locked: boolean;
-    loop?: boolean;
-}
-export declare interface IChangeNodeOptions {
-    source?: 'editor' | 'undo' | 'engine';
-    type?: NodeEventType;
-    propPath?: string;
-    index?: number;
-    record?: boolean;
-    dumpImmediately?: boolean;
-}
 export declare interface IChunkContent {
     skeleton: null | string;
     clips: string[];
-}
-export declare interface ICLI {
-    Scene: IServiceManager;
-    SceneEvents: GlobalEventManager;
-}
-export declare interface IClipboardState {
-    type: 'cut' | 'copy' | 'none';
-    paths: string[];
-}
-export declare interface ICloseOptions {
-    urlOrUUID?: string;
-    save?: boolean;
 }
 export declare interface ICocosConfigurationNode {
     id: string;
@@ -7488,48 +7378,8 @@ export declare interface ICocosConfigurationPropertySchema {
 export declare interface ICollisionMatrix {
     [x: string]: number;
 }
-export declare interface IComponent extends IProperty {
-    value: {
-        enabled: IPropertyValueType;
-        uuid: IPropertyValueType;
-        name: IPropertyValueType;
-    } & Record<string, IPropertyValueType>;
-    mountedRoot?: string;
-    component_path?: string;
-}
-export declare interface IComponentService extends IServiceEvents {
-    add(params: IAddComponentOptions): Promise<IComponent>;
-    remove(params: IRemoveComponentOptions): Promise<boolean>;
-    setProperty(params: ISetPropertyOptions): Promise<boolean>;
-    query(params: IQueryComponentOptions | string): Promise<IComponent | null>;
-    queryAll(): Promise<string[]>;
-    reset(params: IQueryComponentOptions): Promise<boolean>;
-    queryClasses(options?: IQueryClassesOptions): Promise<{
-        name: string;
-    }[]>;
-    queryFunctionOfNode(path: string): Promise<any>;
-    queryComponents(): Promise<Array<{
-        name: string;
-        cid: string;
-        path: string;
-    }>>;
-    executeMethod(options: IExecuteComponentMethodOptions): Promise<any>;
-    hasScript(name: string): Promise<boolean>;
-    getPathByUuid(uuid: string): string;
-    init(): void;
-    unregisterCompMgrEvents(): void;
-}
 export declare interface IConfiguration {
     [key: string]: any;
-}
-export declare interface ICopyParams {
-    paths: string[];
-}
-export declare interface ICreateByAssetParams extends IBaseCreateNodeParams {
-    dbURL: string;
-}
-export declare interface ICreateByNodeTypeParams extends IBaseCreateNodeParams {
-    nodeType: NodeType;
 }
 export declare interface ICreateMenuInfo {
     label: string;
@@ -7541,18 +7391,6 @@ export declare interface ICreateMenuInfo {
     group?: string;
     fileNameCheckConfigs?: FileNameCheckConfig[];
 }
-export declare interface ICreateOptions {
-    type: ICreateType;
-    baseName: string;
-    targetDirectory: string;
-    templateType?: TSceneTemplateType;
-}
-export declare interface ICreatePrefabFromNodeParams {
-    nodePath: string;
-    dbURL: string;
-    overwrite?: boolean;
-}
-export declare type ICreateType = typeof CREATE_TYPES[number];
 export declare type ICroppingConfig = {
     name: string;
     flags: IFlags_2,
@@ -7568,30 +7406,12 @@ export declare interface ICustomJointTextureLayout {
     textureLength: number;
     contents: IChunkContent[];
 }
-export declare interface ICustomLayerConfig {
-    name: string;
-    value: number;
-}
-export declare interface ICustomLayerConfig {
-    name: string;
-    value: number;
-}
-export declare interface ICutParams {
-    paths: string[];
-}
 export declare type IDefaultConfig = {
     key: IDefaultConfigKeys;
     name: string;
     diyConfig: (cache: Record<string, IDisplayModuleCache>, flags: IFlags_2, includeModules: string[]) => void;
 }
 export declare type IDefaultConfigKeys = 'defaultConfig' | 'default2d' | 'default3d' | 'defaultNative' | 'defaultSmallGames'
-export declare interface IDeleteNodeParams {
-    path: string;
-    keepWorldTransform?: boolean;
-}
-export declare interface IDeleteNodeResult {
-    path: string;
-}
 export declare interface IDesignResolution {
     height: number;
     width: number;
@@ -7601,29 +7421,13 @@ export declare interface IDesignResolution {
 }
 export declare interface IDisplayModuleCache {
     _value: boolean;
-    _option?: string; 
-    _flags?: IFlags_2; 
+    _option?: string;
+    _flags?: IFlags_2;
 }
 export declare interface IDisplayModuleItem extends IFeatureItem {
     _value: boolean;
     _option?: string;
     options?: Record<string, IDisplayModuleItem>;
-}
-export declare interface IDuplicateParams {
-    paths: string[];
-}
-export declare interface IEditorService extends IServiceEvents {
-    getCurrentEditorType(): 'scene' | 'prefab' | 'unknown';
-    open(params: IOpenOptions): Promise<TEditorEntity>;
-    close(params: ICloseOptions): Promise<boolean>;
-    save(params: ISaveOptions): Promise<IAssetInfo>;
-    reload(params: IReloadOptions): Promise<ReloadResult>;
-    create(params: ICreateOptions): Promise<IBaseIdentifier>;
-    hasOpen(): Promise<boolean>;
-    queryCurrent(): Promise<TEditorEntity | null>;
-    getRootNode(): TEditorInstance | null;
-    lock(): Promise<void>;
-    unlock(): void;
 }
 export declare interface IEngineConfig extends IEngineModuleConfig {
     physicsConfig: IPhysicsConfig;
@@ -7657,16 +7461,6 @@ export declare interface IEngineProjectConfig extends Exclude<IEngineConfig, 'in
     configs?: Record<string, IEngineModuleProjectConfig>;
     globalConfigKey?: string;
 }
-export declare interface IEngineService extends IServiceEvents {
-    init(): Promise<void>;
-    repaintInEditMode(): Promise<void>;
-    initCustomLayer(layers?: ICustomLayerConfig[]): Promise<void>;
-}
-export declare interface IExecuteComponentMethodOptions {
-    path: string;
-    name: string;
-    args: any[];
-}
 export declare interface IFbxSetting {
     unitConversion?: 'geometry-level' | 'hierarchy-level' | 'disabled';
     animationBakeRate?: 0 | 24 | 25 | 30 | 60;
@@ -7691,62 +7485,11 @@ export declare interface IGetPostConfig {
     url: string | RegExp;
     handler: (req: Request_2, res: Response_2, next?: NextFunction) => Promise<void>;
 }
-export declare interface IGetPrefabInfoParams {
-    nodePath: string;
-}
-export declare interface IGizmoService {
-    gizmoRootNode: any;
-    foregroundNode: any;
-    backgroundNode: any;
-    transformToolData: any;
-    transformToolName: string;
-    isViewMode: boolean;
-    is2D: boolean;
-    init(): void;
-    initFromConfig(): Promise<void>;
-    saveConfig(): Promise<void>;
-    changeTool(name: string): void;
-    setCoordinate(coord: 'local' | 'global'): void;
-    setPivot(pivot: 'pivot' | 'center'): void;
-    lockGizmoTool(locked: boolean): void;
-    isGizmoToolLocked(): boolean;
-    setIconVisible(visible: boolean): void;
-    showAllGizmoOfNode(node: any, recursive?: boolean): void;
-    removeAllGizmoOfNode(node: any, recursive?: boolean): void;
-    clearAllGizmos(): void;
-    callAllGizmoFuncOfNode(node: any, funcName: string, ...params: any[]): boolean;
-    onUpdate(deltaTime: number): void;
-    queryToolsVisibility3d(): boolean;
-    setToolsVisibility3d(value: boolean): void;
-    isIconGizmo3D(): boolean;
-    setIconGizmo3D(value: boolean): void;
-    queryIconGizmoSize(): number;
-    setIconGizmoSize(size: number): void;
-    queryGridColor(): number[];
-    setGridColor(color: number[]): void;
-    queryOriginAxes2D(): IOriginAxesConfig;
-    setOriginAxes2D(config: IOriginAxesConfig): void;
-    queryOriginAxes3D(): IOriginAxesConfig;
-    setOriginAxes3D(config: IOriginAxesConfig): void;
-    queryTransformSnapConfigs(): any;
-    setTransformSnapConfigs(name: string, value: any): void;
-    queryRectSnapConfig(): IRectSnapConfigData;
-    setRectSnapConfig(config: Partial<IRectSnapConfigData>): void;
-    querySelectNodes(): any[];
-    hasSelected(uuid: string): boolean;
-    onResize(): void;
-    showSelectionRegion(left: number, right: number, top: number, bottom: number): void;
-    hideSelectionRegion(): void;
-    execGizmoMethods(name: string, funcName: string, params?: any[]): any;
-}
 export declare interface IInitEngineInfo {
     importBase: string;
     nativeBase: string;
     writablePath: string;
     serverURL?: string;
-}
-export declare interface IIsPrefabInstanceParams {
-    nodePath: string;
 }
 export declare interface ImageAssetUserData {
     type: ImageImportType;
@@ -7790,12 +7533,6 @@ export declare interface IModuleConfig {
 }
 export declare type IModuleItem = IFeatureItem | IFeatureGroup;
 export declare type IModules = Record<string, IModuleItem>;
-export declare interface IMoveArrayElementParams {
-    nodePath: string;
-    path: string;
-    target: number;
-    offset: number;
-}
 export declare function importAsset(source: string, target: string, options?: AssetOperationOption): Promise<IAssetInfo[]>;
 export declare interface ImportMap {
     imports?: Record<string, string>;
@@ -7810,107 +7547,15 @@ export declare function init_6(): Promise<void>;
 export declare function init_7(projectPath: string): Promise<void>;
 export declare function initEngine(enginePath: string, projectPath: string, serverURL?: string): Promise<void>;
 export declare function initProgrammingFacet(): Promise<ProgrammingFacet>;
-export declare interface INode {
-    path: string;
-    active: IProperty;
-    locked: IProperty;
-    name: IProperty;
-    position: IProperty;
-    rotation: IProperty;
-    mobility: IProperty;
-    scale: IProperty;
-    layer: IProperty;
-    uuid: IProperty;
-    children: IProperty[];
-    parent: IProperty;
-    __comps__: IComponent[];
-    __type__: string;
-    __prefab__?: IPrefab;
-    _prefabInstance?: any;
-    removedComponents?: IRemovedComponentInfo[];
-    mountedRoot?: string;
-}
-export declare interface INodeDumpOptions {
-    includeChildren?: boolean;
-    includeComponents?: boolean;
-}
-export declare interface INodeService extends IServiceEvents {
-    createByType(params: ICreateByNodeTypeParams): Promise<INode | null>;
-    createByAsset(params: ICreateByAssetParams): Promise<INode | null>;
-    delete(params: IDeleteNodeParams): Promise<IDeleteNodeResult | null>;
-    query(params?: IQueryNodeParams): Promise<INode | IScene | null>;
-    queryNodeTree(params: IQueryNodeTreeParams): Promise<INodeTreeItem | null>;
-    queryNodesByAssetUuid(uuid: string): string[];
-    queryNodesMissAsset(): Promise<string[]>;
-    previewSetProperty(options: ISetPropertyOptions): Promise<boolean>;
-    cancelPreviewSetProperty(options: ISetPropertyOptions): Promise<boolean>;
-    setProperty(options: ISetPropertyOptions): Promise<boolean>;
-    reset(path: string): Promise<boolean>;
-    resetProperty(options: ISetPropertyOptions): Promise<boolean>;
-    updatePropertyFromNull(options: ISetPropertyOptions): Promise<boolean>;
-    setNodeAndChildrenLayer(options: ISetPropertyOptions): Promise<void>;
-    getPathByUuid(uuid: string): string;
-    setParent(params: ISetParentParams): Promise<string[]>;
-    reorder(params: IReorderParams): Promise<boolean>;
-    copy(params: ICopyParams): Promise<string[]>;
-    paste(params: IPasteParams): Promise<string[]>;
-    duplicate(params: IDuplicateParams): Promise<string[]>;
-    cut(params: ICutParams): Promise<string[]>;
-    queryClipboardState(): Promise<IClipboardState>;
-    moveArrayElement(params: IMoveArrayElementParams): Promise<boolean>;
-    removeArrayElement(params: IRemoveArrayElementParams): Promise<boolean>;
-    changeNodeLock(params: IChangeNodeLockParams): Promise<void>;
-}
-export declare interface INodeTreeComponent {
-    isCustom: boolean;
-    type: string;
-    value: string;
-    extends: string[];
-}
-export declare interface INodeTreeItem {
-    name: string;
-    active: boolean;
-    locked: boolean;
-    type: string;
-    uuid: string;
-    children: INodeTreeItem[];
-    prefab: IPrefabStateInfo;
-    parent: string;
-    path: string;
-    isScene: boolean;
-    readonly: boolean;
-    components: INodeTreeComponent[];
-}
-export declare interface IOpenOptions extends INodeDumpOptions {
-    urlOrUUID: string;
-}
-export declare interface IOperationService {
-    addListener(type: OperationEvent, listener: Function, priority?: number): void;
-    removeListener(type: OperationEvent, listener: Function): void;
-    dispatch(type: OperationEvent, ...args: any[]): void;
-    emitMouseEvent(type: string, event: ISceneMouseEvent, dpr?: number): void;
-    requestPointerLock(): void;
-    exitPointerLock(): void;
-    changePointer(type: string): void;
-}
-export declare interface IOriginAxesConfig {
-    x: boolean;
-    y: boolean;
-    z: boolean;
-}
-export declare interface IPasteParams {
-    parentPath?: string;
-    keepWorldTransform?: boolean;
-}
 export declare interface IPhysicsConfig {
-    gravity: IVec3Like; 
-    allowSleep: boolean; 
-    sleepThreshold: number; 
-    autoSimulation: boolean; 
-    fixedTimeStep: number; 
-    maxSubSteps: number; 
-    defaultMaterial?: string; 
-    useNodeChains: boolean; 
+    gravity: IVec3Like;
+    allowSleep: boolean;
+    sleepThreshold: number;
+    autoSimulation: boolean;
+    fixedTimeStep: number;
+    maxSubSteps: number;
+    defaultMaterial?: string;
+    useNodeChains: boolean;
     collisionMatrix: ICollisionMatrix;
     physicsEngine: string;
     physX?: {
@@ -7921,41 +7566,13 @@ export declare interface IPhysicsConfig {
     };
 }
 export declare interface IPhysicsMaterial {
-    friction: number; 
-    rollingFriction: number; 
-    spinningFriction: number; 
-    restitution: number; 
+    friction: number;
+    rollingFriction: number;
+    spinningFriction: number;
+    restitution: number;
 }
 export declare interface IPluginScriptInfo extends PluginScriptInfo {
     url: string;
-}
-export declare interface IPrefab {
-    uuid: string;
-    fileId: string;
-    rootUuid: string;
-    sync: boolean;
-    prefabStateInfo: IPrefabStateInfo;
-    targetOverrides?: ITargetOverrideInfo[];
-    instance?: IProperty;
-}
-export declare interface IPrefabService extends IServiceEvents {
-    createPrefabFromNode(params: ICreatePrefabFromNodeParams): Promise<INode>;
-    applyPrefabChanges(params: IApplyPrefabChangesParams): Promise<boolean>;
-    revertToPrefab(params: IRevertToPrefabParams): Promise<boolean>;
-    unpackPrefabInstance(params: IUnpackPrefabInstanceParams): Promise<INode>;
-    isPrefabInstance(params: IIsPrefabInstanceParams): Promise<boolean>;
-    getPrefabInfo(params: IGetPrefabInfoParams): Promise<IPrefab | null>;
-    unlinkPrefab(params: IUnlinkPrefabParams): Promise<boolean>;
-    removePrefabInfoFromNode(node: Node_2, removeNested?: boolean): void;
-}
-export declare interface IPrefabStateInfo {
-    state: PrefabState;
-    isUnwrappable: boolean;
-    isRevertable: boolean;
-    isApplicable: boolean;
-    isAddedChild: boolean;
-    isNested: boolean;
-    assetUuid: string;
 }
 export declare interface IProject {
     get path(): string;
@@ -7970,231 +7587,9 @@ export declare interface IProject {
     getInfo(key?: string): ProjectInfo | any;
     updateInfo<T>(keyOrValue: string | ProjectInfo, value?: T): Promise<boolean>;
 }
-export declare interface IProperty {
-    value: { [key: string]: IPropertyValueType } | IPropertyValueType;
-    default?: any; 
-    values?: ({ [key: string]: IPropertyValueType } | IPropertyValueType)[];
-    lock?: { [key in keyof Vec4]?: IPropertyLock };
-    cid?: string;
-    type?: string;
-    ui?: { name: string; data?: any }; 
-    readonly?: boolean;
-    visible?: boolean;
-    name?: string;
-    elementTypeData?: IProperty; 
-    path: string; 
-    isArray?: boolean;
-    invalid?: boolean;
-    extends?: string[]; 
-    displayName?: string; 
-    displayOrder?: number; 
-    help?: string; 
-    group?: IPropertyGroupOptions; 
-    tooltip?: string; 
-    editor?: any; 
-    animatable?: boolean; 
-    radioGroup?: boolean; 
-    enumList?: any[]; 
-    bitmaskList?: any[];
-    min?: number; 
-    max?: number; 
-    step?: number; 
-    slide?: boolean; 
-    unit?: string; 
-    radian?: boolean; 
-    multiline?: boolean; 
-    optionalTypes?: string[]; 
-    userData?: { [key: string]: any }; 
-}
-export declare interface IPropertyGroupOptions {
-    id: string 
-    name: string,
-    displayOrder: number, 
-    style: string 
-}
-export declare type IPropertyLock = { 
-    default: number; 
-    message: string 
-};
-export declare type IPropertyValueType = IProperty | IProperty[] | null | undefined | number | boolean | string | Vec4 | Vec3 | Vec2 | Mat4 | any | Array<unknown>
-export declare interface IQueryClassesOptions {
-    extends?: string | string[];
-    excludeSelf?: boolean;
-}
-export declare interface IQueryComponentOptions {
-    path: string;
-}
-export declare interface IQueryNodeParams extends INodeDumpOptions {
-    path: string;
-}
-export declare interface IQueryNodeTreeParams {
-    path?: string;
-}
-export declare interface IRectSnapConfigData {
-    enableSnapping: boolean;
-    snapThreshold: number;
-}
 export declare interface IRedirectInfo {
     type: string;
     uuid: string;
-}
-export declare interface IRedoService {
-    redo(): Promise<IUndoRedoResult>;
-    canRedo(): boolean;
-}
-export declare interface IReloadOptions {
-    urlOrUUID?: string;
-    preserveUndoHistory?: boolean;
-}
-export declare interface IRemoveArrayElementParams {
-    nodePath: string;
-    path: string;
-    index: number;
-}
-export declare interface IRemoveComponentOptions {
-    path: string;
-}
-export declare interface IRemovedComponentInfo {
-    name: string;
-    fileID: string;
-}
-export declare interface IReorderParams {
-    path: string;
-    target: number;
-    offset: number;
-}
-export declare interface IRevertToPrefabParams {
-    nodePath: string;
-}
-export declare interface ISaveOptions {
-    urlOrUUID?: string;
-}
-export declare interface IScene {
-    path: string;
-    name: IProperty;
-    active: IProperty;
-    locked: IProperty;
-    _globals: Record<string, IProperty>;
-    isScene: boolean;
-    autoReleaseAssets: IProperty;
-    uuid: IProperty;
-    children: IProperty[];
-    parent: string;
-    __type__: string;
-    targetOverrides?: ITargetOverrideInfo[];
-}
-export declare interface ISceneMouseEvent {
-    x: number;
-    y: number;
-    clientX: number;
-    clientY: number;
-    deltaX: number;
-    deltaY: number;
-    wheelDeltaX: number;
-    wheelDeltaY: number;
-    moveDeltaX: number;
-    moveDeltaY: number;
-    leftButton: boolean;
-    middleButton: boolean;
-    rightButton: boolean;
-    button: number;
-    buttons: number;
-    movementX: number;
-    movementY: number;
-    ctrlKey: boolean;
-    shiftKey: boolean;
-    altKey: boolean;
-    metaKey: boolean;
-    hitPoint?: any;
-    type?: string;
-    handleName?: string;
-}
-export declare interface ISceneViewService {
-    init(): void;
-    initFromConfig(): Promise<void>;
-    saveConfig(): Promise<void>;
-    setSceneLightOn(enable: boolean): void;
-    querySceneLightOn(): boolean;
-    onSceneOpened(scene: any): void;
-    onSceneClosed(): void;
-    onComponentAdded(comp: Component): void;
-    onComponentRemoved(comp: Component): void;
-}
-export declare interface IScriptService extends IServiceEvents {
-    investigatePackerDriver(): Promise<void>;
-    loadScript(): Promise<void>;
-    removeScript(): Promise<void>;
-    scriptChange(): Promise<void>;
-    queryScriptCid(uuid: string): Promise<string | null>;
-    queryScriptName(uuid: string): Promise<string | null>;
-    isCustomComponent(classConstructor: Function): boolean;
-    suspend(condition: Promise<any>): void;
-}
-export declare interface ISelectionService {
-    select(path: string): void;
-    unselect(path: string): void;
-    clear(): void;
-    query(): string[];
-    isSelect(path: string): boolean;
-    reset(): void;
-}
-export declare interface IServiceEvents {
-    onEditorOpened?(): void;
-    onEditorReload?(): void;
-    onEditorClosed?(): void;
-    onEditorSaved?(): void;
-    onNodeBeforeChanged?(node: Node_2): void;
-    onBeforeRemoveNode?(node: Node_2): void;
-    onBeforeAddNode?(node: Node_2): void;
-    onNodeChanged?(node: Node_2, opts: IChangeNodeOptions): void;
-    onBeforeNodeAdded?(node: Node_2): void;
-    onAddNode?(node: Node_2): void;
-    onRemoveNode?(node: Node_2): void;
-    onNodeAdded?(node: Node_2): void;
-    onNodeRemoved?(node: Node_2): void;
-    onAddComponent?(comp: Component): void;
-    onRemoveComponent?(comp: Component): void;
-    onSetPropertyComponent?(comp: Component): void;
-    onComponentAdded?(comp: Component): void;
-    onComponentRemoved?(comp: Component): void;
-    onBeforeChangeComponent?(node: Node_2): void;
-    onBeforeAddComponent?(name: string, node: Node_2): void;
-    onBeforeRemoveComponent?(comp: Component): void;
-    onAssetDeleted?(uuid: string): void;
-    onAssetChanged?(uuid: string): void;
-    onAssetRefreshed?(uuid: string): void;
-    onScriptExecutionFinished?(): void;
-    onSelectionSelect?(path: string, paths: string[]): void;
-    onSelectionUnselect?(path: string, paths: string[]): void;
-    onSelectionClear?(): void;
-}
-export declare interface IServiceManager {
-    Editor: IEditorService;
-    Node: INodeService;
-    Component: IComponentService;
-    Script: IScriptService;
-    Asset: IAssetService;
-    Engine: IEngineService;
-    Prefab: IPrefabService;
-    Selection: ISelectionService;
-    Operation: IOperationService;
-    Undo: IUndoService;
-    Redo: IRedoService;
-    Camera: ICameraService;
-    Gizmo: IGizmoService;
-    SceneView: ISceneViewService;
-    UI: IUIService;
-}
-export declare interface ISetParentParams {
-    paths: string[];
-    parentPath: string;
-    keepWorldTransform?: boolean;
-}
-export declare interface ISetPropertyOptions {
-    nodePath: string;
-    path: string;
-    dump: IProperty;
-    record?: boolean;
 }
 export declare interface ISocketConfig {
     connection: (socket: any) => void;
@@ -8228,31 +7623,24 @@ export declare interface IStaticFileConfig {
     path: string;
 }
 export declare type ISupportCreateCCType =
-| 'cc.AnimationClip'        
-| 'cc.Script'               
-| 'cc.SpriteAtlas'          
-| 'cc.EffectAsset'          
-| 'cc.SceneAsset'           
-| 'cc.Prefab'               
-| 'cc.Material'             
-| 'cc.TextureCube'          
-| 'cc.TerrainAsset'         
-| 'cc.PhysicsMaterial'      
-| 'cc.LabelAtlas'           
-| 'cc.RenderTexture'        
-| 'cc.AnimationGraph'       
-| 'cc.AnimationMask'        
+| 'cc.AnimationClip'
+| 'cc.Script'
+| 'cc.SpriteAtlas'
+| 'cc.EffectAsset'
+| 'cc.SceneAsset'
+| 'cc.Prefab'
+| 'cc.Material'
+| 'cc.TextureCube'
+| 'cc.TerrainAsset'
+| 'cc.PhysicsMaterial'
+| 'cc.LabelAtlas'
+| 'cc.RenderTexture'
+| 'cc.AnimationGraph'
+| 'cc.AnimationMask'
 | 'cc.AnimationGraphVariant';
 export declare type ISupportCreateType = typeof SUPPORT_CREATE_TYPES[number];
-export declare interface ITargetOverrideInfo {
-    source: string;
-    sourceInfo?: string[];
-    propertyPath: string[];
-    target: string;
-    targetInfo?: string[];
-}
 export declare interface IUerDataConfigItem {
-    key?: string; 
+    key?: string;
     label?: string;
     description?: string;
     default?: any;
@@ -8266,75 +7654,6 @@ export declare interface IUerDataConfigItem {
             value: string;
         }>;
     };
-}
-export declare interface IUIService {
-    alignSelection(type: UIAlignType): Promise<void>;
-    distributeSelection(type: UIAlignType): Promise<void>;
-}
-export declare interface IUndoBeginOptions {
-    label?: string;
-    tag?: string;
-    customCommand?: IUndoCommand;
-}
-export declare interface IUndoCommand {
-    meta: IUndoCommandMeta;
-    undo(): Promise<IUndoRedoResult>;
-    redo(): Promise<IUndoRedoResult>;
-}
-export declare interface IUndoCommandMeta {
-    id: string;
-    label: string;
-    type: string;
-    scope: IUndoScope;
-    timestamp: number;
-}
-export declare interface IUndoGroupOptions {
-    label?: string;
-}
-export declare interface IUndoRedoResult {
-    success: boolean;
-    commandId?: string;
-    label?: string;
-    reason?: string;
-}
-export declare interface IUndoScope {
-    assetUuid?: string;
-    assetUrl?: string;
-    editorType?: 'scene' | 'prefab' | 'animation' | string;
-    mode?: 'general' | 'prefab' | 'animation' | 'preview' | string;
-}
-export declare interface IUndoService {
-    beginRecording(uuids: string[], options?: IUndoBeginOptions): string;
-    endRecording(commandId: string): Promise<void>;
-    cancelRecording(commandId: string): void;
-    undo(): Promise<IUndoRedoResult>;
-    redo(): Promise<IUndoRedoResult>;
-    beginGroup(options?: IUndoGroupOptions): string;
-    endGroup(groupId: string): IUndoRedoResult;
-    cancelGroup(groupId: string): IUndoRedoResult;
-    isGroupActive(): boolean;
-    push(command: IUndoCommand): void;
-    reset(): void;
-    clearHistory(): void;
-    isDirty(): boolean;
-    canUndo(): boolean;
-    canRedo(): boolean;
-    markSaved(): void;
-    hasActiveRecording(uuid?: string): boolean;
-    isApplying(): boolean;
-}
-export declare interface IUnlinkPrefabParams {
-    nodePath: string;
-    removeNested?: boolean;
-}
-export declare interface IUnpackPrefabInstanceParams {
-    nodePath: string;
-    recursive?: boolean;
-}
-export declare interface IVec3 {
-    x: number;
-    y: number;
-    z: number;
 }
 export declare interface IVec3Like {
     x: number;
@@ -8381,24 +7700,6 @@ export declare type MacroItem = {
     value: boolean;
 }
 export declare type MakeRequired<T, K extends keyof T> = T & Required<Pick<T, K>>;
-export declare interface Mat4 {
-    m00: number;
-    m01: number;
-    m02: number;
-    m03: number;
-    m04: number;
-    m05: number;
-    m06: number;
-    m07: number;
-    m08: number;
-    m09: number;
-    m10: number;
-    m11: number;
-    m12: number;
-    m13: number;
-    m14: number;
-    m15: number;
-}
 export declare namespace Mcp {
     export {
         register,
@@ -8449,64 +7750,6 @@ export declare interface ModuleRenderConfig {
     migrationScript?: string;
 }
 export declare function moveAsset(source: string, target: string, options?: AssetOperationOption): Promise<any>;
-export declare enum NodeEventType {
-    TRANSFORM_CHANGED = "transform-changed",
-    SIZE_CHANGED = "size-changed",
-    ANCHOR_CHANGED = "anchor-changed",
-    CHILD_ADDED = "child-added",
-    CHILD_REMOVED = "child-removed",
-    PARENT_CHANGED = "parent-changed",
-    CHILD_CHANGED = "child-changed",
-    COMPONENT_CHANGED = "component-changed",
-    ACTIVE_IN_HIERARCHY_CHANGE = "active-in-hierarchy-changed",
-    NOTIFY_NODE_CHANGED = "notify-node-changed",
-    PREFAB_INFO_CHANGED = "prefab-info-changed",
-    LIGHT_PROBE_CHANGED = "light-probe-changed",
-    SET_PROPERTY = "set-property",
-    MOVE_ARRAY_ELEMENT = "move-array-element",
-    REMOVE_ARRAY_ELEMENT = "remove-array-element",
-    CREATE_COMPONENT = "create-component",
-    RESET_COMPONENT = "reset-component"
-}
-export declare enum NodeType {
-    EMPTY = "Empty",
-    TERRAIN = "Terrain",
-    CAMERA = "Camera",
-    SPRITE = "Sprite",
-    SPRITE_SPLASH = "SpriteSplash",
-    GRAPHICS = "Graphics",
-    LABEL = "Label",
-    MASK = "Mask",
-    PARTICLE = "Particle",
-    TILED_MAP = "TiledMap",
-    CAPSULE = "Capsule",
-    CONE = "Cone",
-    CUBE = "Cube",
-    CYLINDER = "Cylinder",
-    PLANE = "Plane",
-    QUAD = "Quad",
-    SPHERE = "Sphere",
-    TORUS = "Torus",
-    BUTTON = "Button",
-    CANVAS = "Canvas",
-    EDIT_BOX = "EditBox",
-    LAYOUT = "Layout",
-    PAGE_VIEW = "PageView",
-    PROGRESS_BAR = "ProgressBar",
-    RICH_TEXT = "RichText",
-    SCROLL_VIEW = "ScrollView",
-    SLIDER = "Slider",
-    TOGGLE = "Toggle",
-    TOGGLE_GROUP = "ToggleGroup",
-    VIDEO_PLAYER = "VideoPlayer",
-    WEB_VIEW = "WebView",
-    WIDGET = "Widget",
-    DIRECTIONAL_LIGHT = "Light-Directional",
-    SPHERE_LIGHT = "Light-Sphere",
-    SPOT_LIGHT = "Light-Spot",
-    PROBE_LIGHT = "Light-Probe-Group",
-    REFLECTION_LIGHT = "Light-Reflection-Probe"
-}
 export declare enum NormalImportSetting {
     optional = 0,
     exclude = 1,
@@ -8534,7 +7777,6 @@ export declare function onPackBuildStart(listener: (e: {
 export declare function onProgress(listener: (current: number, total: number, url: string, state: 'processing' | 'success' | 'failed') => void): () => void;
 export declare function onReady(listener: () => void): () => void;
 export declare function open_2(projectPath: string): Promise<void>;
-export declare type OperationEvent = SceneDragEvent | SceneKeyboardEvent | SceneMouseEvent | 'resize';
 export declare interface ParticleAssetUserData {
     totalParticles: number;
     life: number;
@@ -8595,12 +7837,6 @@ export declare interface PluginScriptUserData {
 export declare interface PrefabAssetUserData {
     persistent?: boolean;
     syncNodeName?: string;
-}
-export declare enum PrefabState {
-    NotAPrefab = 0,
-    PrefabChild = 1,
-    PrefabInstance = 2,
-    PrefabLostAsset = 3
 }
 export declare class ProgrammingFacet {
     private _packerDriverUpdateCount;
@@ -8695,11 +7931,11 @@ export declare function queryAssetInfo(urlOrUUIDOrPath: string, dataKeys?: strin
 export declare function queryAssetInfos(options?: QueryAssetsOption): Promise<IAssetInfo[]>;
 export declare function queryAssetMeta(urlOrUUIDOrPath: string): Promise<IAssetMeta<'unknown'> | null>;
 export declare interface QueryAssetsOption {
-    ccType?: string | string[], 
-    isBundle?: boolean, 
-    importer?: string | string[], 
-    pattern?: string, 
-    extname?: string | string[], 
+    ccType?: string | string[],
+    isBundle?: boolean,
+    importer?: string | string[],
+    pattern?: string,
+    extname?: string | string[],
     userData?: Record<string, boolean | string | number>;
     type?: string;
 }
@@ -8722,14 +7958,6 @@ export declare function register(): Promise<string>;
 export declare function register_2(name: string, module: IMiddlewareContribution): Promise<void>;
 export declare function reimportAsset(pathOrUrlOrUUID: string): Promise<IAssetInfo>;
 export declare function reload(): Promise<void>;
-export declare enum ReloadResult {
-    SUCCESS = 0,
-    FAILED = 1,
-    QUEUED = 2,
-    NO_EDITOR = 3,
-    ASSET_NOT_FOUND = 4,
-    EDITOR_NOT_FOUND = 5
-}
 export declare function remove(key: string, scope?: ConfigurationScope): Promise<boolean>;
 export declare function renameAsset(source: string, newName: string, options?: AssetOperationOption): Promise<any>;
 export declare interface RenderTextureAssetUserData extends TextureBaseAssetUserData {
@@ -8750,10 +7978,6 @@ export declare namespace Scene {
         startupWorker
     }
 }
-export declare const SCENE_TEMPLATE_TYPE: readonly ["2d", "3d", "quality"];
-export declare type SceneDragEvent = 'onDragLeave' | 'onDragOver' | 'onDrop';
-export declare type SceneKeyboardEvent = 'keydown' | 'keyup';
-export declare type SceneMouseEvent = 'dblclick' | 'mousedown' | 'mousemove' | 'mouseup' | 'mousewheel';
 export declare namespace Scripting {
     export {
         init_7 as init,
@@ -8871,8 +8095,6 @@ export declare enum TangentImportSetting {
     require = 2,
     recalculate = 3
 }
-export declare type TEditorEntity = IScene | INode;
-export declare type TEditorInstance = Scene_2 | Node_2;
 export declare interface Texture2DAssetUserData extends TextureBaseAssetUserData {
     isUuid?: boolean;
     imageUuidOrDatabaseUri?: string;
@@ -8900,29 +8122,12 @@ export declare interface TextureCubeAssetUserData extends TextureBaseAssetUserDa
 }
 export declare interface ThumbnailInfo {
     type: 'icon' | 'image',
-    value: string; 
+    value: string;
 }
 export declare type ThumbnailSize = 'large' | 'small' | 'middle' | 'origin';
-export declare type TSceneTemplateType = typeof SCENE_TEMPLATE_TYPE[number];
-export declare type UIAlignType = 'top' | 'v-center' | 'bottom' | 'left' | 'h-center' | 'right';
 export declare function unregister(): Promise<void>;
 export declare function updateAssetUserData(urlOrUuidOrPath: string, path: string, value: any): Promise<any>;
 export declare function updateDefaultUserData(handler: string, path: string, value: any): Promise<void>;
-export declare interface Vec2 {
-    x: number;
-    y: number;
-}
-export declare interface Vec3 {
-    x: number;
-    y: number;
-    z: number;
-}
-export declare interface Vec4 {
-    x: number;
-    y: number;
-    z: number;
-    w: number;
-}
 export declare type WrapMode = 'repeat' | 'clamp-to-edge' | 'mirrored-repeat';
 export { }
 "

--- a/packages/cocos-cli-types/__tests__/dts-snapshot.test.ts
+++ b/packages/cocos-cli-types/__tests__/dts-snapshot.test.ts
@@ -19,6 +19,7 @@ function stripComments(content: string): string {
     return content
         .replace(/\/\*[\s\S]*?\*\//g, '')
         .replace(/\/\/.*$/gm, '')
+        .replace(/[ \t]+$/gm, '')
         .replace(/^\s*\n/gm, '');
 }
 

--- a/packages/cocos-cli-types/package.json
+++ b/packages/cocos-cli-types/package.json
@@ -2,7 +2,7 @@
     "name": "@cocos/cocos-cli-types",
     "description": "types for cocos cli",
     "author": "cocos cli",
-    "version": "0.0.1-alpha.29.1",
+    "version": "0.0.1-alpha.30.1",
     "main": "index.d.ts",
     "types": "index.d.ts",
     "exports": {


### PR DESCRIPTION
## 摘要
- 将 @cocos/cocos-cli-types 发布版本更新到 0.0.1-alpha.30.1。
- 刷新 DTS snapshot，移除当前入口不再导出的声明。
- 让 DTS snapshot 测试在剥离注释后清理行尾空白，避免生成无语义的尾随空格。

## QA 手测验证步骤
- 拉取该 PR 分支，在本地打开 `packages/cocos-cli-types/package.json`，确认包版本为 `0.0.1-alpha.30.1`。
- 在使用该类型包的 TypeScript 工程或临时 TS 文件中，分别从 `@cocos/cocos-cli-types` 和 `@cocos/cocos-cli-types/cli` 导入常用类型，确认编辑器类型跳转、补全和 TypeScript 诊断正常。
- 检查 root/subpath exports 仍指向对应的 `.d.ts` 文件，确认消费者不需要调整 import 路径。

## 补充验证
- [x] `npm test -- --roots packages/cocos-cli-types --runInBand`
- [x] `git diff --cached --check`