### PR TITLE
fix(scene): reject cyclic node reparenting

### DIFF
--- a/src/core/scene/scene-process/service/node/index.ts
+++ b/src/core/scene/scene-process/service/node/index.ts
@@ -984,6 +984,10 @@ export class NodeManager {
             const oldParent = node.parent;
             const parentChanged = oldParent !== parentNode;
 
+            if (parentNode === node || parentNode.isChildOf(node)) {
+                throw new Error('Cannot set parent: target parent is the node itself or its descendant.');
+            }
+
             if (oldParent) {
                 this.emit('node:before-change', oldParent);
             }

--- a/src/core/scene/test/node-reload-events.test.ts
+++ b/src/core/scene/test/node-reload-events.test.ts
@@ -114,7 +114,7 @@ class MockEditorComponentManager extends EventEmitter {
 }
 
 function createNode(uuid: string) {
-    return {
+    const node: any = {
         uuid,
         name: uuid,
         isValid: true,
@@ -126,7 +126,26 @@ function createNode(uuid: string) {
         on: jest.fn(),
         off: jest.fn(),
         getComponent: jest.fn(() => null),
+        setParent: jest.fn((parent: any) => {
+            node.parent = parent;
+        }),
+        isChildOf: jest.fn((parent: any) => {
+            let current = node.parent;
+            while (current) {
+                if (current === parent) {
+                    return true;
+                }
+                current = current.parent;
+            }
+            return false;
+        }),
     };
+    return node;
+}
+
+function appendChild(parent: any, child: any) {
+    child.parent = parent;
+    parent.children.push(child);
 }
 
 function loadNodeManager(editorNode: MockEditorNodeManager, editorComponent: MockEditorComponentManager) {
@@ -217,5 +236,48 @@ describe('Node manager reload event lifecycle', () => {
         editorComponent.emit('add', 'component-uuid', { uuid: 'component-uuid', node: createNode('node') });
 
         expect(componentAddedListener).not.toHaveBeenCalled();
+    });
+});
+
+describe('Node manager setParent', () => {
+    afterEach(() => {
+        jest.resetModules();
+        delete (globalThis as any).EditorExtends;
+    });
+
+    it('rejects moving a node under itself or its descendant', () => {
+        const editorNode = new MockEditorNodeManager();
+        const editorComponent = new MockEditorComponentManager();
+        const scene = createNode('scene');
+        const parent = createNode('parent');
+        const child = createNode('child');
+        const grandchild = createNode('grandchild');
+        appendChild(scene, parent);
+        appendChild(parent, child);
+        appendChild(child, grandchild);
+        editorNode.setNodes({ scene, parent, child, grandchild });
+
+        const { nodeMgr } = loadNodeManager(editorNode, editorComponent);
+
+        expect(() => nodeMgr.setParent('parent', 'parent')).toThrow(/descendant/);
+        expect(() => nodeMgr.setParent('child', 'parent')).toThrow(/descendant/);
+        expect(() => nodeMgr.setParent('grandchild', 'parent')).toThrow(/descendant/);
+        expect(parent.setParent).not.toHaveBeenCalled();
+    });
+
+    it('keeps valid reparenting unchanged', () => {
+        const editorNode = new MockEditorNodeManager();
+        const editorComponent = new MockEditorComponentManager();
+        const root = createNode('root');
+        const child = createNode('child');
+        const nextParent = createNode('next-parent');
+        appendChild(root, child);
+        appendChild(root, nextParent);
+        editorNode.setNodes({ root, child, 'next-parent': nextParent });
+
+        const { nodeMgr } = loadNodeManager(editorNode, editorComponent);
+
+        expect(nodeMgr.setParent('next-parent', 'child')).toEqual(['child']);
+        expect(child.setParent).toHaveBeenCalledWith(nextParent, false);
     });
 });


### PR DESCRIPTION
## 变更说明
- 阻止场景节点被设置到自身或后代节点下，避免形成父子循环。
- 补充 NodeManager setParent 单测，覆盖非法重挂和合法重挂路径。
