### PR TITLE
fix(assets): return 404 when assets-query-url misses

### DIFF
--- a/src/api/assets/assets.ts
+++ b/src/api/assets/assets.ts
@@ -745,8 +745,13 @@ export class AssetsApi {
 
         try {
             ret.data = assetManager.queryUrl(uuidOrPath);
+            if (!ret.data) {
+                ret.code = COMMON_STATUS.NOT_FOUND;
+                ret.data = null;
+                ret.reason = `Asset URL can not be found: ${uuidOrPath}. Please refresh asset db and try again.`;
+            }
         } catch (e) {
-            ret.code = COMMON_STATUS.FAIL;
+            ret.code = getCommonErrorStatus(e);
             console.error('query URL fail:', e instanceof Error ? e.message : String(e));
             ret.reason = e instanceof Error ? e.message : String(e);
         }

--- a/tests/bug-497-api-error-status.test.ts
+++ b/tests/bug-497-api-error-status.test.ts
@@ -6,6 +6,7 @@ const mockCreateAssetByType = jest.fn();
 const mockImportAsset = jest.fn();
 const mockSaveAsset = jest.fn();
 const mockQueryPath = jest.fn();
+const mockQueryUrl = jest.fn();
 const mockQueryLinesInFile = jest.fn();
 const mockEraseLinesInRange = jest.fn();
 const mockReplaceTextInFile = jest.fn();
@@ -32,6 +33,7 @@ jest.mock('../src/core/assets', () => ({
         importAsset: (...args: unknown[]) => mockImportAsset(...args),
         saveAsset: (...args: unknown[]) => mockSaveAsset(...args),
         queryPath: (...args: unknown[]) => mockQueryPath(...args),
+        queryUrl: (...args: unknown[]) => mockQueryUrl(...args),
     },
 }));
 
@@ -83,6 +85,7 @@ describe('Bug #497 common API error status codes', () => {
         mockImportAsset.mockReset();
         mockSaveAsset.mockReset();
         mockQueryPath.mockReset();
+        mockQueryUrl.mockReset();
         mockQueryLinesInFile.mockReset();
         mockEraseLinesInRange.mockReset();
         mockReplaceTextInFile.mockReset();
@@ -230,6 +233,28 @@ describe('Bug #497 common API error status codes', () => {
         expect(result.code).toBe(HTTP_STATUS.NOT_FOUND);
         expect(result.data).toBeNull();
         expect(result.reason).toContain('Asset path can not be found');
+    });
+
+    it('returns 400 when querying asset URL with a parameter error', async () => {
+        mockQueryUrl.mockImplementation(() => {
+            throw new Error('parameter error');
+        });
+
+        const result = await new AssetsApi().queryUrl('bad');
+
+        expect(result.code).toBe(HTTP_STATUS.BAD_REQUEST);
+        expect(result.data).toBeNull();
+        expect(result.reason).toBe('parameter error');
+    });
+
+    it('returns 404 when querying asset URL cannot resolve a URL', async () => {
+        mockQueryUrl.mockReturnValue('');
+
+        const result = await new AssetsApi().queryUrl('yj56j');
+
+        expect(result.code).toBe(HTTP_STATUS.NOT_FOUND);
+        expect(result.data).toBeNull();
+        expect(result.reason).toContain('Asset URL can not be found');
     });
 
     it('returns 400 when saving invalid scene or prefab content', async () => {


### PR DESCRIPTION
## 调查结论

`assets-query-url` 查询不存在资源时仍返回 `code: 200, data: ""`，原因是 API 包装层直接透传了 `assetManager.queryUrl()` 的空字符串结果；而 `assets-query-asset-meta` 已经对空结果做了 `404 + data:null` 处理。

## 修复内容

- `assets-query-url` 查不到 URL 时统一返回 `404`，`data:null`，并补充明确 reason。
- `queryUrl` 异常分支接入 `getCommonErrorStatus()`，参数错误可返回 `400`。
- 补充回归测试覆盖：
  - `queryUrl` 参数错误返回 `400`
  - `queryUrl` 空结果返回 `404`
