### PR TITLE
fix: use package.json as sole indicator of project existence

### DIFF
--- a/src/core/project/script/index.ts
+++ b/src/core/project/script/index.ts
@@ -147,7 +147,7 @@ export class Project implements IProject {
     public static async create(projectPath: string, type: ProjectType = '3d'): Promise<boolean> {
         try {
             const packageJSONPath = Project.getPackageJsonPath(projectPath);
-            if (existsSync(projectPath) || existsSync(packageJSONPath)) {
+            if (existsSync(packageJSONPath)) {
                 throw new Error('Failed to create project, project exist');
             }
             await mkdir(projectPath, { recursive: true });


### PR DESCRIPTION
fix an issue

```console
PS C:\Users\24306\cocos-project> cocos create --project .

Creating project...
Path: C:\Users\24306\cocos-project
Type: 3d
Warning: target path already exists, will try to create inside it.
Error: Failed to create project, project exist
    at Project.create (C:\Users\24306\git_learning\cocos-cli\dist\core\project\script\index.js:60:23)
    at ProjectManager.create (C:\Users\24306\git_learning\cocos-cli\dist\core\project-manager.js:58:30)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
    at async CocosAPI.createProject (C:\Users\24306\git_learning\cocos-cli\dist\api\index.js:110:16)
    at async Command.<anonymous> (C:\Users\24306\git_learning\cocos-cli\dist\commands\create.js:66:28)
✗ Failed to create project.
```