### PR TITLE
Preserve dirty scene on prefab reload

### DIFF
--- a/src/core/scene/scene-process/service/prefab.ts
+++ b/src/core/scene/scene-process/service/prefab.ts
@@ -409,7 +409,7 @@ export class PrefabService extends BaseService<IPrefabEvents> implements IPrefab
         if (nodeOperation.assetToNodesMap.has(uuid) && await Service.Editor.hasOpen()) {
             this._softReload.schedule({
                 changedUuid: uuid,
-                preserveUndoHistory: reloadState.preserveUndoHistory,
+                preserveUndoHistory: reloadState.preserveUndoHistory || !!Service.Undo?.isDirty?.(),
                 editorUuid: reloadState.editorUuid ?? getCurrentEditorUuid(),
             });
         }

--- a/src/core/scene/test/service-core/message-callsite.test.ts
+++ b/src/core/scene/test/service-core/message-callsite.test.ts
@@ -198,12 +198,18 @@ jest.mock('../../scene-process/service/scene/utils', () => ({
     sceneUtils: {},
 }));
 
+const mockConsumePreserveUndoHistoryForPrefabReload = jest.fn(() => ({ preserveUndoHistory: false, editorUuid: null }));
+const mockPrefabSoftReloadSchedule = jest.fn();
+
 jest.mock('../../scene-process/service/prefab/prefab-undo', () => ({
-    PrefabUndoHelper: jest.fn().mockImplementation(() => ({})),
+    PrefabUndoHelper: jest.fn().mockImplementation(() => ({
+        consumePreserveUndoHistoryForPrefabReload: mockConsumePreserveUndoHistoryForPrefabReload,
+    })),
 }));
 
 jest.mock('../../scene-process/service/prefab/soft-reload', () => ({
     PrefabSoftReloadScheduler: jest.fn().mockImplementation(() => ({
+        schedule: mockPrefabSoftReloadSchedule,
         waitForIdle: jest.fn().mockResolvedValue(undefined),
     })),
 }));
@@ -448,6 +454,8 @@ describe('ServiceEvents 事件发射集成测试', () => {
 
         beforeAll(() => {
             prefabUtilsMock = require('../../scene-process/service/prefab/utils').prefabUtils;
+            require('../../scene-process/service/editor');
+            require('../../scene-process/service/undo');
             const { PrefabService } = require('../../scene-process/service/prefab');
             prefabService = new PrefabService();
         });
@@ -463,6 +471,31 @@ describe('ServiceEvents 事件发射集成测试', () => {
                 objFlags: 0,
             }));
             NodeMock.getNodePath = jest.fn((node: any) => `/${node.name}`);
+            mockConsumePreserveUndoHistoryForPrefabReload.mockReturnValue({ preserveUndoHistory: false, editorUuid: null });
+        });
+
+        it('onAssetChanged preserves undo history when current editor is dirty', async () => {
+            const { Service } = require('../../scene-process/service/core');
+            const { nodeOperation } = require('../../scene-process/service/prefab/node');
+            const originalHasOpen = Service.Editor.hasOpen;
+            const originalIsDirty = Service.Undo.isDirty;
+            nodeOperation.assetToNodesMap.clear();
+            try {
+                nodeOperation.assetToNodesMap.set('prefab-uuid', ['node-uuid']);
+                Service.Editor.hasOpen = jest.fn().mockResolvedValue(true);
+                Service.Undo.isDirty = jest.fn(() => true);
+
+                await prefabService.onAssetChanged('prefab-uuid');
+
+                expect(mockPrefabSoftReloadSchedule).toHaveBeenCalledWith(expect.objectContaining({
+                    changedUuid: 'prefab-uuid',
+                    preserveUndoHistory: true,
+                }));
+            } finally {
+                Service.Editor.hasOpen = originalHasOpen;
+                Service.Undo.isDirty = originalIsDirty;
+                nodeOperation.assetToNodesMap.clear();
+            }
         });
 
         it('filterChildOfAssetOfPrefabInstance 中 prefab 子节点应 emit scene:change-node', () => {


### PR DESCRIPTION
## 变更说明
- Prefab 资源变化触发 soft reload 时，如果当前场景已有未保存改动，会保留 undo history，避免 reload 清掉场景 dirty 状态。
- 增加 PrefabService 入口回归测试，覆盖 dirty 场景收到 Prefab asset change 时的 preserveUndoHistory 行为。

## QA 验证步骤
- 打开一个项目，新建并打开 A 场景。
- 在 A 场景中新建节点并创建 B Prefab，让 A 场景保持未保存状态。
- 打开 B Prefab，修改 B Prefab 使其也处于未保存状态。
- 保存 B Prefab。
- 回到 A 场景，确认 A 场景仍显示为未保存状态，没有因为 Prefab reload 被清掉 dirty。
- 保存 A 场景后，确认 A 场景 dirty 状态正常消失。
