### PR TITLE
feat(assets): add query property schema api

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -108,6 +108,28 @@ export declare interface AssetOperationOption {
     overwrite?: boolean;
     rename?: boolean;
 }
+export declare interface AssetPropertySchema {
+    label: string;
+    description?: string;
+    type: AssetPropertySchemaType;
+    default?: unknown;
+    options?: AssetPropertySchemaOption[];
+    assetType?: string;
+    min?: number;
+    max?: number;
+    step?: number;
+    readOnly?: boolean;
+    order?: number;
+    properties?: Record<string, AssetPropertySchema>;
+    items?: AssetPropertySchema | AssetPropertySchema[];
+    raw?: unknown;
+}
+export declare type AssetPropertySchemaMap = Record<string, AssetPropertySchema>;
+export declare interface AssetPropertySchemaOption {
+    label: string;
+    value: string | number | boolean;
+}
+export declare type AssetPropertySchemaType = 'string' | 'number' | 'boolean' | 'enum' | 'asset' | 'array' | 'object';
 export declare interface AssetUserDataMap {
     'animation-clip': AnimationClipAssetUserData;
     'auto-atlas': AutoAtlasAssetUserData;
@@ -728,6 +750,7 @@ export declare function queryAssetUserDataConfig(urlOrUuidOrPath: string): Promi
 export declare function queryAssetUsers(uuidOrUrl: string, type?: QueryAssetType): Promise<string[]>;
 export declare function queryCreateMap(): Promise<ICreateMenuInfo[]>;
 export declare function queryPath(urlOrUuid: string): Promise<string>;
+export declare function queryPropertySchema(importer: string): Promise<AssetPropertySchemaMap>;
 export declare function querySerializedData(uuidOrUrlOrPath: string): Promise<SerializedAssetQueryResult>;
 export declare function querySortedPlugins(filterOptions?: FilterPluginOptions): Promise<IPluginScriptInfo[]>;
 export declare function queryThumbnailHandlers(): string[];
@@ -6969,6 +6992,28 @@ export declare interface AssetOperationOption {
     overwrite?: boolean;
     rename?: boolean;
 }
+export declare interface AssetPropertySchema {
+    label: string;
+    description?: string;
+    type: AssetPropertySchemaType;
+    default?: unknown;
+    options?: AssetPropertySchemaOption[];
+    assetType?: string;
+    min?: number;
+    max?: number;
+    step?: number;
+    readOnly?: boolean;
+    order?: number;
+    properties?: Record<string, AssetPropertySchema>;
+    items?: AssetPropertySchema | AssetPropertySchema[];
+    raw?: unknown;
+}
+export declare type AssetPropertySchemaMap = Record<string, AssetPropertySchema>;
+export declare interface AssetPropertySchemaOption {
+    label: string;
+    value: string | number | boolean;
+}
+export declare type AssetPropertySchemaType = 'string' | 'number' | 'boolean' | 'enum' | 'asset' | 'array' | 'object';
 export declare namespace Assets {
     export {
         init,
@@ -7004,6 +7049,7 @@ export declare namespace Assets {
         queryAssetUserDataConfig,
         updateAssetUserData,
         queryAssetConfigMap,
+        queryPropertySchema,
         queryThumbnailHandlers,
         generateThumbnail,
         onAssetAdded,
@@ -7031,6 +7077,10 @@ export declare namespace Assets {
         SerializedAssetDump,
         SerializedAssetPatch,
         SerializedAssetQueryResult,
+        AssetPropertySchemaType,
+        AssetPropertySchemaOption,
+        AssetPropertySchema,
+        AssetPropertySchemaMap,
         IAssetInfo,
         AssetOperationOption,
         DeleteAssetOptions,
@@ -8191,6 +8241,7 @@ export declare function queryLayerBuiltin(): Promise<{
     value: number;
 }[]>;
 export declare function queryPath(urlOrUuid: string): Promise<string>;
+export declare function queryPropertySchema(importer: string): Promise<AssetPropertySchemaMap>;
 export declare function querySerializedData(uuidOrUrlOrPath: string): Promise<SerializedAssetQueryResult>;
 export declare function querySortedPlugins(filterOptions?: FilterPluginOptions): Promise<IPluginScriptInfo[]>;
 export declare function querySortingLayerBuiltin(): Promise<readonly __private._cocos_sorting_sorting_layers__SortingItem[]>;

--- a/src/api/assets/assets.ts
+++ b/src/api/assets/assets.ts
@@ -77,6 +77,8 @@ import {
     TUpdateAssetUserDataResult,
     SchemaAssetConfigMapResult,
     TAssetConfigMapResult,
+    SchemaAssetPropertySchemaResult,
+    TAssetPropertySchemaResult,
     TUUIDOrPath,
     TUrlOrUUID,
     TUrlOrPath,
@@ -926,6 +928,33 @@ export class AssetsApi {
         } catch (e) {
             ret.code = COMMON_STATUS.FAIL;
             console.error('query asset config map fail:', e instanceof Error ? e.message : String(e));
+            ret.reason = e instanceof Error ? e.message : String(e);
+        }
+
+        return ret;
+    }
+
+    /**
+     * Query Asset Property Schema // 查询资源导入属性 schema
+     */
+    @tool('assets-query-property-schema')
+    @title('Query Asset Import Property Schema') // 查询资源导入属性 schema
+    @description('Query the standardized import property schema for a specific asset importer. The result is designed for panels to render import settings automatically and includes stable fields such as label, type, default, options, assetType, min, max, step, readOnly, and order. The raw field is only for debugging and should not be used as a UI contract.') // 查询指定资源导入器的标准化导入属性 schema，用于面板自动渲染导入设置。
+    @result(SchemaAssetPropertySchemaResult)
+    async queryPropertySchema(
+        @param(SchemaUserDataHandler) importer: TUserDataHandler
+    ): Promise<CommonResultType<TAssetPropertySchemaResult>> {
+        const code: HttpStatusCode = COMMON_STATUS.SUCCESS;
+        const ret: CommonResultType<TAssetPropertySchemaResult> = {
+            code: code,
+            data: {},
+        };
+
+        try {
+            ret.data = await assetManager.queryPropertySchema(importer);
+        } catch (e) {
+            ret.code = getCommonErrorStatus(e);
+            console.error('query asset property schema fail:', e instanceof Error ? e.message : String(e));
             ret.reason = e instanceof Error ? e.message : String(e);
         }
 

--- a/src/api/assets/schema.ts
+++ b/src/api/assets/schema.ts
@@ -342,3 +342,28 @@ export const SchemaAssetConfig = z.object({
 
 export const SchemaAssetConfigMapResult = z.record(z.string(), SchemaAssetConfig).describe('Asset configuration map, key is asset handler name, value is corresponding configuration information'); // 资源配置映射表，键为资源处理器名称，值为对应的配置信息
 export type TAssetConfigMapResult = z.infer<typeof SchemaAssetConfigMapResult>;
+
+export const SchemaAssetPropertySchemaOption = z.object({
+    label: z.string().describe('Option display label'), // 选项显示名称
+    value: z.union([z.string(), z.number(), z.boolean()]).describe('Option value'), // 选项值
+}).describe('Asset property schema option'); // 资源属性 schema 选项
+
+export const SchemaAssetPropertySchema: z.ZodType<any> = z.lazy(() => z.object({
+    label: z.string().describe('Property display label'), // 属性显示名称
+    description: z.string().optional().describe('Property description'), // 属性描述
+    type: z.enum(['string', 'number', 'boolean', 'enum', 'asset', 'array', 'object']).describe('Property value/control type'), // 属性值或控件类型
+    default: z.any().optional().describe('Static default value'), // 静态默认值
+    options: z.array(SchemaAssetPropertySchemaOption).optional().describe('Enum/select options'), // 枚举/下拉选项
+    assetType: z.string().optional().describe('Allowed Cocos asset type for asset picker'), // Asset Picker 允许的 Cocos 资源类型
+    min: z.number().optional().describe('Minimum number value'), // 数值最小值
+    max: z.number().optional().describe('Maximum number value'), // 数值最大值
+    step: z.number().optional().describe('Number input step'), // 数值步进
+    readOnly: z.boolean().optional().describe('Whether the property is read-only'), // 是否只读
+    order: z.number().optional().describe('Display order'), // 展示顺序
+    properties: z.record(z.string(), SchemaAssetPropertySchema).optional().describe('Nested object properties'), // 嵌套对象属性
+    items: z.union([SchemaAssetPropertySchema, z.array(SchemaAssetPropertySchema)]).optional().describe('Array item schema'), // 数组元素 schema
+    raw: z.any().optional().describe('Original legacy userDataConfig item for debugging only'), // 原始旧配置，仅用于调试
+}).describe('Standardized asset import property schema')); // 标准化资源导入属性 schema
+
+export const SchemaAssetPropertySchemaResult = z.record(z.string(), SchemaAssetPropertySchema).describe('Asset import property schema map, key is property name'); // 资源导入属性 schema 映射
+export type TAssetPropertySchemaResult = z.infer<typeof SchemaAssetPropertySchemaResult>;

--- a/src/core/assets/@types/protected/asset-handler.d.ts
+++ b/src/core/assets/@types/protected/asset-handler.d.ts
@@ -93,6 +93,9 @@ export interface AssetHandlerBase extends CustomHandlerBase {
     // 对应导入资源在导入后的资源类型信息，未传递默认为 cc.Asset
     assetType?: IAssetType;
 
+    // Schema-only userData config. It is not registered as runtime default userData.
+    propertySchemaConfig?: Record<string, IUerDataConfigItem>;
+
     // 指定资源的 userData 配置
     userDataConfig?: {
         // 用于 userData 默认值的渲染界面

--- a/src/core/assets/@types/public.d.ts
+++ b/src/core/assets/@types/public.d.ts
@@ -37,6 +37,32 @@ export interface SerializedAssetQueryResult {
     dump: SerializedAssetDump;
 }
 
+export type AssetPropertySchemaType = 'string' | 'number' | 'boolean' | 'enum' | 'asset' | 'array' | 'object';
+
+export interface AssetPropertySchemaOption {
+    label: string;
+    value: string | number | boolean;
+}
+
+export interface AssetPropertySchema {
+    label: string;
+    description?: string;
+    type: AssetPropertySchemaType;
+    default?: unknown;
+    options?: AssetPropertySchemaOption[];
+    assetType?: string;
+    min?: number;
+    max?: number;
+    step?: number;
+    readOnly?: boolean;
+    order?: number;
+    properties?: Record<string, AssetPropertySchema>;
+    items?: AssetPropertySchema | AssetPropertySchema[];
+    raw?: unknown;
+}
+
+export type AssetPropertySchemaMap = Record<string, AssetPropertySchema>;
+
 // 如果使用了 datakeys 过滤，请使用此接口定义
 export interface IAssetInfo {
     name: string; // 资源名字

--- a/src/core/assets/asset-handler/assets/auto-atlas.ts
+++ b/src/core/assets/asset-handler/assets/auto-atlas.ts
@@ -1,5 +1,5 @@
 import { Asset } from '@cocos/asset-db';
-import { makeDefaultTextureBaseAssetUserData } from './texture-base';
+import { createTextureBaseUserDataConfig, makeDefaultTextureBaseAssetUserData } from './texture-base';
 
 import { getDependUUIDList } from '../utils';
 import { AssetHandler } from '../../@types/protected';
@@ -34,6 +34,112 @@ const AutoAtlasHandler: AssetHandler = {
 
     // pac 文件实际上在编辑器下没用到，只有构建时会用。因此这里把类型设置为 cc.SpriteAtlas，方便构建时当成图集来处理。
     assetType: 'cc.SpriteAtlas',
+    propertySchemaConfig: {
+            maxWidth: {
+                label: 'Max Width',
+                default: defaultAutoAtlasUserData.maxWidth,
+                render: {
+                    ui: 'ui-number-input',
+                    attributes: { min: 1, step: 1 },
+                },
+            },
+            maxHeight: {
+                label: 'Max Height',
+                default: defaultAutoAtlasUserData.maxHeight,
+                render: {
+                    ui: 'ui-number-input',
+                    attributes: { min: 1, step: 1 },
+                },
+            },
+            padding: {
+                label: 'Padding',
+                default: defaultAutoAtlasUserData.padding,
+                render: {
+                    ui: 'ui-number-input',
+                    attributes: { min: 0, step: 1 },
+                },
+            },
+            allowRotation: {
+                label: 'Allow Rotation',
+                default: defaultAutoAtlasUserData.allowRotation,
+                render: { ui: 'ui-checkbox' },
+            },
+            forceSquared: {
+                label: 'Force Squared',
+                default: defaultAutoAtlasUserData.forceSquared,
+                render: { ui: 'ui-checkbox' },
+            },
+            powerOfTwo: {
+                label: 'Power Of Two',
+                default: defaultAutoAtlasUserData.powerOfTwo,
+                render: { ui: 'ui-checkbox' },
+            },
+            algorithm: {
+                label: 'Algorithm',
+                default: defaultAutoAtlasUserData.algorithm,
+                render: {
+                    ui: 'ui-select',
+                    items: [
+                        { label: 'MaxRects', value: 'MaxRects' },
+                    ],
+                },
+            },
+            format: {
+                label: 'Format',
+                default: defaultAutoAtlasUserData.format,
+                render: {
+                    ui: 'ui-select',
+                    items: [
+                        { label: 'PNG', value: 'png' },
+                        { label: 'JPG', value: 'jpg' },
+                    ],
+                },
+            },
+            quality: {
+                label: 'Quality',
+                default: defaultAutoAtlasUserData.quality,
+                render: {
+                    ui: 'ui-number-input',
+                    attributes: { min: 0, max: 100, step: 1 },
+                },
+            },
+            contourBleed: {
+                label: 'Contour Bleed',
+                default: defaultAutoAtlasUserData.contourBleed,
+                render: { ui: 'ui-checkbox' },
+            },
+            paddingBleed: {
+                label: 'Padding Bleed',
+                default: defaultAutoAtlasUserData.paddingBleed,
+                render: { ui: 'ui-checkbox' },
+            },
+            filterUnused: {
+                label: 'Filter Unused',
+                default: defaultAutoAtlasUserData.filterUnused,
+                render: { ui: 'ui-checkbox' },
+            },
+            removeTextureInBundle: {
+                label: 'Remove Texture In Bundle',
+                default: defaultAutoAtlasUserData.removeTextureInBundle,
+                render: { ui: 'ui-checkbox' },
+            },
+            removeImageInBundle: {
+                label: 'Remove Image In Bundle',
+                default: defaultAutoAtlasUserData.removeImageInBundle,
+                render: { ui: 'ui-checkbox' },
+            },
+            removeSpriteAtlasInBundle: {
+                label: 'Remove SpriteAtlas In Bundle',
+                default: defaultAutoAtlasUserData.removeSpriteAtlasInBundle,
+                render: { ui: 'ui-checkbox' },
+            },
+            textureSetting: {
+                label: 'Texture Setting',
+                type: 'object',
+                default: defaultAutoAtlasUserData.textureSetting,
+                itemConfigs: createTextureBaseUserDataConfig(),
+            },
+    },
     createInfo: {
         generateMenuInfo() {
             return [

--- a/src/core/assets/asset-handler/assets/fbx.ts
+++ b/src/core/assets/asset-handler/assets/fbx.ts
@@ -6,6 +6,69 @@ export const FbxHandler: AssetHandlerBase = {
 
     // Handler 的名字，用于指定 Handler as 等
     name: 'fbx',
+
+    propertySchemaConfig: {
+        ...(GltfHandler.propertySchemaConfig ?? {}),
+        legacyFbxImporter: {
+            label: 'Legacy FBX Importer',
+            default: false,
+            render: { ui: 'ui-checkbox' },
+        },
+        fbx: {
+            label: 'FBX',
+            type: 'object',
+            default: {
+                unitConversion: 'geometry-level',
+                animationBakeRate: 24,
+                preferLocalTimeSpan: true,
+                smartMaterialEnabled: false,
+                matchMeshNames: false,
+            },
+            itemConfigs: {
+                unitConversion: {
+                    label: 'Unit Conversion',
+                    default: 'geometry-level',
+                    render: {
+                        ui: 'ui-select',
+                        items: [
+                            { label: 'Geometry Level', value: 'geometry-level' },
+                            { label: 'Hierarchy Level', value: 'hierarchy-level' },
+                            { label: 'Disabled', value: 'disabled' },
+                        ],
+                    },
+                },
+                animationBakeRate: {
+                    label: 'Animation Bake Rate',
+                    default: 24,
+                    render: {
+                        ui: 'ui-select',
+                        items: [
+                            { label: 'Original', value: '0' },
+                            { label: '24 FPS', value: '24' },
+                            { label: '25 FPS', value: '25' },
+                            { label: '30 FPS', value: '30' },
+                            { label: '60 FPS', value: '60' },
+                        ],
+                    },
+                },
+                preferLocalTimeSpan: {
+                    label: 'Prefer Local Time Span',
+                    default: true,
+                    render: { ui: 'ui-checkbox' },
+                },
+                smartMaterialEnabled: {
+                    label: 'Smart Material',
+                    default: false,
+                    render: { ui: 'ui-checkbox' },
+                },
+                matchMeshNames: {
+                    label: 'Match Mesh Names',
+                    default: false,
+                    render: { ui: 'ui-checkbox' },
+                },
+            },
+        },
+    },
 };
 
 export default FbxHandler;

--- a/src/core/assets/asset-handler/assets/gltf.ts
+++ b/src/core/assets/asset-handler/assets/gltf.ts
@@ -16,6 +16,7 @@ import {
     ImageMeta,
     LODsOption,
 } from '../../@types/userDatas';
+import { NormalImportSetting, TangentImportSetting } from '../../@types/interface';
 import { convertsEncodedSeparatorsInURI } from './utils/uri-utils';
 import { AnimationClip, MeshRenderer, Node } from 'cc';
 
@@ -46,6 +47,130 @@ const lodash = require('lodash');
 export const GltfHandler: AssetHandlerBase = {
     // Handler 的名字，用于指定 Handler as 等
     name: 'gltf',
+
+    propertySchemaConfig: {
+            dumpMaterials: {
+                label: 'Dump Materials',
+                default: false,
+                render: { ui: 'ui-checkbox' },
+            },
+            mountAllAnimationsOnPrefab: {
+                label: 'Mount All Animations On Prefab',
+                default: false,
+                render: { ui: 'ui-checkbox' },
+            },
+            allowMeshDataAccess: {
+                label: 'Allow Mesh Data Access',
+                default: true,
+                render: { ui: 'ui-checkbox' },
+            },
+            addVertexColor: {
+                label: 'Add Vertex Color',
+                default: false,
+                render: { ui: 'ui-checkbox' },
+            },
+            promoteSingleRootNode: {
+                label: 'Promote Single Root Node',
+                default: false,
+                render: { ui: 'ui-checkbox' },
+            },
+            generateLightmapUVNode: {
+                label: 'Generate Lightmap UV',
+                default: false,
+                render: { ui: 'ui-checkbox' },
+            },
+            normals: {
+                label: 'Normals',
+                default: NormalImportSetting.require,
+                render: {
+                    ui: 'ui-select',
+                    items: [
+                        { label: 'Optional', value: String(NormalImportSetting.optional) },
+                        { label: 'Exclude', value: String(NormalImportSetting.exclude) },
+                        { label: 'Require', value: String(NormalImportSetting.require) },
+                        { label: 'Recalculate', value: String(NormalImportSetting.recalculate) },
+                    ],
+                },
+            },
+            tangents: {
+                label: 'Tangents',
+                default: TangentImportSetting.require,
+                render: {
+                    ui: 'ui-select',
+                    items: [
+                        { label: 'Exclude', value: String(TangentImportSetting.exclude) },
+                        { label: 'Optional', value: String(TangentImportSetting.optional) },
+                        { label: 'Require', value: String(TangentImportSetting.require) },
+                        { label: 'Recalculate', value: String(TangentImportSetting.recalculate) },
+                    ],
+                },
+            },
+            morphNormals: {
+                label: 'Morph Normals',
+                default: NormalImportSetting.exclude,
+                render: {
+                    ui: 'ui-select',
+                    items: [
+                        { label: 'Exclude', value: String(NormalImportSetting.exclude) },
+                        { label: 'Optional', value: String(NormalImportSetting.optional) },
+                    ],
+                },
+            },
+            meshOptimizer: {
+                label: 'Mesh Optimizer',
+                type: 'object',
+                default: {
+                    enable: false,
+                    algorithm: 'simplify',
+                    simplifyOptions: getDefaultSimplifyOptions(),
+                },
+                itemConfigs: {
+                    enable: {
+                        label: 'Enable',
+                        default: false,
+                        render: { ui: 'ui-checkbox' },
+                    },
+                    algorithm: {
+                        label: 'Algorithm',
+                        default: 'simplify',
+                        render: {
+                            ui: 'ui-select',
+                            items: [
+                                { label: 'Simplify', value: 'simplify' },
+                                { label: 'gltfpack', value: 'gltfpack' },
+                            ],
+                        },
+                    },
+                    simplifyOptions: {
+                        label: 'Simplify Options',
+                        type: 'object',
+                        default: getDefaultSimplifyOptions(),
+                        itemConfigs: {
+                            targetRatio: {
+                                label: 'Target Ratio',
+                                default: 1,
+                                render: { ui: 'ui-number-input', attributes: { min: 0, max: 1, step: 0.01 } },
+                            },
+                            enableSmartLink: {
+                                label: 'Enable Smart Link',
+                                default: true,
+                                render: { ui: 'ui-checkbox' },
+                            },
+                            agressiveness: {
+                                label: 'Agressiveness',
+                                default: 7,
+                                render: { ui: 'ui-number-input', attributes: { min: 0, step: 1 } },
+                            },
+                            maxIterationCount: {
+                                label: 'Max Iteration Count',
+                                default: 100,
+                                render: { ui: 'ui-number-input', attributes: { min: 1, step: 1 } },
+                            },
+                        },
+                    },
+                },
+            },
+    },
 
     importer: {
         // 版本号如果变更，则会强制重新导入

--- a/src/core/assets/asset-handler/assets/sprite-frame.ts
+++ b/src/core/assets/asset-handler/assets/sprite-frame.ts
@@ -7,6 +7,7 @@ import { AssetHandler } from '../../@types/protected';
 import { SpriteFrameBaseAssetUserData, SpriteFrameAssetUserData } from '../../@types/userDatas';
 import { getTrimRect, getDependUUIDList } from '../utils';
 import i18n from '../../../base/i18n';
+import { makeDefaultSpriteFrameBaseAssetUserData } from './texture-base';
 
 try {
     require('sharp');
@@ -18,6 +19,8 @@ try {
 const Sharp = require('sharp');
 
 Sharp.cache(false);
+
+const defaultSpriteFrameUserData = makeDefaultSpriteFrameBaseAssetUserData();
 
 export const SpriteFrameHandler: AssetHandler = {
     // Handler 的名字，用于指定 Handler as 等
@@ -48,6 +51,76 @@ export const SpriteFrameHandler: AssetHandler = {
                     ],
                 },
             },
+        },
+    },
+    propertySchemaConfig: {
+        trimThreshold: {
+            default: defaultSpriteFrameUserData.trimThreshold,
+            label: 'Trim Threshold',
+            render: {
+                ui: 'ui-number-input',
+                attributes: { min: 0, step: 1 },
+            },
+        },
+        packable: {
+            default: defaultSpriteFrameUserData.packable,
+            label: 'Packable',
+            render: { ui: 'ui-checkbox' },
+        },
+        pixelsToUnit: {
+            default: defaultSpriteFrameUserData.pixelsToUnit,
+            label: 'Pixels To Unit',
+            render: {
+                ui: 'ui-number-input',
+                attributes: { min: 1, step: 1 },
+            },
+        },
+        pivotX: {
+            default: defaultSpriteFrameUserData.pivotX,
+            label: 'Pivot X',
+            render: {
+                ui: 'ui-number-input',
+                attributes: { min: 0, max: 1, step: 0.01 },
+            },
+        },
+        pivotY: {
+            default: defaultSpriteFrameUserData.pivotY,
+            label: 'Pivot Y',
+            render: {
+                ui: 'ui-number-input',
+                attributes: { min: 0, max: 1, step: 0.01 },
+            },
+        },
+        meshType: {
+            default: defaultSpriteFrameUserData.meshType,
+            label: 'Mesh Type',
+            render: {
+                ui: 'ui-select',
+                items: [
+                    { label: 'Rect', value: '0' },
+                    { label: 'Polygon', value: '1' },
+                ],
+            },
+        },
+        borderTop: {
+            default: defaultSpriteFrameUserData.borderTop,
+            label: 'Border Top',
+            render: { ui: 'ui-number-input', attributes: { min: 0, step: 1 } },
+        },
+        borderBottom: {
+            default: defaultSpriteFrameUserData.borderBottom,
+            label: 'Border Bottom',
+            render: { ui: 'ui-number-input', attributes: { min: 0, step: 1 } },
+        },
+        borderLeft: {
+            default: defaultSpriteFrameUserData.borderLeft,
+            label: 'Border Left',
+            render: { ui: 'ui-number-input', attributes: { min: 0, step: 1 } },
+        },
+        borderRight: {
+            default: defaultSpriteFrameUserData.borderRight,
+            label: 'Border Right',
+            render: { ui: 'ui-number-input', attributes: { min: 0, step: 1 } },
         },
     },
     importer: {

--- a/src/core/assets/asset-handler/assets/texture-base.ts
+++ b/src/core/assets/asset-handler/assets/texture-base.ts
@@ -2,6 +2,7 @@
 
 import { Asset } from '@cocos/asset-db';
 import { Filter, SpriteFrameBaseAssetUserData, TextureBaseAssetUserData, WrapMode } from '../../@types/userDatas';
+import type { IUerDataConfigItem } from '../../@types/protected';
 
 export const defaultMinFilter: Filter = 'linear';
 export const defaultMagFilter: Filter = 'linear';
@@ -17,6 +18,62 @@ export function makeDefaultTextureBaseAssetUserData(): TextureBaseAssetUserData 
         magfilter: defaultMagFilter,
         mipfilter: defaultMipFilter,
         anisotropy: 0,
+    };
+}
+
+export function createTextureBaseUserDataConfig(): Record<string, IUerDataConfigItem> {
+    return {
+        wrapModeS: {
+            label: 'Wrap Mode S',
+            default: defaultWrapModeS,
+            render: {
+                ui: 'ui-select',
+                items: createWrapModeOptions(),
+            },
+        },
+        wrapModeT: {
+            label: 'Wrap Mode T',
+            default: defaultWrapModeT,
+            render: {
+                ui: 'ui-select',
+                items: createWrapModeOptions(),
+            },
+        },
+        minfilter: {
+            label: 'Min Filter',
+            default: defaultMinFilter,
+            render: {
+                ui: 'ui-select',
+                items: createFilterOptions(),
+            },
+        },
+        magfilter: {
+            label: 'Mag Filter',
+            default: defaultMagFilter,
+            render: {
+                ui: 'ui-select',
+                items: createFilterOptions().filter((item) => item.value !== 'none'),
+            },
+        },
+        mipfilter: {
+            label: 'Mip Filter',
+            default: defaultMipFilter,
+            render: {
+                ui: 'ui-select',
+                items: createFilterOptions(),
+            },
+        },
+        anisotropy: {
+            label: 'Anisotropy',
+            default: 0,
+            render: {
+                ui: 'ui-number-input',
+                attributes: {
+                    min: 0,
+                    step: 1,
+                },
+            },
+        },
     };
 }
 
@@ -59,6 +116,22 @@ export function makeDefaultSpriteFrameBaseAssetUserData(): SpriteFrameBaseAssetU
             maxPos: [],
         },
     };
+}
+
+function createWrapModeOptions() {
+    return [
+        { label: 'Repeat', value: 'repeat' },
+        { label: 'Clamp To Edge', value: 'clamp-to-edge' },
+        { label: 'Mirrored Repeat', value: 'mirrored-repeat' },
+    ];
+}
+
+function createFilterOptions() {
+    return [
+        { label: 'None', value: 'none' },
+        { label: 'Nearest', value: 'nearest' },
+        { label: 'Linear', value: 'linear' },
+    ];
 }
 
 export function getWrapMode(wrapMode: WrapMode) {

--- a/src/core/assets/asset-handler/assets/texture.ts
+++ b/src/core/assets/asset-handler/assets/texture.ts
@@ -6,7 +6,7 @@ import { AssetHandler } from '../../@types/protected';
 import { Texture2DAssetUserData } from '../../@types/userDatas';
 import { getDependUUIDList } from '../utils';
 import { makeDefaultTexture2DAssetUserData } from './image/utils';
-import { applyTextureBaseAssetUserData } from './texture-base';
+import { applyTextureBaseAssetUserData, createTextureBaseUserDataConfig } from './texture-base';
 import { url2uuid } from '../../utils';
 
 export const TextureHandler: AssetHandler = {
@@ -15,6 +15,27 @@ export const TextureHandler: AssetHandler = {
 
     // 引擎内对应的类型
     assetType: 'cc.Texture2D',
+
+    propertySchemaConfig: {
+        ...createTextureBaseUserDataConfig(),
+        imageUuidOrDatabaseUri: {
+            label: 'Image',
+            default: '',
+            render: {
+                ui: 'ui-asset',
+                attributes: {
+                    assetType: 'cc.ImageAsset',
+                },
+            },
+        },
+        isUuid: {
+            label: 'Use UUID',
+            default: true,
+            render: {
+                ui: 'ui-checkbox',
+            },
+        },
+    },
 
     importer: {
         // 版本号如果变更，则会强制重新导入

--- a/src/core/assets/manager/asset-handler.ts
+++ b/src/core/assets/manager/asset-handler.ts
@@ -12,6 +12,8 @@ import type { AssetHandlerInfo } from '../asset-handler/config';
 import assetConfig from '../asset-config';
 import { copyPath, createDirectoryPath, writePath } from './filesystem';
 import eol from 'eol';
+import { convertUserDataConfigToPropertySchema, mergeUserDataConfigForPropertySchema } from '../property-schema';
+import type { AssetPropertySchemaMap } from '../@types/public';
 
 interface HandlerInfo extends AssetHandlerInfo {
     pkgName: string;
@@ -545,6 +547,20 @@ class AssetHandlerManager {
         }
         return assetHandler.userDataConfig.default;
     }
+
+    async queryPropertySchema(importer: string): Promise<AssetPropertySchemaMap> {
+        const assetHandler = await this.ensureHandler(importer);
+        if (!assetHandler) {
+            throw new Error(`Asset handler not found: ${importer}`);
+        }
+
+        const propertyConfig = mergeUserDataConfigForPropertySchema(
+            assetHandler.userDataConfig?.default,
+            assetHandler.propertySchemaConfig,
+        );
+        return convertUserDataConfigToPropertySchema(propertyConfig);
+    }
+
     async runImporterHook(asset: IAsset, hookName: 'before' | 'after') {
         const assetHandler = this.name2handler[asset.meta.importer];
         // 1. 先执行资源处理器内的钩子

--- a/src/core/assets/manager/asset.ts
+++ b/src/core/assets/manager/asset.ts
@@ -52,6 +52,7 @@ class AssetManager extends EventEmitter {
 
     // ----------- assetHandlerManager ------------
     queryAssetConfigMap = assetHandlerManager.queryAssetConfigMap.bind(assetHandlerManager);
+    queryPropertySchema = assetHandlerManager.queryPropertySchema.bind(assetHandlerManager);
     updateDefaultUserData = assetHandlerManager.updateDefaultUserData.bind(assetHandlerManager);
     getCreateMap = assetHandlerManager.getCreateMap.bind(assetHandlerManager);
     queryAssetUserDataConfig = assetHandlerManager.queryUserDataConfig.bind(assetHandlerManager);
@@ -359,6 +360,7 @@ export interface TypedAssetManager extends EventEmitter {
     saveSerializedData: typeof serializedData.saveSerializedData;
 
     queryAssetConfigMap: typeof assetHandlerManager.queryAssetConfigMap;
+    queryPropertySchema: typeof assetHandlerManager.queryPropertySchema;
     updateDefaultUserData: typeof assetHandlerManager.updateDefaultUserData;
     getCreateMap: typeof assetHandlerManager.getCreateMap;
     queryAssetUserDataConfig: typeof assetHandlerManager.queryUserDataConfig;

--- a/src/core/assets/property-schema.ts
+++ b/src/core/assets/property-schema.ts
@@ -1,0 +1,250 @@
+import type { AssetPropertySchema, AssetPropertySchemaMap, AssetPropertySchemaOption } from './@types/public';
+import type { IUerDataConfigItem } from './@types/protected';
+import {
+    createTitleFromKey,
+    normalizeDisplayText,
+    translateMetadataText,
+} from '../configuration/script/metadata';
+
+type LegacyConfigItem = IUerDataConfigItem & {
+    assetType?: string;
+    readOnly?: boolean;
+    readonly?: boolean;
+    order?: number;
+};
+
+type LegacyRenderAttributes = Record<string, string | boolean | number>;
+
+const UI_TYPE_MAP: Record<string, AssetPropertySchema['type']> = {
+    'ui-checkbox': 'boolean',
+    'ui-number-input': 'number',
+    'ui-num-input': 'number',
+    'ui-slider': 'number',
+    'ui-input': 'string',
+    'ui-textarea': 'string',
+    'ui-select': 'enum',
+    'ui-asset': 'asset',
+    'ui-asset-picker': 'asset',
+};
+
+export function convertUserDataConfigToPropertySchema(
+    config: Record<string, IUerDataConfigItem> | undefined
+): AssetPropertySchemaMap {
+    const result: AssetPropertySchemaMap = {};
+    if (!config) {
+        return result;
+    }
+
+    for (const [key, item] of Object.entries(config)) {
+        const fieldName = item.key || key;
+        result[fieldName] = convertUserDataConfigItemToPropertySchema(fieldName, item);
+    }
+
+    return result;
+}
+
+export function mergeUserDataConfigForPropertySchema(
+    runtimeConfig: Record<string, IUerDataConfigItem> | undefined,
+    schemaOnlyConfig: Record<string, IUerDataConfigItem> | undefined
+): Record<string, IUerDataConfigItem> | undefined {
+    if (!runtimeConfig && !schemaOnlyConfig) {
+        return undefined;
+    }
+
+    return {
+        ...(runtimeConfig ?? {}),
+        ...(schemaOnlyConfig ?? {}),
+    };
+}
+
+export function convertUserDataConfigItemToPropertySchema(
+    key: string,
+    item: IUerDataConfigItem
+): AssetPropertySchema {
+    const legacyItem = item as LegacyConfigItem;
+    const attributes = item.render?.attributes;
+    const schema: AssetPropertySchema = {
+        label: normalizeDisplayText(item.label, createTitleFromKey(key)),
+        type: inferSchemaType(item),
+        raw: item,
+    };
+
+    const description = translateMetadataText(item.description);
+    if (description) {
+        schema.description = description;
+    }
+
+    if (item.default !== undefined) {
+        schema.default = item.default;
+    }
+
+    const options = convertOptions(item, schema.default);
+    if (options.length) {
+        schema.options = options;
+        schema.type = 'enum';
+    }
+
+    const assetType = readStringAttribute(attributes, 'assetType') ?? legacyItem.assetType;
+    if (assetType) {
+        schema.type = 'asset';
+        schema.assetType = assetType;
+    }
+
+    const min = readNumberAttribute(attributes, 'min') ?? readNumberAttribute(attributes, 'minimum');
+    if (min !== undefined) {
+        schema.min = min;
+    }
+
+    const max = readNumberAttribute(attributes, 'max') ?? readNumberAttribute(attributes, 'maximum');
+    if (max !== undefined) {
+        schema.max = max;
+    }
+
+    const step = readNumberAttribute(attributes, 'step');
+    if (step !== undefined) {
+        schema.step = step;
+    }
+
+    const readOnly = readBooleanAttribute(attributes, 'readOnly')
+        ?? readBooleanAttribute(attributes, 'readonly')
+        ?? legacyItem.readOnly
+        ?? legacyItem.readonly;
+    if (readOnly !== undefined) {
+        schema.readOnly = readOnly;
+    }
+
+    const order = readNumberAttribute(attributes, 'order') ?? legacyItem.order;
+    if (order !== undefined) {
+        schema.order = order;
+    }
+
+    applyNestedConfig(schema, item);
+
+    return schema;
+}
+
+function inferSchemaType(item: IUerDataConfigItem): AssetPropertySchema['type'] {
+    if (item.type === 'array' || item.type === 'object') {
+        return item.type;
+    }
+
+    const uiType = item.render?.ui?.toLowerCase();
+    if (uiType && UI_TYPE_MAP[uiType]) {
+        return UI_TYPE_MAP[uiType];
+    }
+
+    const value = item.default;
+    if (Array.isArray(value)) {
+        return 'array';
+    }
+
+    if (value !== null && typeof value === 'object') {
+        return 'object';
+    }
+
+    if (typeof value === 'number') {
+        return 'number';
+    }
+
+    if (typeof value === 'boolean') {
+        return 'boolean';
+    }
+
+    return 'string';
+}
+
+function convertOptions(item: IUerDataConfigItem, defaultValue: unknown): AssetPropertySchemaOption[] {
+    return (item.render?.items ?? []).map((option) => ({
+        label: normalizeDisplayText(option.label, String(option.value)),
+        value: normalizeOptionValue(option.value, defaultValue),
+    }));
+}
+
+function normalizeOptionValue(value: string | number | boolean, defaultValue: unknown): string | number | boolean {
+    if (typeof value !== 'string') {
+        return value;
+    }
+
+    if (typeof defaultValue === 'boolean') {
+        if (value === 'true') {
+            return true;
+        }
+        if (value === 'false') {
+            return false;
+        }
+    }
+
+    if (typeof defaultValue === 'number') {
+        const numericValue = Number(value);
+        if (Number.isFinite(numericValue)) {
+            return numericValue;
+        }
+    }
+
+    return value;
+}
+
+function applyNestedConfig(schema: AssetPropertySchema, item: IUerDataConfigItem): void {
+    const { itemConfigs } = item;
+    if (!itemConfigs) {
+        return;
+    }
+
+    if (Array.isArray(itemConfigs)) {
+        const children = itemConfigs.map((child, index) => (
+            convertUserDataConfigItemToPropertySchema(child.key || String(index), child)
+        ));
+        if (schema.type === 'array') {
+            schema.items = children.length === 1 ? children[0] : children;
+        } else {
+            schema.type = 'object';
+            schema.properties = Object.fromEntries(children.map((child, index) => [itemConfigs[index].key || String(index), child]));
+        }
+        return;
+    }
+
+    const children = convertUserDataConfigToPropertySchema(itemConfigs);
+    if (schema.type === 'array') {
+        schema.items = {
+            label: 'Item',
+            type: 'object',
+            default: {},
+            properties: children,
+        };
+        return;
+    }
+
+    schema.type = 'object';
+    schema.properties = children;
+}
+
+function readStringAttribute(attributes: LegacyRenderAttributes | undefined, name: string): string | undefined {
+    const value = attributes?.[name];
+    return typeof value === 'string' && value ? value : undefined;
+}
+
+function readNumberAttribute(attributes: LegacyRenderAttributes | undefined, name: string): number | undefined {
+    const value = attributes?.[name];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return value;
+    }
+    if (typeof value === 'string' && value !== '') {
+        const numericValue = Number(value);
+        return Number.isFinite(numericValue) ? numericValue : undefined;
+    }
+    return undefined;
+}
+
+function readBooleanAttribute(attributes: LegacyRenderAttributes | undefined, name: string): boolean | undefined {
+    const value = attributes?.[name];
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (value === 'true') {
+        return true;
+    }
+    if (value === 'false') {
+        return false;
+    }
+    return undefined;
+}

--- a/src/core/assets/test/property-schema.test.ts
+++ b/src/core/assets/test/property-schema.test.ts
@@ -1,0 +1,190 @@
+import {
+    convertUserDataConfigItemToPropertySchema,
+    convertUserDataConfigToPropertySchema,
+    mergeUserDataConfigForPropertySchema,
+} from '../property-schema';
+
+describe('asset property schema conversion', () => {
+    it('maps legacy userDataConfig controls to stable property schema fields', () => {
+        const schema = convertUserDataConfigToPropertySchema({
+            type: {
+                label: 'Import Type',
+                default: 'sprite-frame',
+                render: {
+                    ui: 'ui-select',
+                    items: [
+                        { label: 'Raw', value: 'raw' },
+                        { label: 'Sprite Frame', value: 'sprite-frame' },
+                    ],
+                },
+            },
+            flipVertical: {
+                label: 'Flip Vertical',
+                render: {
+                    ui: 'ui-checkbox',
+                },
+            },
+            quality: {
+                label: 'Quality',
+                default: 80,
+                render: {
+                    ui: 'ui-number-input',
+                    attributes: {
+                        min: 0,
+                        max: 100,
+                        step: 1,
+                    },
+                },
+            },
+            image: {
+                label: 'Image',
+                default: '',
+                render: {
+                    ui: 'ui-asset',
+                    attributes: {
+                        assetType: 'cc.ImageAsset',
+                    },
+                },
+            },
+        });
+
+        expect(schema.type).toMatchObject({
+            label: 'Import Type',
+            type: 'enum',
+            default: 'sprite-frame',
+            options: [
+                { label: 'Raw', value: 'raw' },
+                { label: 'Sprite Frame', value: 'sprite-frame' },
+            ],
+        });
+        expect(schema.flipVertical.type).toBe('boolean');
+        expect(schema.quality).toMatchObject({
+            type: 'number',
+            min: 0,
+            max: 100,
+            step: 1,
+        });
+        expect(schema.image).toMatchObject({
+            type: 'asset',
+            assetType: 'cc.ImageAsset',
+        });
+    });
+
+    it('normalizes numeric enum option values when the default is numeric', () => {
+        const schema = convertUserDataConfigItemToPropertySchema('meshType', {
+            label: 'Mesh Type',
+            default: 0,
+            render: {
+                ui: 'ui-select',
+                items: [
+                    { label: 'Rect', value: '0' },
+                    { label: 'Polygon', value: '1' },
+                ],
+            },
+        });
+
+        expect(schema.type).toBe('enum');
+        expect(schema.options).toEqual([
+            { label: 'Rect', value: 0 },
+            { label: 'Polygon', value: 1 },
+        ]);
+    });
+
+    it('keeps nested object itemConfigs as nested properties', () => {
+        const schema = convertUserDataConfigItemToPropertySchema('textureSetting', {
+            label: 'Texture Setting',
+            type: 'object',
+            default: {
+                anisotropy: 0,
+            },
+            itemConfigs: {
+                anisotropy: {
+                    label: 'Anisotropy',
+                    default: 0,
+                    render: {
+                        ui: 'ui-number-input',
+                        attributes: {
+                            min: 0,
+                            step: 1,
+                        },
+                    },
+                },
+            },
+        });
+
+        expect(schema).toMatchObject({
+            label: 'Texture Setting',
+            type: 'object',
+            properties: {
+                anisotropy: {
+                    label: 'Anisotropy',
+                    type: 'number',
+                    default: 0,
+                    min: 0,
+                    step: 1,
+                },
+            },
+        });
+    });
+
+    it('treats array-form itemConfigs as object properties when the parent is not an array', () => {
+        const schema = convertUserDataConfigItemToPropertySchema('rect', {
+            label: 'Rect',
+            itemConfigs: [
+                {
+                    key: 'x',
+                    label: 'X',
+                    default: 0,
+                    render: { ui: 'ui-number-input' },
+                },
+            ],
+        });
+
+        expect(schema).toMatchObject({
+            label: 'Rect',
+            type: 'object',
+            properties: {
+                x: {
+                    label: 'X',
+                    type: 'number',
+                    default: 0,
+                },
+            },
+        });
+    });
+
+    it('merges schema-only config for property schema without mutating runtime userDataConfig', () => {
+        const runtimeConfig = {
+            runtimeOnly: {
+                label: 'Runtime Only',
+                default: true,
+                render: { ui: 'ui-checkbox' },
+            },
+        };
+        const schemaOnlyConfig = {
+            schemaOnly: {
+                label: 'Schema Only',
+                default: 1,
+                render: { ui: 'ui-number-input' },
+            },
+        };
+
+        const mergedConfig = mergeUserDataConfigForPropertySchema(runtimeConfig, schemaOnlyConfig);
+        const schema = convertUserDataConfigToPropertySchema(mergedConfig);
+
+        expect(schema).toMatchObject({
+            runtimeOnly: {
+                label: 'Runtime Only',
+                type: 'boolean',
+                default: true,
+            },
+            schemaOnly: {
+                label: 'Schema Only',
+                type: 'number',
+                default: 1,
+            },
+        });
+        expect(runtimeConfig).toHaveProperty('runtimeOnly');
+        expect(runtimeConfig).not.toHaveProperty('schemaOnly');
+    });
+});

--- a/src/lib/assets/assets.ts
+++ b/src/lib/assets/assets.ts
@@ -1,4 +1,4 @@
-import type { AnimationMaskChange, AnimationMaskDump, AssetOperationOption, CreateAssetByTypeOptions, DeleteAssetOptions, IAssetFileSystemProvider, IAssetInfo, IAssetMeta, ISupportCreateType, QueryAssetsOption, SerializedAssetPatch, SerializedAssetQueryResult } from '../../core/assets/@types/public';
+import type { AnimationMaskChange, AnimationMaskDump, AssetOperationOption, AssetPropertySchemaMap, CreateAssetByTypeOptions, DeleteAssetOptions, IAssetFileSystemProvider, IAssetInfo, IAssetMeta, ISupportCreateType, QueryAssetsOption, SerializedAssetPatch, SerializedAssetQueryResult } from '../../core/assets/@types/public';
 import type { CreateAssetOptions, IAssetConfig, IAssetDBInfo, ICreateMenuInfo, IUerDataConfigItem, QueryAssetType, ThumbnailInfo, ThumbnailSize } from '../../core/assets/@types/protected';
 import type { FilterPluginOptions, IPluginScriptInfo } from '../../core/scripting/interface';
 import { assetDBManager, assetManager } from '../../core/assets';
@@ -347,6 +347,13 @@ export async function updateAssetUserData(
  */
 export async function queryAssetConfigMap(): Promise<Record<string, IAssetConfig>> {
     return await assetManager.queryAssetConfigMap();
+}
+
+/**
+ * Query Asset Property Schema // 查询资源导入属性 schema
+ */
+export async function queryPropertySchema(importer: string): Promise<AssetPropertySchemaMap> {
+    return await assetManager.queryPropertySchema(importer);
 }
 
 /**

--- a/tests/assets-query-property-schema-api.test.ts
+++ b/tests/assets-query-property-schema-api.test.ts
@@ -1,0 +1,58 @@
+const mockQueryPropertySchema = jest.fn();
+
+jest.mock('../src/core/assets', () => ({
+    assetDBManager: {},
+    assetManager: {
+        queryPropertySchema: (...args: unknown[]) => mockQueryPropertySchema(...args),
+    },
+}));
+
+jest.mock('../src/api/decorator/decorator.js', () => jest.requireActual('../src/api/decorator/decorator'), { virtual: true });
+
+import { COMMON_STATUS } from '../src/api/base/schema-base';
+import { AssetsApi } from '../src/api/assets/assets';
+import { toolRegistry } from '../src/api/decorator/decorator.js';
+
+describe('assets-query-property-schema api', () => {
+    beforeEach(() => {
+        mockQueryPropertySchema.mockReset();
+    });
+
+    it('registers an MCP tool with importer parameter', () => {
+        const tool = toolRegistry.get('assets-query-property-schema');
+
+        expect(tool).toBeDefined();
+        expect(tool?.meta.paramSchemas.map((param) => param.name)).toEqual(['importer']);
+    });
+
+    it('delegates to assetManager.queryPropertySchema', async () => {
+        const schema = {
+            type: {
+                label: 'Import Type',
+                type: 'enum',
+                default: 'sprite-frame',
+            },
+        };
+        mockQueryPropertySchema.mockResolvedValue(schema);
+
+        const result = await new AssetsApi().queryPropertySchema('image');
+
+        expect(result).toEqual({
+            code: COMMON_STATUS.SUCCESS,
+            data: schema,
+        });
+        expect(mockQueryPropertySchema).toHaveBeenCalledWith('image');
+    });
+
+    it('returns 404 when the importer is unknown', async () => {
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        mockQueryPropertySchema.mockRejectedValue(new Error('Asset handler not found: missing'));
+
+        const result = await new AssetsApi().queryPropertySchema('missing');
+
+        consoleErrorSpy.mockRestore();
+        expect(result.code).toBe(COMMON_STATUS.NOT_FOUND);
+        expect(result.data).toEqual({});
+        expect(result.reason).toBe('Asset handler not found: missing');
+    });
+});

--- a/tests/lib/assets-api.test.ts
+++ b/tests/lib/assets-api.test.ts
@@ -49,4 +49,18 @@ describe('lib assets api', () => {
         expect(querySpy).toHaveBeenCalledWith('test-uuid');
         expect(saveSpy).toHaveBeenCalledWith('test-uuid', {});
     });
+
+    it('exposes queryPropertySchema and delegates to assetManager', async () => {
+        const schema = {
+            type: {
+                label: 'Import Type',
+                type: 'enum' as const,
+                default: 'sprite-frame',
+            },
+        };
+        const spy = jest.spyOn(assetManager, 'queryPropertySchema').mockResolvedValue(schema);
+
+        await expect(Assets.queryPropertySchema('image')).resolves.toEqual(schema);
+        expect(spy).toHaveBeenCalledWith('image');
+    });
 });


### PR DESCRIPTION
## 变更说明

新增 `assets.queryPropertySchema(importer)` 能力，用于查询指定 importer 的标准化导入属性 schema，方便面板或外部工具自动渲染导入配置。

## 主要改动

- 新增 MCP 工具 `assets-query-property-schema`，并在 lib assets API 暴露 `queryPropertySchema`。
- 新增 `AssetPropertySchema*` 公共类型和 userDataConfig 到 property schema 的转换逻辑。
- 为 `texture`、`auto-atlas`、`sprite-frame`、`gltf`、`fbx` 补充导入属性 schema。
- 新增 `propertySchemaConfig`，让仅用于 schema 展示的字段不注册为运行时默认 `userData`。
- 补充 API/lib/schema 转换相关测试，并更新 dts snapshot。