### PR TITLE
[break] feat(builder): expose build cache cleanup API

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -1192,6 +1192,7 @@ export declare interface BuildBundleConfiguration {
     custom: CustomBundleConfigMap;
 }
 export declare function buildBundleOnly(bundleOptions: IBundleBuildOptions): Promise<IBuildResultData>;
+export declare type BuildCacheScope = 'project' | 'global' | 'all';
 export declare interface BuildCheckResult {
     valid: boolean;
     level?: 'error' | 'warn';
@@ -1546,6 +1547,11 @@ export declare interface ChokidarOptions {
     	persistent?: boolean;
     	useFsEvents?: boolean;
     	usePolling?: boolean;
+}
+export declare function clearCache(scope: BuildCacheScope): Promise<ClearCacheResult>;
+export declare interface ClearCacheResult {
+    scope: BuildCacheScope;
+    cleared: string[];
 }
 export declare class CocosParams<T> {
     platformParams: T;

--- a/src/core/builder/cache.ts
+++ b/src/core/builder/cache.ts
@@ -1,0 +1,148 @@
+import { emptyDir, ensureDir, lstat, pathExists, readdir, remove } from 'fs-extra';
+import { basename, extname, join, parse, resolve } from 'path';
+import builderConfig from './share/builder-config';
+import { GlobalPaths } from '../../global';
+
+export type BuildCacheScope = 'project' | 'global' | 'all';
+
+export interface ClearCacheResult {
+    scope: BuildCacheScope;
+    cleared: string[];
+}
+
+const BUILD_ASSET_CACHE_VERSION = '1.0.1';
+
+function getProjectBuilderCacheRoot() {
+    const projectTempDir = builderConfig.projectTempDir;
+    return basename(projectTempDir) === 'builder' ? projectTempDir : join(projectTempDir, 'builder');
+}
+
+function getProjectAssetCacheRoot() {
+    return join(builderConfig.projectTempDir, 'asset-db');
+}
+
+function getGlobalCacheRoots() {
+    const engineBin = join(GlobalPaths.enginePath, 'bin');
+    return [
+        join(engineBin, 'temp'),
+        join(engineBin, '.cache', 'editor-cache'),
+        join(engineBin, '.cache', 'dev-cli'),
+    ];
+}
+
+function uniquePaths(paths: string[]) {
+    return Array.from(new Set(paths.map((path) => resolve(path))));
+}
+
+function assertSafeCachePath(path: string) {
+    const resolved = resolve(path);
+    const root = parse(resolved).root;
+    if (!resolved || resolved === root) {
+        throw new Error(`Unsafe cache path: ${path}`);
+    }
+    return resolved;
+}
+
+function containsPath(parent: string, child: string) {
+    const resolvedParent = assertSafeCachePath(parent);
+    const resolvedChild = resolve(child);
+    return resolvedParent === resolvedChild || resolvedChild.startsWith(resolvedParent + '\\') || resolvedChild.startsWith(resolvedParent + '/');
+}
+
+async function clearProjectAssetBuildCache(assetCacheRoot: string, cleared: string[]) {
+    const resolvedRoot = assertSafeCachePath(assetCacheRoot);
+    if (!await pathExists(resolvedRoot)) {
+        return;
+    }
+
+    async function walk(dir: string) {
+        const entries = await readdir(dir);
+        await Promise.all(entries.map(async (entry) => {
+            const current = join(dir, entry);
+            const stats = await lstat(current);
+            if (!stats.isDirectory()) {
+                return;
+            }
+            if (entry === `build${BUILD_ASSET_CACHE_VERSION}`) {
+                await emptyDir(current);
+                cleared.push(current);
+                return;
+            }
+            await walk(current);
+        }));
+    }
+
+    await walk(resolvedRoot);
+}
+
+async function clearProjectBuilderCache(builderCacheRoot: string, skipRoots: string[], cleared: string[]) {
+    const resolvedRoot = assertSafeCachePath(builderCacheRoot);
+    if (!await pathExists(resolvedRoot)) {
+        await ensureDir(resolvedRoot);
+        return;
+    }
+
+    const resolvedSkipRoots = uniquePaths(skipRoots);
+
+    async function clearDir(dir: string) {
+        const entries = await readdir(dir);
+        await Promise.all(entries.map(async (entry) => {
+            const current = join(dir, entry);
+            const resolvedCurrent = resolve(current);
+            if (resolvedSkipRoots.some((skipRoot) => containsPath(skipRoot, resolvedCurrent))) {
+                return;
+            }
+
+            const stats = await lstat(current);
+            if (stats.isDirectory()) {
+                await clearDir(current);
+                return;
+            }
+            if (extname(current) === '.log') {
+                return;
+            }
+            await remove(current);
+            cleared.push(current);
+        }));
+    }
+
+    await clearDir(resolvedRoot);
+}
+
+async function clearProjectCache(): Promise<string[]> {
+    const cleared: string[] = [];
+    const assetCacheRoot = getProjectAssetCacheRoot();
+    await clearProjectAssetBuildCache(assetCacheRoot, cleared);
+    await clearProjectBuilderCache(getProjectBuilderCacheRoot(), [assetCacheRoot], cleared);
+    return cleared;
+}
+
+async function clearGlobalCache(): Promise<string[]> {
+    const cleared: string[] = [];
+    for (const cacheRoot of uniquePaths(getGlobalCacheRoots())) {
+        const resolvedRoot = assertSafeCachePath(cacheRoot);
+        await emptyDir(resolvedRoot);
+        cleared.push(resolvedRoot);
+    }
+    return cleared;
+}
+
+export async function clearCache(scope: BuildCacheScope): Promise<ClearCacheResult> {
+    if (scope !== 'project' && scope !== 'global' && scope !== 'all') {
+        throw new Error(`Invalid builder cache scope: ${scope}`);
+    }
+
+    const cleared = scope === 'project'
+        ? await clearProjectCache()
+        : scope === 'global'
+            ? await clearGlobalCache()
+            : [
+                ...await clearProjectCache(),
+                ...await clearGlobalCache(),
+            ];
+
+    return {
+        scope,
+        cleared,
+    };
+}

--- a/src/core/builder/cache.ts
+++ b/src/core/builder/cache.ts
@@ -21,6 +21,10 @@ function getProjectAssetCacheRoot() {
     return join(builderConfig.projectTempDir, 'asset-db');
 }
 
+function getLegacyProjectAssetCacheRoot() {
+    return join(getProjectBuilderCacheRoot(), 'asset-db');
+}
+
 function getGlobalCacheRoots() {
     const engineBin = join(GlobalPaths.enginePath, 'bin');
     return [
@@ -112,8 +116,12 @@ async function clearProjectBuilderCache(builderCacheRoot: string, skipRoots: str
 async function clearProjectCache(): Promise<string[]> {
     const cleared: string[] = [];
     const assetCacheRoot = getProjectAssetCacheRoot();
+    const legacyAssetCacheRoot = getLegacyProjectAssetCacheRoot();
     await clearProjectAssetBuildCache(assetCacheRoot, cleared);
-    await clearProjectBuilderCache(getProjectBuilderCacheRoot(), [assetCacheRoot], cleared);
+    if (resolve(legacyAssetCacheRoot) !== resolve(assetCacheRoot)) {
+        await clearProjectAssetBuildCache(legacyAssetCacheRoot, cleared);
+    }
+    await clearProjectBuilderCache(getProjectBuilderCacheRoot(), [assetCacheRoot, legacyAssetCacheRoot], cleared);
     return cleared;
 }
 

--- a/src/core/builder/index.ts
+++ b/src/core/builder/index.ts
@@ -14,6 +14,8 @@ import { middlewareService } from '../../server/middleware/core';
 import BuildMiddleware from './build.middleware';
 import { BuildGlobalInfo } from './share/global';
 import { fillIncludeModulesFromProjectConfig } from './share/common-options-validator';
+export { clearCache } from './cache';
+export type { BuildCacheScope, ClearCacheResult } from './cache';
 
 export async function init(platform?: string) {
     await builderConfig.init();

--- a/src/core/builder/manager/plugin.ts
+++ b/src/core/builder/manager/plugin.ts
@@ -1126,7 +1126,7 @@ export class PluginManager extends EventEmitter {
         if (platformConfig) {
             const createTemplateLabel = platformConfig.createTemplateLabel;
             if (!createTemplateLabel) {
-                console.debug(`no build template for ${nameOrPlatform}`);
+                console.error(`no build template for ${nameOrPlatform}`);
                 return;
             }
             nameOrPlatform = createTemplateLabel;
@@ -1134,7 +1134,7 @@ export class PluginManager extends EventEmitter {
 
         const templateConfig = this.buildTemplateConfigMap[nameOrPlatform];
         if (!templateConfig) {
-            console.debug(`no build template for ${nameOrPlatform}`);
+            console.error(`no build template for ${nameOrPlatform}`);
             return;
         }
 

--- a/src/core/builder/platforms/native-common/index.ts
+++ b/src/core/builder/platforms/native-common/index.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import { IDisplayOptions } from '../../@types';
 import { IBuildStageItem, IInternalBuildPluginConfig, IPlatformBuildPluginConfig } from '../../@types/protected';
 import Utils from '../../../base/utils';
+import { GlobalPaths } from '../../../../global';
 
 const customBuildStages: IBuildStageItem[] = [{
     name: 'make',
@@ -75,7 +76,7 @@ export const commonOptions: IInternalBuildPluginConfig & Pick<IPlatformBuildPlug
     },
     buildTemplateConfig: {
         templates: [{
-            path: join(__dirname, '../../../../../resources/3d/engine/templates/native/index.ejs'),
+            path: join(GlobalPaths.enginePath, 'templates/native/index.ejs'),
             destUrl: 'index.ejs',
         }],
         version: '1.0.0',

--- a/src/core/builder/platforms/web-desktop/config.ts
+++ b/src/core/builder/platforms/web-desktop/config.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { IPlatformBuildPluginConfig } from '../../@types/protected';
 import { GlobalPaths } from '../../../../global';
 const PLATFORM = 'web-desktop';
-const buildTemplateDir = join(GlobalPaths.staticDir, `build-templates/${PLATFORM}`);
+const buildTemplateDir = join(GlobalPaths.enginePath, `templates/${PLATFORM}`);
 
 const config: IPlatformBuildPluginConfig = {
     displayName: 'i18n:web-desktop.title',

--- a/src/core/builder/platforms/web-mobile/config.ts
+++ b/src/core/builder/platforms/web-mobile/config.ts
@@ -6,7 +6,7 @@ import { GlobalPaths } from '../../../../global';
 
 const PLATFORM = 'web-mobile';
 
-const buildTemplateDir = join(GlobalPaths.staticDir, `build-templates/${PLATFORM}`);
+const buildTemplateDir = join(GlobalPaths.enginePath, `templates/${PLATFORM}`);
 
 const config: IPlatformBuildPluginConfig = {
     displayName: 'i18n:web-mobile.title',

--- a/src/core/builder/share/builder-config.ts
+++ b/src/core/builder/share/builder-config.ts
@@ -481,7 +481,7 @@ class BuilderConfig {
 
         this._projectRoot = project.default.path;
         this._buildTemplateDir = join(this._projectRoot, 'build-templates');
-        this._projectTempDir = join(this._projectRoot, 'temp', 'builder',);
+        this._projectTempDir = join(this._projectRoot, 'temp');
         this.commonOptionConfigs.name.default = project.default.getInfo().name || 'gameName';
         this._init = true;
         try {

--- a/src/core/builder/test/clear-cache.spec.ts
+++ b/src/core/builder/test/clear-cache.spec.ts
@@ -29,7 +29,7 @@ describe('builder clearCache', () => {
     beforeEach(async () => {
         tempRoot = await mkdtemp(join(tmpdir(), 'cocos-cli-clear-cache-'));
         mockBuilderConfig.projectRoot = join(tempRoot, 'project');
-        mockBuilderConfig.projectTempDir = join(mockBuilderConfig.projectRoot, 'temp', 'builder');
+        mockBuilderConfig.projectTempDir = join(mockBuilderConfig.projectRoot, 'temp');
         mockGlobalPaths.enginePath = join(tempRoot, 'engine');
     });
 
@@ -40,8 +40,8 @@ describe('builder clearCache', () => {
     it('clears project builder cache while preserving logs and non-build asset-db files', async () => {
         const assetBuildCacheFile = join(mockBuilderConfig.projectTempDir, 'asset-db', 'assets', 'ab', 'uuid', 'build1.0.1', 'release.json');
         const assetOtherFile = join(mockBuilderConfig.projectTempDir, 'asset-db', 'assets', 'ab', 'uuid', 'thumbnail.png');
-        const builderCacheFile = join(mockBuilderConfig.projectTempDir, 'CompressTexture', 'compress-info.json');
-        const logFile = join(mockBuilderConfig.projectTempDir, 'log', 'build.log');
+        const builderCacheFile = join(mockBuilderConfig.projectTempDir, 'builder', 'CompressTexture', 'compress-info.json');
+        const logFile = join(mockBuilderConfig.projectTempDir, 'builder', 'log', 'build.log');
 
         await outputFile(assetBuildCacheFile, '{}');
         await outputFile(assetOtherFile, 'image');
@@ -55,6 +55,20 @@ describe('builder clearCache', () => {
         expect(await pathExists(assetOtherFile)).toBe(true);
         expect(await pathExists(builderCacheFile)).toBe(false);
         expect(await pathExists(logFile)).toBe(true);
+    });
+
+    it('clears legacy asset build cache under temp builder while preserving non-build files', async () => {
+        const legacyAssetBuildCacheFile = join(mockBuilderConfig.projectTempDir, 'builder', 'asset-db', 'assets', 'ab', 'uuid', 'build1.0.1', 'release.json');
+        const legacyAssetOtherFile = join(mockBuilderConfig.projectTempDir, 'builder', 'asset-db', 'assets', 'ab', 'uuid', 'thumbnail.png');
+
+        await outputFile(legacyAssetBuildCacheFile, '{}');
+        await outputFile(legacyAssetOtherFile, 'image');
+
+        const result = await clearCache('project');
+
+        expect(result.scope).toBe('project');
+        expect(await pathExists(legacyAssetBuildCacheFile)).toBe(false);
+        expect(await pathExists(legacyAssetOtherFile)).toBe(true);
     });
 
     it('clears global engine cache directories', async () => {
@@ -78,7 +92,7 @@ describe('builder clearCache', () => {
     });
 
     it('clears project and global cache when scope is all', async () => {
-        const projectCacheFile = join(mockBuilderConfig.projectTempDir, 'TexturePacker1.0.1', 'build', 'atlas.json');
+        const projectCacheFile = join(mockBuilderConfig.projectTempDir, 'builder', 'TexturePacker1.0.1', 'build', 'atlas.json');
         const globalCacheFile = join(mockGlobalPaths.enginePath, 'bin', 'temp', 'engine-cache.js');
 
         await outputFile(projectCacheFile, '{}');

--- a/src/core/builder/test/clear-cache.spec.ts
+++ b/src/core/builder/test/clear-cache.spec.ts
@@ -1,0 +1,97 @@
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { outputFile, pathExists, readdir } from 'fs-extra';
+
+const mockBuilderConfig = {
+    projectRoot: '',
+    projectTempDir: '',
+};
+
+const mockGlobalPaths = {
+    enginePath: '',
+};
+
+jest.mock('../share/builder-config', () => ({
+    __esModule: true,
+    default: mockBuilderConfig,
+}));
+
+jest.mock('../../../global', () => ({
+    GlobalPaths: mockGlobalPaths,
+}));
+
+import { clearCache } from '../cache';
+
+describe('builder clearCache', () => {
+    let tempRoot = '';
+
+    beforeEach(async () => {
+        tempRoot = await mkdtemp(join(tmpdir(), 'cocos-cli-clear-cache-'));
+        mockBuilderConfig.projectRoot = join(tempRoot, 'project');
+        mockBuilderConfig.projectTempDir = join(mockBuilderConfig.projectRoot, 'temp', 'builder');
+        mockGlobalPaths.enginePath = join(tempRoot, 'engine');
+    });
+
+    afterEach(async () => {
+        await rm(tempRoot, { recursive: true, force: true });
+    });
+
+    it('clears project builder cache while preserving logs and non-build asset-db files', async () => {
+        const assetBuildCacheFile = join(mockBuilderConfig.projectTempDir, 'asset-db', 'assets', 'ab', 'uuid', 'build1.0.1', 'release.json');
+        const assetOtherFile = join(mockBuilderConfig.projectTempDir, 'asset-db', 'assets', 'ab', 'uuid', 'thumbnail.png');
+        const builderCacheFile = join(mockBuilderConfig.projectTempDir, 'CompressTexture', 'compress-info.json');
+        const logFile = join(mockBuilderConfig.projectTempDir, 'log', 'build.log');
+
+        await outputFile(assetBuildCacheFile, '{}');
+        await outputFile(assetOtherFile, 'image');
+        await outputFile(builderCacheFile, '{}');
+        await outputFile(logFile, 'log');
+
+        const result = await clearCache('project');
+
+        expect(result.scope).toBe('project');
+        expect(await pathExists(assetBuildCacheFile)).toBe(false);
+        expect(await pathExists(assetOtherFile)).toBe(true);
+        expect(await pathExists(builderCacheFile)).toBe(false);
+        expect(await pathExists(logFile)).toBe(true);
+    });
+
+    it('clears global engine cache directories', async () => {
+        const engineTempFile = join(mockGlobalPaths.enginePath, 'bin', 'temp', 'engine-cache.js');
+        const editorCacheFile = join(mockGlobalPaths.enginePath, 'bin', '.cache', 'editor-cache', 'wechatgame', 'meta.json');
+        const devCliCacheFile = join(mockGlobalPaths.enginePath, 'bin', '.cache', 'dev-cli', 'cc.js');
+        const engineLogFile = join(mockGlobalPaths.enginePath, 'bin', '.cache', 'logs', 'log.txt');
+
+        await outputFile(engineTempFile, 'engine');
+        await outputFile(editorCacheFile, '{}');
+        await outputFile(devCliCacheFile, 'cc');
+        await outputFile(engineLogFile, 'log');
+
+        const result = await clearCache('global');
+
+        expect(result.scope).toBe('global');
+        await expect(readdir(join(mockGlobalPaths.enginePath, 'bin', 'temp'))).resolves.toEqual([]);
+        await expect(readdir(join(mockGlobalPaths.enginePath, 'bin', '.cache', 'editor-cache'))).resolves.toEqual([]);
+        await expect(readdir(join(mockGlobalPaths.enginePath, 'bin', '.cache', 'dev-cli'))).resolves.toEqual([]);
+        expect(await pathExists(engineLogFile)).toBe(true);
+    });
+
+    it('clears project and global cache when scope is all', async () => {
+        const projectCacheFile = join(mockBuilderConfig.projectTempDir, 'TexturePacker1.0.1', 'build', 'atlas.json');
+        const globalCacheFile = join(mockGlobalPaths.enginePath, 'bin', 'temp', 'engine-cache.js');
+
+        await outputFile(projectCacheFile, '{}');
+        await outputFile(globalCacheFile, 'engine');
+
+        const result = await clearCache('all');
+
+        expect(result.scope).toBe('all');
+        expect(await pathExists(projectCacheFile)).toBe(false);
+        await expect(readdir(join(mockGlobalPaths.enginePath, 'bin', 'temp'))).resolves.toEqual([]);
+    });
+
+    it('rejects invalid cache scope at runtime', async () => {
+        await expect(clearCache('invalid' as any)).rejects.toThrow('Invalid builder cache scope');
+    });
+});

--- a/src/core/builder/test/lib-clear-cache.spec.ts
+++ b/src/core/builder/test/lib-clear-cache.spec.ts
@@ -1,0 +1,35 @@
+const clearCacheMock = jest.fn(async (scope: 'project' | 'global' | 'all') => ({
+    scope,
+    cleared: [],
+}));
+
+jest.mock('../index', () => ({
+    clearCache: clearCacheMock,
+}));
+
+jest.mock('../manager/plugin', () => ({
+    pluginManager: {},
+}));
+
+describe('lib/builder clearCache API', () => {
+    beforeEach(() => {
+        clearCacheMock.mockClear();
+    });
+
+    async function getBuilderLib() {
+        return import('../../../lib/builder/builder');
+    }
+
+    it('delegates cache cleanup to core builder', async () => {
+        const builderLib = await getBuilderLib();
+
+        const result = await builderLib.clearCache('project');
+
+        expect(clearCacheMock).toHaveBeenCalledTimes(1);
+        expect(clearCacheMock).toHaveBeenCalledWith('project');
+        expect(result).toEqual({
+            scope: 'project',
+            cleared: [],
+        });
+    });
+});

--- a/src/core/builder/test/query-platform-build-schema.spec.ts
+++ b/src/core/builder/test/query-platform-build-schema.spec.ts
@@ -646,11 +646,11 @@ describe('PluginManager platform config schema queries', () => {
     });
 
     it('does nothing when no build template is registered for the platform', async () => {
-        const debug = jest.spyOn(console, 'debug').mockImplementation();
+        const error = jest.spyOn(console, 'error').mockImplementation();
         await pm.createBuildTemplate('test');
 
-        expect(debug).toHaveBeenCalledWith('no build template for test');
+        expect(error).toHaveBeenCalledWith('no build template for test');
         expect(existsSync((builderConfig as any).buildTemplateDir)).toBe(false);
-        debug.mockRestore();
+        error.mockRestore();
     });
 });

--- a/src/lib/builder/builder.ts
+++ b/src/lib/builder/builder.ts
@@ -1,9 +1,11 @@
 import type { BuildStageProgressCallback, IBuildCommandOption, IBuildResultData, IBuildStageOptions, IBuildTaskOption, IBundleBuildOptions, IPackOptions, IPreviewSettingsResult, Platform, PreviewPackResult } from '../../core/builder/@types/private';
 import type { BuildConfiguration } from '../../core/builder/@types/config-export';
 import type { BuildCheckResult, PlatformBuildSchema, PlatformConfigItem } from '../../core/builder/@types/protected';
+import type { BuildCacheScope, ClearCacheResult } from '../../core/builder/cache';
 
 export type * from '../../core/builder/@types/private';
 export type * from '../../core/builder/@types/config-export';
+export type { BuildCacheScope, ClearCacheResult };
 
 export async function init(platform?: string): Promise<void> {
     const builder = await import('../../core/builder');
@@ -95,6 +97,11 @@ export async function refreshDisplayI18nFields(): Promise<void> {
 export async function createBuildTemplate(nameOrPlatform: string): Promise<void> {
     const builder = await import('../../core/builder');
     return builder.createBuildTemplate(nameOrPlatform);
+}
+
+export async function clearCache(scope: BuildCacheScope): Promise<ClearCacheResult> {
+    const builder = await import('../../core/builder');
+    return builder.clearCache(scope);
 }
 
 export async function checkBuildOption(platform: string, key: string, value: unknown, options: IBuildTaskOption): Promise<BuildCheckResult> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,7 @@
         "node_modules",
         "**/test/**",
         "**/*.test.ts",
+        "src/core/builder/platforms/**/src/view/**",
         "tests/**",
         "e2e/**"
     ]


### PR DESCRIPTION
Add clearCache(scope) for project, global, and all builder cache cleanup.

Project cleanup clears serialized asset build caches and builder temp caches while preserving logs. Global cleanup clears engine bin/temp, editor-cache, and dev-cli cache roots.

Expose the API through src/lib/builder and add focused unit coverage plus DTS snapshot updates.