### PR TITLE
fix: normalize asset db url schema inputs

### DIFF
--- a/src/api/base/schema-asset-db-url.ts
+++ b/src/api/base/schema-asset-db-url.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod';
+import { pathToDbUrlIfAssetDBPath } from '../../core/assets/asset-db-url';
+import type { AssetDBPathInfo } from '../../core/assets/asset-db-url';
+import { SchemaSubAssetUUID, SchemaUUID, SchemaUrl } from './schema-identifier';
+
+type GlobalWithAssetDBManager = typeof globalThis & {
+    assetDBManager?: {
+        assetDBInfo?: Record<string, AssetDBPathInfo>;
+    };
+};
+
+function getAssetDBInfo(): Record<string, AssetDBPathInfo> {
+    return (globalThis as GlobalWithAssetDBManager).assetDBManager?.assetDBInfo ?? {};
+}
+
+export function normalizeAssetDbUrlInput(value: string): string {
+    return pathToDbUrlIfAssetDBPath(value.trim(), getAssetDBInfo());
+}
+
+export const SchemaAssetDbUrl = z.string()
+    .min(1, 'URL cannot be empty')
+    .describe('AssetDB URL. Equivalent asset-db paths are normalized to db:// URLs.')
+    .transform((value, ctx) => {
+        const parsed = SchemaUrl.safeParse(normalizeAssetDbUrlInput(value));
+
+        if (!parsed.success) {
+            parsed.error.errors.forEach((err) => {
+                ctx.addIssue(err);
+            });
+            return z.NEVER;
+        }
+
+        return parsed.data;
+    });
+
+export const SchemaAssetDbUrlOrUUID = z.string()
+    .min(1, 'Value cannot be empty')
+    .describe('AssetDB URL or UUID. Equivalent asset-db paths are normalized to db:// URLs.')
+    .transform((value, ctx) => {
+        const cleaned = value.trim();
+        const normalized = normalizeAssetDbUrlInput(cleaned);
+
+        if (cleaned.startsWith('db://') || normalized.startsWith('db://')) {
+            const parsed = SchemaAssetDbUrl.safeParse(cleaned);
+
+            if (!parsed.success) {
+                parsed.error.errors.forEach((err) => {
+                    ctx.addIssue(err);
+                });
+                return z.NEVER;
+            }
+
+            return parsed.data;
+        }
+
+        const uuidResult = SchemaUUID.safeParse(cleaned);
+        if (uuidResult.success) {
+            return uuidResult.data;
+        }
+
+        const subAssetUUIDResult = SchemaSubAssetUUID.safeParse(cleaned);
+        if (subAssetUUIDResult.success) {
+            return subAssetUUIDResult.data;
+        }
+
+        ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Invalid parameter. Use a db:// AssetDB URL, an equivalent asset-db path, or a UUID.',
+        });
+        return z.NEVER;
+    });

--- a/src/api/scene/node-schema.ts
+++ b/src/api/scene/node-schema.ts
@@ -5,7 +5,7 @@ import { INodeInfo } from '../../core/scene';
 import { SchemaVec3 } from '../base/schema-value-types';
 import { SchemaNodeIdentifier, SchemaComponentIdentifier } from '../base/schema-identifier';
 import { SchemaPrefabInfo } from './prefab-info-schema';
-import { SchemaUrl } from '../base/schema-identifier';
+import { SchemaAssetDbUrl } from '../base/schema-asset-db-url';
 import { SchemaComponent } from './component-schema';
 
 // 节点属性的 schema，
