### PR TITLE
fix(gizmo): route gizmo control-begin/end through ServiceEvents so the events actually broadcast

### DIFF
--- a/src/core/scene/scene-process/service/gizmo/base/gizmo-base.ts
+++ b/src/core/scene/scene-process/service/gizmo/base/gizmo-base.ts
@@ -12,6 +12,20 @@ function getService(): any {
     }
 }
 
+/**
+ * 获取全局事件总线（惰性访问，避免循环依赖）。
+ * 广播事件必须走 ServiceEvents，而不是 getService()：后者返回的是 Service 注册表 Proxy，
+ * 其 get 陷阱对未注册的名字（如 'broadcast'）会 throw，`?.` 挡不住抛错，导致事件永远发不出去。
+ */
+function getServiceEvents(): any {
+    try {
+        const { ServiceEvents } = require('../../core/global-events');
+        return ServiceEvents;
+    } catch (e) {
+        return null;
+    }
+}
+
 class GizmoBase<T extends Component = Component> {
     private _hidden = true;
     private _target: T | null;
@@ -80,8 +94,8 @@ class GizmoBase<T extends Component = Component> {
         this._isControlBegin = true;
         this.recordChanges(propPath);
         try {
-            const svc = getService();
-            svc?.broadcast?.('gizmo:control-begin', propPath);
+            const svcEvents = getServiceEvents();
+            svcEvents?.broadcast?.('gizmo:control-begin', propPath);
         } catch (e) {
             // not ready
         }
@@ -97,8 +111,8 @@ class GizmoBase<T extends Component = Component> {
         this._isControlBegin = false;
         this.commitChanges();
         try {
-            const svc = getService();
-            svc?.broadcast?.('gizmo:control-end', propPath);
+            const svcEvents = getServiceEvents();
+            svcEvents?.broadcast?.('gizmo:control-end', propPath);
         } catch (e) {
             // not ready
         }


### PR DESCRIPTION
## Problem

`GizmoBase.onControlBegin` / `onControlEnd` never actually broadcast their events (`gizmo:control-begin` / `gizmo:control-end`). Any code listening for them — e.g. to react to a gizmo drag start/stop — was never notified.

Root cause: the broadcast was sent through the wrong object.

```ts
const svc = getService();                 // returns the `Service` registry Proxy
svc?.broadcast?.('gizmo:control-begin');  // <- wrong target
```

`getService()` returns the `Service` **registry Proxy** (its keys are service names like `Engine` / `Node` / `Gizmo`). Its `get` trap **throws** for any name that is not a registered service:

```ts
get(_, prop) {
    const svc = _serviceRegistry[prop];
    if (!svc) throw new Error(`[Service] '${prop}' is not registered.`);
    return svc;
}
```

`broadcast` is not a service, so `svc.broadcast` throws. Optional chaining (`?.`) does not guard against a thrown error, so the throw propagated to the surrounding `try/catch` and was silently swallowed — the event was never emitted. (`broadcast` actually lives on `ServiceEvents` / `BaseService`, not on the `Service` registry.)

## Fix

Route the broadcasts through the global event bus `ServiceEvents` instead of the service registry. A lazily-required `getServiceEvents()` (mirroring the existing `getService()` pattern, kept lazy to avoid a circular import) returns the real `ServiceEvents` singleton, whose `broadcast()` method emits normally:

```ts
const svcEvents = getServiceEvents();
svcEvents?.broadcast?.('gizmo:control-begin', propPath);
```

Other `getService()` calls in this file (`.Engine`, `.Gizmo`, `.Undo`, `.Camera`) are genuine service lookups and are left unchanged.