### PR TITLE
Fix generated tsconfig relative paths

### DIFF
--- a/src/core/scripting/intelligence/index.ts
+++ b/src/core/scripting/intelligence/index.ts
@@ -123,15 +123,15 @@ export class TypeScriptConfigBuilder {
             compilerOptions,
 
             include: [
-                '../../assets/**/*',
-                '../../extensions/**/*'
+                '../assets/**/*',
+                '../extensions/**/*'
             ],
             exclude: [
-                '../../node_modules',
-                '../../library',
-                '../../local',
-                '../../build',
-                '../../profiles'
+                '../node_modules',
+                '../library',
+                '../local',
+                '../build',
+                '../profiles'
             ]
         };
 
@@ -205,7 +205,7 @@ export class TypeScriptConfigBuilder {
 
     private tsConfigTypePath(path: string): string {
         // Path should be relative to the directory of this config file itself
-        const rel = ps.relative(ps.dirname(this._configFilePath), path);
+        const rel = ps.relative(ps.dirname(this._realTsConfigPath), path);
         // No `.d.ts` is allowed
         const extensionLess = rel.endsWith('.d.ts') ? rel.substr(0, rel.length - 5) : rel;
         // Let's convert it to slash for generic


### PR DESCRIPTION
## 变更说明
- 修正生成的 `temp/tsconfig.cocos.json` 中 `include` / `exclude` 相对路径，指向项目根目录下的资源与排除目录。
- 将声明文件 `types` 路径改为相对真实 `tsconfig.json` 计算，避免因临时 tsconfig 目录多退一级。