### PR TITLE
[break] expose build stage progress callback

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -1142,6 +1142,7 @@ export declare class BuildResult implements IBuildResult {
     getJsonPathInfo(uuid: string): IImportAssetPathInfo[];
     getImportAssetPaths(uuid: string): IImportAssetPathInfo[];
 }
+export declare type BuildStageProgressCallback = (message: string, progress: number) => void;
 export declare class BuildStageTask extends BuildTaskBase implements IBuildStageTask {
     options: IBuildOptionBase;
     hooksInfo: IBuildHooksInfo;
@@ -1589,7 +1590,7 @@ export declare type EnumItem = string | {
     labelI18nKey?: string;
     value: string | number;
 };
-export declare function executeBuildStageTask(taskId: string, stageName: string, options: IBuildStageOptions): Promise<IBuildResultData>;
+export declare function executeBuildStageTask(taskId: string, stageName: string, options: IBuildStageOptions, onProgress?: BuildStageProgressCallback): Promise<IBuildResultData>;
 export declare interface ExecuteHookTaskOption {
     pkgName: string;
     hook: string;

--- a/src/core/builder/@types/protected/options.ts
+++ b/src/core/builder/@types/protected/options.ts
@@ -371,6 +371,8 @@ export interface IBuildStageOptions {
     logDest?: string;
 }
 
+export type BuildStageProgressCallback = (message: string, progress: number) => void;
+
 export const enum BuildExitCode {
     PARAM_ERROR = 32,
     BUILD_FAILED = 34,

--- a/src/core/builder/index.ts
+++ b/src/core/builder/index.ts
@@ -1,6 +1,6 @@
 import { readJSONSync } from 'fs-extra';
 import i18n from '../base/i18n';
-import { BuildExitCode, IBuildCommandOption, IBuildResultData, IBuildStageOptions, IBuildTaskOption, IBundleBuildOptions, IPreviewSettingsResult, Platform } from './@types/private';
+import { BuildExitCode, BuildStageProgressCallback, IBuildCommandOption, IBuildResultData, IBuildStageOptions, IBuildTaskOption, IBundleBuildOptions, IPreviewSettingsResult, Platform } from './@types/private';
 import { pluginManager } from './manager/plugin';
 import { formatMSTime } from './share/utils';
 import { newConsole } from '../base/console';
@@ -192,15 +192,19 @@ export async function createBuildStageTask(taskId: string, stageName: string, op
     });
 }
 
-export async function executeBuildStageTask(taskId: string, stageName: string, options: IBuildStageOptions): Promise<IBuildResultData> {
+export async function executeBuildStageTask(taskId: string, stageName: string, options: IBuildStageOptions, onProgress?: BuildStageProgressCallback): Promise<IBuildResultData> {
     if (!options.taskName) {
         options.taskName = stageName + ' build';
     }
     const restoreLogSink = newConsole.createLogSinkRestorer();
+    let buildStageTask: Awaited<ReturnType<typeof createBuildStageTask>> | undefined;
 
     try {
         ensureBuildLogSink(options, options.taskName);
-        const buildStageTask = await createBuildStageTask(taskId, stageName, options);
+        buildStageTask = await createBuildStageTask(taskId, stageName, options);
+        if (onProgress) {
+            buildStageTask.on('update', onProgress);
+        }
         const stageConfig = pluginManager.getBuildStageWithHookTasks(options.platform, stageName);
         const stageLabel = stageConfig!.name;
 
@@ -221,6 +225,9 @@ export async function executeBuildStageTask(taskId: string, stageName: string, o
         console.error(error);
         return { code: BuildExitCode.BUILD_FAILED, reason: error?.message || String(error) };
     } finally {
+        if (buildStageTask && onProgress) {
+            buildStageTask.off('update', onProgress);
+        }
         restoreLogSink();
     }
 }

--- a/src/core/builder/test/execute-build-stage-task.spec.ts
+++ b/src/core/builder/test/execute-build-stage-task.spec.ts
@@ -1,0 +1,137 @@
+const mockGetBuildStageWithHookTasks = jest.fn();
+const mockGetHooksInfo = jest.fn();
+const mockRequireFile = jest.fn();
+const mockRestoreLogSink = jest.fn();
+
+jest.mock('../manager/plugin', () => ({
+    pluginManager: {
+        getBuildStageWithHookTasks: mockGetBuildStageWithHookTasks,
+        getHooksInfo: mockGetHooksInfo,
+    },
+}));
+
+jest.mock('../share/builder-config', () => ({
+    __esModule: true,
+    default: {
+        projectRoot: 'project-root',
+        projectTempDir: 'project-root/temp',
+    },
+}));
+
+jest.mock('../share/common-options-validator', () => ({
+    fillIncludeModulesFromProjectConfig: jest.fn(),
+}));
+
+jest.mock('../../base/console', () => ({
+    newConsole: {
+        createLogSinkRestorer: jest.fn(() => mockRestoreLogSink),
+        record: jest.fn(),
+        trackMemoryStart: jest.fn(),
+        trackMemoryEnd: jest.fn(),
+        trackTimeStart: jest.fn(),
+        trackTimeEnd: jest.fn(() => 1),
+        pluginTask: jest.fn(),
+        debug: jest.fn(),
+        success: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+jest.mock('../../base/utils', () => ({
+    __esModule: true,
+    default: {
+        Path: {
+            resolveToRaw: jest.fn((path: string) => path),
+            resolveToUrl: jest.fn((path: string) => `project://${path}`),
+        },
+        Math: {
+            clamp01: jest.fn((value: number) => Math.max(0, Math.min(1, value))),
+        },
+        File: {
+            requireFile: mockRequireFile,
+        },
+    },
+}));
+
+jest.mock('../../assets/manager/asset', () => ({
+    __esModule: true,
+    default: {
+        queryAsset: jest.fn(),
+    },
+}));
+
+describe('executeBuildStageTask', () => {
+    const stageConfig = {
+        name: 'run',
+        hook: 'run',
+        displayName: 'Run',
+        parallelism: 'all' as const,
+    };
+    const hooksInfo = {
+        pkgNameOrder: ['web-desktop'],
+        infos: {
+            'web-desktop': {
+                path: 'web-desktop/hooks',
+                internal: true,
+            },
+        },
+    };
+    const hookModule = {
+        throwError: true,
+        run: jest.fn(),
+    };
+    let consoleLog: jest.SpyInstance;
+    let consoleDebug: jest.SpyInstance;
+    let consoleError: jest.SpyInstance;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        consoleLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+        consoleDebug = jest.spyOn(console, 'debug').mockImplementation(() => {});
+        consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+        mockGetBuildStageWithHookTasks.mockReturnValue(stageConfig);
+        mockGetHooksInfo.mockReturnValue(hooksInfo);
+        mockRequireFile.mockReturnValue(hookModule);
+        hookModule.run.mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+        consoleLog.mockRestore();
+        consoleDebug.mockRestore();
+        consoleError.mockRestore();
+    });
+
+    it('forwards build stage progress updates through callback', async () => {
+        const { executeBuildStageTask } = await import('../index');
+        const onProgress = jest.fn();
+
+        const result = await executeBuildStageTask('task-id', 'run', {
+            dest: 'build/web-desktop',
+            platform: 'web-desktop',
+        }, onProgress);
+
+        expect(result).toEqual({
+            code: 0,
+            dest: 'project://build/web-desktop',
+            custom: {},
+        });
+        expect(onProgress).toHaveBeenCalledWith('init options success', 0.1);
+        expect(onProgress).toHaveBeenCalledWith(expect.stringContaining('web-desktop:run completed'), expect.any(Number));
+        expect(hookModule.run).toHaveBeenCalledWith('build/web-desktop', undefined);
+    });
+
+    it('returns the thrown hook error message as failed result reason', async () => {
+        const { executeBuildStageTask } = await import('../index');
+        hookModule.run.mockRejectedValueOnce(new Error('custom stage failed'));
+
+        const result = await executeBuildStageTask('task-id', 'run', {
+            dest: 'build/web-desktop',
+            platform: 'web-desktop',
+        }, jest.fn());
+
+        expect(result).toEqual({
+            code: 34,
+            reason: 'custom stage failed',
+        });
+    });
+});

--- a/src/lib/builder/builder.ts
+++ b/src/lib/builder/builder.ts
@@ -1,4 +1,4 @@
-import type { IBuildCommandOption, IBuildResultData, IBuildStageOptions, IBuildTaskOption, IBundleBuildOptions, IPackOptions, IPreviewSettingsResult, Platform, PreviewPackResult } from '../../core/builder/@types/private';
+import type { BuildStageProgressCallback, IBuildCommandOption, IBuildResultData, IBuildStageOptions, IBuildTaskOption, IBundleBuildOptions, IPackOptions, IPreviewSettingsResult, Platform, PreviewPackResult } from '../../core/builder/@types/private';
 import type { BuildConfiguration } from '../../core/builder/@types/config-export';
 import type { BuildCheckResult, PlatformBuildSchema, PlatformConfigItem } from '../../core/builder/@types/protected';
 
@@ -30,9 +30,9 @@ export async function createBundleBuildTask(bundleOptions: IBundleBuildOptions) 
     return builder.createBundleBuildTask(bundleOptions);
 }
 
-export async function executeBuildStageTask(taskId: string, stageName: string, options: IBuildStageOptions): Promise<IBuildResultData> {
+export async function executeBuildStageTask(taskId: string, stageName: string, options: IBuildStageOptions, onProgress?: BuildStageProgressCallback): Promise<IBuildResultData> {
     const builder = await import('../../core/builder');
-    return builder.executeBuildStageTask(taskId, stageName, options);
+    return builder.executeBuildStageTask(taskId, stageName, options, onProgress);
 }
 
 export async function createBuildStageTask(taskId: string, stageName: string, options: IBuildStageOptions) {


### PR DESCRIPTION
Add an optional progress callback to executeBuildStageTask so callers can subscribe to BuildStageTask update events for arbitrary stages such as make and run.

The callback is attached after the stage task is created and removed in finally to avoid listener leaks. The lib builder entry now forwards the callback and the public dts snapshot is updated accordingly.

Add focused coverage for progress forwarding and for preserving thrown hook error messages in the failed build result reason.