### PR TITLE
[feat] add collisionGroups property to engine physics config metadata

### DIFF
--- a/src/core/engine/metadata.ts
+++ b/src/core/engine/metadata.ts
@@ -78,6 +78,11 @@ export function createEngineMetadataNodes(options: IEngineMetadataOptions): ICoc
                 title: 'i18n:configuration.engine.physicsConfig.collisionMatrix.title',
                 description: 'i18n:configuration.engine.physicsConfig.collisionMatrix.description',
             },
+            'engine.physicsConfig.collisionGroups': {
+                type: 'array',
+                default: [],
+                title: 'i18n:configuration.engine.physicsConfig.collisionGroups.title',
+            },
             'engine.physicsConfig.defaultMaterial': {
                 type: 'string',
                 default: options.defaultConfig.physicsConfig.defaultMaterial,


### PR DESCRIPTION
## Summary

- Add `collisionGroups` array property to engine physics config metadata
- Property is placed before `defaultMaterial` in the physics config section
- Includes i18n title key for localization support

## Changes

- `src/core/engine/metadata.ts`: Added `engine.physicsConfig.collisionGroups` property with type `array`, default `[]`, and i18n title

## Test Plan

- Verify the collision groups property appears in the engine configuration panel
- Confirm the i18n title resolves correctly