### PR TITLE
fix: make serialized asset enum schema Pink-compatible

### DIFF
--- a/src/api/assets/schema.ts
+++ b/src/api/assets/schema.ts
@@ -171,7 +171,7 @@ export const SchemaSerializedAssetProperty: z.ZodType<any> = z.lazy(() => z.obje
     readonly: z.boolean().optional().describe('Whether property is read-only'), // 是否只读
     visible: z.boolean().optional().describe('Whether property is visible'), // 是否可见
     isArray: z.boolean().optional().describe('Whether property value is an array'), // 是否数组
-    enumList: z.array(z.any()).optional().describe('Enum option list'), // 枚举选项列表
+    enumList: z.array(z.unknown()).optional().describe('Enum option list'), // 枚举选项列表
     optionalTypes: z.array(z.string()).optional().describe('Optional concrete types for variable type properties'), // 可变类型的可选类型列表
     elementTypeData: z.lazy(() => SchemaSerializedAssetProperty).optional().describe('Default dump data for array elements'), // 数组元素默认 dump
 }).passthrough().describe('Creator-compatible serialized asset IProperty dump'));

--- a/tests/assets-serialized-data-api.test.ts
+++ b/tests/assets-serialized-data-api.test.ts
@@ -18,7 +18,31 @@ jest.mock('../src/core/assets', () => ({
 }));
 
 import { AssetsApi } from '../src/api/assets/assets';
+import { SchemaSerializedAssetPatch, SchemaUrlOrUUIDOrPath } from '../src/api/assets/schema';
 import { COMMON_STATUS } from '../src/api/base/schema-base';
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+function findArraySchemasWithoutItems(node: unknown, path = '$', result: string[] = []): string[] {
+    if (!node || typeof node !== 'object') {
+        return result;
+    }
+
+    if (!Array.isArray(node) && (node as { type?: unknown }).type === 'array' && !('items' in node)) {
+        result.push(path);
+    }
+
+    if (Array.isArray(node)) {
+        node.forEach((child, index) => findArraySchemasWithoutItems(child, `${path}[${index}]`, result));
+        return result;
+    }
+
+    Object.entries(node as Record<string, unknown>).forEach(([key, value]) => {
+        findArraySchemasWithoutItems(value, `${path}.${key}`, result);
+    });
+
+    return result;
+}
 
 describe('assets serialized data api', () => {
     beforeEach(() => {
@@ -59,5 +83,17 @@ describe('assets serialized data api', () => {
             data: result,
         });
         expect(mockSaveSerializedData).toHaveBeenCalledWith('test-uuid', patch);
+    });
+
+    it('emits Pink-compatible array items for saveSerializedData schema', () => {
+        const inputSchema = zodToJsonSchema(z.object({
+            uuidOrUrlOrPath: SchemaUrlOrUUIDOrPath,
+            patch: SchemaSerializedAssetPatch,
+        }), {
+            target: 'jsonSchema7',
+            $refStrategy: 'none',
+        });
+
+        expect(findArraySchemasWithoutItems(inputSchema)).toEqual([]);
     });
 });


### PR DESCRIPTION
### 背景

Pink 会在发送聊天请求前校验 MCP tool 的 `function.parameters`，并要求所有 `type: "array"` 的 schema 节点都必须带 `items`。`assets-save-serialized-data` 的 `enumList: z.array(z.any())` 经 `zod-to-json-schema` 转换后会生成缺少 `items` 的 array schema，导致 Pink 报错：`tool parameters array type must have items`。

### 修改

- 将 `enumList` 从 `z.array(z.any())` 调整为 `z.array(z.unknown())`，运行时仍接受任意数组元素，但 JSON Schema 会生成 `items: {}`。
- 为 `assets-save-serialized-data` 入参 schema 增加回归测试，确保转换后的 schema 不再包含缺少 `items` 的 array 节点。