### PR TITLE
Fix(scene/gizmo): resolve selected node by path to fix gizmo keyboard/snap operations.

### DIFF
--- a/src/core/scene/scene-process/service/gizmo/gizmo-operation.ts
+++ b/src/core/scene/scene-process/service/gizmo/gizmo-operation.ts
@@ -25,9 +25,9 @@ function getServiceProp(name: string): any {
     }
 }
 
-function getNodeByUuid(uuid: string): Node | null {
+function getNodeByPath(path: string): Node | null {
     const EditorExtends = (cc as any).EditorExtends || (globalThis as any).EditorExtends;
-    return EditorExtends?.Node?.getNode?.(uuid) ?? null;
+    return EditorExtends?.Node?.getNodeByPath?.(path) ?? null;
 }
 
 function getNodePath(node: Node): string {
@@ -282,9 +282,9 @@ class GizmoOperation {
 
         // 与编辑器一致：vertexSnap 检查
         const selection = getServiceProp('Selection');
-        const uuids: string[] = selection?.query?.() ?? [];
-        if (uuids[0]) {
-            const node = getNodeByUuid(uuids[0]);
+        const paths: string[] = selection?.query?.() ?? [];
+        if (paths[0]) {
+            const node = getNodeByPath(paths[0]);
             if (node) {
                 const res = getServiceProp('Gizmo')?.callAllGizmoFuncOfNode?.(node, 'onVertexSnapMove', event);
                 if (res === false) {
@@ -452,9 +452,9 @@ class GizmoOperation {
         if (this._regionSelecting) return false;
 
         const selection = getServiceProp('Selection');
-        const uuids: string[] = selection?.query?.() ?? [];
-        if (uuids.length > 0) {
-            const node = getNodeByUuid(uuids[0]);
+        const paths: string[] = selection?.query?.() ?? [];
+        if (paths.length > 0) {
+            const node = getNodeByPath(paths[0]);
             if (node) {
                 const res = getServiceProp('Gizmo')?.callAllGizmoFuncOfNode?.(node, 'onKeyDown', event);
                 return res;
@@ -465,9 +465,9 @@ class GizmoOperation {
 
     public onKeyUp(event: ISceneKeyboardEvent): boolean | void {
         const selection = getServiceProp('Selection');
-        const uuids: string[] = selection?.query?.() ?? [];
-        if (uuids.length > 0) {
-            const node = getNodeByUuid(uuids[0]);
+        const paths: string[] = selection?.query?.() ?? [];
+        if (paths.length > 0) {
+            const node = getNodeByPath(paths[0]);
             if (node) {
                 const res = getServiceProp('Gizmo')?.callAllGizmoFuncOfNode?.(node, 'onKeyUp', event);
                 return res;


### PR DESCRIPTION
Related issue: https://zentao.sud.center/index.php?m=bug&f=view&bugID=414


# Root Cause

In `gizmo-operation.ts`, `onKeyDown` / `onKeyUp` / `_changeMouseHover` resolve the selected node from `Selection.query()` using `getNodeByUuid`. However, `Selection.query()` returns node paths, not UUIDs (see `selection.ts` `query()` returning `e.path`). Therefore, `EditorExtends.Node.getNode(path)` (a UUID lookup) always returns `null`, `callAllGizmoFuncOfNode` is never invoked, and the gizmo's `onKeyDown` / `onKeyUp` / `onVertexSnapMove` never receive events.

# Fix

Resolve the node with `getNodeByPath` (`EditorExtends.Node.getNodeByPath(path)`) in all three places, matching the path semantics returned by `Selection.query()`.

# Impact

- Vertex snap (`V`), surface snap (`Ctrl+Shift`), arrow-key nudge, and hover snap all work again.
- Only the selected-node resolution changes; no other logic is affected.