@@ -87,7 +87,7 @@ const SchemaNodeCreateBase = z.object({
 }).describe('To configure options for node creation, the Scene must be open first.'); // 创建节点的选项参数, 需先打开场景;
 
 export const SchemaNodeCreateByAsset = SchemaNodeCreateBase.extend({
-    dbURL: SchemaUrl.describe('Prefab asset path, if created from a prefab, please pass this parameter, format is custom db path e.g. db://assets/abc.prefab'), // 预制体资源路径，如果是从某个预制体创建，请传入这个参数，格式为自定义的db 路径比如 db://assets/abc.prefab
+    dbURL: SchemaAssetDbUrl.describe('Prefab asset path, if created from a prefab, please pass this parameter, format is custom db path e.g. db://assets/abc.prefab'), // 预制体资源路径，如果是从某个预制体创建，请传入这个参数，格式为自定义的db 路径比如 db://assets/abc.prefab
 });
 
 export const SchemaNodeCreateByType = SchemaNodeCreateBase.extend({

--- a/src/api/scene/prefab-schema.ts
+++ b/src/api/scene/prefab-schema.ts
@@ -1,13 +1,13 @@
 import { z } from 'zod';
 import { SchemaPrefabInfo } from './prefab-info-schema';
-import { SchemaUrl } from '../base/schema-identifier';
+import { SchemaAssetDbUrl } from '../base/schema-asset-db-url';
 
 // Create Prefab Options // 创建预制体参数
 export const SchemaCreatePrefabFromNodeOptions = z.object({
     /** Source node path to convert to prefab */ // 要转换为预制体的源节点路径
     nodePath: z.string().describe('Source node path to convert to prefab'), // 要转换为预制体的源节点路径
     /** Prefab asset save URL */ // 预制体资源保存 URL
-    dbURL: SchemaUrl.describe('Prefab asset save URL. Note: The final node name will change according to the resource name saved at the end of the URL'), // 预制体资源保存 URL，注意：最终节点名会跟着 URL 最后存的资源名进程变更
+    dbURL: SchemaAssetDbUrl.describe('Prefab asset save URL. Note: The final node name will change according to the resource name saved at the end of the URL'), // 预制体资源保存 URL，注意：最终节点名会跟着 URL 最后存的资源名进程变更
     /** Whether to force overwrite existing resources */ // 是否强制覆盖现有资源
     overwrite: z.boolean().optional().describe('Whether to force overwrite existing resources'), // 是否强制覆盖现有资源
 }).describe('Create Prefab Options'); // 创建预制体参数

--- a/src/api/scene/schema.ts
+++ b/src/api/scene/schema.ts
@@ -5,7 +5,7 @@ import { SchemaNode, SchemaNodeQueryResult } from './node-schema';
 import { SchemaSceneIdentifier, SchemaNodeIdentifier, SchemaComponentIdentifier } from '../base/schema-identifier';
 import { SchemaSaveAssetResult } from '../assets/schema';
 import { SchemaPrefabInfo } from './prefab-info-schema';
-import { SchemaUrlOrUUID } from '../base/schema-identifier';
+import { SchemaAssetDbUrl, SchemaAssetDbUrlOrUUID } from '../base/schema-asset-db-url';
 
 const SchemaScene = SchemaSceneIdentifier.extend({
     name: z.string().describe('Scene/Prefab Name'), // 场景/预制体名称
@@ -29,20 +29,20 @@ export const SchemaReload = z.nativeEnum(ReloadResult).describe('Reload Scene/Pr
 export const SchemaCreateOptions = z.object({
     baseName: z.string().describe('Asset Name'), // 资源名称
     templateType: z.enum(SCENE_TEMPLATE_TYPE).optional().describe('Scene Template Type (Optional, only effective for scene asset type)'), // 场景模板类型（可选，资源类型为场景才生效）
-    dbURL: z.string().describe('Target directory for storing asset files, e.g., db://assets'), // 目标目录用于存放资源文件，例如 db://assets
+    dbURL: SchemaAssetDbUrl.describe('Target directory for storing asset files, e.g., db://assets'), // 目标目录用于存放资源文件，例如 db://assets
 }).describe('Create Scene/Prefab Parameters'); // 创建场景/预制体参数
 
 export const SchemaCreateResult = SchemaSceneIdentifier.describe('Create Scene/Prefab Result Info'); // 创建场景/预制体操作的结果信息
 
 // 打开场景选项
 export const SchemaOpenOptions = z.object({
-    dbURLOrUUID: SchemaUrlOrUUID, // 资源的 URL、UUID 或文件路径
+    dbURLOrUUID: SchemaAssetDbUrlOrUUID, // 资源的 URL、UUID 或文件路径
     includeChildren: z.boolean().default(true).describe('Whether to include child nodes as INodeIdentifier[] in the result'), // 是否包含子节点
     includeComponents: z.boolean().default(false).describe('Whether to include components as IComponentIdentifier[]. Only effective for prefab; scene nodes have no components so this is ignored.'), // 是否包含组件（仅对 prefab 有效；scene 节点本身无组件，传入此参数无效）
 }).describe('Open scene options');
 
 
-export type TAssetUrlOrUUID = z.infer<typeof SchemaUrlOrUUID>;
+export type TAssetUrlOrUUID = z.infer<typeof SchemaAssetDbUrlOrUUID>;
 export type TOpenOptions = z.infer<typeof SchemaOpenOptions>;
 export type TCurrentResult = z.infer<typeof SchemaCurrentResult>;
 export type TOpenResult = z.infer<typeof SchemaOpenResult>;

--- a/src/api/system/file-editor-schema.ts
+++ b/src/api/system/file-editor-schema.ts
@@ -1,13 +1,13 @@
 
 import { z } from 'zod';
-import { SchemaUrl } from '../base/schema-identifier';
+import { SchemaAssetDbUrl } from '../base/schema-asset-db-url';
 
 const FILE_EXTENSIONS = ['js', 'ts', 'jsx', 'tsx', 'json',
     'txt', 'md', 'xml', 'html', 'css'] as const;
 
 // Information for inserting content at line n of the file // 在文件第 n 行插入内容的信息
 export const SchemaInsertTextAtLineInfo = z.object({
-    dbURL: SchemaUrl.describe('Asset URL of the file to be modified'), // 需要修改的文件的资产URL
+    dbURL: SchemaAssetDbUrl.describe('Asset URL of the file to be modified'), // 需要修改的文件的资产URL
     fileType: z.enum(FILE_EXTENSIONS).describe('File type'), // 文件类型
     lineNumber: z.number().min(1).default(1).describe('Line number (starting from 1)'), // 行号(从1开始)
     text: z.string().describe('Text content to insert'), // 需要插入的文本内容
@@ -15,7 +15,7 @@ export const SchemaInsertTextAtLineInfo = z.object({
 
 // Delete content from startLine to endLine of the file // 删除文件的第 startLine 到 endLine 行的内容
 export const SchemaEraseLinesInRangeInfo = z.object({
-    dbURL: SchemaUrl.describe('Asset URL of the file to be modified'), // 需要修改的文件的资产URL
+    dbURL: SchemaAssetDbUrl.describe('Asset URL of the file to be modified'), // 需要修改的文件的资产URL
     fileType: z.enum(FILE_EXTENSIONS).describe('File type'), // 文件类型
     startLine: z.number().min(1).default(1).describe('Start deleting from startLine'), // 从第 startLine 行开始删除
     endLine: z.number().min(1).default(1).describe('End deleting at endLine (endLine is also deleted)'), // 从第 endLine 行结束删除(endLine也删除)
@@ -23,7 +23,7 @@ export const SchemaEraseLinesInRangeInfo = z.object({
 
 // Replace target text in file with replacement text // 替换文件的 目标文本 为 替换文本
 export const SchemaReplaceTextInFileInfo = z.object({
-    dbURL: SchemaUrl.describe('Asset URL of the file to be modified'), // 需要修改的文件的资产URL
+    dbURL: SchemaAssetDbUrl.describe('Asset URL of the file to be modified'), // 需要修改的文件的资产URL
     fileType: z.enum(FILE_EXTENSIONS).describe('File type'), // 文件类型
     targetText: z.string().nonempty().describe('Target text'), // 目标文本
     replacementText: z.string().describe('Replacement text'), // 替换文本
@@ -31,7 +31,7 @@ export const SchemaReplaceTextInFileInfo = z.object({
 }).describe('Replace target text (text or regex) in file with replacement text'); // 替换文件的 目标文本（文本或者正则表达式） 为 替换文本
 
 export const SchemaQueryFileTextInfo = z.object({
-    dbURL: SchemaUrl.describe('Asset URL of the file to be queried'), // 需要查询文件的资产URL
+    dbURL: SchemaAssetDbUrl.describe('Asset URL of the file to be queried'), // 需要查询文件的资产URL
     fileType: z.enum(FILE_EXTENSIONS).describe('File type'), // 文件类型
     startLine: z.number().min(1).default(1).describe('Start querying from startLine (default starts from line 1)'), // 从第 startLine 行开始查询(默认从第1行开始)
     lineCount: z.number().default(-1).describe('Number of lines to query starting from startLine (negative number for all lines, default -1)'), // 从第 startLine 行开始查询的行数(负数为全部行，默认-1)

--- a/src/core/assets/asset-db-url.ts
+++ b/src/core/assets/asset-db-url.ts
@@ -1,0 +1,71 @@
+'use strict';
+
+import { isAbsolute, posix, win32 } from 'path';
+import * as PathUtils from '../base/utils/path';
+
+export interface AssetDBPathInfo {
+    name: string;
+    target: string;
+}
+
+function isAbsolutePath(value: string): boolean {
+    return isAbsolute(value) || win32.isAbsolute(value) || posix.isAbsolute(value);
+}
+
+function normalizeForUrl(value: string): string {
+    return PathUtils.normalize(value).replace(/\\/g, '/').replace(/\/+$/, '');
+}
+
+function normalizeForCompare(value: string): string {
+    const normalized = normalizeForUrl(value);
+    return process.platform === 'win32' || /^[a-zA-Z]:\//.test(normalized)
+        ? normalized.toLowerCase()
+        : normalized;
+}
+
+function containsPath(root: string, candidate: string): boolean {
+    const normalizedRoot = normalizeForCompare(root);
+    const normalizedCandidate = normalizeForCompare(candidate);
+
+    return normalizedCandidate === normalizedRoot || normalizedCandidate.startsWith(`${normalizedRoot}/`);
+}
+
+function relativeInsideRoot(root: string, candidate: string): string {
+    const normalizedRoot = normalizeForUrl(root);
+    const normalizedCandidate = normalizeForUrl(candidate);
+
+    return normalizedCandidate === normalizedRoot ? '' : normalizedCandidate.slice(normalizedRoot.length + 1);
+}
+
+export function pathToDbUrlIfAssetDBPath(pathOrUrlOrUUID: string, assetDBInfo: Record<string, AssetDBPathInfo>) {
+    if (!pathOrUrlOrUUID || pathOrUrlOrUUID.startsWith('db://')) {
+        return pathOrUrlOrUUID;
+    }
+
+    if (!isAbsolutePath(pathOrUrlOrUUID)) {
+        const normalizedRelativePath = pathOrUrlOrUUID
+            .replace(/\\/g, '/')
+            .replace(/^\.\/+/, '')
+            .replace(/\/+$/, '');
+        const [dbName, ...relativeParts] = normalizedRelativePath.split('/').filter(Boolean);
+        const dbInfo = dbName && (assetDBInfo[dbName] ?? Object.values(assetDBInfo).find((info) => info.name === dbName));
+
+        if (dbInfo) {
+            return relativeParts.length ? `db://${dbInfo.name}/${relativeParts.join('/')}` : `db://${dbInfo.name}`;
+        }
+
+        return pathOrUrlOrUUID;
+    }
+
+    const matchedDBInfo = Object.values(assetDBInfo)
+        .filter((info) => info?.target && containsPath(info.target, pathOrUrlOrUUID))
+        .sort((a, b) => normalizeForCompare(b.target).length - normalizeForCompare(a.target).length)[0];
+
+    if (!matchedDBInfo) {
+        return pathOrUrlOrUUID;
+    }
+
+    const relativePath = relativeInsideRoot(matchedDBInfo.target, pathOrUrlOrUUID);
+
+    return relativePath ? `db://${matchedDBInfo.name}/${relativePath}` : `db://${matchedDBInfo.name}`;
+}

--- a/src/core/assets/utils.ts
+++ b/src/core/assets/utils.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import { Asset, VirtualAsset, queryUUID, Utils as dbUtils, queryAsset as dbQueryAsset, queryPath } from '@cocos/asset-db/index';
-import { extname, isAbsolute, join, relative, resolve } from 'path';
+import { extname, isAbsolute, join, resolve } from 'path';
 import { readFile, readJSON } from 'fs-extra';
 import type { Asset as CCAsset, Details } from 'cc';
 import type { CCON } from 'cc/editor/serialization';
@@ -11,6 +11,7 @@ import { IAsset, IExportData, ISerializedOptions, SerializedAsset } from './@typ
 import { DeleteAssetOptions } from './@types/public';
 import { removeAssetSource } from './manager/filesystem';
 import { MissingClass } from '../engine/editor-extends/missing-reporter/missing-class-reporter';
+export { pathToDbUrlIfAssetDBPath } from './asset-db-url';
 
 export function url2path(url: string) {
     if (isAbsolute(url)) {
@@ -22,42 +23,6 @@ export function url2path(url: string) {
     }
 
     return Utils.Path.resolveToRaw(url);
-}
-
-export function pathToDbUrlIfAssetDBPath(pathOrUrlOrUUID: string, assetDBInfo: Record<string, { name: string; target: string }>) {
-    if (!pathOrUrlOrUUID || pathOrUrlOrUUID.startsWith('db://')) {
-        return pathOrUrlOrUUID;
-    }
-
-    if (!isAbsolute(pathOrUrlOrUUID)) {
-        const normalizedRelativePath = pathOrUrlOrUUID
-            .replace(/\\/g, '/')
-            .replace(/^\.\/+/, '')
-            .replace(/\/+$/, '');
-        const [dbName, ...relativeParts] = normalizedRelativePath.split('/').filter(Boolean);
-        const dbInfo = dbName && assetDBInfo[dbName];
-
-        if (dbInfo) {
-            return relativeParts.length ? `db://${dbInfo.name}/${relativeParts.join('/')}` : `db://${dbInfo.name}`;
-        }
-
-        return pathOrUrlOrUUID;
-    }
-
-    const matchedDBInfo = Object.values(assetDBInfo)
-        .filter((info) => info?.target && Utils.Path.contains(info.target, pathOrUrlOrUUID))
-        .sort((a, b) => Utils.Path.normalize(b.target).length - Utils.Path.normalize(a.target).length)[0];
-
-    if (!matchedDBInfo) {
-        return pathOrUrlOrUUID;
-    }
-
-    const relativePath = relative(
-        Utils.Path.normalize(matchedDBInfo.target),
-        Utils.Path.normalize(pathOrUrlOrUUID),
-    ).replace(/\\/g, '/');
-
-    return relativePath ? `db://${matchedDBInfo.name}/${relativePath}` : `db://${matchedDBInfo.name}`;
 }
 
 export function dirnameForDbUrlOrPath(pathOrUrlOrUUID: string) {

--- a/tests/asset-db-url-normalization-schema.test.ts
+++ b/tests/asset-db-url-normalization-schema.test.ts
@@ -1,0 +1,93 @@
+jest.mock('../src/core/scene', () => ({
+    SCENE_TEMPLATE_TYPE: ['default'],
+    NodeType: {
+        Sprite: 'sprite',
+    },
+}));
+
+jest.mock('../src/core/scene/common/editor/type', () => ({
+    ReloadResult: {
+        SUCCESS: 'success',
+        FAILED: 'failed',
+    },
+}));
+
+import { SchemaAssetDbUrl, SchemaAssetDbUrlOrUUID } from '../src/api/base/schema-asset-db-url';
+import { SchemaCreateOptions, SchemaOpenOptions } from '../src/api/scene/schema';
+import { SchemaNodeCreateByAsset, SchemaNodeQuery } from '../src/api/scene/node-schema';
+import { SchemaCreatePrefabFromNodeOptions } from '../src/api/scene/prefab-schema';
+import { SchemaInsertTextAtLineInfo } from '../src/api/system/file-editor-schema';
+
+describe('AssetDB URL normalization schemas', () => {
+    const previousAssetDBManager = (globalThis as any).assetDBManager;
+
+    beforeEach(() => {
+        (globalThis as any).assetDBManager = {
+            assetDBInfo: {
+                assets: {
+                    name: 'assets',
+                    target: 'E:\\pink\\testqwen3.72\\assets',
+                },
+            },
+        };
+    });
+
+    afterAll(() => {
+        (globalThis as any).assetDBManager = previousAssetDBManager;
+    });
+
+    it('normalizes relative AssetDB paths before strict db URL validation', () => {
+        expect(SchemaAssetDbUrl.parse('assets/scripts/GameBoard.ts')).toBe('db://assets/scripts/GameBoard.ts');
+        expect(SchemaAssetDbUrl.parse('assets\\scripts\\GameBoard.ts')).toBe('db://assets/scripts/GameBoard.ts');
+    });
+
+    it('normalizes absolute paths inside an AssetDB root', () => {
+        expect(SchemaAssetDbUrl.parse('e:/pink/testqwen3.72/assets/scripts/GameBoard.ts')).toBe('db://assets/scripts/GameBoard.ts');
+    });
+
+    it('keeps valid db URLs and rejects non-AssetDB paths', () => {
+        expect(SchemaAssetDbUrl.parse('db://assets/scripts/GameBoard.ts')).toBe('db://assets/scripts/GameBoard.ts');
+        expect(SchemaAssetDbUrl.safeParse('Canvas/GameBoard').success).toBe(false);
+        expect(SchemaAssetDbUrl.safeParse('C:\\outside\\GameBoard.ts').success).toBe(false);
+    });
+
+    it('normalizes file editor dbURL fields', () => {
+        const parsed = SchemaInsertTextAtLineInfo.parse({
+            dbURL: 'assets/scripts/GameBoard.ts',
+            fileType: 'ts',
+            lineNumber: 44,
+            text: 'const value = 1;',
+        });
+
+        expect(parsed.dbURL).toBe('db://assets/scripts/GameBoard.ts');
+    });
+
+    it('normalizes scene and prefab AssetDB fields without changing node paths', () => {
+        expect(SchemaCreateOptions.parse({
+            baseName: 'Game',
+            dbURL: 'assets/scenes',
+        }).dbURL).toBe('db://assets/scenes');
+
+        expect(SchemaOpenOptions.parse({
+            dbURLOrUUID: 'assets/scenes/Game.scene',
+        }).dbURLOrUUID).toBe('db://assets/scenes/Game.scene');
+
+        expect(SchemaNodeCreateByAsset.parse({
+            path: 'assets/scripts',
+            dbURL: 'assets/prefabs/Enemy.prefab',
+        }).dbURL).toBe('db://assets/prefabs/Enemy.prefab');
+
+        expect(SchemaCreatePrefabFromNodeOptions.parse({
+            nodePath: 'assets/scripts',
+            dbURL: 'assets/prefabs/Enemy.prefab',
+        }).dbURL).toBe('db://assets/prefabs/Enemy.prefab');
+
+        expect(SchemaNodeQuery.parse({
+            path: 'assets/scripts',
+        }).path).toBe('assets/scripts');
+    });
+
+    it('keeps UUID support for mixed URL-or-UUID fields', () => {
+        expect(SchemaAssetDbUrlOrUUID.parse('123456781234123412341234567890ab')).toBe('12345678-1234-1234-1234-1234567890ab');
+    });
+});


### PR DESCRIPTION
## 背景

弱模型在调用 Cocos CLI MCP 工具时，可能把明确的 AssetDB URL 字段传成 `assets/...`、`assets\...` 或项目内绝对路径，导致参数在 MCP SDK/Zod pre-validation 阶段被 `SchemaUrl` 拒绝。

## 修改内容

- 新增轻量 AssetDB 路径归一化 helper，将等价 AssetDB 路径转换为 `db://...`。
- 新增 `SchemaAssetDbUrl` / `SchemaAssetDbUrlOrUUID`，在严格校验前做归一化。
- 接入文件编辑、`scene-create`、`scene-open`、`scene-create-node-by-asset`、`create-prefab-from-node` 等明确 AssetDB URL 字段。
- 新增测试覆盖相对路径、Windows 反斜杠、项目内绝对路径、UUID、非 AssetDB 路径不误转，以及节点路径不被归一化。
