### PR TITLE
Feature/assets serialized data

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -446,6 +446,53 @@ export declare function init(): Promise<void>;
 export declare interface IPluginScriptInfo extends PluginScriptInfo {
     url: string;
 }
+export declare interface IProperty {
+    value: { [key: string]: IPropertyValueType } | IPropertyValueType;
+    default?: any;
+    values?: ({ [key: string]: IPropertyValueType } | IPropertyValueType)[];
+    lock?: { [key in keyof Vec4]?: IPropertyLock };
+    cid?: string;
+    type?: string;
+    ui?: { name: string; data?: any };
+    readonly?: boolean;
+    visible?: boolean;
+    name?: string;
+    elementTypeData?: IProperty;
+    path: string;
+    isArray?: boolean;
+    invalid?: boolean;
+    extends?: string[];
+    displayName?: string;
+    displayOrder?: number;
+    help?: string;
+    group?: IPropertyGroupOptions;
+    tooltip?: string;
+    editor?: any;
+    animatable?: boolean;
+    radioGroup?: boolean;
+    enumList?: any[];
+    bitmaskList?: any[];
+    min?: number;
+    max?: number;
+    step?: number;
+    slide?: boolean;
+    unit?: string;
+    radian?: boolean;
+    multiline?: boolean;
+    optionalTypes?: string[];
+    userData?: { [key: string]: any };
+}
+export declare interface IPropertyGroupOptions {
+    id: string
+    name: string,
+    displayOrder: number,
+    style: string
+}
+export declare type IPropertyLock = {
+    default: number;
+    message: string
+};
+export declare type IPropertyValueType = IProperty | IProperty[] | null | undefined | number | boolean | string | Vec4 | Vec3 | Vec2 | Mat4 | any | Array<unknown>
 export declare interface IRedirectInfo {
     type: string;
     uuid: string;
@@ -517,6 +564,24 @@ export declare const enum LogLevel {
     WARN = 2,
     LOG = 3,
     DEBUG = 4
+}
+export declare interface Mat4 {
+    m00: number;
+    m01: number;
+    m02: number;
+    m03: number;
+    m04: number;
+    m05: number;
+    m06: number;
+    m07: number;
+    m08: number;
+    m09: number;
+    m10: number;
+    m11: number;
+    m12: number;
+    m13: number;
+    m14: number;
+    m15: number;
 }
 export declare interface MeshClusterOptions {
     enable: boolean;
@@ -641,6 +706,7 @@ export declare function queryAssetUserDataConfig(urlOrUuidOrPath: string): Promi
 export declare function queryAssetUsers(uuidOrUrl: string, type?: QueryAssetType): Promise<string[]>;
 export declare function queryCreateMap(): Promise<ICreateMenuInfo[]>;
 export declare function queryPath(urlOrUuid: string): Promise<string>;
+export declare function querySerializedData(uuidOrUrlOrPath: string): Promise<SerializedAssetQueryResult>;
 export declare function querySortedPlugins(filterOptions?: FilterPluginOptions): Promise<IPluginScriptInfo[]>;
 export declare function queryThumbnailHandlers(): string[];
 export declare function queryUrl(uuidOrPath: string): Promise<string>;
@@ -659,9 +725,11 @@ export declare interface RtSpriteFrameAssetUserData {
 }
 export declare function saveAsset(pathOrUrlOrUUID: string, data: string | Buffer): Promise<IAssetInfo>;
 export declare function saveAssetMeta(uuid: string, meta: IAssetMeta): Promise<void>;
+export declare function saveSerializedData(uuidOrUrlOrPath: string, patch: SerializedAssetPatch): Promise<SerializedAssetQueryResult>;
 export declare interface ScriptModuleUserData {
     isPlugin: false;
 }
+export declare type SerializedAssetDump = Record<string, IProperty> | IProperty;
 export declare interface SerializedAssetFinder {
     meshes?: Array<string | null>;
     animations?: Array<string | null>;
@@ -670,6 +738,18 @@ export declare interface SerializedAssetFinder {
     materials?: Array<string | null>;
     scenes?: Array<string | null>;
 }
+export declare type SerializedAssetPatch = SerializedAssetDump | Partial<Record<string, IProperty | unknown>>;
+export declare interface SerializedAssetQueryResult {
+    uuid: string;
+    url: string;
+    type: string;
+    importer: string;
+    dump: SerializedAssetDump;
+}
+export declare const serializedData: {
+    query: typeof querySerializedData;
+    save: typeof saveSerializedData;
+};
 export declare function setFileSystemProvider(provider: IAssetFileSystemProvider): void;
 export declare interface SimplifyOptions {
     targetRatio?: number;
@@ -763,6 +843,21 @@ export declare interface ThumbnailInfo {
 export declare type ThumbnailSize = 'large' | 'small' | 'middle' | 'origin';
 export declare function updateAssetUserData(urlOrUuidOrPath: string, path: string, value: any): Promise<any>;
 export declare function updateDefaultUserData(handler: string, path: string, value: any): Promise<void>;
+export declare interface Vec2 {
+    x: number;
+    y: number;
+}
+export declare interface Vec3 {
+    x: number;
+    y: number;
+    z: number;
+}
+export declare interface Vec4 {
+    x: number;
+    y: number;
+    z: number;
+    w: number;
+}
 export declare type WrapMode = 'repeat' | 'clamp-to-edge' | 'mirrored-repeat';
 export { }
 "
@@ -6829,6 +6924,8 @@ export declare namespace Assets {
         importAsset,
         reimportAsset,
         saveAsset,
+        querySerializedData,
+        saveSerializedData,
         queryUUID,
         queryPath,
         queryUrl,
@@ -6854,6 +6951,8 @@ export declare namespace Assets {
         QueryAssetType,
         FilterPluginOptions,
         IPluginScriptInfo,
+        serializedData,
+        IProperty,
         IAssetDeleteOptions,
         IAssetFileSystemProvider,
         IAssetOperationContext,
@@ -6862,6 +6961,9 @@ export declare namespace Assets {
         IAssetRenameOptions,
         IAssetWriteFileOptions,
         IAssetMeta,
+        SerializedAssetDump,
+        SerializedAssetPatch,
+        SerializedAssetQueryResult,
         IAssetInfo,
         AssetOperationOption,
         DeleteAssetOptions,
@@ -7593,6 +7695,53 @@ export declare interface IProject {
     getInfo(key?: string): ProjectInfo | any;
     updateInfo<T>(keyOrValue: string | ProjectInfo, value?: T): Promise<boolean>;
 }
+export declare interface IProperty {
+    value: { [key: string]: IPropertyValueType } | IPropertyValueType;
+    default?: any;
+    values?: ({ [key: string]: IPropertyValueType } | IPropertyValueType)[];
+    lock?: { [key in keyof Vec4]?: IPropertyLock };
+    cid?: string;
+    type?: string;
+    ui?: { name: string; data?: any };
+    readonly?: boolean;
+    visible?: boolean;
+    name?: string;
+    elementTypeData?: IProperty;
+    path: string;
+    isArray?: boolean;
+    invalid?: boolean;
+    extends?: string[];
+    displayName?: string;
+    displayOrder?: number;
+    help?: string;
+    group?: IPropertyGroupOptions;
+    tooltip?: string;
+    editor?: any;
+    animatable?: boolean;
+    radioGroup?: boolean;
+    enumList?: any[];
+    bitmaskList?: any[];
+    min?: number;
+    max?: number;
+    step?: number;
+    slide?: boolean;
+    unit?: string;
+    radian?: boolean;
+    multiline?: boolean;
+    optionalTypes?: string[];
+    userData?: { [key: string]: any };
+}
+export declare interface IPropertyGroupOptions {
+    id: string
+    name: string,
+    displayOrder: number,
+    style: string
+}
+export declare type IPropertyLock = {
+    default: number;
+    message: string
+};
+export declare type IPropertyValueType = IProperty | IProperty[] | null | undefined | number | boolean | string | Vec4 | Vec3 | Vec2 | Mat4 | any | Array<unknown>
 export declare interface IRedirectInfo {
     type: string;
     uuid: string;
@@ -7706,6 +7855,24 @@ export declare type MacroItem = {
     value: boolean;
 }
 export declare type MakeRequired<T, K extends keyof T> = T & Required<Pick<T, K>>;
+export declare interface Mat4 {
+    m00: number;
+    m01: number;
+    m02: number;
+    m03: number;
+    m04: number;
+    m05: number;
+    m06: number;
+    m07: number;
+    m08: number;
+    m09: number;
+    m10: number;
+    m11: number;
+    m12: number;
+    m13: number;
+    m14: number;
+    m15: number;
+}
 export declare namespace Mcp {
     export {
         register,
@@ -7954,6 +8121,7 @@ export declare function queryLayerBuiltin(): Promise<{
     value: number;
 }[]>;
 export declare function queryPath(urlOrUuid: string): Promise<string>;
+export declare function querySerializedData(uuidOrUrlOrPath: string): Promise<SerializedAssetQueryResult>;
 export declare function querySortedPlugins(filterOptions?: FilterPluginOptions): Promise<IPluginScriptInfo[]>;
 export declare function querySortingLayerBuiltin(): Promise<readonly __private._cocos_sorting_sorting_layers__SortingItem[]>;
 export declare function queryThumbnailHandlers(): string[];
@@ -7978,6 +8146,7 @@ export declare interface RtSpriteFrameAssetUserData {
 export declare function save(force?: boolean): Promise<void>;
 export declare function saveAsset(pathOrUrlOrUUID: string, data: string | Buffer): Promise<IAssetInfo>;
 export declare function saveAssetMeta(uuid: string, meta: IAssetMeta): Promise<void>;
+export declare function saveSerializedData(uuidOrUrlOrPath: string, patch: SerializedAssetPatch): Promise<SerializedAssetQueryResult>;
 export declare namespace Scene {
     export {
         init_6 as init,
@@ -8002,6 +8171,7 @@ export declare namespace Scripting {
 export declare interface ScriptModuleUserData {
     isPlugin: false;
 }
+export declare type SerializedAssetDump = Record<string, IProperty> | IProperty;
 export declare interface SerializedAssetFinder {
     meshes?: Array<string | null>;
     animations?: Array<string | null>;
@@ -8010,6 +8180,18 @@ export declare interface SerializedAssetFinder {
     materials?: Array<string | null>;
     scenes?: Array<string | null>;
 }
+export declare type SerializedAssetPatch = SerializedAssetDump | Partial<Record<string, IProperty | unknown>>;
+export declare interface SerializedAssetQueryResult {
+    uuid: string;
+    url: string;
+    type: string;
+    importer: string;
+    dump: SerializedAssetDump;
+}
+export declare const serializedData: {
+    query: typeof querySerializedData;
+    save: typeof saveSerializedData;
+};
 export declare namespace Server {
     export {
         start_2 as start,
@@ -8134,6 +8316,21 @@ export declare type ThumbnailSize = 'large' | 'small' | 'middle' | 'origin';
 export declare function unregister(): Promise<void>;
 export declare function updateAssetUserData(urlOrUuidOrPath: string, path: string, value: any): Promise<any>;
 export declare function updateDefaultUserData(handler: string, path: string, value: any): Promise<void>;
+export declare interface Vec2 {
+    x: number;
+    y: number;
+}
+export declare interface Vec3 {
+    x: number;
+    y: number;
+    z: number;
+}
+export declare interface Vec4 {
+    x: number;
+    y: number;
+    z: number;
+    w: number;
+}
 export declare type WrapMode = 'repeat' | 'clamp-to-edge' | 'mirrored-repeat';
 export { }
 "

--- a/packages/cocos-cli-types/__tests__/assets.test.ts
+++ b/packages/cocos-cli-types/__tests__/assets.test.ts
@@ -1,4 +1,4 @@
-import type { AssetHandlerType, AssetDBOptions, IAssetInfo, IAssetType } from '../assets';
+import type { AssetHandlerType, AssetDBOptions, IAssetInfo, IAssetType, IProperty, SerializedAssetQueryResult } from '../assets';
 
 describe('cocos-cli-types: assets', () => {
     it('should be able to import AssetHandlerType', () => {
@@ -26,5 +26,28 @@ describe('cocos-cli-types: assets', () => {
     it('should be able to import IAssetType', () => {
         let type: IAssetType = 'cc.Texture2D';
         expect(type).toBe('cc.Texture2D');
+    });
+
+    it('should be able to import serialized data types and namespace', () => {
+        const property: IProperty = {
+            name: 'friction',
+            path: 'friction',
+            type: 'Float',
+            value: 0.5,
+        };
+        const result: SerializedAssetQueryResult = {
+            uuid: 'test-uuid',
+            url: 'db://assets/test.pmtl',
+            type: 'cc.PhysicsMaterial',
+            importer: 'physics-material',
+            dump: { friction: property },
+        };
+
+        const query: typeof import('../assets').serializedData.query = async () => result;
+        const save: typeof import('../assets').serializedData.save = async () => result;
+
+        expect(result.dump).toEqual({ friction: property });
+        expect(query).toEqual(expect.any(Function));
+        expect(save).toEqual(expect.any(Function));
     });
 });

--- a/src/api/assets/assets.ts
+++ b/src/api/assets/assets.ts
@@ -12,6 +12,8 @@ import {
     SchemaSourcePath,
     SchemaSaveAssetPath,
     SchemaAssetData,
+    SchemaSerializedAssetPatch,
+    SchemaSerializedAssetResult,
     TUrlOrUUIDOrPath,
     TSaveAssetPath,
     TDataKeys,
@@ -19,6 +21,8 @@ import {
     TSupportCreateType,
     TAssetOperationOption,
     TAssetData,
+    TSerializedAssetPatch,
+    TSerializedAssetResult,
     SchemaAssetInfoResult,
     SchemaAssetMetaResult,
     SchemaCreateMapResult,
@@ -402,6 +406,61 @@ export class AssetsApi {
         } catch (e) {
             ret.code = getCommonErrorStatus(e);
             console.error('save asset fail:', e instanceof Error ? e.message : String(e));
+            ret.reason = e instanceof Error ? e.message : String(e);
+        }
+
+        return ret;
+    }
+
+    /**
+     * Query Serialized Asset Data // 查询序列化资源属性数据
+     */
+    @tool('assets-query-serialized-data')
+    @title('Query Serialized Asset Data')
+    @description('Query Creator-compatible serialized asset dump data through assets.serializedData.query. Supports only cc.PhysicsMaterial and cc.RenderPipeline in the first batch. The returned dump is the raw IProperty structure consumed by ui-prop type="dump": PhysicsMaterial returns a property map, while RenderPipeline returns one top-level IProperty.')
+    @result(SchemaSerializedAssetResult)
+    async querySerializedData(
+        @param(SchemaUrlOrUUIDOrPath) uuidOrUrlOrPath: TUrlOrUUIDOrPath
+    ): Promise<CommonResultType<TSerializedAssetResult>> {
+        const code: HttpStatusCode = COMMON_STATUS.SUCCESS;
+        const ret: CommonResultType<TSerializedAssetResult> = {
+            code: code,
+            data: null,
+        };
+
+        try {
+            ret.data = await assetManager.querySerializedData(uuidOrUrlOrPath);
+        } catch (e) {
+            ret.code = getCommonErrorStatus(e);
+            console.error('query serialized asset data fail:', e instanceof Error ? e.message : String(e));
+            ret.reason = e instanceof Error ? e.message : String(e);
+        }
+
+        return ret;
+    }
+
+    /**
+     * Save Serialized Asset Data // 保存序列化资源属性数据
+     */
+    @tool('assets-save-serialized-data')
+    @title('Save Serialized Asset Data')
+    @description('Save Creator-compatible serialized asset dump data through assets.serializedData.save. Supports only cc.PhysicsMaterial and cc.RenderPipeline in the first batch. Prefer passing an IProperty or full dump patch returned by assets-query-serialized-data; unknown fields are rejected, and hidden or readonly fields can only pass through unchanged.')
+    @result(SchemaSerializedAssetResult)
+    async saveSerializedData(
+        @param(SchemaUrlOrUUIDOrPath) uuidOrUrlOrPath: TUrlOrUUIDOrPath,
+        @param(SchemaSerializedAssetPatch) patch: TSerializedAssetPatch
+    ): Promise<CommonResultType<TSerializedAssetResult>> {
+        const code: HttpStatusCode = COMMON_STATUS.SUCCESS;
+        const ret: CommonResultType<TSerializedAssetResult> = {
+            code: code,
+            data: null,
+        };
+
+        try {
+            ret.data = await assetManager.saveSerializedData(uuidOrUrlOrPath, patch);
+        } catch (e) {
+            ret.code = getCommonErrorStatus(e);
+            console.error('save serialized asset data fail:', e instanceof Error ? e.message : String(e));
             ret.reason = e instanceof Error ? e.message : String(e);
         }
 

--- a/src/api/assets/schema.ts
+++ b/src/api/assets/schema.ts
@@ -161,6 +161,31 @@ export const SchemaSourcePath = z.string().min(1).describe('Source file path, lo
 export const SchemaSaveAssetPath = SchemaUrlOrUUIDOrPath.describe('Required existing asset URL, UUID, or file path to save. This must refer to an asset that already exists in the asset database.'); // 保存已有资源时使用的 URL、UUID 或文件路径
 export const SchemaAssetData = z.string().min(1).describe('Required complete file content to save. Do not omit this field, pass an empty string, or pass partial/truncated script content.'); // 要保存的完整资源数据
 
+// Serialized asset data related // 序列化资源数据相关
+export const SchemaSerializedAssetProperty: z.ZodType<any> = z.lazy(() => z.object({
+    name: z.string().optional().describe('Property name'), // 属性名
+    value: z.any().describe('Property value or nested property map'), // 属性值或嵌套属性映射
+    default: z.any().optional().describe('Default value'), // 默认值
+    type: z.string().optional().describe('Cocos class or value type'), // Cocos 类或值类型
+    path: z.string().optional().describe('Dump property path'), // dump 属性路径
+    readonly: z.boolean().optional().describe('Whether property is read-only'), // 是否只读
+    visible: z.boolean().optional().describe('Whether property is visible'), // 是否可见
+    isArray: z.boolean().optional().describe('Whether property value is an array'), // 是否数组
+    enumList: z.array(z.any()).optional().describe('Enum option list'), // 枚举选项列表
+    optionalTypes: z.array(z.string()).optional().describe('Optional concrete types for variable type properties'), // 可变类型的可选类型列表
+    elementTypeData: z.lazy(() => SchemaSerializedAssetProperty).optional().describe('Default dump data for array elements'), // 数组元素默认 dump
+}).passthrough().describe('Creator-compatible serialized asset IProperty dump'));
+
+export const SchemaSerializedAssetDump = z.union([
+    z.record(z.string(), SchemaSerializedAssetProperty),
+    SchemaSerializedAssetProperty,
+]).describe('Creator-compatible serialized asset dump. PhysicsMaterial returns a property map, RenderPipeline returns a top-level IProperty.');
+
+export const SchemaSerializedAssetPatch = z.union([
+    SchemaSerializedAssetDump,
+    z.record(z.string(), z.any()),
+]).describe('Serialized asset patch. Prefer IProperty or full dump patches; raw value maps are accepted only for convenience.');
+
 // Return value Schema // 返回值 Schema
 export const SchemaAssetInfoResult = SchemaAssetInfo.nullable().describe('Asset detailed information object, including name, type, path, UUID, etc.'); // 资源详细信息对象，包含名称、类型、路径、UUID 等字段
 export const SchemaAssetMetaResult = SchemaAssetMeta.nullable().describe('Asset metadata object, including import configuration, user data, etc.'); // 资源元数据对象，包含导入配置、用户数据等
@@ -171,6 +196,13 @@ export const SchemaCreatedAssetResult = SchemaAssetInfo.nullable().describe('Cre
 export const SchemaImportedAssetResult = z.array(SchemaAssetInfo).describe('Imported asset information array, includes folder and all its sub-assets information when importing folder'); // 导入的资源信息数组，当导入文件夹时会包含文件夹及其所有子资源的信息
 export const SchemaReimportResult = SchemaAssetInfo.nullable().describe('Re-import operation result'); // 重新导入操作结果
 export const SchemaSaveAssetResult = SchemaAssetInfo.nullable().describe('Asset information object after saving asset'); // 保存资源后的资源信息对象
+export const SchemaSerializedAssetResult = z.object({
+    uuid: z.string().describe('Asset UUID'), // 资源 UUID
+    url: z.string().describe('Asset db URL'), // 资源 db URL
+    type: z.string().describe('Cocos asset type'), // Cocos 资源类型
+    importer: z.string().describe('Asset importer name'), // 资源导入器名称
+    dump: SchemaSerializedAssetDump.describe('Creator-compatible raw dump'), // Creator 兼容 raw dump
+}).nullable().describe('Serialized asset query/save result'); // 序列化资源 query/save 结果
 export const SchemaRefreshDirResult = z.null().describe('Refresh asset directory result'); // 刷新资源目录结果
 export const SchemaUUIDResult = z.string().nullable().describe('Unique identifier UUID of the asset'); // 资源的唯一标识符 UUID
 export const SchemaPathResult = z.string().nullable().describe('File system path of the asset'); // 资源的文件系统路径
@@ -226,6 +258,7 @@ export type TAssetNewName = z.infer<typeof SchemaAssetNewName>;
 export type TAssetOperationOption = z.infer<typeof SchemaAssetOperationOption> | undefined;
 export type TSourcePath = z.infer<typeof SchemaSourcePath>;
 export type TAssetData = z.infer<typeof SchemaAssetData>;
+export type TSerializedAssetPatch = z.infer<typeof SchemaSerializedAssetPatch>;
 export type TAssetInfoResult = z.infer<typeof SchemaAssetInfoResult>;
 export type TAssetMetaResult = z.infer<typeof SchemaAssetMetaResult>;
 export type TCreateMapResult = z.infer<typeof SchemaCreateMapResult>;
@@ -237,6 +270,7 @@ export type TCreateAssetOptions = z.infer<typeof SchemaCreateAssetOptions>;
 export type TImportedAssetResult = z.infer<typeof SchemaImportedAssetResult>;
 export type TReimportResult = z.infer<typeof SchemaAssetInfoResult>;
 export type TSaveAssetResult = z.infer<typeof SchemaSaveAssetResult>;
+export type TSerializedAssetResult = z.infer<typeof SchemaSerializedAssetResult>;
 export type TRefreshDirResult = z.infer<typeof SchemaRefreshDirResult>;
 export type TUUIDResult = z.infer<typeof SchemaUUIDResult>;
 export type TPathResult = z.infer<typeof SchemaPathResult>;

--- a/src/core/assets/@types/public.d.ts
+++ b/src/core/assets/@types/public.d.ts
@@ -1,4 +1,6 @@
 import { AssetHandlerType, ISupportCreateType, AssetUserDataMap, IAssetType } from './asset-types';
+import type { IProperty } from '../../scene/@types/public';
+export type { IProperty } from '../../scene/@types/public';
 export type {
     IAssetDeleteOptions,
     IAssetFileSystemProvider,
@@ -22,6 +24,17 @@ export interface IAssetMeta<T extends ISupportCreateType | 'unknown' = 'unknown'
     displayName?: string;
     id?: string;
     name?: string;
+}
+
+export type SerializedAssetDump = Record<string, IProperty> | IProperty;
+export type SerializedAssetPatch = SerializedAssetDump | Partial<Record<string, IProperty | unknown>>;
+
+export interface SerializedAssetQueryResult {
+    uuid: string;
+    url: string;
+    type: string;
+    importer: string;
+    dump: SerializedAssetDump;
 }
 
 // 如果使用了 datakeys 过滤，请使用此接口定义

--- a/src/core/assets/manager/asset.ts
+++ b/src/core/assets/manager/asset.ts
@@ -7,6 +7,7 @@ import type { ThumbnailInfo, ThumbnailSize } from '../@types/protected/asset-han
 import assetQuery from './query';
 import assetOperation from './operation';
 import assetHandlerManager from './asset-handler';
+import * as serializedData from '../serialized-data';
 
 /**
  * 对外暴露一系列的资源查询、操作接口等
@@ -46,6 +47,8 @@ class AssetManager extends EventEmitter {
     outputExportData = assetOperation.outputExportData.bind(assetOperation);
     createAssetByType = assetOperation.createAssetByType.bind(assetOperation);
     updateUserData = assetOperation.updateUserData.bind(assetOperation);
+    querySerializedData = serializedData.querySerializedData;
+    saveSerializedData = serializedData.saveSerializedData;
 
     // ----------- assetHandlerManager ------------
     queryAssetConfigMap = assetHandlerManager.queryAssetConfigMap.bind(assetHandlerManager);
@@ -352,6 +355,8 @@ export interface TypedAssetManager extends EventEmitter {
     outputExportData: typeof assetOperation.outputExportData;
     createAssetByType: typeof assetOperation.createAssetByType;
     updateUserData: typeof assetOperation.updateUserData;
+    querySerializedData: typeof serializedData.querySerializedData;
+    saveSerializedData: typeof serializedData.saveSerializedData;
 
     queryAssetConfigMap: typeof assetHandlerManager.queryAssetConfigMap;
     updateDefaultUserData: typeof assetHandlerManager.updateDefaultUserData;

--- a/src/core/assets/serialized-data.ts
+++ b/src/core/assets/serialized-data.ts
@@ -1,0 +1,479 @@
+'use strict';
+
+declare const cc: any;
+
+import { readJSON } from 'fs-extra';
+import cloneDeep from 'lodash/cloneDeep';
+import isEqual from 'lodash/isEqual';
+import { deserialize as deserializeAssetSource } from './asset-handler/utils';
+import type { IAsset } from './@types/protected';
+import type { IAssetInfo } from './@types/public';
+import type { IProperty } from '../scene/@types/public';
+import assetOperation from './manager/operation';
+import assetQuery from './manager/query';
+import { serialize as editorSerialize } from '../engine/editor-extends';
+
+export type SerializedAssetDump = Record<string, IProperty> | IProperty;
+export type SerializedAssetPatch = SerializedAssetDump | Partial<Record<string, IProperty | unknown>>;
+
+export interface SerializedAssetQueryResult {
+    uuid: string;
+    url: string;
+    type: string;
+    importer: string;
+    dump: SerializedAssetDump;
+}
+
+const SUPPORTED_TYPES = new Set(['cc.PhysicsMaterial', 'cc.RenderPipeline']);
+
+const RENDER_PIPELINE_CHANGE_TYPES: Record<string, { componentKey: string; optionalTypes: string[] }> = {
+    _flows: {
+        componentKey: 'flow',
+        optionalTypes: [],
+    },
+    _stages: {
+        componentKey: 'stage',
+        optionalTypes: [],
+    },
+};
+
+export async function querySerializedData(uuidOrUrlOrPath: string): Promise<SerializedAssetQueryResult> {
+    const { asset, assetInfo } = resolveSerializedAsset(uuidOrUrlOrPath);
+    const instance = await loadSerializedAssetInstance(asset);
+
+    return {
+        uuid: asset.uuid,
+        url: assetInfo.url,
+        type: assetInfo.type,
+        importer: assetInfo.importer,
+        dump: await encodeSerializedAssetDump(instance, assetInfo.type),
+    };
+}
+
+export async function saveSerializedData(
+    uuidOrUrlOrPath: string,
+    patch: SerializedAssetPatch,
+): Promise<SerializedAssetQueryResult> {
+    const { asset, assetInfo } = resolveSerializedAsset(uuidOrUrlOrPath);
+    const instance = await loadSerializedAssetInstance(asset);
+    let normalizedInstance = instance;
+
+    if (assetInfo.type === 'cc.RenderPipeline' && isPropertyLike(patch)) {
+        normalizedInstance = createRenderPipelineInstanceIfNeeded(normalizedInstance, patch);
+    }
+
+    const currentDump = await encodeSerializedAssetDump(normalizedInstance, assetInfo.type);
+    const currentFieldDump = getFieldDumpFromAssetDump(assetInfo.type, currentDump);
+    const patchFieldDump = normalizePatchFieldDump(assetInfo.type, currentFieldDump, patch);
+
+    await applyFieldDumpPatch(normalizedInstance, currentFieldDump, patchFieldDump);
+
+    const serialized = getEditorSerialize()(normalizedInstance);
+    await assetOperation.saveAsset(asset.uuid, formatSerializedContent(serialized));
+
+    return querySerializedData(asset.uuid);
+}
+
+function resolveSerializedAsset(uuidOrUrlOrPath: string): { asset: IAsset; assetInfo: IAssetInfo } {
+    const asset = assetQuery.queryAsset(uuidOrUrlOrPath);
+    if (!asset) {
+        throw new Error(`Serialized asset can not be found: ${uuidOrUrlOrPath}`);
+    }
+
+    const assetInfo = assetQuery.encodeAsset(asset);
+    if (!SUPPORTED_TYPES.has(assetInfo.type)) {
+        throw new Error(`Unsupported serialized asset type: ${assetInfo.type}. Only cc.PhysicsMaterial and cc.RenderPipeline are supported.`);
+    }
+
+    if (!asset.source) {
+        throw new Error(`Serialized asset has no source file: ${uuidOrUrlOrPath}`);
+    }
+
+    return { asset, assetInfo };
+}
+
+async function loadSerializedAssetInstance(asset: IAsset): Promise<any> {
+    const source = await readJSON(asset.source);
+    const instance = deserializeAssetSource(source);
+    if (!instance) {
+        throw new Error(`Deserialize serialized asset failed: ${asset.url || asset.uuid}`);
+    }
+    if ('_uuid' in instance) {
+        instance._uuid = asset.uuid;
+    }
+    return instance;
+}
+
+async function encodeSerializedAssetDump(instance: any, type: string): Promise<SerializedAssetDump> {
+    const { encodeObject } = await loadDumpEncode();
+
+    if (type === 'cc.RenderPipeline') {
+        const dump = encodeComponentAsset(instance, modifyRenderPipelineProp, encodeObject);
+        return {
+            name: 'Pipeline',
+            type: instance.constructor.name,
+            value: dump,
+            visible: true,
+            readonly: false,
+            optionalTypes: queryRenderComponents('pipeline'),
+            path: '',
+        };
+    }
+
+    return encodeComponentAsset(instance, modifyPropName, encodeObject);
+}
+
+function encodeComponentAsset(
+    instance: any,
+    modifyProp: (prop: IProperty, name?: string) => void,
+    encodeObject: (object: any, attributes: any, owner?: any, objectKey?: string, isTemplate?: boolean) => IProperty,
+): Record<string, IProperty> {
+    const ctor = instance.constructor;
+    if (!ctor.__props__) {
+        throw new Error(`Serialized asset type has no editable properties: ${ctor.name || 'Unknown'}`);
+    }
+
+    const value: Record<string, IProperty> = {};
+    ctor.__props__.forEach((key: string) => {
+        try {
+            if (!(key in instance)) {
+                return;
+            }
+            const attrs = cc.Class.attr(ctor, key);
+            const dumpData = encodeObject(instance[key], attrs, instance, key);
+            if (dumpData.type !== 'Unknown') {
+                value[key] = dumpData;
+                modifyProp(value[key], key);
+            }
+        } catch (error) {
+            console.warn(`Asset property dump failed:\n Asset: ${ctor.name}\n Property: ${key}`);
+            console.warn(error);
+            delete value[key];
+        }
+    });
+    return value;
+}
+
+function modifyPropName(prop: IProperty, name?: string) {
+    prop.name = name;
+
+    if (prop.value && typeof prop.value === 'object') {
+        for (const key in prop.value as Record<string, unknown>) {
+            const child = (prop.value as Record<string, unknown>)[key];
+            if (child && typeof child === 'object') {
+                modifyPropName(child as IProperty, key);
+            }
+        }
+    }
+}
+
+function modifyRenderPipelineProp(prop: IProperty, name?: string) {
+    prop.name = name;
+
+    if (prop.visible === false) {
+        return;
+    }
+
+    if (prop.value && typeof prop.value === 'object') {
+        const changeType = name ? RENDER_PIPELINE_CHANGE_TYPES[name] : undefined;
+
+        if (changeType) {
+            changeType.optionalTypes = queryRenderComponents(changeType.componentKey);
+        }
+
+        if (prop.isArray && prop.elementTypeData && changeType) {
+            modifyRenderPipelineProp(prop.elementTypeData);
+            prop.elementTypeData.optionalTypes = changeType.optionalTypes;
+        }
+
+        for (const key in prop.value as Record<string, unknown>) {
+            const child = (prop.value as Record<string, unknown>)[key];
+            if (child && typeof child === 'object') {
+                modifyRenderPipelineProp(child as IProperty, key);
+
+                if (prop.isArray && changeType) {
+                    (child as IProperty).optionalTypes = changeType.optionalTypes;
+                }
+            }
+        }
+    }
+}
+
+function queryRenderComponents(type: string | undefined = undefined): string[] {
+    const editorExtends = (globalThis as any).EditorExtends;
+    const menus = editorExtends?.Component?.getMenus?.() || [];
+    const prefix = `hidden:render_${type}/`;
+
+    return menus
+        .map((item: any) => {
+            if (!item?.component || typeof item.menuPath !== 'string') {
+                return null;
+            }
+            if (!item.menuPath.includes(prefix)) {
+                return null;
+            }
+            return item.menuPath.replace(prefix, '');
+        })
+        .filter(Boolean);
+}
+
+function getFieldDumpFromAssetDump(type: string, dump: SerializedAssetDump): Record<string, IProperty> {
+    if (type === 'cc.RenderPipeline') {
+        if (!isPropertyLike(dump) || !isRecord(dump.value)) {
+            throw new Error('Invalid RenderPipeline serialized dump.');
+        }
+        return dump.value as Record<string, IProperty>;
+    }
+    return dump as Record<string, IProperty>;
+}
+
+function normalizePatchFieldDump(
+    type: string,
+    currentDump: Record<string, IProperty>,
+    patch: SerializedAssetPatch,
+): Record<string, IProperty> {
+    const patchRecord = type === 'cc.RenderPipeline' && isPropertyLike(patch)
+        ? patch.value
+        : patch;
+
+    if (!isRecord(patchRecord)) {
+        throw new Error('Serialized asset patch must be a dump object.');
+    }
+
+    const result: Record<string, IProperty> = {};
+    for (const [key, value] of Object.entries(patchRecord)) {
+        const current = currentDump[key];
+        if (!current) {
+            throw new Error(`Unknown serialized field: ${key}`);
+        }
+
+        const next = isPropertyLike(value)
+            ? cloneDeep(value)
+            : {
+                ...cloneDeep(current),
+                value,
+            };
+
+        validatePropertyPatch(key, current, next);
+        result[key] = next;
+    }
+    return result;
+}
+
+function validatePropertyPatch(path: string, current: IProperty, next: IProperty) {
+    const changed = !isEqual(current.value, next.value);
+    if ((current.visible === false || current.readonly === true) && changed) {
+        throw new Error(`Serialized field is readonly or hidden and can not be modified: ${path}`);
+    }
+
+    if (Array.isArray(current.value) && Array.isArray(next.value)) {
+        for (let i = 0; i < next.value.length; i++) {
+            const nextChild = next.value[i];
+            const currentChild = findCurrentArrayChild(current.value, nextChild, i);
+            if (!currentChild) {
+                continue;
+            }
+            if (isPropertyLike(currentChild) && isPropertyLike(nextChild)) {
+                validatePropertyPatch(`${path}.${i}`, currentChild, nextChild);
+            }
+        }
+        return;
+    }
+
+    if (!isRecord(current.value) || !isRecord(next.value)) {
+        return;
+    }
+
+    for (const [key, value] of Object.entries(next.value)) {
+        const currentChild = current.value[key];
+        if (!currentChild) {
+            throw new Error(`Unknown serialized field: ${path}.${key}`);
+        }
+        if (isPropertyLike(currentChild) && isPropertyLike(value)) {
+            validatePropertyPatch(`${path}.${key}`, currentChild, value);
+        }
+    }
+}
+
+function findCurrentArrayChild(currentValue: unknown[], nextChild: unknown, index: number): unknown {
+    if (isPropertyLike(nextChild) && typeof nextChild.name === 'string') {
+        const originalIndex = Number(nextChild.name);
+        if (Number.isInteger(originalIndex) && originalIndex >= 0 && originalIndex < currentValue.length) {
+            return currentValue[originalIndex];
+        }
+    }
+    return currentValue[index];
+}
+
+async function applyFieldDumpPatch(
+    instance: any,
+    currentDump: Record<string, IProperty>,
+    patchDump: Record<string, IProperty>,
+) {
+    for (const key in patchDump) {
+        const current = currentDump[key];
+        if (current.visible === false || current.readonly === true) {
+            continue;
+        }
+        await setValue(instance, patchDump, key);
+    }
+}
+
+async function setValue(prop: any, dump: Record<string, any> | any, key: string) {
+    if (!dump) {
+        return;
+    }
+
+    if (typeof dump !== 'object') {
+        if (key === 'uuid' && '_uuid' in prop) {
+            prop._uuid = dump;
+            return;
+        }
+        prop[key] = dump;
+        return;
+    }
+
+    if (!dump[key].isArray) {
+        if (dump[key].value === null || typeof dump[key].value !== 'object') {
+            prop[key] = dump[key].value;
+        } else {
+            const names = Object.keys(dump[key].value);
+            for (const name of names) {
+                if (name === 'uuid') {
+                    const uuid = extractUuidValue(dump[key].value[name]);
+                    prop[key] = uuid ? createAssetReference(uuid, dump[key].type) : null;
+                } else {
+                    await setValue(prop[key], dump[key].value, name);
+                }
+            }
+        }
+    } else {
+        const propKeyAttr = cc.Class.attr(prop.constructor, key);
+
+        if (!Array.isArray(prop[key])) {
+            const dumpUtil = await loadDumpUtils();
+            prop[key] = dumpUtil.default.ccClassAttrPropertyDefaultValue(propKeyAttr);
+        }
+
+        if (!Array.isArray(prop[key])) {
+            delete prop[key];
+        } else {
+            const oldLength = prop[key].length;
+            const newLength = Array.isArray(dump[key].value) ? dump[key].value.length : 0;
+            if (newLength > oldLength) {
+                for (let i = oldLength; i < newLength; i++) {
+                    prop[key][i] = await createValueForDumpItem(dump[key].value[i]);
+                    await setValue(prop[key], dump[key].value, i.toString());
+                }
+            } else if (newLength < oldLength) {
+                while (prop[key].length > newLength) {
+                    prop[key].pop();
+                }
+            } else if (oldLength) {
+                const arrayClone = prop[key].slice();
+                prop[key] = [];
+                for (let i = 0; i < oldLength; i++) {
+                    if (dump[key].value[i] === undefined) {
+                        continue;
+                    }
+                    prop[key][i] = arrayClone[dump[key].value[i].name];
+                }
+            }
+
+            for (let i = 0; i < prop[key].length; i++) {
+                const itemDump = dump[key].value[i];
+                if (itemDump?.type && (!prop[key][i] || itemDump.type !== prop[key][i].constructor.name)) {
+                    const typeClass = cc.js.getClassByName(itemDump.type);
+                    if (typeClass) {
+                        prop[key][i] = new typeClass();
+                    }
+                }
+
+                await setValue(prop[key], dump[key].value, i.toString());
+            }
+        }
+    }
+}
+
+async function createValueForDumpItem(itemDump: IProperty) {
+    if (!itemDump?.type) {
+        return null;
+    }
+
+    const typeClass = cc.js.getClassByName(itemDump.type);
+    if (typeClass) {
+        return new typeClass();
+    }
+
+    const assetDumpUtil = await loadAssetDumpUtil();
+    return assetDumpUtil.default.getDefaultValue(itemDump.type);
+}
+
+function createRenderPipelineInstanceIfNeeded(instance: any, patch: IProperty) {
+    if (!patch.type || instance.constructor.name === patch.type) {
+        return instance;
+    }
+
+    const ctor = cc.js.getClassByName(patch.type);
+    if (!ctor) {
+        throw new Error(`RenderPipeline type can not be found: ${patch.type}`);
+    }
+
+    const next = new ctor();
+    if ('_uuid' in next && '_uuid' in instance) {
+        next._uuid = instance._uuid;
+    }
+    return next;
+}
+
+function extractUuidValue(value: unknown): string {
+    if (isPropertyLike(value)) {
+        return typeof value.value === 'string' ? value.value : '';
+    }
+    return typeof value === 'string' ? value : '';
+}
+
+function createAssetReference(uuid: string, type?: string) {
+    const ctor = type ? cc.js.getClassByName(type) : undefined;
+    return getEditorSerialize().asAsset(uuid, ctor);
+}
+
+function getEditorSerialize() {
+    const serialize = (globalThis as any).EditorExtends?.serialize || editorSerialize;
+    if (!serialize) {
+        throw new Error('EditorExtends.serialize is not initialized.');
+    }
+    return serialize;
+}
+
+function formatSerializedContent(serialized: string | object) {
+    return typeof serialized === 'string'
+        ? serialized
+        : JSON.stringify(serialized, null, 4);
+}
+
+function isPropertyLike(value: unknown): value is IProperty {
+    return isRecord(value) && Object.prototype.hasOwnProperty.call(value, 'value');
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+let dumpEncodeModule: Promise<typeof import('../scene/scene-process/service/dump/encode')> | undefined;
+function loadDumpEncode() {
+    dumpEncodeModule = dumpEncodeModule || import('../scene/scene-process/service/dump/encode');
+    return dumpEncodeModule;
+}
+
+let dumpUtilsModule: Promise<typeof import('../scene/scene-process/service/dump/utils')> | undefined;
+function loadDumpUtils() {
+    dumpUtilsModule = dumpUtilsModule || import('../scene/scene-process/service/dump/utils');
+    return dumpUtilsModule;
+}
+
+let assetDumpUtilModule: Promise<typeof import('../scene/scene-process/service/dump/asset')> | undefined;
+function loadAssetDumpUtil() {
+    assetDumpUtilModule = assetDumpUtilModule || import('../scene/scene-process/service/dump/asset');
+    return assetDumpUtilModule;
+}

--- a/src/core/assets/serialized-data.ts
+++ b/src/core/assets/serialized-data.ts
@@ -12,6 +12,7 @@ import type { IProperty } from '../scene/@types/public';
 import assetOperation from './manager/operation';
 import assetQuery from './manager/query';
 import { serialize as editorSerialize } from '../engine/editor-extends';
+import i18n from '../base/i18n';
 
 export type SerializedAssetDump = Record<string, IProperty> | IProperty;
 export type SerializedAssetPatch = SerializedAssetDump | Partial<Record<string, IProperty | unknown>>;
@@ -36,6 +37,30 @@ const RENDER_PIPELINE_CHANGE_TYPES: Record<string, { componentKey: string; optio
         optionalTypes: [],
     },
 };
+
+const ATTRIBUTE_PROPS = [
+    'enumList',
+    'radioGroup',
+    'bitmaskList',
+    'displayName',
+    'group',
+    'multiline',
+    'step',
+    'slide',
+    'tooltip',
+    'animatable',
+    'unit',
+    'radian',
+    'displayOrder',
+];
+
+const AUTO_I18N_ATTRIBUTE_NAMES = [
+    'displayName',
+    'tooltip',
+] as const;
+
+const MAX_CLASS_NAME_LOOKUP_DEPTH = 10;
+const AUTO_I18N_CLASS_PREFIXES = ['cc.', 'sp.'];
 
 export async function querySerializedData(uuidOrUrlOrPath: string): Promise<SerializedAssetQueryResult> {
     const { asset, assetInfo } = resolveSerializedAsset(uuidOrUrlOrPath);
@@ -105,10 +130,8 @@ async function loadSerializedAssetInstance(asset: IAsset): Promise<any> {
 }
 
 async function encodeSerializedAssetDump(instance: any, type: string): Promise<SerializedAssetDump> {
-    const { encodeObject } = await loadDumpEncode();
-
     if (type === 'cc.RenderPipeline') {
-        const dump = encodeComponentAsset(instance, modifyRenderPipelineProp, encodeObject);
+        const dump = encodeComponentAsset(instance, modifyRenderPipelineProp);
         return {
             name: 'Pipeline',
             type: instance.constructor.name,
@@ -120,13 +143,12 @@ async function encodeSerializedAssetDump(instance: any, type: string): Promise<S
         };
     }
 
-    return encodeComponentAsset(instance, modifyPropName, encodeObject);
+    return encodeComponentAsset(instance, modifyPropName);
 }
 
 function encodeComponentAsset(
     instance: any,
     modifyProp: (prop: IProperty, name?: string) => void,
-    encodeObject: (object: any, attributes: any, owner?: any, objectKey?: string, isTemplate?: boolean) => IProperty,
 ): Record<string, IProperty> {
     const ctor = instance.constructor;
     if (!ctor.__props__) {
@@ -140,7 +162,7 @@ function encodeComponentAsset(
                 return;
             }
             const attrs = cc.Class.attr(ctor, key);
-            const dumpData = encodeObject(instance[key], attrs, instance, key);
+            const dumpData = encodeSerializedObject(instance[key], attrs, instance, key);
             if (dumpData.type !== 'Unknown') {
                 value[key] = dumpData;
                 modifyProp(value[key], key);
@@ -152,6 +174,373 @@ function encodeComponentAsset(
         }
     });
     return value;
+}
+
+function encodeSerializedObject(
+    object: any,
+    attributes: any,
+    owner: any = null,
+    objectKey?: string,
+    isTemplate?: boolean,
+): IProperty {
+    attributes = attributes || {};
+    const ctor = getPropertyConstructor(object, attributes);
+    let defValue = getPropertyDefault(attributes);
+
+    if (defValue && typeof defValue === 'object' && defValue.constructor && Array.isArray(defValue.constructor.__props__)) {
+        const result: { type: string; value: Record<string, IProperty> } = {
+            type: getTypeName(defValue.constructor),
+            value: {},
+        };
+        defValue.constructor.__props__.forEach((key: string) => {
+            const attrs = cc.Class.attr(defValue.constructor, key);
+            const dumpData = encodeSerializedObject(defValue[key], attrs, defValue, key);
+            if (dumpData.type !== 'Unknown') {
+                result.value[key] = dumpData;
+            }
+        });
+        defValue = result;
+    }
+
+    let type = getTypeName(ctor);
+    if (owner === null && attributes.default !== null && attributes.default !== undefined) {
+        const defCtor = getPropertyConstructor(attributes.default, attributes);
+        const defType = getTypeName(defCtor);
+        if (defType !== type) {
+            type = 'Unknown';
+        }
+    }
+
+    const data: IProperty = {
+        name: objectKey,
+        value: null,
+        default: defValue,
+        type,
+        path: '',
+        readonly: !!attributes.readonly,
+        visible: attributes.visible ?? true,
+        animatable: attributes.animatable === undefined ? true : !!attributes.animatable,
+    };
+
+    if (attributes.userData) {
+        data.userData = attributes.userData;
+    }
+
+    applyPropertyAttributes(data, attributes, owner);
+
+    if (Array.isArray(defValue) || Array.isArray(object)) {
+        data.isArray = true;
+    }
+
+    if (data.isArray) {
+        if (!Array.isArray(object) || data.type === 'Array') {
+            data.type = 'Unknown';
+        } else {
+            const childAttribute: any = { ...attributes, visible: true };
+            if (childAttribute.readonly && childAttribute.readonly.deep !== undefined) {
+                childAttribute.readonly = childAttribute.readonly.deep;
+            }
+
+            const propertyDefaultValue = getPropertyDefaultValue(attributes);
+            childAttribute.default = getElementDefaultValue(attributes, propertyDefaultValue);
+
+            if (!isTemplate) {
+                data.elementTypeData = encodeSerializedObject(childAttribute.default, childAttribute, propertyDefaultValue, undefined, true);
+            }
+
+            const resultValue: IProperty[] = [];
+            for (let i = 0; i < object.length; i++) {
+                const item = object[i];
+                if (item && item.constructor) {
+                    childAttribute.ctor = item.constructor;
+                }
+
+                const result = encodeSerializedObject(item, childAttribute, owner);
+                if (result.type !== 'Unknown') {
+                    resultValue.push(result);
+                } else if (data.elementTypeData) {
+                    resultValue.push(data.elementTypeData);
+                }
+            }
+            data.value = resultValue;
+        }
+    } else if (encodeKnownPropertyType(data.type, object, data, { ctor })) {
+        // Encoded by known type handler.
+    } else if (ArrayBuffer.isView(object)) {
+        encodeKnownPropertyType('TypedArray', object, data, { ctor });
+    } else if (isChildClassOf(ctor, cc.ValueType)) {
+        encodeKnownPropertyType('cc.ValueType', object, data, { ctor });
+    } else if (isChildClassOf(ctor, cc.Node)) {
+        encodeKnownPropertyType('cc.Node', object, data, { ctor });
+    } else if (isChildClassOf(ctor, cc.Component)) {
+        encodeKnownPropertyType('cc.Component', object, data, { ctor });
+    } else if (isChildClassOf(ctor, cc.Asset)) {
+        encodeKnownPropertyType('cc.Asset', object, data, { ctor });
+    } else if (ctor && ctor.__props__) {
+        if (object) {
+            const result: Record<string, IProperty> = {};
+            ctor.__props__.forEach((key: string) => {
+                const attrs = cc.Class.attr(object, key);
+                if (attributes.readonly && attributes.readonly.deep) {
+                    attrs.readonly = { deep: true };
+                }
+
+                const dumpData = encodeSerializedObject(object[key], attrs, object, key);
+                if (dumpData.type !== 'Unknown') {
+                    result[key] = dumpData;
+                }
+                applyConstructorRewriteType(dumpData, object[key], attrs);
+            });
+            data.value = result;
+        } else {
+            data.value = null;
+        }
+    } else if (data.type !== 'Unknown') {
+        data.value = object;
+    }
+
+    if (ctor) {
+        data.extends = getTypeInheritanceChain(ctor);
+    }
+
+    return data;
+}
+
+function getPropertyDefault(attribute: any) {
+    return typeof attribute.default === 'function' ? attribute.default() : attribute.default;
+}
+
+function getPropertyConstructor(object: any, attribute: any) {
+    if (attribute && attribute.ctor) {
+        return attribute.ctor;
+    }
+    return object === null || object === undefined ? null : object.constructor;
+}
+
+function getTypeName(ctor: any) {
+    return ctor ? cc.js.getClassName(ctor) || ctor.name || 'Unknown' : 'Unknown';
+}
+
+function getTypeInheritanceChain(ctor: any) {
+    return cc.Class.getInheritanceChain(ctor)
+        .map((itemCtor: any) => getTypeName(itemCtor))
+        .filter(Boolean);
+}
+
+function applyPropertyAttributes(data: IProperty, attributes: any, owner: any) {
+    ['visible', 'min', 'max'].forEach((name) => {
+        const value = resolveAttributeValue(name, attributes, owner);
+        if (value !== undefined) {
+            (data as any)[name] = value;
+        }
+    });
+
+    if (!attributes.ctor && attributes.type) {
+        data.type = `${attributes.type}`;
+    }
+
+    if ('enumList' in attributes && attributes.type === 'Enum') {
+        data.type = 'Enum';
+    }
+
+    if (attributes.hasGetter && !attributes.hasSetter) {
+        data.readonly = true;
+    }
+
+    ATTRIBUTE_PROPS.forEach((propName) => {
+        if (Object.prototype.hasOwnProperty.call(attributes, propName)) {
+            (data as any)[propName] = attributes[propName];
+        }
+    });
+
+    applyAutoI18nAttributes(data, attributes, owner);
+    translateI18nStringsDeep(data);
+}
+
+function resolveAttributeValue(attributeName: string, attributes: any, owner: any) {
+    const attribute = attributes[attributeName];
+    if (attribute === undefined) {
+        return undefined;
+    }
+    if (typeof attribute === 'function') {
+        if (!owner) {
+            return undefined;
+        }
+        const value = attribute.call(owner);
+        return typeof value === 'boolean' ? !!value : value;
+    }
+    return typeof attribute === 'boolean' ? !!attribute : attribute;
+}
+
+function encodeKnownPropertyType(type: string | undefined, object: any, data: IProperty, opts: any) {
+    switch (type || '') {
+        case 'Number':
+        case 'Enum':
+        case 'String':
+            data.value = object;
+            return true;
+        case 'TypedArray':
+            data.value = object ? new (object.constructor)(object) : object;
+            return true;
+        case 'cc.ValueType': {
+            try {
+                const dump = getEditorSerialize()(object, { stringify: false, forceInline: true }) as any;
+                delete dump.__type__;
+                data.value = dump;
+            } catch (error) {
+                console.warn('Value dump failed.');
+                console.warn(error);
+
+                const dump = getEditorSerialize()(new opts.ctor(), { stringify: false, forceInline: true }) as any;
+                delete dump.__type__;
+                data.value = dump;
+            }
+            return true;
+        }
+        case 'cc.Node':
+        case 'cc.Component':
+            data.value = { uuid: object ? object.uuid || '' : '' };
+            return true;
+        case 'cc.Asset': {
+            const uuid = object ? object._uuid || '' : '';
+            data.value = { uuid: uuid.startsWith('pm_') ? '' : uuid };
+            return true;
+        }
+        default:
+            return false;
+    }
+}
+
+function applyAutoI18nAttributes(data: IProperty, attributes: any, owner: any) {
+    if (typeof data.name !== 'string' || !owner || typeof owner !== 'object') {
+        return;
+    }
+
+    const ownerTypeName = findClassName(owner, data.name);
+    if (!ownerTypeName) {
+        return;
+    }
+
+    AUTO_I18N_ATTRIBUTE_NAMES.forEach((attributeName) => {
+        if (Object.prototype.hasOwnProperty.call(attributes, attributeName)) {
+            return;
+        }
+        (data as any)[attributeName] = `i18n:ENGINE.classes.${ownerTypeName}.properties.${data.name}.${attributeName}`;
+    });
+}
+
+function findClassName(ccClassObject: any, property: string): string {
+    let depth = 0;
+    let proto = ccClassObject;
+    while (proto && depth < MAX_CLASS_NAME_LOOKUP_DEPTH) {
+        const className = cc.js.getClassName(proto);
+        if (
+            className
+            && AUTO_I18N_CLASS_PREFIXES.some((prefix) => className.startsWith(prefix))
+            && Object.prototype.hasOwnProperty.call(proto, property)
+        ) {
+            return className;
+        }
+        proto = Object.getPrototypeOf(proto);
+        depth++;
+    }
+
+    return '';
+}
+
+function translateI18nStringsDeep(obj: any, depth = 0): void {
+    if (!obj || typeof obj !== 'object') {
+        return;
+    }
+    if (depth > 10) {
+        console.warn('[translateI18nStringsDeep] Max recursion depth exceeded; nested i18n strings at this level will not be translated:', obj);
+        return;
+    }
+    for (const key of Object.keys(obj)) {
+        const value = obj[key];
+        if (typeof value === 'string') {
+            obj[key] = i18n.transI18nName(value);
+        } else if (Array.isArray(value)) {
+            for (let i = 0; i < value.length; i++) {
+                if (typeof value[i] === 'string') {
+                    value[i] = i18n.transI18nName(value[i]);
+                } else {
+                    translateI18nStringsDeep(value[i], depth + 1);
+                }
+            }
+        } else {
+            translateI18nStringsDeep(value, depth + 1);
+        }
+    }
+}
+
+function isChildClassOf(ctor: any, base: any) {
+    return !!ctor && !!base && cc.js.isChildClassOf(ctor, base);
+}
+
+function applyConstructorRewriteType(data: IProperty, object: any, attributes: any) {
+    if (object && typeof object === 'object' && !Array.isArray(object) && object.constructor && attributes?.ctor && !(object instanceof attributes.ctor)) {
+        data.type = 'Unknown';
+    }
+}
+
+function getElementDefaultValue(parentAttrs: any, parentInitializer: unknown) {
+    if (parentAttrs.type) {
+        return getPropertyDefaultValue(parentAttrs);
+    }
+    return getElementDefaultValueFromParentInitializer(parentInitializer);
+}
+
+function getElementDefaultValueFromParentInitializer(parentInitializer: unknown) {
+    if (!parentInitializer || !Array.isArray(parentInitializer) || parentInitializer.length === 0) {
+        return null;
+    }
+
+    const firstElement = parentInitializer[0];
+    switch (typeof firstElement) {
+        case 'number': return 0;
+        case 'string': return '';
+        case 'boolean': return false;
+        default: return null;
+    }
+}
+
+function getPropertyDefaultValue(attrs: any) {
+    if (attrs.type === undefined) {
+        return attrs.default ? getPropertyDefault(attrs) : null;
+    }
+
+    const defaultMap: Record<string, unknown> = {
+        Boolean: false,
+        String: '',
+        Float: 0,
+        Integer: 0,
+        BitMask: 0,
+    };
+    if (defaultMap[attrs.type] !== undefined) {
+        return defaultMap[attrs.type];
+    }
+
+    if (attrs.type === 'Enum') {
+        return attrs.enumList?.[0]?.value || 0;
+    }
+
+    if (attrs.type === 'Object') {
+        const { ctor } = attrs;
+        if (isChildClassOf(ctor, cc.Asset) || isChildClassOf(ctor, cc.Node) || isChildClassOf(ctor, cc.Component)) {
+            return null;
+        }
+        if (ctor) {
+            try {
+                return new ctor();
+            } catch (error) {
+                console.error(error);
+                return null;
+            }
+        }
+    }
+
+    return null;
 }
 
 function modifyPropName(prop: IProperty, name?: string) {
@@ -351,8 +740,7 @@ async function setValue(prop: any, dump: Record<string, any> | any, key: string)
         const propKeyAttr = cc.Class.attr(prop.constructor, key);
 
         if (!Array.isArray(prop[key])) {
-            const dumpUtil = await loadDumpUtils();
-            prop[key] = dumpUtil.default.ccClassAttrPropertyDefaultValue(propKeyAttr);
+            prop[key] = getPropertyDefaultValue(propKeyAttr);
         }
 
         if (!Array.isArray(prop[key])) {
@@ -362,7 +750,7 @@ async function setValue(prop: any, dump: Record<string, any> | any, key: string)
             const newLength = Array.isArray(dump[key].value) ? dump[key].value.length : 0;
             if (newLength > oldLength) {
                 for (let i = oldLength; i < newLength; i++) {
-                    prop[key][i] = await createValueForDumpItem(dump[key].value[i]);
+                    prop[key][i] = createValueForDumpItem(dump[key].value[i]);
                     await setValue(prop[key], dump[key].value, i.toString());
                 }
             } else if (newLength < oldLength) {
@@ -395,7 +783,7 @@ async function setValue(prop: any, dump: Record<string, any> | any, key: string)
     }
 }
 
-async function createValueForDumpItem(itemDump: IProperty) {
+function createValueForDumpItem(itemDump: IProperty) {
     if (!itemDump?.type) {
         return null;
     }
@@ -405,8 +793,68 @@ async function createValueForDumpItem(itemDump: IProperty) {
         return new typeClass();
     }
 
-    const assetDumpUtil = await loadAssetDumpUtil();
-    return assetDumpUtil.default.getDefaultValue(itemDump.type);
+    return getDefaultValueByType(itemDump.type);
+}
+
+function getDefaultValueByType(type: string, data?: any) {
+    switch (type) {
+        case 'Boolean':
+            return data ? data[0] : false;
+        case 'Number':
+        case 'Integer':
+        case 'Float':
+            return data ? data[0] : 0;
+        case 'String':
+            return data ? data[0] : '';
+        case 'cc.Vec2':
+            return data ? new cc.math.Vec2(data[0] || 0, data[1] || 0) : new cc.math.Vec2();
+        case 'cc.Vec3':
+            return data ? new cc.math.Vec3(data[0] || 0, data[1] || 0, data[2] || 0) : new cc.math.Vec3();
+        case 'cc.Vec4':
+            return data ? new cc.math.Vec4(data[0] || 0, data[1] || 0, data[2] || 0, data[3] || 0) : new cc.math.Vec4();
+        case 'cc.Quat':
+            return data ? new cc.math.Quat(data[0] || 0, data[1] || 0, data[2] || 0, data[3] || 1) : new cc.Quat();
+        case 'cc.Color':
+            if (Array.isArray(data)) {
+                if (data[3] === undefined) {
+                    data[3] = 1;
+                }
+                return new cc.Color(data[0] * 255, data[1] * 255, data[2] * 255, data[3] * 255);
+            }
+            return new cc.Color();
+        case 'cc.Mat4':
+            if (Array.isArray(data)) {
+                return new cc.math.Mat4(
+                    data[0],
+                    data[1],
+                    data[2],
+                    data[3],
+                    data[4],
+                    data[5],
+                    data[6],
+                    data[7],
+                    data[8],
+                    data[9],
+                    data[10],
+                    data[11],
+                    data[12],
+                    data[13],
+                    data[14],
+                    data[15],
+                );
+            }
+            return new cc.Mat4();
+        case 'cc.Asset':
+            return new cc.Asset();
+        case 'cc.TextureBase':
+            return new cc.TextureBase();
+        case 'cc.Texture2D':
+            return new cc.Texture2D();
+        case 'cc.TextureCube':
+            return new cc.TextureCube();
+        default:
+            return false;
+    }
 }
 
 function createRenderPipelineInstanceIfNeeded(instance: any, patch: IProperty) {
@@ -458,22 +906,4 @@ function isPropertyLike(value: unknown): value is IProperty {
 
 function isRecord(value: unknown): value is Record<string, any> {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-let dumpEncodeModule: Promise<typeof import('../scene/scene-process/service/dump/encode')> | undefined;
-function loadDumpEncode() {
-    dumpEncodeModule = dumpEncodeModule || import('../scene/scene-process/service/dump/encode');
-    return dumpEncodeModule;
-}
-
-let dumpUtilsModule: Promise<typeof import('../scene/scene-process/service/dump/utils')> | undefined;
-function loadDumpUtils() {
-    dumpUtilsModule = dumpUtilsModule || import('../scene/scene-process/service/dump/utils');
-    return dumpUtilsModule;
-}
-
-let assetDumpUtilModule: Promise<typeof import('../scene/scene-process/service/dump/asset')> | undefined;
-function loadAssetDumpUtil() {
-    assetDumpUtilModule = assetDumpUtilModule || import('../scene/scene-process/service/dump/asset');
-    return assetDumpUtilModule;
 }

--- a/src/core/assets/test/serialized-data.test.ts
+++ b/src/core/assets/test/serialized-data.test.ts
@@ -1,0 +1,227 @@
+'use strict';
+
+jest.mock('gl', () => {
+    const createShader = (type: number) => ({ type });
+    const noop = () => undefined;
+    return () => ({
+        VERTEX_SHADER: 35633,
+        FRAGMENT_SHADER: 35632,
+        COMPILE_STATUS: 35713,
+        LINK_STATUS: 35714,
+        getSupportedExtensions: () => [],
+        getExtension: noop,
+        createShader,
+        shaderSource: noop,
+        compileShader: noop,
+        getShaderParameter: () => true,
+        getShaderInfoLog: () => '',
+        deleteShader: noop,
+        createProgram: () => ({}),
+        attachShader: noop,
+        linkProgram: noop,
+        getProgramParameter: () => true,
+        getProgramInfoLog: () => '',
+        deleteProgram: noop,
+    });
+});
+
+import { join } from 'path';
+import { readFileSync, readJSONSync, remove } from 'fs-extra';
+import { globalSetup } from '../../test/global-setup';
+import { TestGlobalEnv } from '../../../tests/global-env';
+import { assetManager } from '..';
+import type { IProperty } from '../../scene/@types/public';
+
+type DumpMap = Record<string, IProperty>;
+
+describe('serialized asset data', function () {
+    const name = `serialized-data-${Date.now()}`;
+
+    beforeAll(async () => {
+        await globalSetup();
+    });
+
+    afterAll(async () => {
+        try {
+            await assetManager.removeAsset(TestGlobalEnv.testRootUrl);
+        } catch (error) {
+            // Test root may already be absent if a previous test cleaned it.
+        }
+        await remove(TestGlobalEnv.testRoot);
+        await remove(TestGlobalEnv.testRoot + '.meta');
+    });
+
+    it('queries PhysicsMaterial as a Creator-compatible field dump map', async () => {
+        const assetInfo = await assetManager.createAssetByType(
+            'physics-material',
+            TestGlobalEnv.testRoot,
+            `${name}-physics`,
+            { overwrite: true },
+        );
+
+        const result = await assetManager.querySerializedData(assetInfo.uuid);
+        const dump = result.dump as DumpMap;
+
+        expect(result.uuid).toBe(assetInfo.uuid);
+        expect(result.url).toBe(assetInfo.url);
+        expect(result.type).toBe('cc.PhysicsMaterial');
+        expect(result.importer).toBe('physics-material');
+        expect(dump.friction).toMatchObject({
+            name: 'friction',
+            type: 'Float',
+            value: 0.5,
+            visible: true,
+        });
+        expect(dump.restitution).toMatchObject({
+            name: 'restitution',
+            type: 'Float',
+            value: 0.1,
+            visible: true,
+        });
+    });
+
+    it('saves a PhysicsMaterial IProperty patch and reads the fresh value back', async () => {
+        const assetInfo = await assetManager.createAssetByType(
+            'physics-material',
+            TestGlobalEnv.testRoot,
+            `${name}-physics-save`,
+            { overwrite: true },
+        );
+
+        const before = await assetManager.querySerializedData(assetInfo.uuid);
+        const beforeDump = before.dump as DumpMap;
+
+        await assetManager.saveSerializedData(assetInfo.uuid, {
+            friction: { ...beforeDump.friction, value: 0.25 },
+        });
+
+        const after = await assetManager.querySerializedData(assetInfo.uuid);
+        const afterDump = after.dump as DumpMap;
+        const source = readJSONSync(assetInfo.file);
+
+        expect(afterDump.friction.value).toBe(0.25);
+        expect(source._friction).toBe(0.25);
+    });
+
+    it('rejects unknown serialized fields without changing the source file', async () => {
+        const assetInfo = await assetManager.createAssetByType(
+            'physics-material',
+            TestGlobalEnv.testRoot,
+            `${name}-unknown-field`,
+            { overwrite: true },
+        );
+        const beforeSource = readFileSync(assetInfo.file, 'utf8');
+
+        await expect(assetManager.saveSerializedData(assetInfo.uuid, {
+            unknown: { value: 1, type: 'Float', path: 'unknown' } as IProperty,
+        })).rejects.toThrow(/unknown serialized field/i);
+
+        expect(readFileSync(assetInfo.file, 'utf8')).toBe(beforeSource);
+    });
+
+    it('rejects explicit changes to hidden or readonly fields', async () => {
+        const assetInfo = await assetManager.createAssetByType(
+            'physics-material',
+            TestGlobalEnv.testRoot,
+            `${name}-hidden-field`,
+            { overwrite: true },
+        );
+        const result = await assetManager.querySerializedData(assetInfo.uuid);
+        const dump = result.dump as DumpMap;
+        const protectedKey = Object.keys(dump).find((key) => dump[key].visible === false || dump[key].readonly === true);
+
+        expect(protectedKey).toBeDefined();
+        const protectedProp = dump[protectedKey!];
+
+        await expect(assetManager.saveSerializedData(assetInfo.uuid, {
+            [protectedKey!]: {
+                ...protectedProp,
+                value: typeof protectedProp.value === 'number' ? protectedProp.value + 1 : '__changed__',
+            },
+        })).rejects.toThrow(/readonly|hidden/i);
+    });
+
+    it('queries RenderPipeline as a top-level IProperty with optionalTypes', async () => {
+        const fixture = join(
+            TestGlobalEnv.engineRoot,
+            'editor/assets/default_file_content/render-pipeline/default.rpp',
+        );
+        const assetInfo = await assetManager.createAsset({
+            target: join(TestGlobalEnv.testRoot, `${name}-pipeline.rpp`),
+            content: readFileSync(fixture, 'utf8'),
+            overwrite: true,
+        });
+
+        const result = await assetManager.querySerializedData(assetInfo.uuid);
+        const dump = result.dump as IProperty;
+        const value = dump.value as DumpMap;
+
+        expect(result.type).toBe('cc.RenderPipeline');
+        expect(result.importer).toBe('render-pipeline');
+        expect(dump).toMatchObject({
+            name: 'Pipeline',
+            visible: true,
+            readonly: false,
+        });
+        expect(Array.isArray(dump.optionalTypes)).toBe(true);
+        expect(value._flows).toMatchObject({
+            name: '_flows',
+            isArray: true,
+        });
+    });
+
+    it('rejects unknown nested RenderPipeline fields without changing the source file', async () => {
+        const fixture = join(
+            TestGlobalEnv.engineRoot,
+            'editor/assets/default_file_content/render-pipeline/forward-pipeline.rpp',
+        );
+        const assetInfo = await assetManager.createAsset({
+            target: join(TestGlobalEnv.testRoot, `${name}-pipeline-unknown.rpp`),
+            content: readFileSync(fixture, 'utf8'),
+            overwrite: true,
+        });
+
+        const result = await assetManager.querySerializedData(assetInfo.uuid);
+        const dump = result.dump as IProperty;
+        const value = dump.value as DumpMap;
+        const flows = value._flows.value as IProperty[];
+        const firstFlow = flows[0];
+        const beforeSource = readFileSync(assetInfo.file, 'utf8');
+
+        expect(firstFlow).toBeDefined();
+
+        await expect(assetManager.saveSerializedData(assetInfo.uuid, {
+            ...dump,
+            value: {
+                ...value,
+                _flows: {
+                    ...value._flows,
+                    value: flows.map((flow, index) => index === 0 ? {
+                        ...flow,
+                        value: {
+                            ...(flow.value as DumpMap),
+                            __unknown: {
+                                name: '__unknown',
+                                path: '_flows.0.__unknown',
+                                type: 'Float',
+                                value: 1,
+                            },
+                        },
+                    } : flow),
+                },
+            },
+        })).rejects.toThrow(/unknown serialized field/i);
+
+        expect(readFileSync(assetInfo.file, 'utf8')).toBe(beforeSource);
+    });
+
+    it('rejects unsupported asset types', async () => {
+        const assetInfo = await assetManager.createAsset({
+            target: join(TestGlobalEnv.testRoot, `${name}-text.txt`),
+            content: 'plain text',
+            overwrite: true,
+        });
+
+        await expect(assetManager.querySerializedData(assetInfo.uuid)).rejects.toThrow(/unsupported serialized asset type/i);
+    });
+});

--- a/src/core/assets/test/serialized-data.test.ts
+++ b/src/core/assets/test/serialized-data.test.ts
@@ -170,6 +170,57 @@ describe('serialized asset data', function () {
         });
     });
 
+    it('saves a RenderPipeline nested IProperty patch and reads the fresh value back', async () => {
+        const fixture = join(
+            TestGlobalEnv.engineRoot,
+            'editor/assets/default_file_content/render-pipeline/forward-pipeline.rpp',
+        );
+        const assetInfo = await assetManager.createAsset({
+            target: join(TestGlobalEnv.testRoot, `${name}-pipeline-save.rpp`),
+            content: readFileSync(fixture, 'utf8'),
+            overwrite: true,
+        });
+
+        const before = await assetManager.querySerializedData(assetInfo.uuid);
+        const dump = before.dump as IProperty;
+        const value = dump.value as DumpMap;
+        const flows = value._flows.value as IProperty[];
+        const firstFlow = flows[0];
+        const firstFlowValue = firstFlow.value as DumpMap;
+
+        expect(firstFlowValue._priority.value).toBe(0);
+
+        await assetManager.saveSerializedData(assetInfo.uuid, {
+            ...dump,
+            value: {
+                ...value,
+                _flows: {
+                    ...value._flows,
+                    value: flows.map((flow, index) => index === 0 ? {
+                        ...flow,
+                        value: {
+                            ...(flow.value as DumpMap),
+                            _priority: {
+                                ...((flow.value as DumpMap)._priority),
+                                value: 3,
+                            },
+                        },
+                    } : flow),
+                },
+            },
+        });
+
+        const after = await assetManager.querySerializedData(assetInfo.uuid);
+        const afterDump = after.dump as IProperty;
+        const afterValue = afterDump.value as DumpMap;
+        const afterFlows = afterValue._flows.value as IProperty[];
+        const afterFirstFlowValue = afterFlows[0].value as DumpMap;
+        const source = readJSONSync(assetInfo.file);
+
+        expect(afterFirstFlowValue._priority.value).toBe(3);
+        expect(source[1]._priority).toBe(3);
+    });
+
     it('rejects unknown nested RenderPipeline fields without changing the source file', async () => {
         const fixture = join(
             TestGlobalEnv.engineRoot,

--- a/src/core/engine/@types/cc-engine.d.ts
+++ b/src/core/engine/@types/cc-engine.d.ts
@@ -1,0 +1,12 @@
+/// <reference path="../../../../packages/engine/bin/.declarations/cc.d.ts" />
+/// <reference path="../../../../packages/engine/bin/.declarations/cc.editor.d.ts" />
+
+declare module 'cc/polyfill/engine' {
+    const polyfill: unknown;
+    export default polyfill;
+}
+
+declare module 'cc/overwrite' {
+    const overwrite: (cc: unknown) => void;
+    export default overwrite;
+}

--- a/src/lib/assets/assets.ts
+++ b/src/lib/assets/assets.ts
@@ -1,4 +1,4 @@
-import type { AssetOperationOption, CreateAssetByTypeOptions, DeleteAssetOptions, IAssetFileSystemProvider, IAssetInfo, IAssetMeta, ISupportCreateType, QueryAssetsOption } from '../../core/assets/@types/public';
+import type { AssetOperationOption, CreateAssetByTypeOptions, DeleteAssetOptions, IAssetFileSystemProvider, IAssetInfo, IAssetMeta, ISupportCreateType, QueryAssetsOption, SerializedAssetPatch, SerializedAssetQueryResult } from '../../core/assets/@types/public';
 import type { CreateAssetOptions, IAssetConfig, IAssetDBInfo, ICreateMenuInfo, IUerDataConfigItem, QueryAssetType, ThumbnailInfo, ThumbnailSize } from '../../core/assets/@types/protected';
 import type { FilterPluginOptions, IPluginScriptInfo } from '../../core/scripting/interface';
 import { assetDBManager, assetManager } from '../../core/assets';
@@ -184,6 +184,28 @@ export async function saveAsset(
 ): Promise<IAssetInfo> {
     return await assetManager.saveAsset(pathOrUrlOrUUID, data);
 }
+
+/**
+ * Query serialized asset dump data.
+ */
+export async function querySerializedData(uuidOrUrlOrPath: string): Promise<SerializedAssetQueryResult> {
+    return await assetManager.querySerializedData(uuidOrUrlOrPath);
+}
+
+/**
+ * Save serialized asset dump data.
+ */
+export async function saveSerializedData(
+    uuidOrUrlOrPath: string,
+    patch: SerializedAssetPatch
+): Promise<SerializedAssetQueryResult> {
+    return await assetManager.saveSerializedData(uuidOrUrlOrPath, patch);
+}
+
+export const serializedData = {
+    query: querySerializedData,
+    save: saveSerializedData,
+};
 
 /**
  * Query Asset UUID // 查询资源 UUID

--- a/tests/assets-serialized-data-api.test.ts
+++ b/tests/assets-serialized-data-api.test.ts
@@ -1,0 +1,63 @@
+const mockQuerySerializedData = jest.fn();
+const mockSaveSerializedData = jest.fn();
+
+jest.mock('../src/api/decorator/decorator.js', () => ({
+    description: () => jest.fn(),
+    param: () => jest.fn(),
+    result: () => jest.fn(),
+    title: () => jest.fn(),
+    tool: () => jest.fn(),
+}), { virtual: true });
+
+jest.mock('../src/core/assets', () => ({
+    assetDBManager: {},
+    assetManager: {
+        querySerializedData: (...args: unknown[]) => mockQuerySerializedData(...args),
+        saveSerializedData: (...args: unknown[]) => mockSaveSerializedData(...args),
+    },
+}));
+
+import { AssetsApi } from '../src/api/assets/assets';
+import { COMMON_STATUS } from '../src/api/base/schema-base';
+
+describe('assets serialized data api', () => {
+    beforeEach(() => {
+        mockQuerySerializedData.mockReset();
+        mockSaveSerializedData.mockReset();
+    });
+
+    it('delegates querySerializedData to assetManager', async () => {
+        const result = {
+            uuid: 'test-uuid',
+            url: 'db://assets/test.pmtl',
+            type: 'cc.PhysicsMaterial',
+            importer: 'physics-material',
+            dump: {},
+        };
+        mockQuerySerializedData.mockResolvedValue(result);
+
+        await expect(new AssetsApi().querySerializedData('test-uuid')).resolves.toEqual({
+            code: COMMON_STATUS.SUCCESS,
+            data: result,
+        });
+        expect(mockQuerySerializedData).toHaveBeenCalledWith('test-uuid');
+    });
+
+    it('delegates saveSerializedData to assetManager', async () => {
+        const result = {
+            uuid: 'test-uuid',
+            url: 'db://assets/test.pmtl',
+            type: 'cc.PhysicsMaterial',
+            importer: 'physics-material',
+            dump: {},
+        };
+        const patch = { friction: { value: 0.25 } };
+        mockSaveSerializedData.mockResolvedValue(result);
+
+        await expect(new AssetsApi().saveSerializedData('test-uuid', patch)).resolves.toEqual({
+            code: COMMON_STATUS.SUCCESS,
+            data: result,
+        });
+        expect(mockSaveSerializedData).toHaveBeenCalledWith('test-uuid', patch);
+    });
+});

--- a/tests/lib/assets-api.test.ts
+++ b/tests/lib/assets-api.test.ts
@@ -29,4 +29,24 @@ describe('lib assets api', () => {
         await expect(saveAssetMeta('test-uuid', meta)).resolves.toBeUndefined();
         expect(spy).toHaveBeenCalledWith('test-uuid', meta);
     });
+
+    it('exposes serializedData namespace and delegates query/save to assetManager', async () => {
+        const result = {
+            uuid: 'test-uuid',
+            url: 'db://assets/test.pmtl',
+            type: 'cc.PhysicsMaterial',
+            importer: 'physics-material',
+            dump: {},
+        };
+        const querySpy = jest.spyOn(assetManager, 'querySerializedData').mockResolvedValue(result);
+        const saveSpy = jest.spyOn(assetManager, 'saveSerializedData').mockResolvedValue(result);
+
+        expect(Assets.serializedData.query).toEqual(expect.any(Function));
+        expect(Assets.serializedData.save).toEqual(expect.any(Function));
+
+        await expect(Assets.serializedData.query('test-uuid')).resolves.toEqual(result);
+        await expect(Assets.serializedData.save('test-uuid', {})).resolves.toEqual(result);
+        expect(querySpy).toHaveBeenCalledWith('test-uuid');
+        expect(saveSpy).toHaveBeenCalledWith('test-uuid', {});
+    });
 });


### PR DESCRIPTION
## 变更说明

本次新增序列化资产数据查询与保存能力，对外暴露 `assets.serializedData.query/save`，首批支持：

- `cc.PhysicsMaterial`
- `cc.RenderPipeline`

实现上先迁移 Creator 现有行为，保持返回的 `dump` 结构与 Creator Inspector 兼容，方便复用现有 UI 渲染链路。

## 主要改动

- 新增 serialized asset query/save core service
- 接入 `assetManager.querySerializedData/saveSerializedData`
- 向 lib/API/schema 暴露 `assets.serializedData.query/save`
- 补充 `cocos-cli-types` 类型声明与 DTS 快照
- 增加 core、lib、API 测试覆盖

## 功能验证

`cc.PhysicsMaterial` 已覆盖：

- query 返回 Creator 兼容字段 dump
- save 修改 `friction` 后重新 query 能读到新值
- 源文件同步写回
- 未知字段拒绝
- hidden/readonly 字段显式改值拒绝

`cc.RenderPipeline` 已覆盖：

- query 返回顶层 `IProperty`
- 验证 `optionalTypes`
- save 修改嵌套字段 `_flows[0]._priority` 后重新 query 能读到新值
- 源文件同步写回
- 数组嵌套未知字段拒绝，且源文件不变

## 校验策略

`save` 侧做后端强校验：

- 未知字段拒绝
- hidden/readonly 字段未改值时允许随完整 dump 透传并忽略
- hidden/readonly 字段显式改值时拒绝
- 嵌套对象和 RenderPipeline 数组项内的未知字段也会拒绝