### PR TITLE
[break] fix(assets): support whole userData updates

### DIFF
--- a/docs/dev/assets-update-user-data-api-plan.html
+++ b/docs/dev/assets-update-user-data-api-plan.html
@@ -1,0 +1,292 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>assets.updateUserData 接口调整计划</title>
+  <style>
+    :root {
+      --bg: #f6f8fb;
+      --panel: #fff;
+      --text: #17202a;
+      --muted: #667085;
+      --line: #d8dee8;
+      --accent: #0f766e;
+      --accent-soft: #e6f4f1;
+      --warn: #b45309;
+      --warn-soft: #fff7e8;
+      --info: #1d4ed8;
+      --info-soft: #eff6ff;
+      --code: #111827;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: "Microsoft YaHei", "PingFang SC", "Segoe UI", Arial, sans-serif;
+      line-height: 1.62;
+    }
+    main { width: min(1120px, calc(100% - 32px)); margin: 32px auto 56px; }
+    header { padding-bottom: 18px; border-bottom: 4px solid var(--accent); }
+    h1 { margin: 0 0 8px; font-size: 30px; line-height: 1.25; }
+    h2 { margin: 28px 0 12px; font-size: 21px; }
+    h3 { margin: 18px 0 8px; font-size: 17px; }
+    p { margin: 0 0 10px; }
+    code { padding: 1px 5px; border-radius: 4px; background: #eef2f7; color: #111827; font-family: Consolas, "Courier New", monospace; }
+    table { width: 100%; border-collapse: collapse; background: var(--panel); border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
+    th, td { padding: 10px 12px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }
+    th { background: #eef3f8; font-weight: 700; }
+    tr:last-child td { border-bottom: 0; }
+    ul, ol { margin: 8px 0 0 22px; padding: 0; }
+    li { margin: 4px 0; }
+    .meta { color: var(--muted); font-size: 14px; }
+    .grid { display: grid; gap: 12px; }
+    .cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .card { background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 16px; }
+    .metric strong { display: block; font-size: 25px; line-height: 1.15; }
+    .metric span { color: var(--muted); font-size: 14px; }
+    .callout { margin: 16px 0; padding: 14px 16px; border-radius: 8px; border: 1px solid var(--line); border-left: 5px solid var(--accent); background: var(--accent-soft); }
+    .warn { border-left-color: var(--warn); background: var(--warn-soft); }
+    .info { border-left-color: var(--info); background: var(--info-soft); }
+    .tag { display: inline-block; margin: 0 6px 6px 0; padding: 2px 8px; border-radius: 999px; background: #e5edf6; color: #344054; font-size: 13px; }
+    .ok { background: #dcfce7; color: #166534; }
+    .todo { background: #fef3c7; color: #92400e; }
+    .codebox { border-radius: 8px; overflow: hidden; background: var(--code); border: 1px solid #253245; }
+    .codebar { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 8px 10px; color: #cbd5e1; border-bottom: 1px solid #253245; font-size: 13px; }
+    .copy { border: 1px solid #526174; border-radius: 6px; padding: 4px 9px; background: #1f2937; color: #f8fafc; cursor: pointer; }
+    .copy:hover { background: #334155; }
+    pre { margin: 0; padding: 14px; overflow: auto; background: var(--code); color: #f8fafc; font-size: 13px; line-height: 1.5; }
+    pre code { padding: 0; border-radius: 0; background: transparent; color: inherit; }
+    @media (max-width: 820px) {
+      .cols-3 { grid-template-columns: 1fr; }
+      main { width: min(100% - 24px, 1120px); margin-top: 20px; }
+      h1 { font-size: 25px; }
+    }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>assets.updateUserData 接口调整计划</h1>
+    <p class="meta">PR #650 反馈补充 / PinK 资源编辑面板 / 2026-06-26</p>
+  </header>
+
+  <section>
+    <h2>结论</h2>
+    <div class="grid cols-3">
+      <div class="card metric">
+        <strong>拆分接口</strong>
+        <span><code>updateUserData</code> 做整体替换，<code>updateUserDataByPath</code> 做单字段修改。</span>
+      </div>
+      <div class="card metric">
+        <strong>一次保存</strong>
+        <span>常规 PinK 面板提交使用完整 <code>userData</code>，只触发一次 meta 写入和一次资源重导。</span>
+      </div>
+      <div class="card metric">
+        <strong>批量后置</strong>
+        <span>多选资源需要批量接口，但不阻塞下个版本常规资源编辑对接。</span>
+      </div>
+    </div>
+    <div class="callout">
+      当前 <code>path, value</code> 形式不能表达“空 path 代表完整 userData 替换”，且容易误触发字段写入语义。最终方案是保留路径能力，但不让空 path 复用成整体更新。
+    </div>
+  </section>
+
+  <section>
+    <h2>背景与问题</h2>
+    <table>
+      <thead>
+        <tr><th>主题</th><th>现状</th><th>影响</th><th>处理结论</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>PinK 常规资源编辑</td>
+          <td>PinK 面板已持有完整 <code>userData</code>，编辑后提交整体对象。</td>
+          <td>逐字段调用会产生多次 meta 写入，父子资源联动时成本更高。</td>
+          <td>提供 <code>updateUserData(uuid, userData)</code>。</td>
+        </tr>
+        <tr>
+          <td>AI / 精确修改</td>
+          <td>AI 可能只知道某个配置路径和值。</td>
+          <td>整体替换会要求调用方先读完整 userData，增加上下文和误删风险。</td>
+          <td>新增 <code>updateUserDataByPath(uuid, path, value)</code>。</td>
+        </tr>
+        <tr>
+          <td>子资源 UUID</td>
+          <td>PR #650 已支持 <code>parentUuid@subMetaId</code>。</td>
+          <td>需要继续兼容子资源 userData 写入。</td>
+          <td>两个接口均支持父资源 UUID 和子资源复合 UUID。</td>
+        </tr>
+        <tr>
+          <td><code>saveAssetMeta</code></td>
+          <td>整份 meta 保存能力天然能改父子 userData，但公开接口语义过宽。</td>
+          <td>调用方可能修改非 userData 字段，破坏 meta 结构。</td>
+          <td>不恢复公开 <code>saveAssetMeta</code>，只暴露 userData 专用接口。</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>接口方案</h2>
+    <h3>常规接口：整体替换</h3>
+    <div class="codebox">
+      <div class="codebar"><span>TypeScript</span><button class="copy" data-copy="normal-api">复制</button></div>
+      <pre><code id="normal-api">updateUserData(uuid: string, userData: Record&lt;string, any&gt;): Promise&lt;Record&lt;string, any&gt;&gt;
+
+// MCP / public lib:
+assets.updateAssetUserData(uuid, userData)</code></pre>
+    </div>
+    <ul>
+      <li>写入目标是该资源对应 meta 的 <code>userData</code>。</li>
+      <li>传入对象整体替换旧 <code>userData</code>，不存在字段残留。</li>
+      <li>单次调用只执行一次 <code>asset.save()</code> 和一次 <code>asset._assetDB.reimport(asset.uuid)</code>。</li>
+      <li>不接受数组、字符串、数字、布尔值、<code>null</code>。</li>
+    </ul>
+
+    <h3>精确接口：路径更新</h3>
+    <div class="codebox">
+      <div class="codebar"><span>TypeScript</span><button class="copy" data-copy="path-api">复制</button></div>
+      <pre><code id="path-api">updateUserDataByPath(uuid: string, path: string, value: any): Promise&lt;Record&lt;string, any&gt;&gt;
+
+// MCP / public lib:
+assets.updateAssetUserDataByPath(uuid, path, value)</code></pre>
+    </div>
+    <ul>
+      <li><code>path</code> 使用 lodash dot path 语义，例如 <code>texture.wrapMode</code>。</li>
+      <li><code>path</code> 必须非空；整体替换必须走 <code>updateUserData</code>。</li>
+      <li>适用于 AI 或脚本只修改单个配置项的场景。</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>后续批量接口</h2>
+    <div class="callout warn">
+      批量接口不进入本次最小交付范围；常规整体更新先支撑 PinK 下个版本资源编辑功能。
+    </div>
+    <div class="codebox">
+      <div class="codebar"><span>Draft</span><button class="copy" data-copy="batch-api">复制</button></div>
+      <pre><code id="batch-api">updateUserDataBatch(items: Array&lt;{
+  uuid: string;
+  userData: Record&lt;string, any&gt;;
+}&gt;): Promise&lt;Array&lt;{
+  uuid: string;
+  userData: Record&lt;string, any&gt;;
+}&gt;&gt;</code></pre>
+    </div>
+    <table>
+      <thead>
+        <tr><th>批量场景</th><th>建议规则</th><th>原因</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>同名 UUID 重复</td>
+          <td>按归一化 UUID 合并，后出现的完整 <code>userData</code> 覆盖先出现的完整 <code>userData</code>。</td>
+          <td>整体替换语义要避免字段残留；调用方通常不会传重复项。</td>
+        </tr>
+        <tr>
+          <td>父资源与子资源同时修改</td>
+          <td>按父 meta 文件聚合，先修改父 <code>userData</code>，再修改各 <code>subMetas[id].userData</code>，最后每个父 meta 只保存一次。</td>
+          <td>减少 meta 文件写入次数，并保留 PR #650 的子资源能力。</td>
+        </tr>
+        <tr>
+          <td>多选资源</td>
+          <td>按资源所属 meta 文件分组并串行保存。</td>
+          <td>避免多个调用同时写同一 meta 文件。</td>
+        </tr>
+        <tr>
+          <td>错误处理</td>
+          <td>任一资源不存在则返回明确失败；是否支持部分成功需另行确认。</td>
+          <td>PinK 面板需要确定性反馈，避免静默丢配置。</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>实施任务</h2>
+    <table>
+      <thead>
+        <tr><th>状态</th><th>任务</th><th>文件</th><th>验收</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><span class="tag ok">已完成</span></td>
+          <td>底层 <code>updateUserData</code> 改为整体替换，并新增 <code>updateUserDataByPath</code>。</td>
+          <td><code>src/core/assets/manager/operation.ts</code></td>
+          <td>整体替换移除旧字段；路径更新保持单字段修改；均只调用一次 <code>asset.save()</code> 和一次 reimport。</td>
+        </tr>
+        <tr>
+          <td><span class="tag ok">已完成</span></td>
+          <td>MCP/API 参数 schema 与工具名更新。</td>
+          <td><code>src/api/assets/assets.ts</code><br><code>src/api/assets/schema.ts</code></td>
+          <td><code>assets-update-asset-user-data</code> 参数为 <code>uuid, userData</code>；新增 <code>assets-update-asset-user-data-by-path</code>。</td>
+        </tr>
+        <tr>
+          <td><span class="tag ok">已完成</span></td>
+          <td>public lib 暴露对应接口。</td>
+          <td><code>src/lib/assets/assets.ts</code></td>
+          <td>d.ts 中存在 <code>updateAssetUserData(uuid, userData)</code> 与 <code>updateAssetUserDataByPath(uuid, path, value)</code>。</td>
+        </tr>
+        <tr>
+          <td><span class="tag ok">已完成</span></td>
+          <td>补充单测和 d.ts snapshot。</td>
+          <td><code>tests/*</code><br><code>packages/cocos-cli-types/__tests__/__snapshots__/*</code></td>
+          <td>覆盖父/子资源 UUID、整体替换、路径更新、空 path 防误用。</td>
+        </tr>
+        <tr>
+          <td><span class="tag todo">后续</span></td>
+          <td>设计并实现批量接口。</td>
+          <td>待定</td>
+          <td>多选资源、父子资源、重复 UUID 合并后统一写入。</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>验收记录</h2>
+    <table>
+      <thead>
+        <tr><th>命令</th><th>结果</th><th>说明</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>npm.cmd run build</code></td>
+          <td><span class="tag ok">通过</span></td>
+          <td>已生成 schema 和 d.ts snapshot。</td>
+        </tr>
+        <tr>
+          <td><code>npx.cmd tsc -p tsconfig.json --noEmit</code></td>
+          <td><span class="tag ok">通过</span></td>
+          <td>类型检查通过。</td>
+        </tr>
+        <tr>
+          <td><code>npm.cmd run test -- tests/assets-update-asset-user-data-api.test.ts tests/lib/assets-api.test.ts src/core/assets/test/operation-filesystem-bridge.test.ts --runInBand</code></td>
+          <td><span class="tag ok">通过</span></td>
+          <td>相关接口和底层保存、重导行为通过。</td>
+        </tr>
+        <tr>
+          <td><code>npm.cmd run test -- --runInBand</code></td>
+          <td><span class="tag todo">有既有失败</span></td>
+          <td>失败来自当前工作区未跟踪测试：旧 <code>assets-update-asset-meta-user-data</code> 预期，以及 SystemJS / ServiceManager 相关测试；不属于本次改动 diff。</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+</main>
+<script>
+  document.querySelectorAll("[data-copy]").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const target = document.getElementById(button.dataset.copy);
+      if (!target) return;
+      await navigator.clipboard.writeText(target.innerText);
+      const text = button.textContent;
+      button.textContent = "已复制";
+      setTimeout(() => { button.textContent = text; }, 1200);
+    });
+  });
+</script>
+</body>
+</html>

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -895,7 +895,8 @@ export declare interface ThumbnailInfo {
     value: string;
 }
 export declare type ThumbnailSize = 'large' | 'small' | 'middle' | 'origin';
-export declare function updateAssetUserData(urlOrUuidOrPath: string, path: string, value: any): Promise<any>;
+export declare function updateAssetUserData(urlOrUuidOrPath: string, userData: Record<string, any>): Promise<any>;
+export declare function updateAssetUserDataByPath(urlOrUuidOrPath: string, path: string, value: any): Promise<any>;
 export declare function updateDefaultUserData(handler: string, path: string, value: any): Promise<void>;
 export declare interface Vec2 {
     x: number;
@@ -7066,6 +7067,7 @@ export declare namespace Assets {
         updateDefaultUserData,
         queryAssetUserDataConfig,
         updateAssetUserData,
+        updateAssetUserDataByPath,
         queryAssetConfigMap,
         queryPropertySchema,
         queryThumbnailHandlers,
@@ -8454,7 +8456,8 @@ export declare interface ThumbnailInfo {
 }
 export declare type ThumbnailSize = 'large' | 'small' | 'middle' | 'origin';
 export declare function unregister(): Promise<void>;
-export declare function updateAssetUserData(urlOrUuidOrPath: string, path: string, value: any): Promise<any>;
+export declare function updateAssetUserData(urlOrUuidOrPath: string, userData: Record<string, any>): Promise<any>;
+export declare function updateAssetUserDataByPath(urlOrUuidOrPath: string, path: string, value: any): Promise<any>;
 export declare function updateDefaultUserData(handler: string, path: string, value: any): Promise<void>;
 export declare interface Vec2 {
     x: number;

--- a/src/api/assets/assets.ts
+++ b/src/api/assets/assets.ts
@@ -69,9 +69,11 @@ import {
     TAssetMoveOptions,
     TAssetRenameOptions,
     TUserDataHandler,
+    SchemaUpdateAssetUserData,
     SchemaUpdateAssetUserDataPath,
     SchemaUpdateAssetUserDataValue,
     SchemaUpdateAssetUserDataResult,
+    TUpdateAssetUserData,
     TUpdateAssetUserDataPath,
     TUpdateAssetUserDataValue,
     TUpdateAssetUserDataResult,
@@ -960,9 +962,41 @@ export class AssetsApi {
      */
     @tool('assets-update-asset-user-data')
     @title('Update Asset User Data') // 更新资源用户数据
-    @description('Update the userData of the specified asset via path and value. urlOrUuidOrPath accepts an asset URL, UUID, file path, or sub asset UUID in parentUuid@subMetaId format.') // 更新指定资源的用户数据配置。通过路径和值来精确更新资源的用户数据，支持嵌套路径访问。
+    @description('Replace the complete userData object of the specified asset in one save. urlOrUuidOrPath accepts an asset URL, UUID, file path, or sub asset UUID in parentUuid@subMetaId format.') // 一次性整体替换指定资源的 userData，支持父资源与 parentUuid@subMetaId 子资源 UUID。
     @result(SchemaUpdateAssetUserDataResult)
     async updateAssetUserData(
+        @param(SchemaUrlOrUUIDOrPath) urlOrUuidOrPath: TUrlOrUUIDOrPath,
+        @param(SchemaUpdateAssetUserData) userData: TUpdateAssetUserData
+    ): Promise<CommonResultType<TUpdateAssetUserDataResult>> {
+        const code: HttpStatusCode = COMMON_STATUS.SUCCESS;
+        const ret: CommonResultType<TUpdateAssetUserDataResult> = {
+            code: code,
+            data: null,
+        };
+
+        try {
+            ret.data = await assetManager.updateUserData(urlOrUuidOrPath, userData);
+            if (!ret.data) {
+                ret.code = COMMON_STATUS.NOT_FOUND;
+                ret.reason = `❌Asset can not be found: ${urlOrUuidOrPath}. Please refresh asset db and try again.`;
+            }
+        } catch (e) {
+            ret.code = getCommonErrorStatus(e);
+            console.error('update asset user data fail:', e instanceof Error ? e.message : String(e));
+            ret.reason = e instanceof Error ? e.message : String(e);
+        }
+
+        return ret;
+    }
+
+    /**
+     * Update Asset User Data By Path // 按路径更新资源用户数据
+     */
+    @tool('assets-update-asset-user-data-by-path')
+    @title('Update Asset User Data By Path') // 按路径更新资源用户数据
+    @description('Update a single path in the userData of the specified asset. urlOrUuidOrPath accepts an asset URL, UUID, file path, or sub asset UUID in parentUuid@subMetaId format.') // 通过路径和值精确更新指定资源 userData 的单个字段，支持父资源与 parentUuid@subMetaId 子资源 UUID。
+    @result(SchemaUpdateAssetUserDataResult)
+    async updateAssetUserDataByPath(
         @param(SchemaUrlOrUUIDOrPath) urlOrUuidOrPath: TUrlOrUUIDOrPath,
         @param(SchemaUpdateAssetUserDataPath) path: TUpdateAssetUserDataPath,
         @param(SchemaUpdateAssetUserDataValue) value: TUpdateAssetUserDataValue
@@ -974,14 +1008,14 @@ export class AssetsApi {
         };
 
         try {
-            ret.data = await assetManager.updateUserData(urlOrUuidOrPath, path, value);
+            ret.data = await assetManager.updateUserDataByPath(urlOrUuidOrPath, path, value);
             if (!ret.data) {
                 ret.code = COMMON_STATUS.NOT_FOUND;
                 ret.reason = `❌Asset can not be found: ${urlOrUuidOrPath}. Please refresh asset db and try again.`;
             }
         } catch (e) {
             ret.code = getCommonErrorStatus(e);
-            console.error('update asset user data fail:', e instanceof Error ? e.message : String(e));
+            console.error('update asset user data by path fail:', e instanceof Error ? e.message : String(e));
             ret.reason = e instanceof Error ? e.message : String(e);
         }
 

--- a/src/api/assets/schema.ts
+++ b/src/api/assets/schema.ts
@@ -303,6 +303,9 @@ export type TUpdateUserDataOptions = z.infer<typeof SchemaUpdateUserDataOptions>
 export type TUserDataHandler = z.infer<typeof SchemaUserDataHandler>;
 
 // Update Asset User Data related Schema // Update Asset User Data 相关 Schema
+export const SchemaUpdateAssetUserData = z.record(z.string(), z.any()).describe('Complete asset userData object to replace the existing userData'); // 用于整体替换现有 userData 的完整资源 userData 对象
+export type TUpdateAssetUserData = z.infer<typeof SchemaUpdateAssetUserData>;
+
 export const SchemaUpdateAssetUserDataPath = z.string().min(1).describe('User data path, separated by dots, e.g. "texture.wrapMode"'); // 用户数据路径，使用点号分隔，如 "texture.wrapMode"
 export type TUpdateAssetUserDataPath = z.infer<typeof SchemaUpdateAssetUserDataPath>;
 

--- a/src/core/assets/manager/asset.ts
+++ b/src/core/assets/manager/asset.ts
@@ -48,6 +48,7 @@ class AssetManager extends EventEmitter {
     outputExportData = assetOperation.outputExportData.bind(assetOperation);
     createAssetByType = assetOperation.createAssetByType.bind(assetOperation);
     updateUserData = assetOperation.updateUserData.bind(assetOperation);
+    updateUserDataByPath = assetOperation.updateUserDataByPath.bind(assetOperation);
     querySerializedData = serializedData.querySerializedData;
     saveSerializedData = serializedData.saveSerializedData;
 
@@ -362,6 +363,7 @@ export interface TypedAssetManager extends EventEmitter {
     outputExportData: typeof assetOperation.outputExportData;
     createAssetByType: typeof assetOperation.createAssetByType;
     updateUserData: typeof assetOperation.updateUserData;
+    updateUserDataByPath: typeof assetOperation.updateUserDataByPath;
     querySerializedData: typeof serializedData.querySerializedData;
     saveSerializedData: typeof serializedData.saveSerializedData;
 

--- a/src/core/assets/manager/operation.ts
+++ b/src/core/assets/manager/operation.ts
@@ -274,15 +274,48 @@ class AssetOperation extends EventEmitter {
         await asset._assetDB.reimport(asset.uuid);
     }
 
-    async updateUserData<T extends keyof AssetUserDataMap = 'unknown'>(uuidOrURLOrPath: string, path: string, value: any): Promise<AssetUserDataMap[T]> {
+    async updateUserData<T extends keyof AssetUserDataMap = 'unknown'>(uuidOrURLOrPath: string, userData: AssetUserDataMap[T]): Promise<AssetUserDataMap[T] | undefined> {
+        if (!isRecord(userData)) {
+            throw new Error('userData must be an object');
+        }
+
         const asset = assetQuery.queryAsset(uuidOrURLOrPath);
         if (!asset) {
             console.error(`can not find asset ${uuidOrURLOrPath}`);
             return;
         }
+
+        if (!isRecord(asset.meta.userData)) {
+            asset.meta.userData = {} as AssetUserDataMap[T];
+        }
+        const currentUserData = asset.meta.userData as Record<string, unknown>;
+        for (const key of Object.keys(currentUserData)) {
+            delete currentUserData[key];
+        }
+        Object.assign(currentUserData, lodash.cloneDeep(userData));
+        asset.meta.userData = currentUserData as AssetUserDataMap[T];
+        await asset.save();
+        await asset._assetDB.reimport(asset.uuid);
+        return asset?.meta.userData as AssetUserDataMap[T];
+    }
+
+    async updateUserDataByPath<T extends keyof AssetUserDataMap = 'unknown'>(uuidOrURLOrPath: string, path: string, value: any): Promise<AssetUserDataMap[T] | undefined> {
+        if (!path) {
+            throw new Error('path must not be empty. Use updateUserData to replace the complete userData object');
+        }
+
+        const asset = assetQuery.queryAsset(uuidOrURLOrPath);
+        if (!asset) {
+            console.error(`can not find asset ${uuidOrURLOrPath}`);
+            return;
+        }
+        if (!isRecord(asset.meta.userData)) {
+            asset.meta.userData = {} as AssetUserDataMap[T];
+        }
         lodash.set(asset?.meta.userData, path, value);
         await asset.save();
-        return asset?.meta.userData;
+        await asset._assetDB.reimport(asset.uuid);
+        return asset?.meta.userData as AssetUserDataMap[T];
     }
 
     async saveAsset(uuidOrURLOrPath: string, content: string | Buffer) {

--- a/src/core/assets/test/operation-filesystem-bridge.test.ts
+++ b/src/core/assets/test/operation-filesystem-bridge.test.ts
@@ -166,7 +166,42 @@ describe('asset operation filesystem bridge', () => {
         jest.restoreAllMocks();
     });
 
-    it('updateUserData updates sub asset userData through composite uuid without reimport', async () => {
+    it('updateUserData replaces sub asset userData through composite uuid with one reimport', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const reimport = jest.fn();
+        const subAsset = {
+            uuid: '6fa5fbad-0d32-4b63-95d8-24507665775c@6c48a',
+            meta: {
+                userData: {
+                    minfilter: 'linear',
+                    obsolete: true,
+                },
+            },
+            save: jest.fn().mockResolvedValue(true),
+            _assetDB: {
+                reimport,
+            },
+        };
+        mockQueryAsset.mockReturnValue(subAsset);
+
+        const userData = {
+            minfilter: 'nearest',
+            wrapMode: 'clamp',
+        };
+        const result = await assetOperation.updateUserData(
+            '6fa5fbad-0d32-4b63-95d8-24507665775c@6c48a',
+            userData,
+        );
+
+        expect(mockQueryAsset).toHaveBeenCalledWith('6fa5fbad-0d32-4b63-95d8-24507665775c@6c48a');
+        expect(subAsset.meta.userData).toEqual(userData);
+        expect(subAsset.save).toHaveBeenCalledTimes(1);
+        expect(reimport).toHaveBeenCalledTimes(1);
+        expect(reimport).toHaveBeenCalledWith('6fa5fbad-0d32-4b63-95d8-24507665775c@6c48a');
+        expect(result).toBe(subAsset.meta.userData);
+    });
+
+    it('updateUserDataByPath updates sub asset userData through composite uuid with one reimport', async () => {
         const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
         const reimport = jest.fn();
         const subAsset = {
@@ -183,7 +218,7 @@ describe('asset operation filesystem bridge', () => {
         };
         mockQueryAsset.mockReturnValue(subAsset);
 
-        const result = await assetOperation.updateUserData(
+        const result = await assetOperation.updateUserDataByPath(
             '6fa5fbad-0d32-4b63-95d8-24507665775c@6c48a',
             'minfilter',
             'nearest',
@@ -194,8 +229,20 @@ describe('asset operation filesystem bridge', () => {
             minfilter: 'nearest',
         });
         expect(subAsset.save).toHaveBeenCalledTimes(1);
-        expect(reimport).not.toHaveBeenCalled();
+        expect(reimport).toHaveBeenCalledTimes(1);
+        expect(reimport).toHaveBeenCalledWith('6fa5fbad-0d32-4b63-95d8-24507665775c@6c48a');
         expect(result).toBe(subAsset.meta.userData);
+    });
+
+    it('updateUserDataByPath rejects empty path instead of replacing complete userData', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+
+        await expect(assetOperation.updateUserDataByPath(
+            '6fa5fbad-0d32-4b63-95d8-24507665775c@6c48a',
+            '',
+            { minfilter: 'nearest' },
+        )).rejects.toThrow('path must not be empty');
+        expect(mockQueryAsset).not.toHaveBeenCalled();
     });
 
     it('renameAsset should delegate rename steps to filesystem bridge', async () => {

--- a/src/lib/assets/assets.ts
+++ b/src/lib/assets/assets.ts
@@ -345,10 +345,20 @@ export async function queryAssetUserDataConfig(
  */
 export async function updateAssetUserData(
     urlOrUuidOrPath: string,
+    userData: Record<string, any>
+): Promise<any> {
+    return await assetManager.updateUserData(urlOrUuidOrPath, userData);
+}
+
+/**
+ * Update Asset User Data By Path // 按路径更新资源用户数据
+ */
+export async function updateAssetUserDataByPath(
+    urlOrUuidOrPath: string,
     path: string,
     value: any
 ): Promise<any> {
-    return await assetManager.updateUserData(urlOrUuidOrPath, path, value);
+    return await assetManager.updateUserDataByPath(urlOrUuidOrPath, path, value);
 }
 
 /**

--- a/tests/assets-update-asset-user-data-api.test.ts
+++ b/tests/assets-update-asset-user-data-api.test.ts
@@ -1,9 +1,11 @@
 const mockUpdateUserData = jest.fn();
+const mockUpdateUserDataByPath = jest.fn();
 
 jest.mock('../src/core/assets', () => ({
     assetDBManager: {},
     assetManager: {
         updateUserData: (...args: unknown[]) => mockUpdateUserData(...args),
+        updateUserDataByPath: (...args: unknown[]) => mockUpdateUserDataByPath(...args),
     },
 }));
 
@@ -16,6 +18,7 @@ import { AssetsApi } from '../src/api/assets/assets';
 describe('assets-update-asset-user-data api', () => {
     beforeEach(() => {
         mockUpdateUserData.mockReset();
+        mockUpdateUserDataByPath.mockReset();
     });
 
     it('does not register a separate meta userData update tool', () => {
@@ -30,11 +33,31 @@ describe('assets-update-asset-user-data api', () => {
         expect(schema!.parse('6FA5FBAD0D324B6395D824507665775C@6C48A')).toBe('6fa5fbad-0d32-4b63-95d8-24507665775c@6c48a');
     });
 
-    it('delegates sub asset UUID updates to assetManager.updateUserData', async () => {
-        const updatedUserData = { minfilter: 'nearest' };
+    it('delegates complete userData replacement to assetManager.updateUserData', async () => {
+        const userData = { minfilter: 'nearest', wrapMode: 'clamp' };
+        const updatedUserData = { ...userData };
         mockUpdateUserData.mockResolvedValue(updatedUserData);
 
         const result = await new AssetsApi().updateAssetUserData(
+            '6fa5fbad-0d32-4b63-95d8-24507665775c@6c48a',
+            userData,
+        );
+
+        expect(result).toEqual({
+            code: COMMON_STATUS.SUCCESS,
+            data: updatedUserData,
+        });
+        expect(mockUpdateUserData).toHaveBeenCalledWith(
+            '6fa5fbad-0d32-4b63-95d8-24507665775c@6c48a',
+            userData,
+        );
+    });
+
+    it('delegates path updates to assetManager.updateUserDataByPath', async () => {
+        const updatedUserData = { minfilter: 'nearest' };
+        mockUpdateUserDataByPath.mockResolvedValue(updatedUserData);
+
+        const result = await new AssetsApi().updateAssetUserDataByPath(
             '6fa5fbad-0d32-4b63-95d8-24507665775c@6c48a',
             'minfilter',
             'nearest',
@@ -44,7 +67,7 @@ describe('assets-update-asset-user-data api', () => {
             code: COMMON_STATUS.SUCCESS,
             data: updatedUserData,
         });
-        expect(mockUpdateUserData).toHaveBeenCalledWith(
+        expect(mockUpdateUserDataByPath).toHaveBeenCalledWith(
             '6fa5fbad-0d32-4b63-95d8-24507665775c@6c48a',
             'minfilter',
             'nearest',

--- a/tests/lib/assets-api.test.ts
+++ b/tests/lib/assets-api.test.ts
@@ -14,14 +14,14 @@ describe('lib assets api', () => {
         expect((Assets as { updateAssetMetaUserData?: unknown }).updateAssetMetaUserData).toBeUndefined();
     });
 
-    it('updateAssetUserData delegates sub asset uuid to assetManager', async () => {
-        const result = { minfilter: 'nearest' };
+    it('updateAssetUserData delegates complete userData replacement to assetManager', async () => {
+        const userData = { minfilter: 'nearest', wrapMode: 'clamp' };
+        const result = { ...userData };
         const spy = jest.spyOn(assetManager, 'updateUserData').mockResolvedValue(result);
         const updateAssetUserData = (Assets as {
             updateAssetUserData?: (
                 urlOrUuidOrPath: string,
-                path: string,
-                value: unknown
+                userData: Record<string, unknown>
             ) => Promise<unknown>;
         }).updateAssetUserData;
 
@@ -31,7 +31,28 @@ describe('lib assets api', () => {
             throw new Error('updateAssetUserData is not exposed from lib/assets/assets');
         }
 
-        await expect(updateAssetUserData('parent-uuid@6c48a', 'minfilter', 'nearest')).resolves.toBe(result);
+        await expect(updateAssetUserData('parent-uuid@6c48a', userData)).resolves.toBe(result);
+        expect(spy).toHaveBeenCalledWith('parent-uuid@6c48a', userData);
+    });
+
+    it('updateAssetUserDataByPath delegates path updates to assetManager', async () => {
+        const result = { minfilter: 'nearest' };
+        const spy = jest.spyOn(assetManager, 'updateUserDataByPath').mockResolvedValue(result);
+        const updateAssetUserDataByPath = (Assets as {
+            updateAssetUserDataByPath?: (
+                urlOrUuidOrPath: string,
+                path: string,
+                value: unknown
+            ) => Promise<unknown>;
+        }).updateAssetUserDataByPath;
+
+        expect(updateAssetUserDataByPath).toEqual(expect.any(Function));
+
+        if (!updateAssetUserDataByPath) {
+            throw new Error('updateAssetUserDataByPath is not exposed from lib/assets/assets');
+        }
+
+        await expect(updateAssetUserDataByPath('parent-uuid@6c48a', 'minfilter', 'nearest')).resolves.toBe(result);
         expect(spy).toHaveBeenCalledWith('parent-uuid@6c48a', 'minfilter', 'nearest');
     });
 


### PR DESCRIPTION
https://github.com/cocos/cocos-cli/pull/650
已按反馈调整 `updateAssetUserData` 的接口语义：

- `assets-update-asset-user-data` / `updateAssetUserData(uuid, userData)` 现在用于整体替换资源的 `userData`，适配 PinK 面板“编辑后提交完整 userData”的常规交互。
- 新增 `assets-update-asset-user-data-by-path` / `updateAssetUserDataByPath(uuid, path, value)`，保留按路径精确修改能力，主要给 AI 或脚本只改单个配置项的场景使用。
- 父资源 UUID 和 `parentUuid@subMetaId` 子资源 UUID 均继续支持。
- 每次常规/路径更新都会执行一次 meta 保存和一次资源重导，避免只写 meta 但导入结果不更新。
- 空 path 不再作为整体替换入口，防止语义混用；整体替换必须走 `uuid, userData`。

本次暂未实现批量接口。批量更新建议后续按 `{ uuid, userData }[]` 聚合到同一父 meta 文件后统一写入，处理父子资源、重复 UUID 和多选资源场景，减少写入和重导次数。