### PR TITLE
Fix descendant paths after node rename

### DIFF
--- a/src/core/engine/editor-extends/manager/node-path-manager.ts
+++ b/src/core/engine/editor-extends/manager/node-path-manager.ts
@@ -187,6 +187,19 @@ export class NodePathManager {
     getNodePath(uuid: string): string {
         return this._uuidToPath.get(uuid) || '';
     }
+
+    private _getSubtreeEntries(rootPath: string): [string, string][] {
+        return Array.from(this._uuidToPath.entries())
+            .filter(([, path]) => path === rootPath || path.startsWith(`${rootPath}/`));
+    }
+
+    private _replaceSubtreePathPrefix(subtreeEntries: [string, string][], oldPath: string, newPath: string) {
+        for (const [entryUuid, path] of subtreeEntries) {
+            const suffix = path === oldPath ? '' : path.slice(oldPath.length);
+            this._addPathMapping(entryUuid, `${newPath}${suffix}`);
+        }
+    }
+
     move(uuid: string, name: string, newParentUuid: string | undefined, oldParentUuid?: string): string {
         const oldPath = this._uuidToPath.get(uuid);
         if (!oldPath) {
@@ -196,8 +209,7 @@ export class NodePathManager {
         const parentPath = newParentUuid ? (this._uuidToPath.get(newParentUuid) || '') : '';
         const oldName = oldPath.split('/').pop();
         const cleanName = this._sanitizeName(name);
-        const subtreeEntries = Array.from(this._uuidToPath.entries())
-            .filter(([, path]) => path === oldPath || path.startsWith(`${oldPath}/`));
+        const subtreeEntries = this._getSubtreeEntries(oldPath);
 
         for (const [entryUuid, path] of subtreeEntries) {
             this._removePathMapping(entryUuid, path);
@@ -213,10 +225,7 @@ export class NodePathManager {
         const finalName = this.ensureUniqueName(newParentUuid, cleanName);
         const newPath = parentPath ? `${parentPath}/${finalName}` : finalName;
 
-        for (const [entryUuid, path] of subtreeEntries) {
-            const suffix = path === oldPath ? '' : path.slice(oldPath.length);
-            this._addPathMapping(entryUuid, `${newPath}${suffix}`);
-        }
+        this._replaceSubtreePathPrefix(subtreeEntries, oldPath, newPath);
 
         return newPath;
     }
@@ -224,28 +233,30 @@ export class NodePathManager {
 
     updateUuid(uuid: string, newName: string, parentUuid?: string) {
         const oldPath = this._uuidToPath.get(uuid);
-        // 生成新的唯一路径
-        const newPath = this.generateUniquePath(uuid, newName, parentUuid);
+        if (!oldPath) {
+            return;
+        }
 
-        // 更新路径映射
-        this._uuidToPath.set(uuid, newPath);
-        this._pathToUuid.delete(oldPath!);
-        this._pathToUuid.set(newPath, uuid);
+        const parentPath = parentUuid ? (this._uuidToPath.get(parentUuid) || '') : '';
+        const oldName = oldPath.split('/').pop();
+        const cleanName = this._sanitizeName(newName);
+        const subtreeEntries = this._getSubtreeEntries(oldPath);
 
-        const oldLowerPath = oldPath!.toLowerCase();
-        const oldUuids = this._lowerPathToUuids.get(oldLowerPath);
-        if (oldUuids) {
-            oldUuids.delete(uuid);
-            if (oldUuids.size === 0) {
-                this._lowerPathToUuids.delete(oldLowerPath);
+        for (const [entryUuid, path] of subtreeEntries) {
+            this._removePathMapping(entryUuid, path);
+        }
+
+        if (parentUuid) {
+            const nameSet = this._nodeNames.get(parentUuid);
+            if (nameSet && oldName) {
+                nameSet.delete(oldName);
             }
         }
 
-        const newLowerPath = newPath.toLowerCase();
-        if (!this._lowerPathToUuids.has(newLowerPath)) {
-            this._lowerPathToUuids.set(newLowerPath, new Set());
-        }
-        this._lowerPathToUuids.get(newLowerPath)!.add(uuid);
+        const finalName = this.ensureUniqueName(parentUuid, cleanName);
+        const newPath = parentPath ? `${parentPath}/${finalName}` : finalName;
+
+        this._replaceSubtreePathPrefix(subtreeEntries, oldPath, newPath);
     }
 
     getNameSet(uuid: string): Set<string> | null {

--- a/src/core/engine/test/node-manager-change-uuid.test.ts
+++ b/src/core/engine/test/node-manager-change-uuid.test.ts
@@ -52,3 +52,34 @@ describe('NodeManager.changeNodeUUID', () => {
         expect(pathManager.getNodePath('node-old')).toBe('');
     });
 });
+
+describe('NodeManager.updateNodeName', () => {
+    let manager: NodeManager;
+
+    beforeEach(() => {
+        manager = new NodeManager();
+        manager.allow = true;
+        pathManager.clear();
+    });
+
+    function addNode(uuid: string, name: string, parentUuid?: string) {
+        const node = { uuid, name, _id: uuid, parent: parentUuid ? { uuid: parentUuid } : null } as any;
+        manager.add(uuid, node);
+        return node;
+    }
+
+    it('updates descendant path indexes when a node is renamed', () => {
+        addNode('parent', 'A', 'scene');
+        const child = addNode('child', 'B', 'parent');
+        const grandchild = addNode('grandchild', 'D', 'child');
+
+        manager.updateNodeName('parent', 'C');
+
+        expect(manager.getNodePath(child)).toBe('C/B');
+        expect(manager.getNodePath(grandchild)).toBe('C/B/D');
+        expect(manager.getNodeByPath('C/B')).toBe(child);
+        expect(manager.getNodeByPath('C/B/D')).toBe(grandchild);
+        expect(manager.getNodeByPath('A/B')).toBeNull();
+        expect(manager.getNodeByPath('A/B/D')).toBeNull();
+    });
+});

--- a/src/core/engine/test/node-path-manager.test.ts
+++ b/src/core/engine/test/node-path-manager.test.ts
@@ -38,6 +38,30 @@ describe('NodePathManager parent updates', () => {
     });
 });
 
+describe('NodePathManager name updates', () => {
+    let manager: NodePathManager;
+
+    beforeEach(() => {
+        manager = new NodePathManager();
+    });
+
+    it('updates descendant paths when a node is renamed', () => {
+        expect(manager.generateUniquePath('parent', 'A', 'scene')).toBe('A');
+        expect(manager.generateUniquePath('child', 'B', 'parent')).toBe('A/B');
+        expect(manager.generateUniquePath('grandchild', 'D', 'child')).toBe('A/B/D');
+
+        manager.updateUuid('parent', 'C', 'scene');
+
+        expect(manager.getNodePath('parent')).toBe('C');
+        expect(manager.getNodePath('child')).toBe('C/B');
+        expect(manager.getNodePath('grandchild')).toBe('C/B/D');
+        expect(manager.getNodeUuid('C/B')).toBe('child');
+        expect(manager.getNodeUuid('C/B/D')).toBe('grandchild');
+        expect(manager.getNodeResult('A/B').error).toBe('Not found');
+        expect(manager.getNodeResult('A/B/D').error).toBe('Not found');
+    });
+});
+
 describe('NodePathManager.changeUuid', () => {
     let manager: NodePathManager;
 

--- a/src/core/engine/test/node-path-manager.test.ts
+++ b/src/core/engine/test/node-path-manager.test.ts
@@ -60,6 +60,20 @@ describe('NodePathManager name updates', () => {
         expect(manager.getNodeResult('A/B').error).toBe('Not found');
         expect(manager.getNodeResult('A/B/D').error).toBe('Not found');
     });
+
+    it('uniquifies the new name against siblings and keeps descendants attached', () => {
+        expect(manager.generateUniquePath('a', 'A', 'scene')).toBe('A');
+        expect(manager.generateUniquePath('b', 'B', 'scene')).toBe('B');
+        expect(manager.generateUniquePath('bChild', 'C', 'b')).toBe('B/C');
+
+        manager.updateUuid('b', 'A', 'scene');
+
+        expect(manager.getNodePath('b')).toBe('A_001');
+        expect(manager.getNodePath('bChild')).toBe('A_001/C');
+        expect(manager.getNodeUuid('A_001/C')).toBe('bChild');
+        expect(manager.getNodeResult('B').error).toBe('Not found');
+        expect(manager.getNodeResult('B/C').error).toBe('Not found');
+    });
 });
 
 describe('NodePathManager.changeUuid', () => {


### PR DESCRIPTION
## 变更说明

- 重命名节点时同步更新该节点整棵子树的路径映射。
- 重用已有的子树路径替换逻辑，避免子节点仍保留旧父路径。
- 增加 `NodePathManager` 和 `NodeManager.updateNodeName` 的覆盖用例。
