### PR TITLE
fix(builder): hide fb-instant-games / google-play from platform list

### DIFF
--- a/src/core/builder/manager/plugin.ts
+++ b/src/core/builder/manager/plugin.ts
@@ -927,7 +927,13 @@ export class PluginManager extends EventEmitter {
     }
 
     public queryPlatformConfig(): PlatformConfigItem[] {
-        return Object.entries(this.platformConfig).map(([platform, config]) => {
+        // HACK(临时): fb-instant-games / google-play 暂不对外,在平台查询的总出口处过滤掉。
+        //   PinK 构建面板(走 pluginManager.queryPlatformConfig)、core/lib 接口等所有消费方都经此方法,
+        //   统一隐藏。待平台就绪后移除此过滤。
+        const HIDDEN_PLATFORMS = new Set(['fb-instant-games', 'google-play']);
+        return Object.entries(this.platformConfig)
+            .filter(([platform]) => !HIDDEN_PLATFORMS.has(platform))
+            .map(([platform, config]) => {
             const customStages = this.customBuildStages[platform];
             const stageConfigs = customStages
                 ? this.sortPkgNameWidthPriority(Object.keys(customStages))


### PR DESCRIPTION
## Summary
- `queryPlatformConfig()` in the lib builder interface now filters out the `fb-instant-games` and `google-play` platforms before returning, so they are not exposed to upstream consumers (e.g. the PinK build panel).
- Temporary hack (clearly marked with a `HACK` comment): these two platforms are not ready to ship yet. The filter should be removed once they are.