### PR TITLE
Fix plain node undo serialization

### DIFF
--- a/src/core/scene/scene-process/service/prefab/prefab-undo.ts
+++ b/src/core/scene/scene-process/service/prefab/prefab-undo.ts
@@ -20,7 +20,7 @@ export class PrefabUndoHelper {
         if (!node?.isValid) {
             return null;
         }
-        return captureNodeStructureSnapshot(node);
+        return captureNodeStructureSnapshot(node, '', { serialization: 'prefab' });
     }
 
     pushNodeStructureCommand(

--- a/src/core/scene/scene-process/service/undo/commands/node-structure-command-utils.ts
+++ b/src/core/scene/scene-process/service/undo/commands/node-structure-command-utils.ts
@@ -1,4 +1,4 @@
-import { Node } from 'cc';
+import { editorExtrasTag, Node } from 'cc';
 import { NodeEventType, type IUndoCommandMeta, type IUndoRedoResult } from '../../../../common';
 import nodeMgr from '../../node/index';
 import { editorPrefabUtils } from '../../prefab/prefab-editor-utils';
@@ -36,6 +36,12 @@ export interface INodeStructureCaptureTarget {
     path?: string;
 }
 
+export type NodeStructureSerialization = 'auto' | 'node' | 'prefab';
+
+export interface INodeStructureCaptureOptions {
+    serialization?: NodeStructureSerialization;
+}
+
 export function createNodeCommandMeta(type: string, label: string): IUndoCommandMeta {
     return {
         id: createUndoId(type),
@@ -46,7 +52,11 @@ export function createNodeCommandMeta(type: string, label: string): IUndoCommand
     };
 }
 
-export function captureNodeStructureSnapshot(node: Node, fallbackPath = ''): INodeStructureSnapshot | null {
+export function captureNodeStructureSnapshot(
+    node: Node,
+    fallbackPath = '',
+    options: INodeStructureCaptureOptions = {},
+): INodeStructureSnapshot | null {
     if (!node?.isValid) {
         return null;
     }
@@ -54,7 +64,7 @@ export function captureNodeStructureSnapshot(node: Node, fallbackPath = ''): INo
     const parent = node.parent as Node | null;
     let serializedJson = '';
     try {
-        serializedJson = editorPrefabUtils.serialize(node);
+        serializedJson = serializeNodeStructure(node, options.serialization ?? 'auto');
         if (!serializedJson) {
             return null;
         }
@@ -71,6 +81,43 @@ export function captureNodeStructureSnapshot(node: Node, fallbackPath = ''): INo
         serializedJson,
         uuidTree: captureUuidTree(node),
     };
+}
+
+function serializeNodeStructure(node: Node, serialization: NodeStructureSerialization): string {
+    const serialized = shouldSerializeAsPrefab(node, serialization)
+        ? editorPrefabUtils.serialize(node)
+        : EditorExtends.serialize(node);
+    return typeof serialized === 'string' ? serialized : JSON.stringify(serialized);
+}
+
+function shouldSerializeAsPrefab(node: Node, serialization: NodeStructureSerialization): boolean {
+    if (serialization === 'prefab') {
+        return true;
+    }
+    if (serialization === 'node') {
+        return false;
+    }
+    return hasPrefabData(node);
+}
+
+function hasPrefabData(node: Node): boolean {
+    if (node['_prefab']) {
+        return true;
+    }
+
+    if (hasMountedRoot(node)) {
+        return true;
+    }
+
+    if ((node.components ?? []).some(component => component.__prefab || hasMountedRoot(component))) {
+        return true;
+    }
+
+    return (node.children ?? []).some(child => hasPrefabData(child));
+}
+
+function hasMountedRoot(target: unknown): boolean {
+    return Boolean((target as any)?.[editorExtrasTag]?.mountedRoot);
 }
 
 function captureUuidTree(node: Node): INodeUuidSnapshot {

--- a/src/core/scene/test/undo-node-structure-serialization.test.ts
+++ b/src/core/scene/test/undo-node-structure-serialization.test.ts
@@ -1,0 +1,100 @@
+const mockPrefabSerialize = jest.fn();
+const mockGetNodePath = jest.fn((node: MockNode) => node.path);
+
+class MockNode {
+    isValid = true;
+    components: Array<{ uuid: string; __prefab?: unknown }> = [];
+    children: MockNode[] = [];
+    parent: MockNode | null = null;
+    path = '';
+
+    constructor(public uuid: string, public name = uuid) { }
+
+    getSiblingIndex(): number {
+        return this.parent ? this.parent.children.indexOf(this) : 0;
+    }
+}
+
+jest.mock('cc', () => ({
+    editorExtrasTag: Symbol('editorExtrasTag'),
+    Node: MockNode,
+}));
+
+jest.mock('../scene-process/service/node/index', () => ({
+    __esModule: true,
+    default: {},
+}));
+
+jest.mock('../scene-process/service/prefab/prefab-editor-utils', () => ({
+    editorPrefabUtils: {
+        serialize: mockPrefabSerialize,
+    },
+}));
+
+jest.mock('../scene-process/service/undo/commands/command-utils-shared', () => ({
+    createUndoId: jest.fn((type: string) => `${type}:id`),
+    success: jest.fn((meta: unknown) => ({ success: true, meta })),
+    failure: jest.fn((meta: unknown, reason: string) => ({ success: false, meta, reason })),
+    isNodeInCurrentScene: jest.fn(() => false),
+    getEditorNodeManager: jest.fn(() => null),
+    getEditorExtends: jest.fn(() => null),
+    getNodePath: mockGetNodePath,
+}));
+
+import { captureNodeStructureSnapshot } from '../scene-process/service/undo/commands/node-structure-command-utils';
+
+describe('captureNodeStructureSnapshot serialization', () => {
+    beforeEach(() => {
+        mockPrefabSerialize.mockReset();
+        mockPrefabSerialize.mockReturnValue(JSON.stringify({ __type__: 'cc.Prefab' }));
+        mockGetNodePath.mockClear();
+        (global as any).EditorExtends = {
+            serialize: jest.fn((node: MockNode) => JSON.stringify({
+                __type__: 'cc.Node',
+                uuid: node.uuid,
+                name: node.name,
+            })),
+        };
+    });
+
+    it('serializes a plain node as node JSON instead of prefab JSON', () => {
+        const node = new MockNode('plain-node', 'PlainNode');
+        node.path = '/PlainNode';
+
+        const snapshot = captureNodeStructureSnapshot(node as any);
+
+        expect(snapshot).not.toBeNull();
+        expect((global as any).EditorExtends.serialize).toHaveBeenCalledWith(node);
+        expect(mockPrefabSerialize).not.toHaveBeenCalled();
+        expect(JSON.parse(snapshot!.serializedJson)).toMatchObject({
+            __type__: 'cc.Node',
+            uuid: 'plain-node',
+        });
+    });
+
+    it('keeps prefab serialization for prefab-related nodes', () => {
+        const node = new MockNode('prefab-node', 'PrefabNode') as MockNode & { _prefab?: unknown };
+        node.path = '/PrefabNode';
+        node._prefab = { instance: {} };
+
+        const snapshot = captureNodeStructureSnapshot(node as any);
+
+        expect(snapshot).not.toBeNull();
+        expect(mockPrefabSerialize).toHaveBeenCalledWith(node);
+        expect((global as any).EditorExtends.serialize).not.toHaveBeenCalled();
+        expect(JSON.parse(snapshot!.serializedJson)).toMatchObject({
+            __type__: 'cc.Prefab',
+        });
+    });
+
+    it('can force prefab serialization for prefab undo snapshots', () => {
+        const node = new MockNode('plain-prefab-editor-root', 'PlainPrefabRoot');
+        node.path = '/PlainPrefabRoot';
+
+        const snapshot = captureNodeStructureSnapshot(node as any, '', { serialization: 'prefab' });
+
+        expect(snapshot).not.toBeNull();
+        expect(mockPrefabSerialize).toHaveBeenCalledWith(node);
+        expect((global as any).EditorExtends.serialize).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## 变更说明

- 修复节点结构 undo 快照无条件使用 prefab 序列化的问题，普通节点改为保存普通 Node JSON。
- 保留 prefab 相关节点和 prefab undo 的 prefab 序列化路径，避免影响 prefab apply / unlink / unpack 等操作。
- 新增单测覆盖普通节点、prefab 节点和 prefab undo 强制序列化策略。


