### PR TITLE
[break] fix: localize asset property schema

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -120,7 +120,9 @@ export declare interface AssetOperationOption {
 }
 export declare interface AssetPropertySchema {
     label: string;
+    labelI18nKey?: string;
     description?: string;
+    descriptionI18nKey?: string;
     type: AssetPropertySchemaType;
     default?: unknown;
     options?: AssetPropertySchemaOption[];
@@ -137,6 +139,7 @@ export declare interface AssetPropertySchema {
 export declare type AssetPropertySchemaMap = Record<string, AssetPropertySchema>;
 export declare interface AssetPropertySchemaOption {
     label: string;
+    labelI18nKey?: string;
     value: string | number | boolean;
 }
 export declare type AssetPropertySchemaType = 'string' | 'number' | 'boolean' | 'enum' | 'asset' | 'array' | 'object';
@@ -571,7 +574,9 @@ export declare type ISupportCreateType = typeof SUPPORT_CREATE_TYPES[number];
 export declare interface IUerDataConfigItem {
     key?: string;
     label?: string;
+    labelI18nKey?: string;
     description?: string;
+    descriptionI18nKey?: string;
     default?: any;
     type?: 'array' | 'object';
     itemConfigs?: IUerDataConfigItem[] | Record<string, IUerDataConfigItem>;
@@ -580,6 +585,7 @@ export declare interface IUerDataConfigItem {
         attributes?: Record<string, string | boolean | number>;
         items?: Array<{
             label: string;
+            labelI18nKey?: string;
             value: string;
         }>;
     };
@@ -7014,7 +7020,9 @@ export declare interface AssetOperationOption {
 }
 export declare interface AssetPropertySchema {
     label: string;
+    labelI18nKey?: string;
     description?: string;
+    descriptionI18nKey?: string;
     type: AssetPropertySchemaType;
     default?: unknown;
     options?: AssetPropertySchemaOption[];
@@ -7031,6 +7039,7 @@ export declare interface AssetPropertySchema {
 export declare type AssetPropertySchemaMap = Record<string, AssetPropertySchema>;
 export declare interface AssetPropertySchemaOption {
     label: string;
+    labelI18nKey?: string;
     value: string | number | boolean;
 }
 export declare type AssetPropertySchemaType = 'string' | 'number' | 'boolean' | 'enum' | 'asset' | 'array' | 'object';
@@ -7939,7 +7948,9 @@ export declare type ISupportCreateType = typeof SUPPORT_CREATE_TYPES[number];
 export declare interface IUerDataConfigItem {
     key?: string;
     label?: string;
+    labelI18nKey?: string;
     description?: string;
+    descriptionI18nKey?: string;
     default?: any;
     type?: 'array' | 'object';
     itemConfigs?: IUerDataConfigItem[] | Record<string, IUerDataConfigItem>;
@@ -7948,6 +7959,7 @@ export declare interface IUerDataConfigItem {
         attributes?: Record<string, string | boolean | number>;
         items?: Array<{
             label: string;
+            labelI18nKey?: string;
             value: string;
         }>;
     };

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -120,9 +120,7 @@ export declare interface AssetOperationOption {
 }
 export declare interface AssetPropertySchema {
     label: string;
-    labelI18nKey?: string;
     description?: string;
-    descriptionI18nKey?: string;
     type: AssetPropertySchemaType;
     default?: unknown;
     options?: AssetPropertySchemaOption[];
@@ -134,12 +132,10 @@ export declare interface AssetPropertySchema {
     order?: number;
     properties?: Record<string, AssetPropertySchema>;
     items?: AssetPropertySchema | AssetPropertySchema[];
-    raw?: unknown;
 }
 export declare type AssetPropertySchemaMap = Record<string, AssetPropertySchema>;
 export declare interface AssetPropertySchemaOption {
     label: string;
-    labelI18nKey?: string;
     value: string | number | boolean;
 }
 export declare type AssetPropertySchemaType = 'string' | 'number' | 'boolean' | 'enum' | 'asset' | 'array' | 'object';
@@ -574,9 +570,7 @@ export declare type ISupportCreateType = typeof SUPPORT_CREATE_TYPES[number];
 export declare interface IUerDataConfigItem {
     key?: string;
     label?: string;
-    labelI18nKey?: string;
     description?: string;
-    descriptionI18nKey?: string;
     default?: any;
     type?: 'array' | 'object';
     itemConfigs?: IUerDataConfigItem[] | Record<string, IUerDataConfigItem>;
@@ -585,7 +579,6 @@ export declare interface IUerDataConfigItem {
         attributes?: Record<string, string | boolean | number>;
         items?: Array<{
             label: string;
-            labelI18nKey?: string;
             value: string;
         }>;
     };
@@ -7020,9 +7013,7 @@ export declare interface AssetOperationOption {
 }
 export declare interface AssetPropertySchema {
     label: string;
-    labelI18nKey?: string;
     description?: string;
-    descriptionI18nKey?: string;
     type: AssetPropertySchemaType;
     default?: unknown;
     options?: AssetPropertySchemaOption[];
@@ -7034,12 +7025,10 @@ export declare interface AssetPropertySchema {
     order?: number;
     properties?: Record<string, AssetPropertySchema>;
     items?: AssetPropertySchema | AssetPropertySchema[];
-    raw?: unknown;
 }
 export declare type AssetPropertySchemaMap = Record<string, AssetPropertySchema>;
 export declare interface AssetPropertySchemaOption {
     label: string;
-    labelI18nKey?: string;
     value: string | number | boolean;
 }
 export declare type AssetPropertySchemaType = 'string' | 'number' | 'boolean' | 'enum' | 'asset' | 'array' | 'object';
@@ -7948,9 +7937,7 @@ export declare type ISupportCreateType = typeof SUPPORT_CREATE_TYPES[number];
 export declare interface IUerDataConfigItem {
     key?: string;
     label?: string;
-    labelI18nKey?: string;
     description?: string;
-    descriptionI18nKey?: string;
     default?: any;
     type?: 'array' | 'object';
     itemConfigs?: IUerDataConfigItem[] | Record<string, IUerDataConfigItem>;
@@ -7959,7 +7946,6 @@ export declare interface IUerDataConfigItem {
         attributes?: Record<string, string | boolean | number>;
         items?: Array<{
             label: string;
-            labelI18nKey?: string;
             value: string;
         }>;
     };

--- a/src/api/assets/schema.ts
+++ b/src/api/assets/schema.ts
@@ -348,15 +348,12 @@ export type TAssetConfigMapResult = z.infer<typeof SchemaAssetConfigMapResult>;
 
 export const SchemaAssetPropertySchemaOption = z.object({
     label: z.string().describe('Option display label'), // 选项显示名称
-    labelI18nKey: z.string().optional().describe('Original i18n key for option display label'), // 选项显示名称对应的原始 i18n key
     value: z.union([z.string(), z.number(), z.boolean()]).describe('Option value'), // 选项值
 }).describe('Asset property schema option'); // 资源属性 schema 选项
 
 export const SchemaAssetPropertySchema: z.ZodType<any> = z.lazy(() => z.object({
     label: z.string().describe('Property display label'), // 属性显示名称
-    labelI18nKey: z.string().optional().describe('Original i18n key for property display label'), // 属性显示名称对应的原始 i18n key
     description: z.string().optional().describe('Property description'), // 属性描述
-    descriptionI18nKey: z.string().optional().describe('Original i18n key for property description'), // 属性描述对应的原始 i18n key
     type: z.enum(['string', 'number', 'boolean', 'enum', 'asset', 'array', 'object']).describe('Property value/control type'), // 属性值或控件类型
     default: z.any().optional().describe('Static default value'), // 静态默认值
     options: z.array(SchemaAssetPropertySchemaOption).optional().describe('Enum/select options'), // 枚举/下拉选项
@@ -368,7 +365,6 @@ export const SchemaAssetPropertySchema: z.ZodType<any> = z.lazy(() => z.object({
     order: z.number().optional().describe('Display order'), // 展示顺序
     properties: z.record(z.string(), SchemaAssetPropertySchema).optional().describe('Nested object properties'), // 嵌套对象属性
     items: z.union([SchemaAssetPropertySchema, z.array(SchemaAssetPropertySchema)]).optional().describe('Array item schema'), // 数组元素 schema
-    raw: z.any().optional().describe('Original legacy userDataConfig item for debugging only'), // 原始旧配置，仅用于调试
 }).describe('Standardized asset import property schema')); // 标准化资源导入属性 schema
 
 export const SchemaAssetPropertySchemaResult = z.record(z.string(), SchemaAssetPropertySchema).describe('Asset import property schema map, key is property name'); // 资源导入属性 schema 映射

--- a/src/api/assets/schema.ts
+++ b/src/api/assets/schema.ts
@@ -348,12 +348,15 @@ export type TAssetConfigMapResult = z.infer<typeof SchemaAssetConfigMapResult>;
 
 export const SchemaAssetPropertySchemaOption = z.object({
     label: z.string().describe('Option display label'), // 选项显示名称
+    labelI18nKey: z.string().optional().describe('Original i18n key for option display label'), // 选项显示名称对应的原始 i18n key
     value: z.union([z.string(), z.number(), z.boolean()]).describe('Option value'), // 选项值
 }).describe('Asset property schema option'); // 资源属性 schema 选项
 
 export const SchemaAssetPropertySchema: z.ZodType<any> = z.lazy(() => z.object({
     label: z.string().describe('Property display label'), // 属性显示名称
+    labelI18nKey: z.string().optional().describe('Original i18n key for property display label'), // 属性显示名称对应的原始 i18n key
     description: z.string().optional().describe('Property description'), // 属性描述
+    descriptionI18nKey: z.string().optional().describe('Original i18n key for property description'), // 属性描述对应的原始 i18n key
     type: z.enum(['string', 'number', 'boolean', 'enum', 'asset', 'array', 'object']).describe('Property value/control type'), // 属性值或控件类型
     default: z.any().optional().describe('Static default value'), // 静态默认值
     options: z.array(SchemaAssetPropertySchemaOption).optional().describe('Enum/select options'), // 枚举/下拉选项

--- a/src/core/assets/@types/protected/asset-handler.d.ts
+++ b/src/core/assets/@types/protected/asset-handler.d.ts
@@ -272,12 +272,8 @@ export interface IUerDataConfigItem {
     key?: string; // 唯一标识符
     // 配置显示的名字，如果需要翻译，则传入 i18n:${key}
     label?: string;
-    // label 对应的原始 i18n key
-    labelI18nKey?: string;
     // 设置的简单说明
     description?: string;
-    // description 对应的原始 i18n key
-    descriptionI18nKey?: string;
 
     // 默认值
     default?: any;
@@ -289,7 +285,6 @@ export interface IUerDataConfigItem {
         attributes?: Record<string, string | boolean | number>;
         items?: Array<{
             label: string;
-            labelI18nKey?: string;
             value: string;
         }>;
     };

--- a/src/core/assets/@types/protected/asset-handler.d.ts
+++ b/src/core/assets/@types/protected/asset-handler.d.ts
@@ -272,8 +272,12 @@ export interface IUerDataConfigItem {
     key?: string; // 唯一标识符
     // 配置显示的名字，如果需要翻译，则传入 i18n:${key}
     label?: string;
+    // label 对应的原始 i18n key
+    labelI18nKey?: string;
     // 设置的简单说明
     description?: string;
+    // description 对应的原始 i18n key
+    descriptionI18nKey?: string;
 
     // 默认值
     default?: any;
@@ -285,6 +289,7 @@ export interface IUerDataConfigItem {
         attributes?: Record<string, string | boolean | number>;
         items?: Array<{
             label: string;
+            labelI18nKey?: string;
             value: string;
         }>;
     };

--- a/src/core/assets/@types/public.d.ts
+++ b/src/core/assets/@types/public.d.ts
@@ -41,12 +41,15 @@ export type AssetPropertySchemaType = 'string' | 'number' | 'boolean' | 'enum' |
 
 export interface AssetPropertySchemaOption {
     label: string;
+    labelI18nKey?: string;
     value: string | number | boolean;
 }
 
 export interface AssetPropertySchema {
     label: string;
+    labelI18nKey?: string;
     description?: string;
+    descriptionI18nKey?: string;
     type: AssetPropertySchemaType;
     default?: unknown;
     options?: AssetPropertySchemaOption[];

--- a/src/core/assets/@types/public.d.ts
+++ b/src/core/assets/@types/public.d.ts
@@ -41,15 +41,12 @@ export type AssetPropertySchemaType = 'string' | 'number' | 'boolean' | 'enum' |
 
 export interface AssetPropertySchemaOption {
     label: string;
-    labelI18nKey?: string;
     value: string | number | boolean;
 }
 
 export interface AssetPropertySchema {
     label: string;
-    labelI18nKey?: string;
     description?: string;
-    descriptionI18nKey?: string;
     type: AssetPropertySchemaType;
     default?: unknown;
     options?: AssetPropertySchemaOption[];
@@ -61,7 +58,6 @@ export interface AssetPropertySchema {
     order?: number;
     properties?: Record<string, AssetPropertySchema>;
     items?: AssetPropertySchema | AssetPropertySchema[];
-    raw?: unknown;
 }
 
 export type AssetPropertySchemaMap = Record<string, AssetPropertySchema>;

--- a/src/core/assets/asset-handler/assets/auto-atlas.ts
+++ b/src/core/assets/asset-handler/assets/auto-atlas.ts
@@ -36,7 +36,7 @@ const AutoAtlasHandler: AssetHandler = {
     assetType: 'cc.SpriteAtlas',
     propertySchemaConfig: {
             maxWidth: {
-                label: 'Max Width',
+                label: 'i18n:importer.property_schema.auto_atlas.max_width',
                 default: defaultAutoAtlasUserData.maxWidth,
                 render: {
                     ui: 'ui-number-input',
@@ -44,7 +44,7 @@ const AutoAtlasHandler: AssetHandler = {
                 },
             },
             maxHeight: {
-                label: 'Max Height',
+                label: 'i18n:importer.property_schema.auto_atlas.max_height',
                 default: defaultAutoAtlasUserData.maxHeight,
                 render: {
                     ui: 'ui-number-input',
@@ -52,7 +52,7 @@ const AutoAtlasHandler: AssetHandler = {
                 },
             },
             padding: {
-                label: 'Padding',
+                label: 'i18n:importer.property_schema.auto_atlas.padding',
                 default: defaultAutoAtlasUserData.padding,
                 render: {
                     ui: 'ui-number-input',
@@ -60,43 +60,43 @@ const AutoAtlasHandler: AssetHandler = {
                 },
             },
             allowRotation: {
-                label: 'Allow Rotation',
+                label: 'i18n:importer.property_schema.auto_atlas.allow_rotation',
                 default: defaultAutoAtlasUserData.allowRotation,
                 render: { ui: 'ui-checkbox' },
             },
             forceSquared: {
-                label: 'Force Squared',
+                label: 'i18n:importer.property_schema.auto_atlas.force_squared',
                 default: defaultAutoAtlasUserData.forceSquared,
                 render: { ui: 'ui-checkbox' },
             },
             powerOfTwo: {
-                label: 'Power Of Two',
+                label: 'i18n:importer.property_schema.auto_atlas.power_of_two',
                 default: defaultAutoAtlasUserData.powerOfTwo,
                 render: { ui: 'ui-checkbox' },
             },
             algorithm: {
-                label: 'Algorithm',
+                label: 'i18n:importer.property_schema.auto_atlas.algorithm',
                 default: defaultAutoAtlasUserData.algorithm,
                 render: {
                     ui: 'ui-select',
                     items: [
-                        { label: 'MaxRects', value: 'MaxRects' },
+                        { label: 'i18n:importer.property_schema.auto_atlas.max_rects', value: 'MaxRects' },
                     ],
                 },
             },
             format: {
-                label: 'Format',
+                label: 'i18n:importer.property_schema.auto_atlas.format',
                 default: defaultAutoAtlasUserData.format,
                 render: {
                     ui: 'ui-select',
                     items: [
-                        { label: 'PNG', value: 'png' },
-                        { label: 'JPG', value: 'jpg' },
+                        { label: 'i18n:importer.property_schema.auto_atlas.png', value: 'png' },
+                        { label: 'i18n:importer.property_schema.auto_atlas.jpg', value: 'jpg' },
                     ],
                 },
             },
             quality: {
-                label: 'Quality',
+                label: 'i18n:importer.property_schema.auto_atlas.quality',
                 default: defaultAutoAtlasUserData.quality,
                 render: {
                     ui: 'ui-number-input',
@@ -104,37 +104,37 @@ const AutoAtlasHandler: AssetHandler = {
                 },
             },
             contourBleed: {
-                label: 'Contour Bleed',
+                label: 'i18n:importer.property_schema.auto_atlas.contour_bleed',
                 default: defaultAutoAtlasUserData.contourBleed,
                 render: { ui: 'ui-checkbox' },
             },
             paddingBleed: {
-                label: 'Padding Bleed',
+                label: 'i18n:importer.property_schema.auto_atlas.padding_bleed',
                 default: defaultAutoAtlasUserData.paddingBleed,
                 render: { ui: 'ui-checkbox' },
             },
             filterUnused: {
-                label: 'Filter Unused',
+                label: 'i18n:importer.property_schema.auto_atlas.filter_unused',
                 default: defaultAutoAtlasUserData.filterUnused,
                 render: { ui: 'ui-checkbox' },
             },
             removeTextureInBundle: {
-                label: 'Remove Texture In Bundle',
+                label: 'i18n:importer.property_schema.auto_atlas.remove_texture_in_bundle',
                 default: defaultAutoAtlasUserData.removeTextureInBundle,
                 render: { ui: 'ui-checkbox' },
             },
             removeImageInBundle: {
-                label: 'Remove Image In Bundle',
+                label: 'i18n:importer.property_schema.auto_atlas.remove_image_in_bundle',
                 default: defaultAutoAtlasUserData.removeImageInBundle,
                 render: { ui: 'ui-checkbox' },
             },
             removeSpriteAtlasInBundle: {
-                label: 'Remove SpriteAtlas In Bundle',
+                label: 'i18n:importer.property_schema.auto_atlas.remove_sprite_atlas_in_bundle',
                 default: defaultAutoAtlasUserData.removeSpriteAtlasInBundle,
                 render: { ui: 'ui-checkbox' },
             },
             textureSetting: {
-                label: 'Texture Setting',
+                label: 'i18n:importer.property_schema.auto_atlas.texture_setting',
                 type: 'object',
                 default: defaultAutoAtlasUserData.textureSetting,
                 itemConfigs: createTextureBaseUserDataConfig(),

--- a/src/core/assets/asset-handler/assets/fbx.ts
+++ b/src/core/assets/asset-handler/assets/fbx.ts
@@ -10,12 +10,13 @@ export const FbxHandler: AssetHandlerBase = {
     propertySchemaConfig: {
         ...(GltfHandler.propertySchemaConfig ?? {}),
         legacyFbxImporter: {
-            label: 'Legacy FBX Importer',
+            label: 'i18n:ENGINE.assets.fbx.legacyFbxImporter.name',
+            description: 'i18n:ENGINE.assets.fbx.legacyFbxImporter.title',
             default: false,
             render: { ui: 'ui-checkbox' },
         },
         fbx: {
-            label: 'FBX',
+            label: 'i18n:ENGINE.assets.fbx.fbx',
             type: 'object',
             default: {
                 unitConversion: 'geometry-level',
@@ -26,24 +27,25 @@ export const FbxHandler: AssetHandlerBase = {
             },
             itemConfigs: {
                 unitConversion: {
-                    label: 'Unit Conversion',
+                    label: 'i18n:importer.property_schema.fbx.unit_conversion',
                     default: 'geometry-level',
                     render: {
                         ui: 'ui-select',
                         items: [
-                            { label: 'Geometry Level', value: 'geometry-level' },
-                            { label: 'Hierarchy Level', value: 'hierarchy-level' },
-                            { label: 'Disabled', value: 'disabled' },
+                            { label: 'i18n:importer.property_schema.fbx.unit_conversion_geometry_level', value: 'geometry-level' },
+                            { label: 'i18n:importer.property_schema.fbx.unit_conversion_hierarchy_level', value: 'hierarchy-level' },
+                            { label: 'i18n:importer.property_schema.fbx.unit_conversion_disabled', value: 'disabled' },
                         ],
                     },
                 },
                 animationBakeRate: {
-                    label: 'Animation Bake Rate',
+                    label: 'i18n:ENGINE.assets.fbx.animationBakeRate.name',
+                    description: 'i18n:ENGINE.assets.fbx.animationBakeRate.title',
                     default: 24,
                     render: {
                         ui: 'ui-select',
                         items: [
-                            { label: 'Original', value: '0' },
+                            { label: 'i18n:ENGINE.assets.fbx.animationBakeRate.auto', value: '0' },
                             { label: '24 FPS', value: '24' },
                             { label: '25 FPS', value: '25' },
                             { label: '30 FPS', value: '30' },
@@ -52,17 +54,19 @@ export const FbxHandler: AssetHandlerBase = {
                     },
                 },
                 preferLocalTimeSpan: {
-                    label: 'Prefer Local Time Span',
+                    label: 'i18n:ENGINE.assets.fbx.preferLocalTimeSpan.name',
+                    description: 'i18n:ENGINE.assets.fbx.preferLocalTimeSpan.title',
                     default: true,
                     render: { ui: 'ui-checkbox' },
                 },
                 smartMaterialEnabled: {
-                    label: 'Smart Material',
+                    label: 'i18n:ENGINE.assets.fbx.smartMaterialEnabled.name',
+                    description: 'i18n:ENGINE.assets.fbx.smartMaterialEnabled.title',
                     default: false,
                     render: { ui: 'ui-checkbox' },
                 },
                 matchMeshNames: {
-                    label: 'Match Mesh Names',
+                    label: 'i18n:importer.property_schema.fbx.match_mesh_names',
                     default: false,
                     render: { ui: 'ui-checkbox' },
                 },

--- a/src/core/assets/asset-handler/assets/gltf.ts
+++ b/src/core/assets/asset-handler/assets/gltf.ts
@@ -50,74 +50,82 @@ export const GltfHandler: AssetHandlerBase = {
 
     propertySchemaConfig: {
             dumpMaterials: {
-                label: 'Dump Materials',
+                label: 'i18n:ENGINE.assets.fbx.GlTFUserData.dumpMaterials.name',
+                description: 'i18n:ENGINE.assets.fbx.GlTFUserData.dumpMaterials.title',
                 default: false,
                 render: { ui: 'ui-checkbox' },
             },
             mountAllAnimationsOnPrefab: {
-                label: 'Mount All Animations On Prefab',
+                label: 'i18n:ENGINE.assets.fbx.GlTFUserData.mountAllAnimationsOnPrefab.name',
                 default: false,
                 render: { ui: 'ui-checkbox' },
             },
             allowMeshDataAccess: {
-                label: 'Allow Mesh Data Access',
+                label: 'i18n:ENGINE.assets.fbx.allowMeshDataAccess.name',
+                description: 'i18n:ENGINE.assets.fbx.allowMeshDataAccess.title',
                 default: true,
                 render: { ui: 'ui-checkbox' },
             },
             addVertexColor: {
-                label: 'Add Vertex Color',
+                label: 'i18n:ENGINE.assets.fbx.addVertexColor.name',
+                description: 'i18n:ENGINE.assets.fbx.addVertexColor.title',
                 default: false,
                 render: { ui: 'ui-checkbox' },
             },
             promoteSingleRootNode: {
-                label: 'Promote Single Root Node',
+                label: 'i18n:ENGINE.assets.fbx.promoteSingleRootNode.name',
+                description: 'i18n:ENGINE.assets.fbx.promoteSingleRootNode.title',
                 default: false,
                 render: { ui: 'ui-checkbox' },
             },
             generateLightmapUVNode: {
-                label: 'Generate Lightmap UV',
+                label: 'i18n:ENGINE.assets.fbx.generateLightmapUVNode.name',
+                description: 'i18n:ENGINE.assets.fbx.generateLightmapUVNode.title',
                 default: false,
                 render: { ui: 'ui-checkbox' },
             },
             normals: {
-                label: 'Normals',
+                label: 'i18n:ENGINE.assets.fbx.GlTFUserData.normals.name',
+                description: 'i18n:ENGINE.assets.fbx.GlTFUserData.normals.title',
                 default: NormalImportSetting.require,
                 render: {
                     ui: 'ui-select',
                     items: [
-                        { label: 'Optional', value: String(NormalImportSetting.optional) },
-                        { label: 'Exclude', value: String(NormalImportSetting.exclude) },
-                        { label: 'Require', value: String(NormalImportSetting.require) },
-                        { label: 'Recalculate', value: String(NormalImportSetting.recalculate) },
+                        { label: 'i18n:ENGINE.assets.fbx.GlTFUserData.normals.optional.name', value: String(NormalImportSetting.optional) },
+                        { label: 'i18n:ENGINE.assets.fbx.GlTFUserData.normals.exclude.name', value: String(NormalImportSetting.exclude) },
+                        { label: 'i18n:ENGINE.assets.fbx.GlTFUserData.normals.require.name', value: String(NormalImportSetting.require) },
+                        { label: 'i18n:ENGINE.assets.fbx.GlTFUserData.normals.recalculate.name', value: String(NormalImportSetting.recalculate) },
                     ],
                 },
             },
             tangents: {
-                label: 'Tangents',
+                label: 'i18n:ENGINE.assets.fbx.GlTFUserData.tangents.name',
+                description: 'i18n:ENGINE.assets.fbx.GlTFUserData.tangents.title',
                 default: TangentImportSetting.require,
                 render: {
                     ui: 'ui-select',
                     items: [
-                        { label: 'Exclude', value: String(TangentImportSetting.exclude) },
-                        { label: 'Optional', value: String(TangentImportSetting.optional) },
-                        { label: 'Require', value: String(TangentImportSetting.require) },
-                        { label: 'Recalculate', value: String(TangentImportSetting.recalculate) },
+                        { label: 'i18n:ENGINE.assets.fbx.GlTFUserData.tangents.exclude.name', value: String(TangentImportSetting.exclude) },
+                        { label: 'i18n:ENGINE.assets.fbx.GlTFUserData.tangents.optional.name', value: String(TangentImportSetting.optional) },
+                        { label: 'i18n:ENGINE.assets.fbx.GlTFUserData.tangents.require.name', value: String(TangentImportSetting.require) },
+                        { label: 'i18n:ENGINE.assets.fbx.GlTFUserData.tangents.recalculate.name', value: String(TangentImportSetting.recalculate) },
                     ],
                 },
             },
             morphNormals: {
-                label: 'Morph Normals',
+                label: 'i18n:ENGINE.assets.fbx.GlTFUserData.morphNormals.name',
+                description: 'i18n:ENGINE.assets.fbx.GlTFUserData.morphNormals.title',
                 default: NormalImportSetting.exclude,
                 render: {
                     ui: 'ui-select',
                     items: [
-                        { label: 'Exclude', value: String(NormalImportSetting.exclude) },
-                        { label: 'Optional', value: String(NormalImportSetting.optional) },
+                        { label: 'i18n:ENGINE.assets.fbx.GlTFUserData.morphNormals.exclude.name', value: String(NormalImportSetting.exclude) },
+                        { label: 'i18n:ENGINE.assets.fbx.GlTFUserData.morphNormals.optional.name', value: String(NormalImportSetting.optional) },
                     ],
                 },
             },
             meshOptimizer: {
-                label: 'Mesh Optimizer',
+                label: 'i18n:importer.property_schema.gltf.mesh_optimizer',
                 type: 'object',
                 default: {
                     enable: false,
@@ -126,43 +134,43 @@ export const GltfHandler: AssetHandlerBase = {
                 },
                 itemConfigs: {
                     enable: {
-                        label: 'Enable',
+                        label: 'i18n:importer.property_schema.gltf.mesh_optimizer_enable',
                         default: false,
                         render: { ui: 'ui-checkbox' },
                     },
                     algorithm: {
-                        label: 'Algorithm',
+                        label: 'i18n:importer.property_schema.gltf.mesh_optimizer_algorithm',
                         default: 'simplify',
                         render: {
                             ui: 'ui-select',
                             items: [
-                                { label: 'Simplify', value: 'simplify' },
-                                { label: 'gltfpack', value: 'gltfpack' },
+                                { label: 'i18n:importer.property_schema.gltf.mesh_optimizer_simplify', value: 'simplify' },
+                                { label: 'i18n:importer.property_schema.gltf.mesh_optimizer_gltfpack', value: 'gltfpack' },
                             ],
                         },
                     },
                     simplifyOptions: {
-                        label: 'Simplify Options',
+                        label: 'i18n:importer.property_schema.gltf.simplify_options',
                         type: 'object',
                         default: getDefaultSimplifyOptions(),
                         itemConfigs: {
                             targetRatio: {
-                                label: 'Target Ratio',
+                                label: 'i18n:ENGINE.assets.fbx.meshSimplify.targetRatio.name',
                                 default: 1,
                                 render: { ui: 'ui-number-input', attributes: { min: 0, max: 1, step: 0.01 } },
                             },
                             enableSmartLink: {
-                                label: 'Enable Smart Link',
+                                label: 'i18n:importer.property_schema.gltf.enable_smart_link',
                                 default: true,
                                 render: { ui: 'ui-checkbox' },
                             },
                             agressiveness: {
-                                label: 'Agressiveness',
+                                label: 'i18n:importer.property_schema.gltf.agressiveness',
                                 default: 7,
                                 render: { ui: 'ui-number-input', attributes: { min: 0, step: 1 } },
                             },
                             maxIterationCount: {
-                                label: 'Max Iteration Count',
+                                label: 'i18n:importer.property_schema.gltf.max_iteration_count',
                                 default: 100,
                                 render: { ui: 'ui-number-input', attributes: { min: 1, step: 1 } },
                             },

--- a/src/core/assets/asset-handler/assets/image/index.ts
+++ b/src/core/assets/asset-handler/assets/image/index.ts
@@ -155,28 +155,29 @@ export const ImageHandler: AssetHandler = {
         default: {
             type: {
                 label: 'i18n:ENGINE.assets.image.type',
+                description: 'i18n:ENGINE.assets.image.typeTip',
                 default: 'sprite-frame',
                 render: {
                     ui: 'ui-select',
                     items: [
                         {
-                            label: 'raw',
+                            label: 'i18n:importer.property_schema.image.type_raw',
                             value: 'raw',
                         },
                         {
-                            label: 'texture',
+                            label: 'i18n:importer.property_schema.image.type_texture',
                             value: 'texture',
                         },
                         {
-                            label: 'normal map',
+                            label: 'i18n:importer.property_schema.image.type_normal_map',
                             value: 'normal map',
                         },
                         {
-                            label: 'sprite-frame',
+                            label: 'i18n:importer.property_schema.image.type_sprite_frame',
                             value: 'sprite-frame',
                         },
                         {
-                            label: 'texture cube',
+                            label: 'i18n:importer.property_schema.image.type_texture_cube',
                             value: 'texture cube',
                         },
                     ],
@@ -184,6 +185,7 @@ export const ImageHandler: AssetHandler = {
             },
             flipVertical: {
                 label: 'i18n:ENGINE.assets.image.flipVertical',
+                description: 'i18n:ENGINE.assets.image.flipVerticalTip',
                 render: {
                     ui: 'ui-checkbox',
                 },

--- a/src/core/assets/asset-handler/assets/sprite-frame.ts
+++ b/src/core/assets/asset-handler/assets/sprite-frame.ts
@@ -33,19 +33,20 @@ export const SpriteFrameHandler: AssetHandler = {
             trimType: {
                 default: 'auto',
                 label: 'i18n:ENGINE.assets.spriteFrame.trimType',
+                description: 'i18n:ENGINE.assets.spriteFrame.trimTypeTip',
                 render: {
                     ui: 'ui-select',
                     items: [
                         {
-                            label: 'auto',
+                            label: 'i18n:importer.property_schema.sprite_frame.trim_type_auto',
                             value: 'auto',
                         },
                         {
-                            label: 'custom',
+                            label: 'i18n:importer.property_schema.sprite_frame.trim_type_custom',
                             value: 'custom',
                         },
                         {
-                            label: 'none',
+                            label: 'i18n:importer.property_schema.sprite_frame.trim_type_none',
                             value: 'none',
                         },
                     ],
@@ -56,7 +57,8 @@ export const SpriteFrameHandler: AssetHandler = {
     propertySchemaConfig: {
         trimThreshold: {
             default: defaultSpriteFrameUserData.trimThreshold,
-            label: 'Trim Threshold',
+            label: 'i18n:ENGINE.assets.spriteFrame.trimThreshold',
+            description: 'i18n:ENGINE.assets.spriteFrame.trimThresholdTip',
             render: {
                 ui: 'ui-number-input',
                 attributes: { min: 0, step: 1 },
@@ -64,12 +66,14 @@ export const SpriteFrameHandler: AssetHandler = {
         },
         packable: {
             default: defaultSpriteFrameUserData.packable,
-            label: 'Packable',
+            label: 'i18n:ENGINE.assets.spriteFrame.packable',
+            description: 'i18n:ENGINE.assets.spriteFrame.packableTip',
             render: { ui: 'ui-checkbox' },
         },
         pixelsToUnit: {
             default: defaultSpriteFrameUserData.pixelsToUnit,
-            label: 'Pixels To Unit',
+            label: 'i18n:ENGINE.assets.spriteFrame.pixelsToUnit',
+            description: 'i18n:ENGINE.assets.spriteFrame.pixelsToUnitTip',
             render: {
                 ui: 'ui-number-input',
                 attributes: { min: 1, step: 1 },
@@ -77,7 +81,8 @@ export const SpriteFrameHandler: AssetHandler = {
         },
         pivotX: {
             default: defaultSpriteFrameUserData.pivotX,
-            label: 'Pivot X',
+            label: 'i18n:ENGINE.assets.spriteFrame.pivotX',
+            description: 'i18n:ENGINE.assets.spriteFrame.pivotXTip',
             render: {
                 ui: 'ui-number-input',
                 attributes: { min: 0, max: 1, step: 0.01 },
@@ -85,7 +90,8 @@ export const SpriteFrameHandler: AssetHandler = {
         },
         pivotY: {
             default: defaultSpriteFrameUserData.pivotY,
-            label: 'Pivot Y',
+            label: 'i18n:ENGINE.assets.spriteFrame.pivotY',
+            description: 'i18n:ENGINE.assets.spriteFrame.pivotYTip',
             render: {
                 ui: 'ui-number-input',
                 attributes: { min: 0, max: 1, step: 0.01 },
@@ -93,33 +99,38 @@ export const SpriteFrameHandler: AssetHandler = {
         },
         meshType: {
             default: defaultSpriteFrameUserData.meshType,
-            label: 'Mesh Type',
+            label: 'i18n:ENGINE.assets.spriteFrame.meshType',
+            description: 'i18n:ENGINE.assets.spriteFrame.meshTypeTip',
             render: {
                 ui: 'ui-select',
                 items: [
-                    { label: 'Rect', value: '0' },
-                    { label: 'Polygon', value: '1' },
+                    { label: 'i18n:importer.property_schema.sprite_frame.mesh_type_rect', value: '0' },
+                    { label: 'i18n:importer.property_schema.sprite_frame.mesh_type_polygon', value: '1' },
                 ],
             },
         },
         borderTop: {
             default: defaultSpriteFrameUserData.borderTop,
-            label: 'Border Top',
+            label: 'i18n:ENGINE.assets.spriteFrame.borderTop',
+            description: 'i18n:ENGINE.assets.spriteFrame.borderTopTip',
             render: { ui: 'ui-number-input', attributes: { min: 0, step: 1 } },
         },
         borderBottom: {
             default: defaultSpriteFrameUserData.borderBottom,
-            label: 'Border Bottom',
+            label: 'i18n:ENGINE.assets.spriteFrame.borderBottom',
+            description: 'i18n:ENGINE.assets.spriteFrame.borderBottomTip',
             render: { ui: 'ui-number-input', attributes: { min: 0, step: 1 } },
         },
         borderLeft: {
             default: defaultSpriteFrameUserData.borderLeft,
-            label: 'Border Left',
+            label: 'i18n:ENGINE.assets.spriteFrame.borderLeft',
+            description: 'i18n:ENGINE.assets.spriteFrame.borderLeftTip',
             render: { ui: 'ui-number-input', attributes: { min: 0, step: 1 } },
         },
         borderRight: {
             default: defaultSpriteFrameUserData.borderRight,
-            label: 'Border Right',
+            label: 'i18n:ENGINE.assets.spriteFrame.borderRight',
+            description: 'i18n:ENGINE.assets.spriteFrame.borderRightTip',
             render: { ui: 'ui-number-input', attributes: { min: 0, step: 1 } },
         },
     },

--- a/src/core/assets/asset-handler/assets/texture-base.ts
+++ b/src/core/assets/asset-handler/assets/texture-base.ts
@@ -24,7 +24,8 @@ export function makeDefaultTextureBaseAssetUserData(): TextureBaseAssetUserData 
 export function createTextureBaseUserDataConfig(): Record<string, IUerDataConfigItem> {
     return {
         wrapModeS: {
-            label: 'Wrap Mode S',
+            label: 'i18n:ENGINE.assets.texture.wrapModeS',
+            description: 'i18n:ENGINE.assets.texture.wrapModeSTip',
             default: defaultWrapModeS,
             render: {
                 ui: 'ui-select',
@@ -32,7 +33,8 @@ export function createTextureBaseUserDataConfig(): Record<string, IUerDataConfig
             },
         },
         wrapModeT: {
-            label: 'Wrap Mode T',
+            label: 'i18n:ENGINE.assets.texture.wrapModeT',
+            description: 'i18n:ENGINE.assets.texture.wrapModeTTip',
             default: defaultWrapModeT,
             render: {
                 ui: 'ui-select',
@@ -40,7 +42,8 @@ export function createTextureBaseUserDataConfig(): Record<string, IUerDataConfig
             },
         },
         minfilter: {
-            label: 'Min Filter',
+            label: 'i18n:ENGINE.assets.texture.minfilter',
+            description: 'i18n:ENGINE.assets.texture.minfilterTip',
             default: defaultMinFilter,
             render: {
                 ui: 'ui-select',
@@ -48,7 +51,8 @@ export function createTextureBaseUserDataConfig(): Record<string, IUerDataConfig
             },
         },
         magfilter: {
-            label: 'Mag Filter',
+            label: 'i18n:ENGINE.assets.texture.magfilter',
+            description: 'i18n:ENGINE.assets.texture.magfilterTip',
             default: defaultMagFilter,
             render: {
                 ui: 'ui-select',
@@ -56,7 +60,8 @@ export function createTextureBaseUserDataConfig(): Record<string, IUerDataConfig
             },
         },
         mipfilter: {
-            label: 'Mip Filter',
+            label: 'i18n:ENGINE.assets.texture.mipfilter',
+            description: 'i18n:ENGINE.assets.texture.mipfilterTip',
             default: defaultMipFilter,
             render: {
                 ui: 'ui-select',
@@ -64,7 +69,8 @@ export function createTextureBaseUserDataConfig(): Record<string, IUerDataConfig
             },
         },
         anisotropy: {
-            label: 'Anisotropy',
+            label: 'i18n:ENGINE.assets.texture.anisotropy',
+            description: 'i18n:ENGINE.assets.texture.anisotropyTip',
             default: 0,
             render: {
                 ui: 'ui-number-input',
@@ -120,17 +126,17 @@ export function makeDefaultSpriteFrameBaseAssetUserData(): SpriteFrameBaseAssetU
 
 function createWrapModeOptions() {
     return [
-        { label: 'Repeat', value: 'repeat' },
-        { label: 'Clamp To Edge', value: 'clamp-to-edge' },
-        { label: 'Mirrored Repeat', value: 'mirrored-repeat' },
+        { label: 'i18n:importer.property_schema.texture.wrap_repeat', value: 'repeat' },
+        { label: 'i18n:importer.property_schema.texture.wrap_clamp_to_edge', value: 'clamp-to-edge' },
+        { label: 'i18n:importer.property_schema.texture.wrap_mirrored_repeat', value: 'mirrored-repeat' },
     ];
 }
 
 function createFilterOptions() {
     return [
-        { label: 'None', value: 'none' },
-        { label: 'Nearest', value: 'nearest' },
-        { label: 'Linear', value: 'linear' },
+        { label: 'i18n:importer.property_schema.texture.filter_none', value: 'none' },
+        { label: 'i18n:importer.property_schema.texture.filter_nearest', value: 'nearest' },
+        { label: 'i18n:importer.property_schema.texture.filter_linear', value: 'linear' },
     ];
 }
 

--- a/src/core/assets/asset-handler/assets/texture.ts
+++ b/src/core/assets/asset-handler/assets/texture.ts
@@ -19,7 +19,7 @@ export const TextureHandler: AssetHandler = {
     propertySchemaConfig: {
         ...createTextureBaseUserDataConfig(),
         imageUuidOrDatabaseUri: {
-            label: 'Image',
+            label: 'i18n:ENGINE.assets.image.label',
             default: '',
             render: {
                 ui: 'ui-asset',
@@ -29,7 +29,7 @@ export const TextureHandler: AssetHandler = {
             },
         },
         isUuid: {
-            label: 'Use UUID',
+            label: 'i18n:importer.property_schema.texture.use_uuid',
             default: true,
             render: {
                 ui: 'ui-checkbox',

--- a/src/core/assets/property-schema.ts
+++ b/src/core/assets/property-schema.ts
@@ -8,9 +8,15 @@ import {
 
 type LegacyConfigItem = IUerDataConfigItem & {
     assetType?: string;
+    labelI18nKey?: string;
+    descriptionI18nKey?: string;
     readOnly?: boolean;
     readonly?: boolean;
     order?: number;
+};
+
+type LegacyOption = AssetPropertySchemaOption & {
+    labelI18nKey?: string;
 };
 
 type LegacyRenderAttributes = Record<string, string | boolean | number>;
@@ -63,15 +69,22 @@ export function convertUserDataConfigItemToPropertySchema(
 ): AssetPropertySchema {
     const legacyItem = item as LegacyConfigItem;
     const attributes = item.render?.attributes;
+    const label = resolveDisplayText(item.label, legacyItem.labelI18nKey, createTitleFromKey(key));
     const schema: AssetPropertySchema = {
-        label: normalizeDisplayText(item.label, createTitleFromKey(key)),
+        label: label.text,
         type: inferSchemaType(item),
         raw: item,
     };
+    if (label.i18nKey) {
+        schema.labelI18nKey = label.i18nKey;
+    }
 
-    const description = translateMetadataText(item.description);
-    if (description) {
-        schema.description = description;
+    const description = resolveOptionalDisplayText(item.description, legacyItem.descriptionI18nKey);
+    if (description.text) {
+        schema.description = description.text;
+    }
+    if (description.i18nKey) {
+        schema.descriptionI18nKey = description.i18nKey;
     }
 
     if (item.default !== undefined) {
@@ -154,10 +167,58 @@ function inferSchemaType(item: IUerDataConfigItem): AssetPropertySchema['type'] 
 }
 
 function convertOptions(item: IUerDataConfigItem, defaultValue: unknown): AssetPropertySchemaOption[] {
-    return (item.render?.items ?? []).map((option) => ({
-        label: normalizeDisplayText(option.label, String(option.value)),
-        value: normalizeOptionValue(option.value, defaultValue),
-    }));
+    return (item.render?.items ?? []).map((option) => {
+        const legacyOption = option as LegacyOption;
+        const label = resolveDisplayText(option.label, legacyOption.labelI18nKey, String(option.value));
+        const schemaOption: AssetPropertySchemaOption = {
+            label: label.text,
+            value: normalizeOptionValue(option.value, defaultValue),
+        };
+        if (label.i18nKey) {
+            schemaOption.labelI18nKey = label.i18nKey;
+        }
+        return schemaOption;
+    });
+}
+
+function resolveDisplayText(value: string | undefined, i18nKey: string | undefined, fallback: string): {
+    text: string;
+    i18nKey?: string;
+} {
+    const rawI18nKey = getI18nKey(i18nKey) ?? getI18nKey(value);
+    if (rawI18nKey) {
+        return {
+            text: translateMetadataText(rawI18nKey, getPlainDisplayText(value) ?? fallback) ?? fallback,
+            i18nKey: rawI18nKey,
+        };
+    }
+    return {
+        text: normalizeDisplayText(value, fallback),
+    };
+}
+
+function resolveOptionalDisplayText(value: string | undefined, i18nKey: string | undefined): {
+    text?: string;
+    i18nKey?: string;
+} {
+    const rawI18nKey = getI18nKey(i18nKey) ?? getI18nKey(value);
+    if (rawI18nKey) {
+        return {
+            text: translateMetadataText(rawI18nKey, getPlainDisplayText(value)),
+            i18nKey: rawI18nKey,
+        };
+    }
+    return {
+        text: translateMetadataText(value),
+    };
+}
+
+function getPlainDisplayText(value: string | undefined): string | undefined {
+    return value && !getI18nKey(value) ? value : undefined;
+}
+
+function getI18nKey(value: string | undefined): string | undefined {
+    return value?.startsWith('i18n:') ? value : undefined;
 }
 
 function normalizeOptionValue(value: string | number | boolean, defaultValue: unknown): string | number | boolean {

--- a/src/core/assets/property-schema.ts
+++ b/src/core/assets/property-schema.ts
@@ -8,15 +8,9 @@ import {
 
 type LegacyConfigItem = IUerDataConfigItem & {
     assetType?: string;
-    labelI18nKey?: string;
-    descriptionI18nKey?: string;
     readOnly?: boolean;
     readonly?: boolean;
     order?: number;
-};
-
-type LegacyOption = AssetPropertySchemaOption & {
-    labelI18nKey?: string;
 };
 
 type LegacyRenderAttributes = Record<string, string | boolean | number>;
@@ -69,22 +63,14 @@ export function convertUserDataConfigItemToPropertySchema(
 ): AssetPropertySchema {
     const legacyItem = item as LegacyConfigItem;
     const attributes = item.render?.attributes;
-    const label = resolveDisplayText(item.label, legacyItem.labelI18nKey, createTitleFromKey(key));
     const schema: AssetPropertySchema = {
-        label: label.text,
+        label: normalizeDisplayText(item.label, createTitleFromKey(key)),
         type: inferSchemaType(item),
-        raw: item,
     };
-    if (label.i18nKey) {
-        schema.labelI18nKey = label.i18nKey;
-    }
 
-    const description = resolveOptionalDisplayText(item.description, legacyItem.descriptionI18nKey);
-    if (description.text) {
-        schema.description = description.text;
-    }
-    if (description.i18nKey) {
-        schema.descriptionI18nKey = description.i18nKey;
+    const description = translateMetadataText(item.description);
+    if (description) {
+        schema.description = description;
     }
 
     if (item.default !== undefined) {
@@ -167,58 +153,10 @@ function inferSchemaType(item: IUerDataConfigItem): AssetPropertySchema['type'] 
 }
 
 function convertOptions(item: IUerDataConfigItem, defaultValue: unknown): AssetPropertySchemaOption[] {
-    return (item.render?.items ?? []).map((option) => {
-        const legacyOption = option as LegacyOption;
-        const label = resolveDisplayText(option.label, legacyOption.labelI18nKey, String(option.value));
-        const schemaOption: AssetPropertySchemaOption = {
-            label: label.text,
-            value: normalizeOptionValue(option.value, defaultValue),
-        };
-        if (label.i18nKey) {
-            schemaOption.labelI18nKey = label.i18nKey;
-        }
-        return schemaOption;
-    });
-}
-
-function resolveDisplayText(value: string | undefined, i18nKey: string | undefined, fallback: string): {
-    text: string;
-    i18nKey?: string;
-} {
-    const rawI18nKey = getI18nKey(i18nKey) ?? getI18nKey(value);
-    if (rawI18nKey) {
-        return {
-            text: translateMetadataText(rawI18nKey, getPlainDisplayText(value) ?? fallback) ?? fallback,
-            i18nKey: rawI18nKey,
-        };
-    }
-    return {
-        text: normalizeDisplayText(value, fallback),
-    };
-}
-
-function resolveOptionalDisplayText(value: string | undefined, i18nKey: string | undefined): {
-    text?: string;
-    i18nKey?: string;
-} {
-    const rawI18nKey = getI18nKey(i18nKey) ?? getI18nKey(value);
-    if (rawI18nKey) {
-        return {
-            text: translateMetadataText(rawI18nKey, getPlainDisplayText(value)),
-            i18nKey: rawI18nKey,
-        };
-    }
-    return {
-        text: translateMetadataText(value),
-    };
-}
-
-function getPlainDisplayText(value: string | undefined): string | undefined {
-    return value && !getI18nKey(value) ? value : undefined;
-}
-
-function getI18nKey(value: string | undefined): string | undefined {
-    return value?.startsWith('i18n:') ? value : undefined;
+    return (item.render?.items ?? []).map((option) => ({
+        label: normalizeDisplayText(option.label, String(option.value)),
+        value: normalizeOptionValue(option.value, defaultValue),
+    }));
 }
 
 function normalizeOptionValue(value: string | number | boolean, defaultValue: unknown): string | number | boolean {

--- a/src/core/assets/test/property-schema.test.ts
+++ b/src/core/assets/test/property-schema.test.ts
@@ -3,8 +3,15 @@ import {
     convertUserDataConfigToPropertySchema,
     mergeUserDataConfigForPropertySchema,
 } from '../property-schema';
+import i18n from '../../base/i18n';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 describe('asset property schema conversion', () => {
+    afterEach(async () => {
+        await i18n.setLanguage('en');
+    });
+
     it('maps legacy userDataConfig controls to stable property schema fields', () => {
         const schema = convertUserDataConfigToPropertySchema({
             type: {
@@ -88,6 +95,145 @@ describe('asset property schema conversion', () => {
             { label: 'Rect', value: 0 },
             { label: 'Polygon', value: 1 },
         ]);
+    });
+
+    it('localizes display fields while preserving raw i18n keys for render clients', async () => {
+        i18n.registerLanguagePatch('en', 'assets.propertySchemaTest', {
+            field: 'Localized Field',
+            help: 'Localized Help',
+            option: 'Localized Option',
+        });
+        i18n.registerLanguagePatch('zh', 'assets.propertySchemaTest', {
+            field: 'ZH Field',
+            help: 'ZH Help',
+            option: 'ZH Option',
+        });
+
+        await i18n.setLanguage('en');
+        const enSchema = convertUserDataConfigItemToPropertySchema('localized', {
+            label: 'i18n:assets.propertySchemaTest.field',
+            description: 'i18n:assets.propertySchemaTest.help',
+            default: 'enabled',
+            render: {
+                ui: 'ui-select',
+                items: [
+                    { label: 'i18n:assets.propertySchemaTest.option', value: 'enabled' },
+                ],
+            },
+        });
+
+        expect(enSchema).toMatchObject({
+            label: 'Localized Field',
+            labelI18nKey: 'i18n:assets.propertySchemaTest.field',
+            description: 'Localized Help',
+            descriptionI18nKey: 'i18n:assets.propertySchemaTest.help',
+            options: [
+                {
+                    label: 'Localized Option',
+                    labelI18nKey: 'i18n:assets.propertySchemaTest.option',
+                    value: 'enabled',
+                },
+            ],
+        });
+
+        await i18n.setLanguage('zh');
+        const zhSchema = convertUserDataConfigItemToPropertySchema('localized', {
+            label: 'i18n:assets.propertySchemaTest.field',
+            description: 'i18n:assets.propertySchemaTest.help',
+            default: 'enabled',
+            render: {
+                ui: 'ui-select',
+                items: [
+                    { label: 'i18n:assets.propertySchemaTest.option', value: 'enabled' },
+                ],
+            },
+        });
+
+        expect(zhSchema.label).toBe('ZH Field');
+        expect(zhSchema.description).toBe('ZH Help');
+        expect(zhSchema.options?.[0].label).toBe('ZH Option');
+
+        const materializedSchema = convertUserDataConfigItemToPropertySchema('localized', {
+            label: 'Stored Field',
+            labelI18nKey: 'i18n:assets.propertySchemaTest.field',
+            description: 'Stored Help',
+            descriptionI18nKey: 'i18n:assets.propertySchemaTest.help',
+            default: 'enabled',
+            render: {
+                ui: 'ui-select',
+                items: [
+                    {
+                        label: 'Stored Option',
+                        labelI18nKey: 'i18n:assets.propertySchemaTest.option',
+                        value: 'enabled',
+                    },
+                ],
+            },
+        });
+
+        expect(materializedSchema).toMatchObject({
+            label: 'ZH Field',
+            labelI18nKey: 'i18n:assets.propertySchemaTest.field',
+            description: 'ZH Help',
+            descriptionI18nKey: 'i18n:assets.propertySchemaTest.help',
+            options: [
+                {
+                    label: 'ZH Option',
+                    labelI18nKey: 'i18n:assets.propertySchemaTest.option',
+                    value: 'enabled',
+                },
+            ],
+        });
+    });
+
+    it('uses static importer i18n resources loaded by the shared i18n instance', async () => {
+        await i18n.setLanguage('zh');
+
+        const schema = convertUserDataConfigItemToPropertySchema('maxWidth', {
+            label: 'i18n:importer.property_schema.auto_atlas.max_width',
+            default: 1024,
+            render: { ui: 'ui-number-input' },
+        });
+
+        expect(schema.label).toBe('最大宽度');
+        expect(schema.labelI18nKey).toBe('i18n:importer.property_schema.auto_atlas.max_width');
+    });
+
+    it('keeps built-in property schema i18n keys resolvable', () => {
+        const engineAssetsI18n = require('../../../../packages/engine/editor/i18n/en/assets.js');
+        const importerI18n = {
+            en: JSON.parse(readFileSync(join(__dirname, '../../../../static/i18n/en/importer.json'), 'utf8')),
+            zh: JSON.parse(readFileSync(join(__dirname, '../../../../static/i18n/zh/importer.json'), 'utf8')),
+        };
+        const files = [
+            join(__dirname, '../asset-handler/assets/auto-atlas.ts'),
+            join(__dirname, '../asset-handler/assets/gltf.ts'),
+            join(__dirname, '../asset-handler/assets/fbx.ts'),
+            join(__dirname, '../asset-handler/assets/image/index.ts'),
+            join(__dirname, '../asset-handler/assets/sprite-frame.ts'),
+            join(__dirname, '../asset-handler/assets/texture-base.ts'),
+            join(__dirname, '../asset-handler/assets/texture.ts'),
+        ];
+        const missingKeys: string[] = [];
+
+        for (const file of files) {
+            const source = extractPropertySchemaSource(readFileSync(file, 'utf8'));
+            for (const match of source.matchAll(/i18n:ENGINE\.([A-Za-z0-9_.]+)/g)) {
+                if (readNestedValue(engineAssetsI18n, match[1]) === undefined) {
+                    missingKeys.push(match[0]);
+                }
+            }
+            for (const match of source.matchAll(/i18n:importer\.([A-Za-z0-9_.]+)/g)) {
+                if (readNestedValue(importerI18n.en, match[1]) === undefined) {
+                    missingKeys.push(`${match[0]}#en`);
+                }
+                if (readNestedValue(importerI18n.zh, match[1]) === undefined) {
+                    missingKeys.push(`${match[0]}#zh`);
+                }
+            }
+        }
+
+        expect(missingKeys).toEqual([]);
     });
 
     it('keeps nested object itemConfigs as nested properties', () => {
@@ -188,3 +334,21 @@ describe('asset property schema conversion', () => {
         expect(runtimeConfig).not.toHaveProperty('schemaOnly');
     });
 });
+
+function readNestedValue(value: unknown, key: string): unknown {
+    return key.split('.').reduce<unknown>((result, segment) => {
+        if (!result || typeof result !== 'object') {
+            return undefined;
+        }
+        return (result as Record<string, unknown>)[segment];
+    }, value);
+}
+
+function extractPropertySchemaSource(source: string): string {
+    const start = [
+        source.indexOf('propertySchemaConfig'),
+        source.indexOf('userDataConfig'),
+        source.indexOf('createTextureBaseUserDataConfig'),
+    ].filter((index) => index >= 0).sort((a, b) => a - b)[0];
+    return start === undefined ? source : source.slice(start);
+}

--- a/src/core/assets/test/property-schema.test.ts
+++ b/src/core/assets/test/property-schema.test.ts
@@ -75,6 +75,10 @@ describe('asset property schema conversion', () => {
             type: 'asset',
             assetType: 'cc.ImageAsset',
         });
+        expect(schema.type).not.toHaveProperty('raw');
+        expect(schema.flipVertical).not.toHaveProperty('raw');
+        expect(schema.quality).not.toHaveProperty('raw');
+        expect(schema.image).not.toHaveProperty('raw');
     });
 
     it('normalizes numeric enum option values when the default is numeric', () => {
@@ -97,7 +101,7 @@ describe('asset property schema conversion', () => {
         ]);
     });
 
-    it('localizes display fields while preserving raw i18n keys for render clients', async () => {
+    it('localizes display fields before returning the property schema', async () => {
         i18n.registerLanguagePatch('en', 'assets.propertySchemaTest', {
             field: 'Localized Field',
             help: 'Localized Help',
@@ -124,17 +128,17 @@ describe('asset property schema conversion', () => {
 
         expect(enSchema).toMatchObject({
             label: 'Localized Field',
-            labelI18nKey: 'i18n:assets.propertySchemaTest.field',
             description: 'Localized Help',
-            descriptionI18nKey: 'i18n:assets.propertySchemaTest.help',
             options: [
                 {
                     label: 'Localized Option',
-                    labelI18nKey: 'i18n:assets.propertySchemaTest.option',
                     value: 'enabled',
                 },
             ],
         });
+        expect(enSchema).not.toHaveProperty('labelI18nKey');
+        expect(enSchema).not.toHaveProperty('descriptionI18nKey');
+        expect(enSchema.options?.[0]).not.toHaveProperty('labelI18nKey');
 
         await i18n.setLanguage('zh');
         const zhSchema = convertUserDataConfigItemToPropertySchema('localized', {
@@ -152,38 +156,6 @@ describe('asset property schema conversion', () => {
         expect(zhSchema.label).toBe('ZH Field');
         expect(zhSchema.description).toBe('ZH Help');
         expect(zhSchema.options?.[0].label).toBe('ZH Option');
-
-        const materializedSchema = convertUserDataConfigItemToPropertySchema('localized', {
-            label: 'Stored Field',
-            labelI18nKey: 'i18n:assets.propertySchemaTest.field',
-            description: 'Stored Help',
-            descriptionI18nKey: 'i18n:assets.propertySchemaTest.help',
-            default: 'enabled',
-            render: {
-                ui: 'ui-select',
-                items: [
-                    {
-                        label: 'Stored Option',
-                        labelI18nKey: 'i18n:assets.propertySchemaTest.option',
-                        value: 'enabled',
-                    },
-                ],
-            },
-        });
-
-        expect(materializedSchema).toMatchObject({
-            label: 'ZH Field',
-            labelI18nKey: 'i18n:assets.propertySchemaTest.field',
-            description: 'ZH Help',
-            descriptionI18nKey: 'i18n:assets.propertySchemaTest.help',
-            options: [
-                {
-                    label: 'ZH Option',
-                    labelI18nKey: 'i18n:assets.propertySchemaTest.option',
-                    value: 'enabled',
-                },
-            ],
-        });
     });
 
     it('uses static importer i18n resources loaded by the shared i18n instance', async () => {
@@ -196,7 +168,7 @@ describe('asset property schema conversion', () => {
         });
 
         expect(schema.label).toBe('最大宽度');
-        expect(schema.labelI18nKey).toBe('i18n:importer.property_schema.auto_atlas.max_width');
+        expect(schema).not.toHaveProperty('labelI18nKey');
     });
 
     it('keeps built-in property schema i18n keys resolvable', () => {
@@ -271,6 +243,8 @@ describe('asset property schema conversion', () => {
                 },
             },
         });
+        expect(schema).not.toHaveProperty('raw');
+        expect(schema.properties?.anisotropy).not.toHaveProperty('raw');
     });
 
     it('treats array-form itemConfigs as object properties when the parent is not an array', () => {
@@ -297,6 +271,35 @@ describe('asset property schema conversion', () => {
                 },
             },
         });
+        expect(schema).not.toHaveProperty('raw');
+        expect(schema.properties?.x).not.toHaveProperty('raw');
+    });
+
+    it('does not expose raw legacy config through array item schemas', () => {
+        const schema = convertUserDataConfigItemToPropertySchema('entries', {
+            label: 'Entries',
+            type: 'array',
+            itemConfigs: [
+                {
+                    key: 'name',
+                    label: 'Name',
+                    default: '',
+                    render: { ui: 'ui-input' },
+                },
+            ],
+        });
+
+        expect(schema).toMatchObject({
+            label: 'Entries',
+            type: 'array',
+            items: {
+                label: 'Name',
+                type: 'string',
+                default: '',
+            },
+        });
+        expect(schema).not.toHaveProperty('raw');
+        expect(schema.items).not.toHaveProperty('raw');
     });
 
     it('merges schema-only config for property schema without mutating runtime userDataConfig', () => {

--- a/static/i18n/en/importer.json
+++ b/static/i18n/en/importer.json
@@ -46,5 +46,69 @@
         "invalid_class_name": "File class name is invalid, will be automatically renamed after creation",
         "find_class_name_from_file_name_failed": "Cannot get valid class name from file name {fileBasename}, automatically renamed to {className}",
         "transform_failure": "Script {path} transformation failed: ${reason}"
+    },
+    "property_schema": {
+        "auto_atlas": {
+            "max_width": "Max Width",
+            "max_height": "Max Height",
+            "padding": "Padding",
+            "allow_rotation": "Allow Rotation",
+            "force_squared": "Force Squared",
+            "power_of_two": "Power Of Two",
+            "algorithm": "Algorithm",
+            "max_rects": "MaxRects",
+            "format": "Format",
+            "png": "PNG",
+            "jpg": "JPG",
+            "quality": "Quality",
+            "contour_bleed": "Contour Bleed",
+            "padding_bleed": "Padding Bleed",
+            "filter_unused": "Filter Unused",
+            "remove_texture_in_bundle": "Remove Texture In Bundle",
+            "remove_image_in_bundle": "Remove Image In Bundle",
+            "remove_sprite_atlas_in_bundle": "Remove SpriteAtlas In Bundle",
+            "texture_setting": "Texture Setting"
+        },
+        "texture": {
+            "use_uuid": "Use UUID",
+            "wrap_repeat": "Repeat",
+            "wrap_clamp_to_edge": "Clamp To Edge",
+            "wrap_mirrored_repeat": "Mirrored Repeat",
+            "filter_none": "None",
+            "filter_nearest": "Nearest",
+            "filter_linear": "Linear"
+        },
+        "image": {
+            "type_raw": "raw",
+            "type_texture": "texture",
+            "type_normal_map": "normal map",
+            "type_sprite_frame": "sprite-frame",
+            "type_texture_cube": "texture cube"
+        },
+        "sprite_frame": {
+            "trim_type_auto": "auto",
+            "trim_type_custom": "custom",
+            "trim_type_none": "none",
+            "mesh_type_rect": "Rect",
+            "mesh_type_polygon": "Polygon"
+        },
+        "gltf": {
+            "mesh_optimizer": "Mesh Optimizer",
+            "mesh_optimizer_enable": "Enable",
+            "mesh_optimizer_algorithm": "Algorithm",
+            "mesh_optimizer_simplify": "Simplify",
+            "mesh_optimizer_gltfpack": "gltfpack",
+            "simplify_options": "Simplify Options",
+            "enable_smart_link": "Enable Smart Link",
+            "agressiveness": "Aggressiveness",
+            "max_iteration_count": "Max Iteration Count"
+        },
+        "fbx": {
+            "unit_conversion": "Unit Conversion",
+            "unit_conversion_geometry_level": "Geometry Level",
+            "unit_conversion_hierarchy_level": "Hierarchy Level",
+            "unit_conversion_disabled": "Disabled",
+            "match_mesh_names": "Match Mesh Names"
+        }
     }
 }

--- a/static/i18n/zh/importer.json
+++ b/static/i18n/zh/importer.json
@@ -47,6 +47,70 @@
         "find_class_name_from_file_name_failed": "无法从文件名 {fileBasename} 中获取到有效的类名，已自动更名为 {className}",
         "transform_failure": "脚本 {path} 转换失败：${reason}"
     },
+    "property_schema": {
+        "auto_atlas": {
+            "max_width": "最大宽度",
+            "max_height": "最大高度",
+            "padding": "间距",
+            "allow_rotation": "允许旋转",
+            "force_squared": "强制正方形",
+            "power_of_two": "2 的幂",
+            "algorithm": "算法",
+            "max_rects": "MaxRects",
+            "format": "格式",
+            "png": "PNG",
+            "jpg": "JPG",
+            "quality": "质量",
+            "contour_bleed": "轮廓扩边",
+            "padding_bleed": "间距扩边",
+            "filter_unused": "过滤未使用资源",
+            "remove_texture_in_bundle": "从 Bundle 移除 Texture",
+            "remove_image_in_bundle": "从 Bundle 移除 Image",
+            "remove_sprite_atlas_in_bundle": "从 Bundle 移除 SpriteAtlas",
+            "texture_setting": "纹理设置"
+        },
+        "texture": {
+            "use_uuid": "使用 UUID",
+            "wrap_repeat": "重复",
+            "wrap_clamp_to_edge": "边缘钳制",
+            "wrap_mirrored_repeat": "镜像重复",
+            "filter_none": "无",
+            "filter_nearest": "最近点",
+            "filter_linear": "线性"
+        },
+        "image": {
+            "type_raw": "原始资源",
+            "type_texture": "纹理",
+            "type_normal_map": "法线贴图",
+            "type_sprite_frame": "精灵帧",
+            "type_texture_cube": "立方体纹理"
+        },
+        "sprite_frame": {
+            "trim_type_auto": "自动",
+            "trim_type_custom": "自定义",
+            "trim_type_none": "无",
+            "mesh_type_rect": "矩形",
+            "mesh_type_polygon": "多边形"
+        },
+        "gltf": {
+            "mesh_optimizer": "网格优化器",
+            "mesh_optimizer_enable": "启用",
+            "mesh_optimizer_algorithm": "算法",
+            "mesh_optimizer_simplify": "简化",
+            "mesh_optimizer_gltfpack": "gltfpack",
+            "simplify_options": "简化选项",
+            "enable_smart_link": "启用智能连接",
+            "agressiveness": "优化强度",
+            "max_iteration_count": "最大迭代次数"
+        },
+        "fbx": {
+            "unit_conversion": "单位转换",
+            "unit_conversion_geometry_level": "几何级别",
+            "unit_conversion_hierarchy_level": "层级级别",
+            "unit_conversion_disabled": "禁用",
+            "match_mesh_names": "匹配网格名称"
+        }
+    },
     "texture": {
         "anisotropy": "Anisotropy",
         "anisotropy_tip": "应用各向异性过滤算法的最大阈值",


### PR DESCRIPTION
已处理 `assets-query-property-schema` 的 i18n 支持，并收敛返回结构。

### 变更内容
- `queryPropertySchema` 输出会按当前语言物化 `label / description / options.label`。
- 不再返回 `labelI18nKey / descriptionI18nKey / options.labelI18nKey`，渲染端直接使用接口返回的已翻译文案。
- 不再暴露 `raw` 调试字段，避免 Pink 或其他调用方依赖未标准化的 legacy `userDataConfig`。
- 为 `auto-atlas / image / sprite-frame / texture / gltf / fbx` 的 property schema 接入现有 `ENGINE.*` 或 CLI `importer.*` 多语言资源。
- 增加单测，覆盖语言切换、返回字段不暴露 i18n key / raw、内置 schema i18n key 可解析。