### PR TITLE
[break] Support animation editor scene-process APIs

### DIFF
--- a/docs/dev/scene/animation-cli-capability-matrix.md
+++ b/docs/dev/scene/animation-cli-capability-matrix.md
@@ -1,0 +1,129 @@
+# Animation CLI 能力矩阵
+
+本文记录旧动画编辑器依赖的 scene animation CLI 能力，以及当前 `cocos-cli-dev` scene-process `AnimationService` 的实现状态。状态只描述 CLI 后端能力，不包含 PinK 或旧 animator 面板的 UI 状态。
+
+## 状态定义
+
+- **完成**：当前 CLI 已有 typed API 覆盖旧能力，并进入 active scene state、undo/dirty、`queryClip` dump 或 save 流程。
+- **部分完成**：CLI 已覆盖核心路径，但和旧编辑器能力相比存在参数形态、类型覆盖、批量语义或查询菜单缺口。
+- **未完成**：当前 CLI 没有等价 typed operation 或查询接口。
+- **不迁移**：旧能力属于 animator UI、profile/cache 或旧消息总线，不应放入 scene-process 核心。
+
+## 旧能力来源
+
+- 旧 animator IPC：`/Users/cocos/editor-3d-develop/app/builtin/animator/source/panel/share/ipc-event.ts`
+- 旧 scene animation manager：`/Users/cocos/editor-3d-develop/app/builtin/scene/source/script/3d/manager/animation/index.ts`
+- 旧 clip 编辑实现：`/Users/cocos/editor-3d-develop/app/builtin/scene/source/script/3d/manager/animation/editor-animation-clip.ts`
+- 旧曲线实现：`editor-animation-curve.ts`、`editor-animation-combined-curve.ts`、`editor-animation-aux-curve.ts`
+
+## 旧能力分组
+
+| 能力组 | 旧编辑器覆盖范围 | 旧入口示例 |
+|---|---|---|
+| 编辑 session / 播放 / 保存 | 进入/退出动画编辑、切换 root、切换 edit clip、设置时间、播放/暂停/继续/停止、保存、查询当前状态。 | `record-animation`、`change-animation-root`、`change-edit-clip`、`set-edit-time`、`change-clip-state`、`save-clip`、`query-animation-state` |
+| 查询 / dump | 查询 root 信息、clip dump、可编辑属性、节点树、属性帧值、编辑信息、embedded player 可添加菜单。 | `query-animation-root-info`、`query-animation-clip`、`query-animation-properties`、`query-node-tree`、`query-property-value-at-frame`、`query-animation-edit-info`、`query-EmbeddedPlayer-menu` |
+| 属性轨道结构 | 创建/删除/复制属性轨道，删除节点动画数据，迁移节点动画路径，复制节点动画数据。 | `createProp`、`removeProp`、`copyPropTo`、`removeNode`、`changeNodeDataPath`、`copyNode` |
+| 属性 key / 曲线 | 创建/更新/删除/移动/复制/间隔排列/清空 key，修改 keyData，设置曲线 extrapolation，自动重算 duration。 | `createKey`、`updateKey`、`removeKey`、`moveKeys`、`copyKeysTo`、`spacingKeys`、`clearKeys`、`modifyCurveOfKey` |
+| 事件 | 添加、删除、更新、移动、复制 animation event。 | `addEvent`、`deleteEvent`、`updateEvent`、`moveEvents`、`copyEvent` |
+| Embedded player / 辅助曲线 | embedded player group/player 增删改清，辅助曲线增删改名，辅助曲线 key 增删移复制和 keyData 修改，按帧查询辅助曲线值。 | `addEmbeddedPlayerGroup`、`addEmbeddedPlayer`、`clearEmbeddedPlayer`、`addAuxiliaryCurve`、`createAuxKey`、`modifyAuxCurveOfKey`、`query-aux-curve-value-at-frame` |
+
+## 能力矩阵
+
+| 旧编辑器能力 | 旧入口 | 当前 CLI 状态 | 当前入口 | 缺口 / 备注 |
+|---|---|---|---|---|
+| 进入动画编辑 | `record-animation` / `Irecord(..., true)` | 完成 | `enter` | 建立 session、初始化 `AnimationState`、广播状态。 |
+| 退出动画编辑 | `close-scene` / `Irecord(..., false)` | 部分完成 | `exit` | session 退出、停止播放、恢复 selection 已完成；采样状态恢复已收敛到 animation 模块，但仅覆盖 root 子树 node TRS/active 与可克隆或普通对象/数组的 animatable component 属性，不等价于旧全量 node dump restore。 |
+| 切换动画 root | `change-animation-root` / `IchangeAnimNode` | 部分完成 | `enter` | 新 root 通过重新 `enter` 表达；旧 `saveCheck` 脏数据确认/阻断语义不在 CLI 内部，调用方需要先完成保存或确认。 |
+| 切换 edit clip | `change-edit-clip` / `IsetEditClip` | 部分完成 | `changeEditClip` | 会停止当前采样并重置时间到 0；旧 `saveCheck` 脏数据确认/阻断语义不在 CLI 内部。 |
+| 查询 scene mode | `query-scene-mode` | 完成 | `queryState` | 返回 `mode/editorType/active`。 |
+| 查询当前 root/clip | `query-current-animation-info` | 完成 | `queryState` | 返回 root path/uuid、clip uuid、time、play state。 |
+| 查询播放状态 | `query-animation-state` | 完成 | `queryState` | 旧接口只返回 play state；当前统一在 session state 内返回 `playState`。 |
+| 查询动画 root | `query-animation-root` | 完成 | `queryRoot` | 支持 node path/uuid 推导 root。 |
+| 查询 root 综合信息 | `query-animation-root-info` | 部分完成 | `queryRootInfo` | 返回 clips menu、node tree、默认 clip dump、time、baked 标记；Animation 组件 clips 为空时返回空 menu 且 `clipDump: null`；复杂旧轨道 dump 未完全覆盖。 |
+| 查询 clip dump | `query-animation-clip` | 部分完成 | `queryClip` | 当前 session clip 优先走 session state，避免 asset refresh 窗口反查组件 clips 失败；普通查询路径不再为了恢复缺失 clip 而重绑 `Animation.clips/defaultClip`，clip rebind 只保留在 `enter`、`changeEditClip`、asset refresh 等明确写入/恢复路径；旧编辑器支持的 nested object、array、material uniform、valueAdapter 轨道未完全迁移，旧 `isLock` 与 2D 曲线/partKeys 过滤语义也未完整迁移。 |
+| 查询 clips menu | `query-animation-clips-info` | 完成 | `queryClips` | `Animation.defaultClip` 也会纳入候选 clips；Animation 组件 clips 为空时返回空 menu 和空 `defaultClip`。 |
+| 查询播放时间 | `query-animation-clips-time` | 完成 | `queryTime` | time 使用秒。 |
+| 设置编辑时间 / 采样 | `set-edit-time` | 完成 | `setTime` | 受 clip duration clamp，采样后 repaint；CLI 场景测试已覆盖 root 和 child `nodePath` 属性轨道采样，PinK Product gate 仍需在真实插件链路复测关闭。 |
+| 播放控制 | `change-clip-state` | 完成 | `changePlayState` | 支持 play/pause/resume/stop。 |
+| 保存 clip | `save-clip` | 完成 | `save` | 普通 `.anim` 写 asset；骨骼动画写 meta。 |
+| 查询可编辑属性 | `query-animation-properties` | 部分完成 | `queryProperties` | 覆盖 node TRS/active 和组件顶层 animatable 属性；旧递归对象、数组下标、类型继承链、category/menu、asset/uniform adapter、`targetPaths/valueAdapter` 体系未完全迁移。 |
+| 查询嵌入播放器菜单 | `query-EmbeddedPlayer-menu` | 未完成 | 无 | 仅已支持 embedded player 数据编辑和 dump；可添加项菜单查询未迁移。 |
+| 查询动画编辑信息 | `query-animation-edit-info` | 部分完成 | `queryRootInfo` / `queryState` | 当前分散在 root info 和 state；旧结构的完整 `IAniEditInfo` 未保留。 |
+| 查询节点树 | `query-node-tree` | 完成 | `Service.Node.queryNodeTree` / `queryRootInfo.nodeTreeDump` | 不属于 AnimationService 专属能力。 |
+| 查询属性帧值 | `query-property-value-at-frame` | 部分完成 | `queryPropertyValueAtFrame` | 当前通过临时 `AnimationState.setTime/sample/repaint` 读取真实场景值，然后恢复原时间；能力可用，但不是旧编辑器那种纯曲线求值读路径，旧 2D lock UI 元信息不在 CLI 返回。 |
+| 查询辅助曲线列表 | `query-auxiliary-curves` | 完成 | `queryClip.auxiliaryCurves` | 通过 clip dump 返回。 |
+| 查询辅助曲线帧值 | `query-aux-curve-value-at-frame` | 完成 | `queryAuxiliaryCurveValueAtFrame` | 本次补齐，按帧采样辅助曲线值。 |
+| 批处理动画操作 | `animation-operation(funcName,args)` | 完成 | `applyOperation({ operations })` | 新 CLI 只接受 typed operation；旧 `{ funcName,args }` 明确失败。 |
+| 失败批处理回滚 | 旧 manager 内部状态更新 | 完成 | `applyOperation` | 本次补齐：任一 operation normalize/validate/apply 失败都会恢复进入批处理前的 clip snapshot。 |
+| 修改 sample | `changeSample` | 完成 | `changeSample` operation | 纳入 undo/dirty/save。 |
+| 修改 speed | `changeSpeed` | 完成 | `changeSpeed` operation | 纳入 undo/dirty/save。 |
+| 修改 wrapMode | `changeWrapMode` | 完成 | `changeWrapMode` operation | 纳入 undo/dirty/save。 |
+| 自动重算 duration | `recalculateDuration()` | 部分完成 | `applyOperation` 内部 `syncAnimationClipDuration` | CLI 场景测试已覆盖普通曲线、event、embedded player、auxiliary curve；PinK 真实 scene Product gate 仍需复测 save / undo / exit / reenter 全链路，不能按 PinK 口径标完成。 |
+| 创建属性轨道 | `createProp` | 部分完成 | `addPropertyCurve` / `createPropertyKey` | 仅对当前 flat `propKey` 模型完整；旧 `targetPaths/valueAdapter`、nested/object/array/uniform 路径体系未完全表达。 |
+| 删除属性轨道 | `removeProp` | 未完成 | 无 | 当前只能删除 key；缺少「删除整条 track」operation。 |
+| 复制属性轨道 | `copyProp` / `copyPropTo` | 未完成 | 无 | 当前 `copyPropertyKeysTo` 只覆盖同一曲线内按帧复制。 |
+| 创建属性 key | `createKey` | 部分完成 | `createPropertyKey` | 对当前 flat property 模型支持 nodePath/nodeUuid、channel、value 省略时从当前 scene 采样、keyData；复杂旧 property path 未完全覆盖。 |
+| 更新属性 key 值 | `updateKey` | 部分完成 | `updatePropertyKey` | 支持指定 frame/value 更新；旧多帧按当前场景批量更新语义未完整迁移。 |
+| 更新属性 key 曲线数据 | `modifyCurveOfKey` | 部分完成 | `updatePropertyKeyData` / `updatePropertyKey(keyData)` | CLI 代码路径和场景测试已覆盖 RealCurve keyData、`interpMode`、显式 0 值、切线/权重和 `broken`；PinK 真实 scene 读回仍需复测，Quat/Object 等非 RealCurve 的旧能力仍有限。 |
+| 属性曲线 extrapolation | `preExtrap` / `postExtrap` | 完成 | `setPropertyCurveExtrapolation` | 支持 RealCurve track 的 pre/post extrapolation 设置和 `queryClip` dump。 |
+| 删除属性 key | `removeKey` | 完成 | `removePropertyKey` / `removePropertyKeys` | 支持 channel 和批量 frames。 |
+| 移动属性 key | `moveKeys` | 部分完成 | `movePropertyKeys` | 支持统一 offset；旧接口支持每个 key 独立 offset，尚未迁移。 |
+| 复制属性 key | `copyKey` / `copyKeysTo` | 部分完成 | `copyPropertyKeysTo` | 支持同一 node/prop 曲线内复制到目标帧；跨 node/prop 粘贴未完成。 |
+| 间隔排列 key | `spacingKeys` | 未完成 | 无 | 缺少等价 operation。 |
+| 清空轨道 key | `clearKeys` | 未完成 | 无 | 可由前端查询全部 frames 后删除，但 CLI 没有原子 operation。 |
+| 删除节点动画数据 | `removeNode` | 未完成 | 无 | 缺少按 nodePath 删除所有曲线的 operation。 |
+| 迁移节点动画路径 | `changeNodeDataPath` | 未完成 | 无 | 缺少批量改 track path 并处理目标覆盖的 operation。 |
+| 复制节点动画数据 | `copyNode` | 未完成 | 无 | 缺少跨 node 复制所有曲线的 operation。 |
+| 添加事件 | `addEvent` | 完成 | `addEvent` operation | 纳入 undo/dirty/save。 |
+| 删除事件 | `deleteEvent` | 完成 | `deleteEvent` operation | 支持 frames。 |
+| 更新事件 | `updateEvent` | 完成 | `updateEvent` operation | 支持 frames + events dump。 |
+| 移动事件 | `moveEvents` | 完成 | `moveEvents` operation | 支持统一 offset。 |
+| 复制事件 | `copyEvent` | 完成 | `copyEventsTo` operation | 按旧 base frame 语义复制。 |
+| 添加 embedded player group | `addEmbeddedPlayerGroup` | 完成 | 同名 operation | 纳入 dump、undo、save、骨骼 meta。 |
+| 删除 embedded player group | `removeEmbeddedPlayerGroup` | 完成 | 同名 operation | 删除 group 并清理关联 players。 |
+| 清空 embedded player group | `clearEmbeddedPlayerGroup` | 完成 | 同名 operation | 清理 group 下 players。 |
+| 添加 embedded player | `addEmbeddedPlayer` | 完成 | 同名 operation | 支持 particle-system 等 playable dump。 |
+| 删除 embedded player | `deleteEmbeddedPlayer` | 完成 | 同名 operation | 按 dump key 匹配删除。 |
+| 更新 embedded player | `updateEmbeddedPlayer` | 完成 | 同名 operation | 按旧 dump 替换为新 dump。 |
+| 清空 embedded player | `clearEmbeddedPlayer` | 部分完成 | 同名 operation | 当前支持全清或按 group 清理；旧编辑器支持按 `nodePath` 清空，语义未完全对齐。 |
+| 添加辅助曲线 | `addAuxiliaryCurve` | 完成 | 同名 operation | 使用 engine experimental auxiliary curve API。 |
+| 删除辅助曲线 | `removeAuxiliaryCurve` | 完成 | 同名 operation | dump/save/undo 覆盖。 |
+| 重命名辅助曲线 | `renameAuxiliaryCurve` | 完成 | 同名 operation | dump/save/undo 覆盖。 |
+| 创建辅助曲线 key | `createAuxKey` | 完成 | 同名 operation | 本次补齐 keyData 写入。 |
+| 删除辅助曲线 key | `removeAuxKey` | 完成 | 同名 operation | 支持单帧。 |
+| 移动辅助曲线 key | `moveAuxKeys` | 部分完成 | 同名 operation | 支持统一 offset；旧接口支持数组 offset。 |
+| 复制辅助曲线 key | `copyAuxKey` | 部分完成 | 同名 operation | 当前复制同一曲线 key 到目标帧；旧 src/dest data 形态更灵活。 |
+| 修改辅助曲线 keyData | `modifyAuxCurveOfKey` | 完成 | `updateAuxKeyData` | 本次补齐 keyData 写入和 `queryClip` 读回。 |
+| 骨骼动画安全操作限制 | `skelAnimAllowOperations` | 完成 | `applyOperation` 内部 gate | 对 skeleton clip 只允许 sample/speed/wrap、event、embedded player 和 auxiliary curve 操作，拒绝 property track 编辑。 |
+| AnimationController clip 枚举 | 旧 manager 支持 controller clips | 部分完成 | `queryClips` / `enter` | 可枚举和编辑 clip；Controller 状态机结构编辑契约未定义。 |
+| animator 最近 clip cache | `query-last-clip-cache` / `save-clip-cache` | 不迁移 | 无 | 属于旧 animator 面板 profile/cache。 |
+| 旧消息名与事件名 | `scene:animation-*` / `Editor.Message` | 不迁移 | `animation:*` service events | CLI 使用 typed service event，不复刻旧消息总线名字。 |
+
+## PinK 当前 gate 状态
+
+本节按 PinK 真实 Product gate 判定，不等同于上方「当前 CLI 状态」。CLI 场景测试通过只能说明代码路径已具备，不能直接标记 PinK gate 完成。
+
+| PinK gate | 当前状态 | CLI 依据 | 仍需验证 |
+|---|---|---|---|
+| 空 clip 创建首个 key 后 duration 不为 0 | 部分完成 | CLI 场景测试覆盖空 clip property key、child `nodePath` property key、event、embedded player、auxiliary curve 后重算 duration | PinK 权威需求文档已记录 root authoring 和 child `query-clip durationFrames=60` 通过；仍需完整 Product gate 的 save / undo / exit / reenter 回归。 |
+| child `nodePath` track 的 `setTime` / sampling | 部分完成 | CLI 场景测试覆盖 60fps 空 clip 在 child `position.x@60f=100` 后 `setTime(1)` 采样真实子节点，且回到 0 秒恢复为 0 | PinK 权威需求文档仍记录真实插件链路 `query-time=0`、child `position.x=0`；需要把当前 CLI 同步到 PinK 使用路径后复测 G2-B。 |
+| root keyframe edit save/reenter 后 `setTime` / sampling | 未完成 | CLI 已覆盖 move/copy/remove 后重建 evaluator 和本地 keyframe dump，但缺少 PinK G3 同等 save / exit / reenter 场景验证 | PinK 权威需求文档仍记录 exit/reenter 后 `query-time=0`、root `position.x=0`；需要补真实 scene service 路径回归。 |
+| RealCurve `interpMode` / tangent / weight 写入读回 | 部分完成 | CLI 场景测试覆盖 `createPropertyKey`、`updatePropertyKey`、`updatePropertyKeyData` 写入读回，并补显式 0 值保留 | PinK 权威需求文档仍记录真实 scene `query-clip` 未读回；需要同步当前 CLI 后复测曲线菜单 smoke。 |
+| RealCurve `broken` 写入读回 | 部分完成 | CLI 代码路径使用 `editorExtrasTag` 保存和 dump `broken`，场景测试覆盖 `broken: true` 和 `broken: false` 的 undo/redo、save/reenter | PinK 权威需求文档仍记录真实 scene `query-clip` 未读回；需要同步当前 CLI 后复测曲线菜单 smoke。 |
+
+## 本次补充能力状态
+
+| 能力 | 当前状态 | CLI 依据 | 仍需验证 |
+|---|---|---|---|
+| auxiliary curve keyData 写入读回 | 完成 | `createAuxKey(keyData)`、`updateAuxKeyData`、`queryClip.auxiliaryCurves` | 仍需 PinK 真实使用路径复测。 |
+| auxiliary curve 按帧采样 | 完成 | `queryAuxiliaryCurveValueAtFrame` | 仍需 PinK 真实使用路径复测。 |
+| 批处理失败不留下局部写入 | 完成 | `applyOperation` 失败时恢复批处理前 clip snapshot | 仍需 PinK 真实 scene smoke 覆盖。 |
+| 退出动画编辑恢复采样状态 | 部分完成 | animation 模块内 sampled state restore，覆盖 node TRS/active 与可克隆或普通对象/数组的 animatable component 属性 | 不等价于旧全量 node dump restore，仍需 PinK 真实 scene smoke 覆盖。 |
+
+## 后续补齐优先级
+
+1. **P0：同步当前 CLI 到 PinK 使用路径并复测 Product gate**。CLI 场景测试通过不等于 PinK release gate 通过，仍需用真实 PinK scene 覆盖 child authoring / seek / play / save / exit / reenter 和曲线 keyData 菜单 smoke。
+2. **P1：结构型 property/node operation**。优先补 `removeProp`、`copyProp`、`removeNode`、`changeNodeDataPath`、`copyNode`，这些不能靠 Web 本地状态安全替代。
+3. **P1：批量 key 操作语义补齐**。补 `spacingKeys`、`clearKeys`，并评估 `moveKeys` / `moveAuxKeys` 的 per-key offset 是否需要兼容。
+4. **P2：查询菜单与旧 UI 辅助信息**。评估 `query-EmbeddedPlayer-menu`、旧 `IAniEditInfo`、2D lock 元信息是否由 PinK UI 自己管理，还是需要 CLI 暴露。
+5. **P2：AnimationController 编辑契约**。当前可枚举 clip，但状态机结构编辑不应在没有明确产品需求时迁入。

--- a/docs/dev/scene/animation-cli-capability-matrix.md
+++ b/docs/dev/scene/animation-cli-capability-matrix.md
@@ -40,13 +40,13 @@
 | 查询播放状态 | `query-animation-state` | 完成 | `queryState` | 旧接口只返回 play state；当前统一在 session state 内返回 `playState`。 |
 | 查询动画 root | `query-animation-root` | 完成 | `queryRoot` | 支持 node path/uuid 推导 root。 |
 | 查询 root 综合信息 | `query-animation-root-info` | 部分完成 | `queryRootInfo` | 返回 clips menu、node tree、默认 clip dump、time、baked 标记；Animation 组件 clips 为空时返回空 menu 且 `clipDump: null`；复杂旧轨道 dump 未完全覆盖。 |
-| 查询 clip dump | `query-animation-clip` | 部分完成 | `queryClip` | 当前 session clip 优先走 session state，避免 asset refresh 窗口反查组件 clips 失败；普通查询路径不再为了恢复缺失 clip 而重绑 `Animation.clips/defaultClip`，clip rebind 只保留在 `enter`、`changeEditClip`、asset refresh 等明确写入/恢复路径；旧编辑器支持的 nested object、array、material uniform、valueAdapter 轨道未完全迁移，旧 `isLock` 与 2D 曲线/partKeys 过滤语义也未完整迁移。 |
+| 查询 clip dump | `query-animation-clip` | 部分完成 | `queryClip` | 当前 session clip 优先走 session state，避免 asset refresh 窗口反查组件 clips 失败；普通查询路径不再为了恢复缺失 clip 而重绑 `Animation.clips/defaultClip`，clip rebind 只保留在 `enter`、`changeEditClip`、asset refresh 等明确写入/恢复路径；已支持 material uniform 的 `UniformProxyFactory` 轨道解析和 dump；旧编辑器支持的 nested object、array、其他 valueAdapter 轨道未完全迁移，旧 `isLock` 与 2D 曲线/partKeys 过滤语义也未完整迁移。 |
 | 查询 clips menu | `query-animation-clips-info` | 完成 | `queryClips` | `Animation.defaultClip` 也会纳入候选 clips；Animation 组件 clips 为空时返回空 menu 和空 `defaultClip`。 |
 | 查询播放时间 | `query-animation-clips-time` | 完成 | `queryTime` | time 使用秒。 |
 | 设置编辑时间 / 采样 | `set-edit-time` | 完成 | `setTime` | 受 clip duration clamp，采样后 repaint；CLI 场景测试已覆盖 root 和 child `nodePath` 属性轨道采样，PinK Product gate 仍需在真实插件链路复测关闭。 |
 | 播放控制 | `change-clip-state` | 完成 | `changePlayState` | 支持 play/pause/resume/stop。 |
 | 保存 clip | `save-clip` | 完成 | `save` | 普通 `.anim` 写 asset；骨骼动画写 meta。 |
-| 查询可编辑属性 | `query-animation-properties` | 部分完成 | `queryProperties` | 覆盖 node TRS/active 和组件顶层 animatable 属性；旧递归对象、数组下标、类型继承链、category/menu、asset/uniform adapter、`targetPaths/valueAdapter` 体系未完全迁移。 |
+| 查询可编辑属性 | `query-animation-properties` | 部分完成 | `queryProperties` | 覆盖 node TRS/active、组件顶层 animatable 属性、`cc.Sprite.type`、Renderer `sharedMaterials -> materials` 和 material `passes[].properties` uniform 展开；旧递归对象、普通数组下标、类型继承链、其他 `targetPaths/valueAdapter` 体系未完全迁移。 |
 | 查询嵌入播放器菜单 | `query-EmbeddedPlayer-menu` | 未完成 | 无 | 仅已支持 embedded player 数据编辑和 dump；可添加项菜单查询未迁移。 |
 | 查询动画编辑信息 | `query-animation-edit-info` | 部分完成 | `queryRootInfo` / `queryState` | 当前分散在 root info 和 state；旧结构的完整 `IAniEditInfo` 未保留。 |
 | 查询节点树 | `query-node-tree` | 完成 | `Service.Node.queryNodeTree` / `queryRootInfo.nodeTreeDump` | 不属于 AnimationService 专属能力。 |
@@ -59,7 +59,7 @@
 | 修改 speed | `changeSpeed` | 完成 | `changeSpeed` operation | 纳入 undo/dirty/save。 |
 | 修改 wrapMode | `changeWrapMode` | 完成 | `changeWrapMode` operation | 纳入 undo/dirty/save。 |
 | 自动重算 duration | `recalculateDuration()` | 部分完成 | `applyOperation` 内部 `syncAnimationClipDuration` | CLI 场景测试已覆盖普通曲线、event、embedded player、auxiliary curve；PinK 真实 scene Product gate 仍需复测 save / undo / exit / reenter 全链路，不能按 PinK 口径标完成。 |
-| 创建属性轨道 | `createProp` | 部分完成 | `addPropertyCurve` / `createPropertyKey` | 仅对当前 flat `propKey` 模型完整；旧 `targetPaths/valueAdapter`、nested/object/array/uniform 路径体系未完全表达。 |
+| 创建属性轨道 | `createProp` | 部分完成 | `addPropertyCurve` / `createPropertyKey` | 支持当前 flat `propKey` 模型和 material uniform propKey，并会为 material uniform 创建 `UniformProxyFactory` 轨道；旧 `targetPaths/valueAdapter` 的其他用法、nested/object/array 路径体系未完全表达。 |
 | 删除属性轨道 | `removeProp` | 未完成 | 无 | 当前只能删除 key；缺少「删除整条 track」operation。 |
 | 复制属性轨道 | `copyProp` / `copyPropTo` | 未完成 | 无 | 当前 `copyPropertyKeysTo` 只覆盖同一曲线内按帧复制。 |
 | 创建属性 key | `createKey` | 部分完成 | `createPropertyKey` | 对当前 flat property 模型支持 nodePath/nodeUuid、channel、value 省略时从当前 scene 采样、keyData；复杂旧 property path 未完全覆盖。 |

--- a/docs/dev/scene/animation.md
+++ b/docs/dev/scene/animation.md
@@ -40,12 +40,12 @@ Scene process 不负责：
 | 设置时间/采样 | `set-edit-time` | `AnimationService.setTime` | 已落地第一阶段 |
 | 播放控制 | `change-clip-state` | `AnimationService.changePlayState` | 已落地第一阶段 |
 | 切 clip | `change-edit-clip` | `AnimationService.changeEditClip` | 已落地第一阶段 |
-| 批处理编辑 | `animation-operation` | `AnimationService.applyOperation` | 已落地第二阶段基础原语 |
-| 保存 clip | `save-clip` | `AnimationService.save` | 已落地普通 clip；骨骼 meta 后续补齐 |
+| 批处理编辑 | `animation-operation` | `AnimationService.applyOperation` | 已落地 typed operation 原语 |
+| 保存 clip | `save-clip` | `AnimationService.save` | 已落地普通 clip 和骨骼 meta |
 | 查询帧值 | `query-property-value-at-frame` | `AnimationService.queryPropertyValueAtFrame` | 已落地第二阶段 |
-| 辅助曲线 | `query-auxiliary-*` / aux operations | `AnimationService.queryAuxiliaryCurves` / operation | 第三阶段 |
-| embedded player | operation | `AnimationService.applyOperation` | 第三阶段 |
-| inspector drop clip | `inspector-drop-animation` | `AnimationService.addClipToNode` | 第三阶段 |
+| 辅助曲线 | `query-auxiliary-*` / aux operations | `AnimationService.applyOperation` | 已落地第三阶段基础操作 |
+| embedded player | operation | `AnimationService.applyOperation` | 已落地第三阶段基础操作 |
+| inspector drop clip | `inspector-drop-animation` | 待定 | 后续按 UI 迁入需要补 |
 
 ## Service 设计
 
@@ -74,7 +74,15 @@ Scene process 不负责：
 
 - `queryClip` 返回 clip 基础 dump、事件帧 dump、当前时间和 baked animation 标记。
 - `queryPropertyValueAtFrame` 按帧采样当前编辑 clip，读取目标节点或组件属性后恢复原编辑时间。
-- `applyOperation` 使用旧入口兼容的 `{ funcName, args }` 批处理格式，当前支持 `changeSample`、`changeSpeed`、`changeWrapMode`、`addEvent`、`deleteEvent`、`updateEvent`、`moveEvents`、`copyEventsTo`。
+- `applyOperation` 使用 typed `AnimationOperation` 批处理格式，基础操作支持 `changeSample`、`changeSpeed`、`changeWrapMode`、`addEvent`、`deleteEvent`、`updateEvent`、`moveEvents`、`copyEventsTo`。
+
+第三阶段继续补：
+
+- typed operation 不兼容旧 `{ funcName, args }`。后续 animator 面板走新实现，不需要保留旧 animator message 形态。
+- `applyOperation` 增加 embedded player 基础操作：`addEmbeddedPlayer`、`deleteEmbeddedPlayer`、`updateEmbeddedPlayer`、`clearEmbeddedPlayer`、`addEmbeddedPlayerGroup`、`removeEmbeddedPlayerGroup`、`clearEmbeddedPlayerGroup`。
+- `applyOperation` 增加 auxiliary curve 基础操作：`addAuxiliaryCurve`、`removeAuxiliaryCurve`、`renameAuxiliaryCurve`、`createAuxKey`、`removeAuxKey`、`moveAuxKeys`、`copyAuxKey`。
+- `queryClip` 返回 typed `curves`、`events`、`embeddedPlayers`、`embeddedPlayerGroups`、`auxiliaryCurves`、`isSkeleton`。
+- `save` 对普通 `.anim` 写 asset，对骨骼动画 clip 写回 meta 的 events、embedded players、embedded player groups、wrapMode、speed、sample、auxiliary curves。
 
 ## 状态恢复语义
 
@@ -99,7 +107,7 @@ Scene process 不负责：
 
 1. 建立 scene-process service 和文档，完成 session / 查询 / 播放 / 普通 clip 保存闭环。
 2. 迁移 `EditorAnimationClip` 等价的普通 clip 基础编辑原语，补 `applyOperation`、clip dump、帧值查询。
-3. 补骨骼动画 meta 保存、operation 白名单、auxiliary curve、embedded player。
+3. 补骨骼动画 meta 保存、typed operation 白名单、auxiliary curve、embedded player。
 4. 补 asset delete/refresh、script reload、dirty/undo/redo 事件一致性。
 5. 根据 UI 迁入需要补事件订阅，但保持事件名和 scene-process 内部服务解耦。
 
@@ -120,4 +128,13 @@ Scene process 不负责：
 - `src/core/scene/scene-process/service/index.ts`
 - `src/core/scene/scene-process/service/interfaces.ts`
 
-第二阶段已补 `queryClip`、`queryPropertyValueAtFrame`、`applyOperation` 的基础普通 clip 闭环，并覆盖 sample、speed、wrapMode 和事件原语。旧 `EditorAnimationClip` 的复杂 curve/key 原语、骨骼 meta、auxiliary curve 和 embedded player 放到后续阶段。
+第二阶段已补 `queryClip`、`queryPropertyValueAtFrame`、`applyOperation` 的基础普通 clip 闭环，并覆盖 sample、speed、wrapMode 和事件原语。
+
+第三阶段已补 typed operation、基础 embedded player、基础 auxiliary curve、骨骼动画 meta 保存，并将 Animation scene-process 实现拆为：
+
+- `src/core/scene/scene-process/service/animation.ts`：service 入口和 session / 查询 / 播放 / 保存主流程。
+- `src/core/scene/scene-process/service/animation/clip-operations.ts`：typed operation 分发和 clip/event 操作。
+- `src/core/scene/scene-process/service/animation/embedded-player.ts`：embedded player dump、增删改和 meta 序列化。
+- `src/core/scene/scene-process/service/animation/auxiliary-curve.ts`：auxiliary curve dump、key 操作和 meta 序列化。
+- `src/core/scene/scene-process/service/animation/clip-dump.ts`：clip dump 组装。
+- `src/core/scene/scene-process/service/animation/skeleton-meta.ts`：骨骼动画 meta 写回。

--- a/docs/dev/scene/animation.md
+++ b/docs/dev/scene/animation.md
@@ -1,0 +1,117 @@
+# Animation Scene-Process Migration Plan
+
+## 背景
+
+旧动画编辑器入口在 `/Users/cocos/editor-3d-develop/app/builtin/animator`，但真正的后端能力主要落在旧 `scene` 的动画 message 和 `AnimationManager`。CLI 迁移不迁 UI、面板、快捷键、profile/preferences，也不复刻旧 `Editor.Message` 和 `SceneFacadeManager` 架构；本轮只在 `src/core/scene/scene-process` 内补动画编辑能力。
+
+## 迁移边界
+
+Scene process 负责：
+
+- 动画编辑 session：进入、退出、查询状态、切 root、切 clip。
+- 动画查询：root 信息、clip dump、可编辑属性、clip 列表、当前时间、帧采样值。
+- 播放和采样：设置编辑时间、play/pause/resume/stop。
+- 编辑操作：通过统一 `AnimationOperation[]` 批处理 clip/key/event/curve 操作。
+- 保存：普通 `.anim` 保存到 asset，骨骼动画受限操作写回 meta。
+- 退出恢复：停止播放、恢复普通 scene/prefab 模式、恢复 selection、清理预览采样状态。
+
+Scene process 不负责：
+
+- MCP/API tool、main-process proxy、`SceneApi.animation` 暴露。
+- animator 面板、curve-editor 面板、快捷键、菜单。
+- 节点树展开、滚动、过滤、焦点等纯 UI 状态。
+- clip cache 和 profile/preference 开关。
+- 旧 `scene:ready` / `asset-db:*` 等 UI 事件总线名字。
+
+## 能力矩阵
+
+| 旧能力 | 旧入口 | Scene-process 方法 | 状态 |
+|---|---|---|---|
+| 进入动画编辑 | `record-animation(uuid,true,clipUuid)` | `AnimationService.enter` | 已落地第一阶段 |
+| 退出动画编辑 | `record-animation(uuid,false)` / `close-scene` | `AnimationService.exit` | 已落地第一阶段 |
+| 查询 scene 模式 | `query-scene-mode` | `AnimationService.queryState` | 已落地第一阶段 |
+| 当前 root/clip | `query-current-animation-info` | `AnimationService.queryState` | 已落地第一阶段 |
+| 查询动画 root | `query-animation-root` | `AnimationService.queryRoot` | 已落地第一阶段 |
+| 查询 root 信息 | `query-animation-root-info` | `AnimationService.queryRootInfo` | 已落地第一阶段 |
+| 查询 clip dump | `query-animation-clip` | `AnimationService.queryClip` | 第二阶段 |
+| 查询可编辑属性 | `query-animation-properties` | `AnimationService.queryProperties` | 已落地第一阶段 |
+| 查询 clips | `query-animation-clips-info` | `AnimationService.queryClips` | 已落地第一阶段 |
+| 查询时间 | `query-animation-clips-time` | `AnimationService.queryTime` | 已落地第一阶段 |
+| 设置时间/采样 | `set-edit-time` | `AnimationService.setTime` | 已落地第一阶段 |
+| 播放控制 | `change-clip-state` | `AnimationService.changePlayState` | 已落地第一阶段 |
+| 切 clip | `change-edit-clip` | `AnimationService.changeEditClip` | 已落地第一阶段 |
+| 批处理编辑 | `animation-operation` | `AnimationService.applyOperation` | 第二阶段 |
+| 保存 clip | `save-clip` | `AnimationService.save` | 已落地普通 clip；骨骼 meta 后续补齐 |
+| 查询帧值 | `query-property-value-at-frame` | `AnimationService.queryPropertyValueAtFrame` | 第二阶段 |
+| 辅助曲线 | `query-auxiliary-*` / aux operations | `AnimationService.queryAuxiliaryCurves` / operation | 第三阶段 |
+| embedded player | operation | `AnimationService.applyOperation` | 第三阶段 |
+| inspector drop clip | `inspector-drop-animation` | `AnimationService.addClipToNode` | 第三阶段 |
+
+## Service 设计
+
+第一阶段新增 scene-process 能力：
+
+- `enter({ rootPath?, rootUuid?, clipUuid?, restoreSelectionOnExit? })`
+- `exit({ save?, restoreSelection?, restoreSampledSceneState? })`
+- `queryState()`
+- `queryRoot({ nodePath?, nodeUuid?, rootPath?, rootUuid? })`
+- `queryRootInfo({ nodePath?, nodeUuid?, rootPath?, rootUuid? })`
+- `queryClips({ nodePath?, nodeUuid?, rootPath?, rootUuid? })`
+- `queryProperties({ nodePath?, nodeUuid?, rootPath?, rootUuid? })`
+- `queryTime({ clipUuid? })`
+- `setTime({ time })`
+- `changePlayState({ operate, clipUuid? })`
+- `changeEditClip({ clipUuid })`
+- `save()`
+
+第二阶段继续补：
+
+- `queryClip`
+- `queryPropertyValueAtFrame`
+- `applyOperation`
+
+## 状态恢复语义
+
+`enter` 创建 CLI 内部 session，并保存：
+
+- 进入前 `editorType`。
+- 进入前 selection paths。
+- root uuid/path、clip uuid。
+- 当前时间和播放状态。
+
+`exit` 统一做：
+
+- 停止当前动画状态。
+- 退出 `ANIMATION_MODE` tick 状态。
+- 清理 animation state cache。
+- 默认恢复进入前 selection。
+- 返回退出后的状态。
+
+节点树展开、滚动、过滤等 UI 状态不进 scene-process 核心。未来 UI 层需要在进入前自行保存，退出后根据 service 返回的 root/selection/state 恢复。
+
+## 实施阶段
+
+1. 建立 scene-process service 和文档，完成 session / 查询 / 播放 / 普通 clip 保存闭环。
+2. 迁移 `EditorAnimationClip` 等价的普通 clip 编辑原语，补 `applyOperation`、clip dump、帧值查询。
+3. 补骨骼动画 meta 保存、operation 白名单、auxiliary curve、embedded player。
+4. 补 asset delete/refresh、script reload、dirty/undo/redo 事件一致性。
+5. 根据 UI 迁入需要补事件订阅，但保持事件名和 scene-process 内部服务解耦。
+
+## 验收标准
+
+- 类型层：`IServiceManager.Animation` 可用，`IPublicServiceManager`、MCP API、main-process proxy 不暴露 Animation。
+- 行为层：打开 scene 后可进入动画 session、查询状态、设置时间、播放控制、退出并恢复 selection。
+- 保存层：普通 `.anim` clip 修改后可保存到 asset。
+- 失败语义：没有打开 scene、节点不存在、clip 不存在、未进入 session 时必须显式失败，不返回默认成功。
+
+## 当前落地状态
+
+已完成第一阶段 scene-process 链路：
+
+- `src/core/scene/common/animation.ts`
+- `src/core/scene/scene-process/service/animation.ts`
+- `src/core/scene/scene-process/service/engine.ts`
+- `src/core/scene/scene-process/service/index.ts`
+- `src/core/scene/scene-process/service/interfaces.ts`
+
+第一阶段尚未覆盖旧 `EditorAnimationClip` 的曲线/key/event 编辑原语。第二阶段需要迁移或重写 clip dump、帧值查询、`applyOperation`，骨骼 meta、auxiliary curve 和 embedded player 放到第三阶段。

--- a/docs/dev/scene/animation.md
+++ b/docs/dev/scene/animation.md
@@ -84,6 +84,14 @@ Scene process 不负责：
 - `queryClip` 返回 typed `curves`、`events`、`embeddedPlayers`、`embeddedPlayerGroups`、`auxiliaryCurves`、`isSkeleton`。
 - `save` 对普通 `.anim` 写 asset，对骨骼动画 clip 写回 meta 的 events、embedded players、embedded player groups、wrapMode、speed、sample、auxiliary curves。
 
+第四阶段继续补：
+
+- `applyOperation` 默认记录 undo/dirty；一次批处理对应一条 `animation:clip-snapshot` undo command。
+- `applyOperation({ recordUndo: false })` 只修改当前 clip，不写入 undo 栈，不改变 dirty 状态。
+- undo/redo 恢复当前 typed operation 会修改的 clip 数据：sample、speed、wrapMode、events、embedded players/groups、auxiliary curves，并在恢复后重新采样当前编辑时间。
+- 当前编辑 clip 收到 `asset-refresh` 后清理旧 `AnimationState` 并基于刷新后的 clip 重建采样状态。
+- 当前编辑 clip 被删除时退出 animation session；editor close/reload 时清理 animation session 和 state cache，script reload 复用 editor reload 生命周期。
+
 ## 状态恢复语义
 
 `enter` 创建 CLI 内部 session，并保存：
@@ -138,3 +146,10 @@ Scene process 不负责：
 - `src/core/scene/scene-process/service/animation/auxiliary-curve.ts`：auxiliary curve dump、key 操作和 meta 序列化。
 - `src/core/scene/scene-process/service/animation/clip-dump.ts`：clip dump 组装。
 - `src/core/scene/scene-process/service/animation/skeleton-meta.ts`：骨骼动画 meta 写回。
+
+第四阶段已补 animation operation 的 undo/dirty 接入和生命周期清理：
+
+- `src/core/scene/scene-process/service/animation/clip-snapshot.ts`：捕获和恢复 operation 涉及的 clip 编辑快照。
+- `src/core/scene/scene-process/service/animation/undo.ts`：animation clip 快照 undo command。
+- `AnimationService.applyOperation` 默认 push undo command；显式 `recordUndo:false` 跳过 undo/dirty。
+- `AnimationService` 处理当前 clip 的 asset refresh/delete，以及 editor close/reload 时的 session 和 state cache 清理。

--- a/docs/dev/scene/animation.md
+++ b/docs/dev/scene/animation.md
@@ -13,7 +13,7 @@ Scene process 负责：
 - 播放和采样：设置编辑时间、play/pause/resume/stop。
 - 编辑操作：通过统一 `AnimationOperation[]` 批处理 clip/key/event/curve 操作。
 - 保存：普通 `.anim` 保存到 asset，骨骼动画受限操作写回 meta。
-- 退出恢复：停止播放、恢复普通 scene/prefab 模式、恢复 selection、清理预览采样状态。
+- 退出恢复：停止播放、恢复普通 scene/prefab 模式、恢复 selection，并恢复 animation 模块捕获到的预览采样状态。
 
 Scene process 不负责：
 
@@ -25,24 +25,27 @@ Scene process 不负责：
 
 ## 能力矩阵
 
+旧动画编辑器能力与当前 CLI 实现状态的完整清单见 [Animation CLI 能力矩阵](./animation-cli-capability-matrix.md)。下表只保留迁移计划早期的主链路摘要。
+
 | 旧能力 | 旧入口 | Scene-process 方法 | 状态 |
 |---|---|---|---|
 | 进入动画编辑 | `record-animation(uuid,true,clipUuid)` | `AnimationService.enter` | 已落地第一阶段 |
-| 退出动画编辑 | `record-animation(uuid,false)` / `close-scene` | `AnimationService.exit` | 已落地第一阶段 |
+| 退出动画编辑 | `record-animation(uuid,false)` / `close-scene` | `AnimationService.exit` | session 退出已落地；采样状态恢复为部分完成 |
 | 查询 scene 模式 | `query-scene-mode` | `AnimationService.queryState` | 已落地第一阶段 |
 | 当前 root/clip | `query-current-animation-info` | `AnimationService.queryState` | 已落地第一阶段 |
+| 查询播放状态 | `query-animation-state` | `AnimationService.queryState` | 已合并到 state.playState |
 | 查询动画 root | `query-animation-root` | `AnimationService.queryRoot` | 已落地第一阶段 |
-| 查询 root 信息 | `query-animation-root-info` | `AnimationService.queryRootInfo` | 已落地第一阶段 |
-| 查询 clip dump | `query-animation-clip` | `AnimationService.queryClip` | 已落地第二阶段基础 dump |
-| 查询可编辑属性 | `query-animation-properties` | `AnimationService.queryProperties` | 已落地第一阶段 |
-| 查询 clips | `query-animation-clips-info` | `AnimationService.queryClips` | 已落地第一阶段 |
+| 查询 root 信息 | `query-animation-root-info` | `AnimationService.queryRootInfo` | 已落地基础信息；支持无 clip 的 root info，复杂旧 property dump 仍部分缺口 |
+| 查询 clip dump | `query-animation-clip` | `AnimationService.queryClip` | 已落地基础 dump；复杂旧 property track 仍部分缺口 |
+| 查询可编辑属性 | `query-animation-properties` | `AnimationService.queryProperties` | 已落地基础属性；旧递归属性/adapter 仍部分缺口 |
+| 查询 clips | `query-animation-clips-info` | `AnimationService.queryClips` | 已落地第一阶段；Animation 组件 clips 为空时返回空 menu |
 | 查询时间 | `query-animation-clips-time` | `AnimationService.queryTime` | 已落地第一阶段 |
-| 设置时间/采样 | `set-edit-time` | `AnimationService.setTime` | 已落地第一阶段 |
+| 设置时间/采样 | `set-edit-time` | `AnimationService.setTime` | CLI 已覆盖 root/child 采样；PinK 真实 gate 待复测 |
 | 播放控制 | `change-clip-state` | `AnimationService.changePlayState` | 已落地第一阶段 |
-| 切 clip | `change-edit-clip` | `AnimationService.changeEditClip` | 已落地第一阶段 |
+| 切 clip | `change-edit-clip` | `AnimationService.changeEditClip` | 已落地第一阶段；旧 saveCheck 保护语义不在 CLI 内部 |
 | 批处理编辑 | `animation-operation` | `AnimationService.applyOperation` | 已落地 typed operation 原语 |
 | 保存 clip | `save-clip` | `AnimationService.save` | 已落地普通 clip 和骨骼 meta |
-| 查询帧值 | `query-property-value-at-frame` | `AnimationService.queryPropertyValueAtFrame` | 已落地第二阶段 |
+| 查询帧值 | `query-property-value-at-frame` | `AnimationService.queryPropertyValueAtFrame` | 已落地第二阶段；当前通过临时采样读取真实场景值 |
 | 辅助曲线 | `query-auxiliary-*` / aux operations | `AnimationService.applyOperation` | 已落地第三阶段基础操作 |
 | embedded player | operation | `AnimationService.applyOperation` | 已落地第三阶段基础操作 |
 | inspector drop clip | `inspector-drop-animation` | 待定 | 后续按 UI 迁入需要补 |
@@ -73,13 +76,14 @@ Scene process 不负责：
 当前第二阶段先落地普通 clip 的基础闭环：
 
 - `queryClip` 返回 clip 基础 dump、事件帧 dump、当前时间和 baked animation 标记。
+- `queryRootInfo` / `queryClips` 对齐旧编辑器的空 clip 查询语义：Animation 组件存在但 clips 为空时返回空 menu，`queryRootInfo.clipDump` 为 `null`。
 - `queryPropertyValueAtFrame` 按帧采样当前编辑 clip，读取目标节点或组件属性后恢复原编辑时间。
 - `applyOperation` 使用 typed `AnimationOperation` 批处理格式，基础操作支持 `changeSample`、`changeSpeed`、`changeWrapMode`、`addEvent`、`deleteEvent`、`updateEvent`、`moveEvents`、`copyEventsTo`。
 
 第三阶段继续补：
 
 - typed operation 不兼容旧 `{ funcName, args }`。后续 animator 面板走新实现，不需要保留旧 animator message 形态。
-- `applyOperation` 增加 embedded player 基础操作：`addEmbeddedPlayer`、`deleteEmbeddedPlayer`、`updateEmbeddedPlayer`、`clearEmbeddedPlayer`、`addEmbeddedPlayerGroup`、`removeEmbeddedPlayerGroup`、`clearEmbeddedPlayerGroup`。
+- `applyOperation` 增加 embedded player 基础操作：`addEmbeddedPlayer`、`deleteEmbeddedPlayer`、`updateEmbeddedPlayer`、`clearEmbeddedPlayer`、`addEmbeddedPlayerGroup`、`removeEmbeddedPlayerGroup`、`clearEmbeddedPlayerGroup`。其中 `clearEmbeddedPlayer` 当前对齐全清/按 group 清理，未完全覆盖旧编辑器按 `nodePath` 清空的语义。
 - `applyOperation` 增加 auxiliary curve 基础操作：`addAuxiliaryCurve`、`removeAuxiliaryCurve`、`renameAuxiliaryCurve`、`createAuxKey`、`removeAuxKey`、`moveAuxKeys`、`copyAuxKey`。
 - `queryClip` 返回 typed `curves`、`events`、`embeddedPlayers`、`embeddedPlayerGroups`、`auxiliaryCurves`、`isSkeleton`。
 - `save` 对普通 `.anim` 写 asset，对骨骼动画 clip 写回 meta 的 events、embedded players、embedded player groups、wrapMode、speed、sample、auxiliary curves。
@@ -99,12 +103,13 @@ Scene process 不负责：
 - 进入前 `editorType`。
 - 进入前 selection paths。
 - root uuid/path、clip uuid。
-- 当前时间和播放状态。
+- 进入前 root 子树的采样状态快照。
 
 `exit` 统一做：
 
 - 停止当前动画状态。
-- 退出 `ANIMATION_MODE` tick 状态。``
+- 尽量恢复进入前 root 子树采样状态。当前覆盖 node `active` / `position` / `rotation` / `scale`，以及可克隆或普通对象/数组的 animatable component 属性；不等价于旧编辑器全量 node dump restore。
+- 退出 `ANIMATION_MODE` tick 状态。
 - 清理 animation state cache。
 - 默认恢复进入前 selection。
 - 返回退出后的状态。
@@ -168,4 +173,15 @@ Scene process 不负责：
 - `applyOperation` 新增 `createPropertyKey`、`removePropertyKey`、`movePropertyKeys`，支持用 `nodePath` 或 `nodeUuid` 定位动画 root 下的目标节点。
 - property operation 会重新初始化当前 `AnimationState` evaluator，保证新增 track 可立即被 `setTime` / `queryPropertyValueAtFrame` 采样。
 - undo/redo snapshot 已纳入普通属性曲线，恢复后会重新初始化 evaluator 并按当前编辑时间重采样。
-- 组件属性曲线、Color/Quat/ObjectTrack、曲线切线编辑等仍留给 UI 反馈后的后续阶段。
+
+第七阶段已补 PinK authoring gate 相关 CLI 代码路径，但 PinK 真实 scene Product gate 仍需复测后才能按 PinK 口径标完成：
+
+- `applyOperation` 在普通 property key、event、embedded player、auxiliary curve 变化后重算 clip duration；CLI 场景测试已覆盖，PinK 真实 scene gate 待复测。
+- `setTime` 对 root 和 child `nodePath` 属性轨道采样到真实节点；CLI 场景测试已覆盖，PinK G2-B 真实插件链路仍需复测关闭。
+- root keyframe move/copy/remove 后的 `queryClip` dump 和 evaluator 重建已有 CLI 覆盖；PinK G3 save / exit / reenter 后 seek / sampling 仍按真实插件链路复测结果为准。
+- `createPropertyKey`、`updatePropertyKey`、`updatePropertyKeyData` 支持 RealCurve keyData 写入和 `queryClip` 读回，包含 `interpMode`、显式 0 值、切线/权重和 `broken`；CLI 场景测试已覆盖，PinK 真实 scene gate 待复测。
+- `createAuxKey`、`updateAuxKeyData` 支持 auxiliary curve keyData 写入和读回，`queryAuxiliaryCurveValueAtFrame` 支持按帧采样辅助曲线。
+- `applyOperation` 批处理中任一 operation 失败时恢复批处理前 clip snapshot，避免局部写入残留。
+- `queryClip` 普通查询路径不再为了恢复缺失 clip 而重绑 `Animation.clips/defaultClip`；clip rebind 只保留在 `enter`、`changeEditClip`、asset refresh 等明确写入/恢复路径。
+- `exit` 的采样状态恢复收敛在 animation 模块内，不再依赖全量 node dump restore；当前恢复范围是部分完成，详见能力矩阵。
+- 当前未完整迁移的旧能力以能力矩阵为准，主要集中在 property/node 结构型操作、`spacingKeys`、`clearKeys`、嵌入播放器菜单查询、旧 saveCheck 保护语义、旧 `isLock` / 2D 过滤语义和 AnimationController 结构编辑契约。

--- a/docs/dev/scene/animation.md
+++ b/docs/dev/scene/animation.md
@@ -88,7 +88,7 @@ Scene process 不负责：
 
 - `applyOperation` 默认记录 undo/dirty；一次批处理对应一条 `animation:clip-snapshot` undo command。
 - `applyOperation({ recordUndo: false })` 只修改当前 clip，不写入 undo 栈，不改变 dirty 状态。
-- undo/redo 恢复当前 typed operation 会修改的 clip 数据：sample、speed、wrapMode、events、embedded players/groups、auxiliary curves，并在恢复后重新采样当前编辑时间。
+- undo/redo 恢复当前 typed operation 会修改的 clip 数据：sample、speed、wrapMode、普通属性曲线、events、embedded players/groups、auxiliary curves，并在恢复后重新采样当前编辑时间。
 - 当前编辑 clip 收到 `asset-refresh` 后清理旧 `AnimationState` 并基于刷新后的 clip 重建采样状态。
 - 当前编辑 clip 被删除时退出 animation session；editor close/reload 时清理 animation session 和 state cache，script reload 复用 editor reload 生命周期。
 
@@ -104,7 +104,7 @@ Scene process 不负责：
 `exit` 统一做：
 
 - 停止当前动画状态。
-- 退出 `ANIMATION_MODE` tick 状态。
+- 退出 `ANIMATION_MODE` tick 状态。``
 - 清理 animation state cache。
 - 默认恢复进入前 selection。
 - 返回退出后的状态。
@@ -118,6 +118,7 @@ Scene process 不负责：
 3. 补骨骼动画 meta 保存、typed operation 白名单、auxiliary curve、embedded player。
 4. 补 asset delete/refresh、script reload、dirty/undo/redo 事件一致性。
 5. 根据 UI 迁入需要补事件订阅，但保持事件名和 scene-process 内部服务解耦。
+6. 补普通属性曲线 keyframe 最小闭环，先覆盖 node TRS Vec3 属性。
 
 ## 验收标准
 
@@ -153,3 +154,18 @@ Scene process 不负责：
 - `src/core/scene/scene-process/service/animation/undo.ts`：animation clip 快照 undo command。
 - `AnimationService.applyOperation` 默认 push undo command；显式 `recordUndo:false` 跳过 undo/dirty。
 - `AnimationService` 处理当前 clip 的 asset refresh/delete，以及 editor close/reload 时的 session 和 state cache 清理。
+
+第五阶段已补 animation 事件订阅基础契约：
+
+- `animation:state-changed`：session、播放状态和当前 clip 状态变化。
+- `animation:time-changed`：编辑时间采样变化。
+- `animation:clip-changed`：当前 clip 数据变化、undo/redo 恢复和 asset refresh。
+- 事件通过 scene-process `ServiceEvents` 广播并进入 `messageManager`，不复用旧 animator message 名称。
+
+第六阶段已补普通属性曲线 keyframe 最小闭环：
+
+- `queryClip.curves` 现在 dump node TRS Vec3 曲线，当前覆盖 `position`、`scale`、`eulerAngles`。
+- `applyOperation` 新增 `createPropertyKey`、`removePropertyKey`、`movePropertyKeys`，支持用 `nodePath` 或 `nodeUuid` 定位动画 root 下的目标节点。
+- property operation 会重新初始化当前 `AnimationState` evaluator，保证新增 track 可立即被 `setTime` / `queryPropertyValueAtFrame` 采样。
+- undo/redo snapshot 已纳入普通属性曲线，恢复后会重新初始化 evaluator 并按当前编辑时间重采样。
+- 组件属性曲线、Color/Quat/ObjectTrack、曲线切线编辑等仍留给 UI 反馈后的后续阶段。

--- a/docs/dev/scene/animation.md
+++ b/docs/dev/scene/animation.md
@@ -33,16 +33,16 @@ Scene process 不负责：
 | 当前 root/clip | `query-current-animation-info` | `AnimationService.queryState` | 已落地第一阶段 |
 | 查询动画 root | `query-animation-root` | `AnimationService.queryRoot` | 已落地第一阶段 |
 | 查询 root 信息 | `query-animation-root-info` | `AnimationService.queryRootInfo` | 已落地第一阶段 |
-| 查询 clip dump | `query-animation-clip` | `AnimationService.queryClip` | 第二阶段 |
+| 查询 clip dump | `query-animation-clip` | `AnimationService.queryClip` | 已落地第二阶段基础 dump |
 | 查询可编辑属性 | `query-animation-properties` | `AnimationService.queryProperties` | 已落地第一阶段 |
 | 查询 clips | `query-animation-clips-info` | `AnimationService.queryClips` | 已落地第一阶段 |
 | 查询时间 | `query-animation-clips-time` | `AnimationService.queryTime` | 已落地第一阶段 |
 | 设置时间/采样 | `set-edit-time` | `AnimationService.setTime` | 已落地第一阶段 |
 | 播放控制 | `change-clip-state` | `AnimationService.changePlayState` | 已落地第一阶段 |
 | 切 clip | `change-edit-clip` | `AnimationService.changeEditClip` | 已落地第一阶段 |
-| 批处理编辑 | `animation-operation` | `AnimationService.applyOperation` | 第二阶段 |
+| 批处理编辑 | `animation-operation` | `AnimationService.applyOperation` | 已落地第二阶段基础原语 |
 | 保存 clip | `save-clip` | `AnimationService.save` | 已落地普通 clip；骨骼 meta 后续补齐 |
-| 查询帧值 | `query-property-value-at-frame` | `AnimationService.queryPropertyValueAtFrame` | 第二阶段 |
+| 查询帧值 | `query-property-value-at-frame` | `AnimationService.queryPropertyValueAtFrame` | 已落地第二阶段 |
 | 辅助曲线 | `query-auxiliary-*` / aux operations | `AnimationService.queryAuxiliaryCurves` / operation | 第三阶段 |
 | embedded player | operation | `AnimationService.applyOperation` | 第三阶段 |
 | inspector drop clip | `inspector-drop-animation` | `AnimationService.addClipToNode` | 第三阶段 |
@@ -70,6 +70,12 @@ Scene process 不负责：
 - `queryPropertyValueAtFrame`
 - `applyOperation`
 
+当前第二阶段先落地普通 clip 的基础闭环：
+
+- `queryClip` 返回 clip 基础 dump、事件帧 dump、当前时间和 baked animation 标记。
+- `queryPropertyValueAtFrame` 按帧采样当前编辑 clip，读取目标节点或组件属性后恢复原编辑时间。
+- `applyOperation` 使用旧入口兼容的 `{ funcName, args }` 批处理格式，当前支持 `changeSample`、`changeSpeed`、`changeWrapMode`、`addEvent`、`deleteEvent`、`updateEvent`、`moveEvents`、`copyEventsTo`。
+
 ## 状态恢复语义
 
 `enter` 创建 CLI 内部 session，并保存：
@@ -92,7 +98,7 @@ Scene process 不负责：
 ## 实施阶段
 
 1. 建立 scene-process service 和文档，完成 session / 查询 / 播放 / 普通 clip 保存闭环。
-2. 迁移 `EditorAnimationClip` 等价的普通 clip 编辑原语，补 `applyOperation`、clip dump、帧值查询。
+2. 迁移 `EditorAnimationClip` 等价的普通 clip 基础编辑原语，补 `applyOperation`、clip dump、帧值查询。
 3. 补骨骼动画 meta 保存、operation 白名单、auxiliary curve、embedded player。
 4. 补 asset delete/refresh、script reload、dirty/undo/redo 事件一致性。
 5. 根据 UI 迁入需要补事件订阅，但保持事件名和 scene-process 内部服务解耦。
@@ -114,4 +120,4 @@ Scene process 不负责：
 - `src/core/scene/scene-process/service/index.ts`
 - `src/core/scene/scene-process/service/interfaces.ts`
 
-第一阶段尚未覆盖旧 `EditorAnimationClip` 的曲线/key/event 编辑原语。第二阶段需要迁移或重写 clip dump、帧值查询、`applyOperation`，骨骼 meta、auxiliary curve 和 embedded player 放到第三阶段。
+第二阶段已补 `queryClip`、`queryPropertyValueAtFrame`、`applyOperation` 的基础普通 clip 闭环，并覆盖 sample、speed、wrapMode 和事件原语。旧 `EditorAnimationClip` 的复杂 curve/key 原语、骨骼 meta、auxiliary curve 和 embedded player 放到后续阶段。

--- a/docs/dev/scene/animation.md
+++ b/docs/dev/scene/animation.md
@@ -36,8 +36,8 @@ Scene process 不负责：
 | 查询播放状态 | `query-animation-state` | `AnimationService.queryState` | 已合并到 state.playState |
 | 查询动画 root | `query-animation-root` | `AnimationService.queryRoot` | 已落地第一阶段 |
 | 查询 root 信息 | `query-animation-root-info` | `AnimationService.queryRootInfo` | 已落地基础信息；支持无 clip 的 root info，复杂旧 property dump 仍部分缺口 |
-| 查询 clip dump | `query-animation-clip` | `AnimationService.queryClip` | 已落地基础 dump；复杂旧 property track 仍部分缺口 |
-| 查询可编辑属性 | `query-animation-properties` | `AnimationService.queryProperties` | 已落地基础属性；旧递归属性/adapter 仍部分缺口 |
+| 查询 clip dump | `query-animation-clip` | `AnimationService.queryClip` | 已落地基础 dump 和 material uniform track；复杂旧 property track 仍部分缺口 |
+| 查询可编辑属性 | `query-animation-properties` | `AnimationService.queryProperties` | 已落地基础属性、`cc.Sprite.type` 和 material uniform；旧递归属性/其他 adapter 仍部分缺口 |
 | 查询 clips | `query-animation-clips-info` | `AnimationService.queryClips` | 已落地第一阶段；Animation 组件 clips 为空时返回空 menu |
 | 查询时间 | `query-animation-clips-time` | `AnimationService.queryTime` | 已落地第一阶段 |
 | 设置时间/采样 | `set-edit-time` | `AnimationService.setTime` | CLI 已覆盖 root/child 采样；PinK 真实 gate 待复测 |

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -5261,6 +5261,7 @@ import type { Vec3 as Vec3_2 } from 'cc';
 export declare interface AnimationClipAssetUserData {
     name: string;
 }
+export declare type AnimationEditorType = 'scene' | 'prefab' | 'unknown';
 export declare interface AnimationImportSetting {
     name: string;
     duration: number;
@@ -5285,6 +5286,9 @@ export declare interface AnimationImportSetting {
         };
     }>;
 }
+export declare type AnimationMode = 'general' | 'prefab' | 'animation' | 'preview' | 'unknown';
+export declare type AnimationPlayOperation = 'play' | 'pause' | 'resume' | 'stop';
+export declare type AnimationPlayState_2 = 'stop' | 'playing' | 'pause';
 export declare const ASSET_HANDLER_TYPES: string[];
 export declare type AssetHandlerType = typeof ASSET_HANDLER_TYPES[number] | 'database';
 export declare interface AssetUserDataMap {
@@ -5472,6 +5476,92 @@ export declare interface GlTFUserData {
 export declare interface IAddComponentOptions {
     nodePath: string;
     component: string;
+}
+export declare interface IAnimationClipMenuItem {
+    uuid: string;
+    name: string;
+}
+export declare interface IAnimationClipsInfo extends IAnimationRootResult {
+    clipsMenu: IAnimationClipMenuItem[];
+    defaultClip: string;
+}
+export declare interface IAnimationEditClipOptions {
+    clipUuid: string;
+}
+export declare interface IAnimationEnterOptions {
+    rootPath?: string;
+    rootUuid?: string;
+    clipUuid?: string;
+    restoreSelectionOnExit?: boolean;
+}
+export declare interface IAnimationExitOptions {
+    save?: boolean;
+    restoreSelection?: boolean;
+    restoreSampledSceneState?: boolean;
+}
+export declare interface IAnimationPlayStateOptions {
+    operate: AnimationPlayOperation;
+    clipUuid?: string;
+}
+export declare interface IAnimationPropertyInfo {
+    name: string;
+    key: string;
+    displayName: string;
+    type: {
+        value: string;
+    };
+    menuName: string;
+    comp?: string;
+    category?: string;
+}
+export declare interface IAnimationRootInfo extends IAnimationClipsInfo {
+    nodeTreeDump: unknown;
+    clipDump: unknown;
+    time: number;
+    state: AnimationPlayState_2;
+    useBakedAnimation: boolean;
+}
+export declare interface IAnimationRootResult {
+    rootUuid: string;
+    rootPath: string;
+}
+export declare interface IAnimationService extends IServiceEvents {
+    enter(options: IAnimationEnterOptions): Promise<IAnimationStateInfo>;
+    exit(options: IAnimationExitOptions): Promise<IAnimationStateInfo>;
+    queryState(): Promise<IAnimationStateInfo>;
+    queryRoot(options: IAnimationTargetOptions): Promise<IAnimationRootResult>;
+    queryRootInfo(options: IAnimationTargetOptions): Promise<IAnimationRootInfo>;
+    queryClips(options: IAnimationTargetOptions): Promise<IAnimationClipsInfo>;
+    queryProperties(options: IAnimationTargetOptions): Promise<IAnimationPropertyInfo[]>;
+    queryTime(options: IAnimationTimeOptions): Promise<number>;
+    setTime(options: IAnimationSetTimeOptions): Promise<boolean>;
+    changePlayState(options: IAnimationPlayStateOptions): Promise<boolean>;
+    changeEditClip(options: IAnimationEditClipOptions): Promise<boolean>;
+    save(): Promise<boolean>;
+}
+export declare interface IAnimationSetTimeOptions {
+    time: number;
+}
+export declare interface IAnimationStateInfo {
+    active: boolean;
+    editorType: AnimationEditorType;
+    mode: AnimationMode;
+    rootUuid: string;
+    rootPath: string;
+    clipUuid: string;
+    time: number;
+    playState: AnimationPlayState_2;
+    selection: string[];
+    restoreSelectionOnExit: boolean;
+}
+export declare interface IAnimationTargetOptions {
+    nodePath?: string;
+    nodeUuid?: string;
+    rootPath?: string;
+    rootUuid?: string;
+}
+export declare interface IAnimationTimeOptions {
+    clipUuid?: string;
 }
 export declare interface IApplyPrefabChangesParams {
     nodePath: string;
@@ -5714,6 +5804,8 @@ export declare interface IEngineService extends IServiceEvents {
     init(): Promise<void>;
     repaintInEditMode(): Promise<void>;
     initCustomLayer(layers?: ICustomLayerConfig[]): Promise<void>;
+    enterAnimationMode(): void;
+    exitAnimationMode(): void;
 }
 export declare interface IExecuteComponentMethodOptions {
     path: string;
@@ -6127,6 +6219,7 @@ export declare interface IServiceManager {
     Script: IScriptService;
     Asset: IAssetService;
     Engine: IEngineService;
+    Animation: IAnimationService;
     Prefab: IPrefabService;
     Selection: ISelectionService;
     Operation: IOperationService;

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -5871,7 +5871,7 @@ export declare interface IAnimationService extends IServiceEvents {
     setTime(options: IAnimationSetTimeOptions): Promise<boolean>;
     changePlayState(options: IAnimationPlayStateOptions): Promise<boolean>;
     changeEditClip(options: IAnimationEditClipOptions): Promise<boolean>;
-    applyOperation(options: IAnimationOperationOptions): Promise<IAnimationOperationResult>;
+    applyOperations(options: IAnimationOperationOptions): Promise<IAnimationOperationResult>;
     save(options?: IAnimationSaveOptions): Promise<boolean>;
 }
 export declare interface IAnimationSetTimeOptions {

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -5649,6 +5649,12 @@ export declare type IAnimationOperation = {
     keyData?: IAnimationCurveKeyData;
     curveData?: IAnimationCurveKeyData;
 } | {
+    type: 'removePropertyCurve';
+    clipUuid: string;
+    nodePath?: string;
+    nodeUuid?: string;
+    propKey: string;
+} | {
     type: 'removePropertyKey';
     clipUuid: string;
     nodePath?: string;

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -5610,17 +5610,44 @@ export declare type IAnimationOperation = {
     clipUuid: string;
     wrapMode: number;
 } | {
+    type: 'addPropertyCurve';
+    clipUuid: string;
+    nodePath?: string;
+    nodeUuid?: string;
+    propKey: string;
+    value?: IAnimationValue;
+} | {
     type: 'createPropertyKey';
     clipUuid: string;
     nodePath?: string;
     nodeUuid?: string;
     propKey: string;
     frame: number;
-    value: IAnimationValue;
+    value?: IAnimationValue;
     channel?: string;
     keyData?: IAnimationCurveKeyData;
+    curveData?: IAnimationCurveKeyData;
+} | {
+    type: 'updatePropertyKey';
+    clipUuid: string;
+    nodePath?: string;
+    nodeUuid?: string;
+    propKey: string;
+    frame: number;
+    value?: IAnimationValue;
+    channel?: string;
+    keyData?: IAnimationCurveKeyData;
+    curveData?: IAnimationCurveKeyData;
 } | {
     type: 'removePropertyKey';
+    clipUuid: string;
+    nodePath?: string;
+    nodeUuid?: string;
+    propKey: string;
+    frames: number[];
+    channel?: string;
+} | {
+    type: 'removePropertyKeys';
     clipUuid: string;
     nodePath?: string;
     nodeUuid?: string;
@@ -5636,6 +5663,23 @@ export declare type IAnimationOperation = {
     frames: number[];
     offset: number;
     channel?: string;
+} | {
+    type: 'copyPropertyKeysTo';
+    clipUuid: string;
+    nodePath?: string;
+    nodeUuid?: string;
+    propKey: string;
+    frames: number[];
+    dstFrame: number;
+    channel?: string;
+} | {
+    type: 'setPropertyCurveExtrapolation';
+    clipUuid: string;
+    nodePath?: string;
+    nodeUuid?: string;
+    propKey: string;
+    preExtrap?: number;
+    postExtrap?: number;
 } | {
     type: 'addEvent';
     clipUuid: string;

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -5853,6 +5853,9 @@ export declare interface IAnimationRootResult {
     rootUuid: string;
     rootPath: string;
 }
+export declare interface IAnimationSaveOptions {
+    saveScene?: boolean;
+}
 export declare interface IAnimationService extends IServiceEvents {
     enter(options: IAnimationEnterOptions): Promise<IAnimationStateInfo>;
     exit(options: IAnimationExitOptions): Promise<IAnimationStateInfo>;
@@ -5869,7 +5872,7 @@ export declare interface IAnimationService extends IServiceEvents {
     changePlayState(options: IAnimationPlayStateOptions): Promise<boolean>;
     changeEditClip(options: IAnimationEditClipOptions): Promise<boolean>;
     applyOperation(options: IAnimationOperationOptions): Promise<IAnimationOperationResult>;
-    save(): Promise<boolean>;
+    save(options?: IAnimationSaveOptions): Promise<boolean>;
 }
 export declare interface IAnimationSetTimeOptions {
     time: number;

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -6417,8 +6417,8 @@ export declare interface IRedirectInfo {
     uuid: string;
 }
 export declare interface IRedoService {
-    redo(): Promise<IUndoRedoResult>;
-    canRedo(): boolean;
+    redo(options?: IUndoOperationOptions): Promise<IUndoRedoResult>;
+    canRedo(options?: IUndoOperationOptions): boolean;
 }
 export declare interface IReloadOptions {
     urlOrUUID?: string;
@@ -6623,6 +6623,9 @@ export declare interface IUndoCommandMeta {
 export declare interface IUndoGroupOptions {
     label?: string;
 }
+export declare interface IUndoOperationOptions {
+    scope?: Partial<IUndoScope>;
+}
 export declare interface IUndoRedoResult {
     success: boolean;
     commandId?: string;
@@ -6639,8 +6642,8 @@ export declare interface IUndoService {
     beginRecording(uuids: string[], options?: IUndoBeginOptions): string;
     endRecording(commandId: string): Promise<void>;
     cancelRecording(commandId: string): void;
-    undo(): Promise<IUndoRedoResult>;
-    redo(): Promise<IUndoRedoResult>;
+    undo(options?: IUndoOperationOptions): Promise<IUndoRedoResult>;
+    redo(options?: IUndoOperationOptions): Promise<IUndoRedoResult>;
     beginGroup(options?: IUndoGroupOptions): string;
     endGroup(groupId: string): IUndoRedoResult;
     cancelGroup(groupId: string): IUndoRedoResult;
@@ -6649,8 +6652,8 @@ export declare interface IUndoService {
     reset(): void;
     clearHistory(): void;
     isDirty(): boolean;
-    canUndo(): boolean;
-    canRedo(): boolean;
+    canUndo(options?: IUndoOperationOptions): boolean;
+    canRedo(options?: IUndoOperationOptions): boolean;
     markSaved(): void;
     hasActiveRecording(uuid?: string): boolean;
     isApplying(): boolean;

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -5510,10 +5510,17 @@ export declare interface IAnimationClipsInfo extends IAnimationRootResult {
     clipsMenu: IAnimationClipMenuItem[];
     defaultClip: string;
 }
+export declare interface IAnimationCurveChannelDump {
+    key: string;
+    displayName?: string;
+    type?: IAnimationPropertyType;
+    keyframes: IAnimationCurveKeyDump[];
+}
 export declare interface IAnimationCurveDump {
     nodePath: string;
     key: string;
     keyframes: IAnimationCurveKeyDump[] | null;
+    channels?: IAnimationCurveChannelDump[];
     category?: string;
     type?: IAnimationPropertyType;
     displayName?: string;
@@ -5602,6 +5609,33 @@ export declare type IAnimationOperation = {
     type: 'changeWrapMode';
     clipUuid: string;
     wrapMode: number;
+} | {
+    type: 'createPropertyKey';
+    clipUuid: string;
+    nodePath?: string;
+    nodeUuid?: string;
+    propKey: string;
+    frame: number;
+    value: IAnimationValue;
+    channel?: string;
+    keyData?: IAnimationCurveKeyData;
+} | {
+    type: 'removePropertyKey';
+    clipUuid: string;
+    nodePath?: string;
+    nodeUuid?: string;
+    propKey: string;
+    frames: number[];
+    channel?: string;
+} | {
+    type: 'movePropertyKeys';
+    clipUuid: string;
+    nodePath?: string;
+    nodeUuid?: string;
+    propKey: string;
+    frames: number[];
+    offset: number;
+    channel?: string;
 } | {
     type: 'addEvent';
     clipUuid: string;

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -5477,6 +5477,20 @@ export declare interface IAddComponentOptions {
     nodePath: string;
     component: string;
 }
+export declare interface IAnimationClipDump {
+    name: string;
+    duration: number;
+    sample: number;
+    speed: number;
+    wrapMode: number;
+    curves: unknown[];
+    events: IAnimationEventDump[];
+    embeddedPlayers: unknown[];
+    embeddedPlayerGroups: unknown[];
+    time: number;
+    isLock: boolean;
+    useBakedAnimation: boolean;
+}
 export declare interface IAnimationClipMenuItem {
     uuid: string;
     name: string;
@@ -5494,10 +5508,28 @@ export declare interface IAnimationEnterOptions {
     clipUuid?: string;
     restoreSelectionOnExit?: boolean;
 }
+export declare interface IAnimationEventDump {
+    frame: number;
+    func: string;
+    params: unknown[];
+}
 export declare interface IAnimationExitOptions {
     save?: boolean;
     restoreSelection?: boolean;
     restoreSampledSceneState?: boolean;
+}
+export declare interface IAnimationOperation {
+    funcName: string;
+    args: unknown[];
+}
+export declare interface IAnimationOperationOptions {
+    operations: IAnimationOperation[];
+    recordUndo?: boolean;
+}
+export declare interface IAnimationOperationResult {
+    state: 'success' | 'failure';
+    result: unknown;
+    reason?: string;
 }
 export declare interface IAnimationPlayStateOptions {
     operate: AnimationPlayOperation;
@@ -5514,9 +5546,19 @@ export declare interface IAnimationPropertyInfo {
     comp?: string;
     category?: string;
 }
+export declare interface IAnimationQueryClipOptions extends IAnimationTargetOptions {
+    clipUuid?: string;
+}
+export declare interface IAnimationQueryPropertyValueAtFrameOptions {
+    clipUuid?: string;
+    nodePath?: string;
+    nodeUuid?: string;
+    propKey: string;
+    frame: number;
+}
 export declare interface IAnimationRootInfo extends IAnimationClipsInfo {
     nodeTreeDump: unknown;
-    clipDump: unknown;
+    clipDump: IAnimationClipDump | null;
     time: number;
     state: AnimationPlayState_2;
     useBakedAnimation: boolean;
@@ -5531,12 +5573,15 @@ export declare interface IAnimationService extends IServiceEvents {
     queryState(): Promise<IAnimationStateInfo>;
     queryRoot(options: IAnimationTargetOptions): Promise<IAnimationRootResult>;
     queryRootInfo(options: IAnimationTargetOptions): Promise<IAnimationRootInfo>;
+    queryClip(options: IAnimationQueryClipOptions): Promise<IAnimationClipDump>;
     queryClips(options: IAnimationTargetOptions): Promise<IAnimationClipsInfo>;
     queryProperties(options: IAnimationTargetOptions): Promise<IAnimationPropertyInfo[]>;
     queryTime(options: IAnimationTimeOptions): Promise<number>;
+    queryPropertyValueAtFrame(options: IAnimationQueryPropertyValueAtFrameOptions): Promise<unknown>;
     setTime(options: IAnimationSetTimeOptions): Promise<boolean>;
     changePlayState(options: IAnimationPlayStateOptions): Promise<boolean>;
     changeEditClip(options: IAnimationEditClipOptions): Promise<boolean>;
+    applyOperation(options: IAnimationOperationOptions): Promise<IAnimationOperationResult>;
     save(): Promise<boolean>;
 }
 export declare interface IAnimationSetTimeOptions {

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -6608,6 +6608,7 @@ export declare interface IUIService {
 export declare interface IUndoBeginOptions {
     label?: string;
     tag?: string;
+    scope?: IUndoScope;
     customCommand?: IUndoCommand;
 }
 export declare interface IUndoCheckpoint {
@@ -6648,6 +6649,8 @@ export declare interface IUndoRedoResult {
 export declare interface IUndoScope {
     assetUuid?: string;
     assetUrl?: string;
+    nodePath?: string;
+    propPath?: string;
     editorType?: 'scene' | 'prefab' | 'animation' | string;
     mode?: 'general' | 'prefab' | 'animation' | 'preview' | string;
 }

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -5639,6 +5639,16 @@ export declare type IAnimationOperation = {
     keyData?: IAnimationCurveKeyData;
     curveData?: IAnimationCurveKeyData;
 } | {
+    type: 'updatePropertyKeyData';
+    clipUuid: string;
+    nodePath?: string;
+    nodeUuid?: string;
+    propKey: string;
+    frame: number;
+    channel?: string;
+    keyData?: IAnimationCurveKeyData;
+    curveData?: IAnimationCurveKeyData;
+} | {
     type: 'removePropertyKey';
     clipUuid: string;
     nodePath?: string;
@@ -5753,6 +5763,8 @@ export declare type IAnimationOperation = {
     name: string;
     frame: number;
     value: number;
+    keyData?: IAnimationCurveKeyData;
+    curveData?: IAnimationCurveKeyData;
 } | {
     type: 'removeAuxKey';
     clipUuid: string;
@@ -5770,6 +5782,13 @@ export declare type IAnimationOperation = {
     name: string;
     frame: number;
     dstFrame: number;
+} | {
+    type: 'updateAuxKeyData';
+    clipUuid: string;
+    name: string;
+    frame: number;
+    keyData?: IAnimationCurveKeyData;
+    curveData?: IAnimationCurveKeyData;
 };
 export declare interface IAnimationOperationOptions {
     operations: IAnimationOperation[];
@@ -5796,6 +5815,11 @@ export declare interface IAnimationPropertyInfo {
 export declare interface IAnimationPropertyType {
     value: string;
     extends?: string[];
+}
+export declare interface IAnimationQueryAuxiliaryCurveValueAtFrameOptions {
+    clipUuid?: string;
+    name: string;
+    frame: number;
 }
 export declare interface IAnimationQueryClipOptions extends IAnimationTargetOptions {
     clipUuid?: string;
@@ -5829,6 +5853,7 @@ export declare interface IAnimationService extends IServiceEvents {
     queryProperties(options: IAnimationTargetOptions): Promise<IAnimationPropertyInfo[]>;
     queryTime(options: IAnimationTimeOptions): Promise<number>;
     queryPropertyValueAtFrame(options: IAnimationQueryPropertyValueAtFrameOptions): Promise<IAnimationValue>;
+    queryAuxiliaryCurveValueAtFrame(options: IAnimationQueryAuxiliaryCurveValueAtFrameOptions): Promise<IAnimationKeyValueDump | null>;
     setTime(options: IAnimationSetTimeOptions): Promise<boolean>;
     changePlayState(options: IAnimationPlayStateOptions): Promise<boolean>;
     changeEditClip(options: IAnimationEditClipOptions): Promise<boolean>;

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -5477,18 +5477,29 @@ export declare interface IAddComponentOptions {
     nodePath: string;
     component: string;
 }
+export declare interface IAnimationAuxiliaryCurveDump {
+    keyframes: IAnimationAuxiliaryKeyDump[];
+    preExtrap: number;
+    postExtrap: number;
+}
+export declare interface IAnimationAuxiliaryKeyDump extends IAnimationCurveKeyData {
+    frame: number;
+    value: number;
+}
 export declare interface IAnimationClipDump {
     name: string;
     duration: number;
     sample: number;
     speed: number;
     wrapMode: number;
-    curves: unknown[];
+    curves: IAnimationCurveDump[];
     events: IAnimationEventDump[];
-    embeddedPlayers: unknown[];
-    embeddedPlayerGroups: unknown[];
+    embeddedPlayers: IAnimationEmbeddedPlayerDump[];
+    embeddedPlayerGroups: IAnimationEmbeddedPlayerGroup[];
+    auxiliaryCurves: Record<string, IAnimationAuxiliaryCurveDump>;
     time: number;
     isLock: boolean;
+    isSkeleton: boolean;
     useBakedAnimation: boolean;
 }
 export declare interface IAnimationClipMenuItem {
@@ -5499,8 +5510,61 @@ export declare interface IAnimationClipsInfo extends IAnimationRootResult {
     clipsMenu: IAnimationClipMenuItem[];
     defaultClip: string;
 }
+export declare interface IAnimationCurveDump {
+    nodePath: string;
+    key: string;
+    keyframes: IAnimationCurveKeyDump[] | null;
+    category?: string;
+    type?: IAnimationPropertyType;
+    displayName?: string;
+    name?: string;
+    comp?: string;
+    menuName?: string;
+    preExtrap?: number;
+    postExtrap?: number;
+    isCurveSupport?: boolean;
+    parentPropKey?: string;
+    partKeys?: string[];
+}
+export declare interface IAnimationCurveKeyData {
+    inTangent?: number;
+    inTangentWeight?: number;
+    outTangent?: number;
+    outTangentWeight?: number;
+    interpMode?: number;
+    tangentWeightMode?: number;
+    tangentMode?: number;
+    easingMethod?: number;
+    broken?: boolean;
+}
+export declare interface IAnimationCurveKeyDump extends IAnimationCurveKeyData {
+    frame: number;
+    dump: IAnimationKeyValueDump;
+    imgUrl?: string;
+}
 export declare interface IAnimationEditClipOptions {
     clipUuid: string;
+}
+export declare type IAnimationEmbeddedPlayable = {
+    type: 'animation-clip';
+    clip?: string;
+    path?: string;
+} | {
+    type: 'particle-system';
+    path?: string;
+};
+export declare interface IAnimationEmbeddedPlayerDump {
+    begin: number;
+    end: number;
+    reconciledSpeed: boolean;
+    playable?: IAnimationEmbeddedPlayable;
+    group: string;
+    displayName?: string;
+}
+export declare interface IAnimationEmbeddedPlayerGroup {
+    key: string;
+    name: string;
+    type: string;
 }
 export declare interface IAnimationEnterOptions {
     rootPath?: string;
@@ -5511,24 +5575,131 @@ export declare interface IAnimationEnterOptions {
 export declare interface IAnimationEventDump {
     frame: number;
     func: string;
-    params: unknown[];
+    params: IAnimationValue[];
 }
 export declare interface IAnimationExitOptions {
     save?: boolean;
     restoreSelection?: boolean;
     restoreSampledSceneState?: boolean;
 }
-export declare interface IAnimationOperation {
-    funcName: string;
-    args: unknown[];
+export declare interface IAnimationKeyValueDump {
+    value: IAnimationValue;
+    default?: IAnimationValue;
+    extends?: string[];
+    readonly?: boolean;
+    type?: string;
+    visible?: boolean;
 }
+export declare type IAnimationOperation = {
+    type: 'changeSample';
+    clipUuid: string;
+    sample: number;
+} | {
+    type: 'changeSpeed';
+    clipUuid: string;
+    speed: number;
+} | {
+    type: 'changeWrapMode';
+    clipUuid: string;
+    wrapMode: number;
+} | {
+    type: 'addEvent';
+    clipUuid: string;
+    frame: number;
+    func: string;
+    params?: IAnimationValue[];
+} | {
+    type: 'deleteEvent';
+    clipUuid: string;
+    frames: number[];
+} | {
+    type: 'updateEvent';
+    clipUuid: string;
+    frames: number[];
+    events: IAnimationEventDump[];
+} | {
+    type: 'moveEvents';
+    clipUuid: string;
+    frames: number[];
+    offset: number;
+} | {
+    type: 'copyEventsTo';
+    clipUuid: string;
+    frames: number[];
+    dstFrame: number;
+} | {
+    type: 'addEmbeddedPlayer';
+    clipUuid: string;
+    embeddedPlayer: IAnimationEmbeddedPlayerDump;
+} | {
+    type: 'deleteEmbeddedPlayer';
+    clipUuid: string;
+    embeddedPlayer: IAnimationEmbeddedPlayerDump;
+} | {
+    type: 'updateEmbeddedPlayer';
+    clipUuid: string;
+    embeddedPlayer: IAnimationEmbeddedPlayerDump;
+    newEmbeddedPlayer: IAnimationEmbeddedPlayerDump;
+} | {
+    type: 'clearEmbeddedPlayer';
+    clipUuid: string;
+    group?: string;
+} | {
+    type: 'addEmbeddedPlayerGroup';
+    clipUuid: string;
+    group: IAnimationEmbeddedPlayerGroup;
+} | {
+    type: 'removeEmbeddedPlayerGroup';
+    clipUuid: string;
+    key: string;
+} | {
+    type: 'clearEmbeddedPlayerGroup';
+    clipUuid: string;
+    key: string;
+} | {
+    type: 'addAuxiliaryCurve';
+    clipUuid: string;
+    name: string;
+} | {
+    type: 'removeAuxiliaryCurve';
+    clipUuid: string;
+    name: string;
+} | {
+    type: 'renameAuxiliaryCurve';
+    clipUuid: string;
+    name: string;
+    newName: string;
+} | {
+    type: 'createAuxKey';
+    clipUuid: string;
+    name: string;
+    frame: number;
+    value: number;
+} | {
+    type: 'removeAuxKey';
+    clipUuid: string;
+    name: string;
+    frame: number;
+} | {
+    type: 'moveAuxKeys';
+    clipUuid: string;
+    name: string;
+    frames: number[];
+    offset: number;
+} | {
+    type: 'copyAuxKey';
+    clipUuid: string;
+    name: string;
+    frame: number;
+    dstFrame: number;
+};
 export declare interface IAnimationOperationOptions {
     operations: IAnimationOperation[];
     recordUndo?: boolean;
 }
 export declare interface IAnimationOperationResult {
     state: 'success' | 'failure';
-    result: unknown;
+    result: boolean;
     reason?: string;
 }
 export declare interface IAnimationPlayStateOptions {
@@ -5539,12 +5710,14 @@ export declare interface IAnimationPropertyInfo {
     name: string;
     key: string;
     displayName: string;
-    type: {
-        value: string;
-    };
+    type: IAnimationPropertyType;
     menuName: string;
     comp?: string;
     category?: string;
+}
+export declare interface IAnimationPropertyType {
+    value: string;
+    extends?: string[];
 }
 export declare interface IAnimationQueryClipOptions extends IAnimationTargetOptions {
     clipUuid?: string;
@@ -5557,7 +5730,7 @@ export declare interface IAnimationQueryPropertyValueAtFrameOptions {
     frame: number;
 }
 export declare interface IAnimationRootInfo extends IAnimationClipsInfo {
-    nodeTreeDump: unknown;
+    nodeTreeDump: INodeTreeItem | null;
     clipDump: IAnimationClipDump | null;
     time: number;
     state: AnimationPlayState_2;
@@ -5577,7 +5750,7 @@ export declare interface IAnimationService extends IServiceEvents {
     queryClips(options: IAnimationTargetOptions): Promise<IAnimationClipsInfo>;
     queryProperties(options: IAnimationTargetOptions): Promise<IAnimationPropertyInfo[]>;
     queryTime(options: IAnimationTimeOptions): Promise<number>;
-    queryPropertyValueAtFrame(options: IAnimationQueryPropertyValueAtFrameOptions): Promise<unknown>;
+    queryPropertyValueAtFrame(options: IAnimationQueryPropertyValueAtFrameOptions): Promise<IAnimationValue>;
     setTime(options: IAnimationSetTimeOptions): Promise<boolean>;
     changePlayState(options: IAnimationPlayStateOptions): Promise<boolean>;
     changeEditClip(options: IAnimationEditClipOptions): Promise<boolean>;
@@ -5608,6 +5781,9 @@ export declare interface IAnimationTargetOptions {
 export declare interface IAnimationTimeOptions {
     clipUuid?: string;
 }
+export declare type IAnimationValue = string | number | boolean | null | undefined | IAnimationValue[] | {
+    [key: string]: IAnimationValue;
+};
 export declare interface IApplyPrefabChangesParams {
     nodePath: string;
 }

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -5821,6 +5821,10 @@ export declare interface IAnimationPropertyInfo {
 export declare interface IAnimationPropertyType {
     value: string;
     extends?: string[];
+    enumList?: Array<{
+        name: string;
+        value: number;
+    }>;
 }
 export declare interface IAnimationQueryAuxiliaryCurveValueAtFrameOptions {
     clipUuid?: string;

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -5799,6 +5799,7 @@ export declare type IAnimationOperation = {
 export declare interface IAnimationOperationOptions {
     operations: IAnimationOperation[];
     recordUndo?: boolean;
+    absorbPreviousScenePropertyUndo?: boolean;
 }
 export declare interface IAnimationOperationResult {
     state: 'success' | 'failure';
@@ -6626,6 +6627,13 @@ export declare interface IUndoGroupOptions {
 export declare interface IUndoOperationOptions {
     scope?: Partial<IUndoScope>;
 }
+export declare interface IUndoPushWithPreviousOptions {
+    label?: string;
+    type: string;
+    scope: IUndoScope;
+    previousScope?: Partial<IUndoScope>;
+    previousTypes?: string[];
+}
 export declare interface IUndoRedoResult {
     success: boolean;
     commandId?: string;
@@ -6649,6 +6657,7 @@ export declare interface IUndoService {
     cancelGroup(groupId: string): IUndoRedoResult;
     isGroupActive(): boolean;
     push(command: IUndoCommand): void;
+    pushWithPrevious(command: IUndoCommand, options: IUndoPushWithPreviousOptions): void;
     reset(): void;
     clearHistory(): void;
     isDirty(): boolean;

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -5883,6 +5883,7 @@ export declare interface IAnimationStateInfo {
     clipUuid: string;
     time: number;
     playState: AnimationPlayState_2;
+    dirty: boolean;
     selection: string[];
     restoreSelectionOnExit: boolean;
 }
@@ -6609,6 +6610,10 @@ export declare interface IUndoBeginOptions {
     tag?: string;
     customCommand?: IUndoCommand;
 }
+export declare interface IUndoCheckpoint {
+    commandId: string | null;
+    generation: number;
+}
 export declare interface IUndoCommand {
     meta: IUndoCommandMeta;
     undo(): Promise<IUndoRedoResult>;
@@ -6661,6 +6666,9 @@ export declare interface IUndoService {
     reset(): void;
     clearHistory(): void;
     isDirty(): boolean;
+    createCheckpoint(): IUndoCheckpoint;
+    hasScopedDifference(checkpoint: IUndoCheckpoint, scope: Partial<IUndoScope>): boolean;
+    hasDifferenceOutsideScope(checkpoint: IUndoCheckpoint, scope: Partial<IUndoScope>): boolean;
     canUndo(options?: IUndoOperationOptions): boolean;
     canRedo(options?: IUndoOperationOptions): boolean;
     markSaved(): void;

--- a/src/core/preview/scripting-routes.ts
+++ b/src/core/preview/scripting-routes.ts
@@ -4,6 +4,12 @@ import { pathExists, stat, readFile } from 'fs-extra';
 import { GlobalPaths } from '../../global';
 import { readFileSync } from 'fs';
 
+function sendQuickPackChunk(res: Response, filePath: string): void {
+    // QuickPack may emit chunks under project temp paths used by smoke workspaces.
+    // The path is resolved by the loader, not by raw URL-to-file joining.
+    res.sendFile(filePath, { dotfiles: 'allow' });
+}
+
 /**
  * 动态预览的共享资源路由。
  *
@@ -401,7 +407,7 @@ export const scriptingRoutes = [
                 if (packResource.type === 'json') {
                     res.json(packResource.json);
                 } else if (packResource.type === 'chunk') {
-                    res.sendFile(packResource.chunk.path);
+                    sendQuickPackChunk(res, packResource.chunk.path);
                 } else {
                     console.warn(`[Preview Server] Unknown pack resource type for ${fullUrl}:`, packResource);
                     next(new Error('Unknown pack resource type'));
@@ -421,7 +427,7 @@ export const scriptingRoutes = [
             try {
                 const packResource = await facet.loadPackResource(url);
                 if (packResource.type === 'chunk') {
-                    res.sendFile(packResource.chunk.path);
+                    sendQuickPackChunk(res, packResource.chunk.path);
                 } else if (packResource.type === 'json') {
                     res.json(packResource.json);
                 } else {

--- a/src/core/scene/common/animation.ts
+++ b/src/core/scene/common/animation.ts
@@ -182,6 +182,18 @@ export interface IAnimationQueryPropertyValueAtFrameOptions {
 }
 
 /**
+ * 查询辅助曲线在某一帧的采样值。
+ */
+export interface IAnimationQueryAuxiliaryCurveValueAtFrameOptions {
+    /** clip uuid；必须是当前编辑 clip。 */
+    clipUuid?: string;
+    /** 辅助曲线名称。 */
+    name: string;
+    /** 要采样的帧号，不是秒。 */
+    frame: number;
+}
+
+/**
  * 设置当前编辑时间。
  */
 export interface IAnimationSetTimeOptions {
@@ -432,6 +444,7 @@ export type IAnimationOperation =
     | { type: 'addPropertyCurve'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; value?: IAnimationValue }
     | { type: 'createPropertyKey'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frame: number; value?: IAnimationValue; channel?: string; keyData?: IAnimationCurveKeyData; curveData?: IAnimationCurveKeyData }
     | { type: 'updatePropertyKey'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frame: number; value?: IAnimationValue; channel?: string; keyData?: IAnimationCurveKeyData; curveData?: IAnimationCurveKeyData }
+    | { type: 'updatePropertyKeyData'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frame: number; channel?: string; keyData?: IAnimationCurveKeyData; curveData?: IAnimationCurveKeyData }
     | { type: 'removePropertyKey'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frames: number[]; channel?: string }
     | { type: 'removePropertyKeys'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frames: number[]; channel?: string }
     | { type: 'movePropertyKeys'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frames: number[]; offset: number; channel?: string }
@@ -452,10 +465,11 @@ export type IAnimationOperation =
     | { type: 'addAuxiliaryCurve'; clipUuid: string; name: string }
     | { type: 'removeAuxiliaryCurve'; clipUuid: string; name: string }
     | { type: 'renameAuxiliaryCurve'; clipUuid: string; name: string; newName: string }
-    | { type: 'createAuxKey'; clipUuid: string; name: string; frame: number; value: number }
+    | { type: 'createAuxKey'; clipUuid: string; name: string; frame: number; value: number; keyData?: IAnimationCurveKeyData; curveData?: IAnimationCurveKeyData }
     | { type: 'removeAuxKey'; clipUuid: string; name: string; frame: number }
     | { type: 'moveAuxKeys'; clipUuid: string; name: string; frames: number[]; offset: number }
-    | { type: 'copyAuxKey'; clipUuid: string; name: string; frame: number; dstFrame: number };
+    | { type: 'copyAuxKey'; clipUuid: string; name: string; frame: number; dstFrame: number }
+    | { type: 'updateAuxKeyData'; clipUuid: string; name: string; frame: number; keyData?: IAnimationCurveKeyData; curveData?: IAnimationCurveKeyData };
 
 /**
  * 批量执行动画编辑操作。
@@ -523,6 +537,10 @@ export interface IAnimationService extends IServiceEvents {
      * 在指定帧采样属性值；采样后会恢复原编辑时间。
      */
     queryPropertyValueAtFrame(options: IAnimationQueryPropertyValueAtFrameOptions): Promise<IAnimationValue>;
+    /**
+     * 在指定帧采样辅助曲线值。
+     */
+    queryAuxiliaryCurveValueAtFrame(options: IAnimationQueryAuxiliaryCurveValueAtFrameOptions): Promise<IAnimationKeyValueDump | null>;
     /**
      * 设置当前编辑时间并采样场景，time 单位为秒。
      */

--- a/src/core/scene/common/animation.ts
+++ b/src/core/scene/common/animation.ts
@@ -390,10 +390,17 @@ export interface IAnimationTimeChangedEvent extends IAnimationClipEvent {
     playState: AnimationPlayState;
 }
 
+export interface IAnimationPropertyCommittedEvent {
+    nodePath: string;
+    propPath: string;
+    source?: string;
+}
+
 export interface IAnimationEvents {
     'animation:state-changed': [event: IAnimationStateChangedEvent];
     'animation:time-changed': [event: IAnimationTimeChangedEvent];
     'animation:clip-changed': [event: IAnimationClipEvent];
+    'animation:property-committed': [event: IAnimationPropertyCommittedEvent];
 }
 
 /**

--- a/src/core/scene/common/animation.ts
+++ b/src/core/scene/common/animation.ts
@@ -445,6 +445,7 @@ export type IAnimationOperation =
     | { type: 'createPropertyKey'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frame: number; value?: IAnimationValue; channel?: string; keyData?: IAnimationCurveKeyData; curveData?: IAnimationCurveKeyData }
     | { type: 'updatePropertyKey'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frame: number; value?: IAnimationValue; channel?: string; keyData?: IAnimationCurveKeyData; curveData?: IAnimationCurveKeyData }
     | { type: 'updatePropertyKeyData'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frame: number; channel?: string; keyData?: IAnimationCurveKeyData; curveData?: IAnimationCurveKeyData }
+    | { type: 'removePropertyCurve'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string }
     | { type: 'removePropertyKey'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frames: number[]; channel?: string }
     | { type: 'removePropertyKeys'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frames: number[]; channel?: string }
     | { type: 'movePropertyKeys'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frames: number[]; offset: number; channel?: string }

--- a/src/core/scene/common/animation.ts
+++ b/src/core/scene/common/animation.ts
@@ -429,9 +429,14 @@ export type IAnimationOperation =
     | { type: 'changeSample'; clipUuid: string; sample: number }
     | { type: 'changeSpeed'; clipUuid: string; speed: number }
     | { type: 'changeWrapMode'; clipUuid: string; wrapMode: number }
-    | { type: 'createPropertyKey'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frame: number; value: IAnimationValue; channel?: string; keyData?: IAnimationCurveKeyData }
+    | { type: 'addPropertyCurve'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; value?: IAnimationValue }
+    | { type: 'createPropertyKey'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frame: number; value?: IAnimationValue; channel?: string; keyData?: IAnimationCurveKeyData; curveData?: IAnimationCurveKeyData }
+    | { type: 'updatePropertyKey'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frame: number; value?: IAnimationValue; channel?: string; keyData?: IAnimationCurveKeyData; curveData?: IAnimationCurveKeyData }
     | { type: 'removePropertyKey'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frames: number[]; channel?: string }
+    | { type: 'removePropertyKeys'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frames: number[]; channel?: string }
     | { type: 'movePropertyKeys'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frames: number[]; offset: number; channel?: string }
+    | { type: 'copyPropertyKeysTo'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frames: number[]; dstFrame: number; channel?: string }
+    | { type: 'setPropertyCurveExtrapolation'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; preExtrap?: number; postExtrap?: number }
     | { type: 'addEvent'; clipUuid: string; frame: number; func: string; params?: IAnimationValue[] }
     | { type: 'deleteEvent'; clipUuid: string; frames: number[] }
     | { type: 'updateEvent'; clipUuid: string; frames: number[]; events: IAnimationEventDump[] }

--- a/src/core/scene/common/animation.ts
+++ b/src/core/scene/common/animation.ts
@@ -73,6 +73,17 @@ export interface IAnimationCurveKeyDump extends IAnimationCurveKeyData {
 }
 
 /**
+ * 分量曲线 dump。用于表达 Vec/Color/Size 等复合属性的真实 per-channel keyframe。
+ */
+export interface IAnimationCurveChannelDump {
+    /** 分量 key，例如 `x`、`y`、`z`、`r`、`width`。 */
+    key: string;
+    displayName?: string;
+    type?: IAnimationPropertyType;
+    keyframes: IAnimationCurveKeyDump[];
+}
+
+/**
  * queryClip 返回的普通属性曲线 dump。
  */
 export interface IAnimationCurveDump {
@@ -82,6 +93,8 @@ export interface IAnimationCurveDump {
     key: string;
     /** 曲线关键帧；没有可编辑关键帧时可能为 null。 */
     keyframes: IAnimationCurveKeyDump[] | null;
+    /** 复合属性的真实分量曲线；旧 UI 可继续使用上面的聚合 keyframes。 */
+    channels?: IAnimationCurveChannelDump[];
     category?: string;
     type?: IAnimationPropertyType;
     displayName?: string;
@@ -416,9 +429,9 @@ export type IAnimationOperation =
     | { type: 'changeSample'; clipUuid: string; sample: number }
     | { type: 'changeSpeed'; clipUuid: string; speed: number }
     | { type: 'changeWrapMode'; clipUuid: string; wrapMode: number }
-    | { type: 'createPropertyKey'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frame: number; value: IAnimationValue }
-    | { type: 'removePropertyKey'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frames: number[] }
-    | { type: 'movePropertyKeys'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frames: number[]; offset: number }
+    | { type: 'createPropertyKey'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frame: number; value: IAnimationValue; channel?: string; keyData?: IAnimationCurveKeyData }
+    | { type: 'removePropertyKey'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frames: number[]; channel?: string }
+    | { type: 'movePropertyKeys'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frames: number[]; offset: number; channel?: string }
     | { type: 'addEvent'; clipUuid: string; frame: number; func: string; params?: IAnimationValue[] }
     | { type: 'deleteEvent'; clipUuid: string; frames: number[] }
     | { type: 'updateEvent'; clipUuid: string; frames: number[]; events: IAnimationEventDump[] }

--- a/src/core/scene/common/animation.ts
+++ b/src/core/scene/common/animation.ts
@@ -409,7 +409,7 @@ export type IAnimationOperation =
 export interface IAnimationOperationOptions {
     /** 按顺序执行；任一操作失败时停止并返回 failure。 */
     operations: IAnimationOperation[];
-    /** 预留给 undo 录制；当前 scene-process 内部尚未接入完整 undo 语义。 */
+    /** 是否记录 undo/dirty；默认 true，显式传 false 时仅修改当前 clip，不写入 undo 栈。 */
     recordUndo?: boolean;
 }
 

--- a/src/core/scene/common/animation.ts
+++ b/src/core/scene/common/animation.ts
@@ -9,6 +9,16 @@ export type AnimationEditorType = 'scene' | 'prefab' | 'unknown';
 export type AnimationPlayState = 'stop' | 'playing' | 'pause';
 /** changePlayState 支持的播放控制操作。 */
 export type AnimationPlayOperation = 'play' | 'pause' | 'resume' | 'stop';
+/** animation 事件来源，用于 UI 判断是否需要刷新状态、时间轴或 clip 数据。 */
+export type AnimationEventReason =
+    | 'enter'
+    | 'exit'
+    | 'set-time'
+    | 'play-state'
+    | 'change-clip'
+    | 'operation'
+    | 'undo-redo'
+    | 'asset-refresh';
 
 /**
  * Animation API 中可通过 RPC 传递的值。
@@ -338,6 +348,29 @@ export interface IAnimationStateInfo {
     restoreSelectionOnExit: boolean;
 }
 
+export interface IAnimationStateChangedEvent {
+    reason: AnimationEventReason;
+    state: IAnimationStateInfo;
+}
+
+export interface IAnimationClipEvent {
+    reason: AnimationEventReason;
+    rootUuid: string;
+    rootPath: string;
+    clipUuid: string;
+}
+
+export interface IAnimationTimeChangedEvent extends IAnimationClipEvent {
+    time: number;
+    playState: AnimationPlayState;
+}
+
+export interface IAnimationEvents {
+    'animation:state-changed': [event: IAnimationStateChangedEvent];
+    'animation:time-changed': [event: IAnimationTimeChangedEvent];
+    'animation:clip-changed': [event: IAnimationClipEvent];
+}
+
 /**
  * 可创建或编辑动画曲线的属性信息。
  */
@@ -356,7 +389,7 @@ export interface IAnimationPropertyInfo {
  *
  * 所有 operation 都必须携带当前编辑的 clipUuid；clipUuid 不匹配时会返回 failure。
  * frame、frames、offset、dstFrame 都使用采样帧号；setTime/queryTime 的 time 才使用秒。
- * 支持的类型分为 clip 基础属性、事件、embedded player 和辅助曲线四类。
+ * 支持的类型分为 clip 基础属性、普通属性曲线、事件、embedded player 和辅助曲线五类。
  *
  * @example
  * ```ts
@@ -383,6 +416,9 @@ export type IAnimationOperation =
     | { type: 'changeSample'; clipUuid: string; sample: number }
     | { type: 'changeSpeed'; clipUuid: string; speed: number }
     | { type: 'changeWrapMode'; clipUuid: string; wrapMode: number }
+    | { type: 'createPropertyKey'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frame: number; value: IAnimationValue }
+    | { type: 'removePropertyKey'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frames: number[] }
+    | { type: 'movePropertyKeys'; clipUuid: string; nodePath?: string; nodeUuid?: string; propKey: string; frames: number[]; offset: number }
     | { type: 'addEvent'; clipUuid: string; frame: number; func: string; params?: IAnimationValue[] }
     | { type: 'deleteEvent'; clipUuid: string; frames: number[] }
     | { type: 'updateEvent'; clipUuid: string; frames: number[]; events: IAnimationEventDump[] }

--- a/src/core/scene/common/animation.ts
+++ b/src/core/scene/common/animation.ts
@@ -1,158 +1,497 @@
 import type { IServiceEvents } from '../scene-process/service/core';
+import type { INodeTreeItem } from './node';
 
+/** 动画编辑器当前所处的场景模式。 */
 export type AnimationMode = 'general' | 'prefab' | 'animation' | 'preview' | 'unknown';
+/** 当前编辑器类型。 */
 export type AnimationEditorType = 'scene' | 'prefab' | 'unknown';
+/** 当前 clip 的播放状态。 */
 export type AnimationPlayState = 'stop' | 'playing' | 'pause';
+/** changePlayState 支持的播放控制操作。 */
 export type AnimationPlayOperation = 'play' | 'pause' | 'resume' | 'stop';
 
+/**
+ * Animation API 中可通过 RPC 传递的值。
+ * 用于事件参数、关键帧值、属性采样值等不固定结构的数据。
+ */
+export type IAnimationValue = string | number | boolean | null | undefined | IAnimationValue[] | {
+    [key: string]: IAnimationValue;
+};
+
+/**
+ * 可编辑属性的类型描述，value 为 Cocos 类型名，例如 `cc.Vec3`、`cc.Boolean`。
+ */
+export interface IAnimationPropertyType {
+    value: string;
+    extends?: string[];
+}
+
+/**
+ * 曲线关键帧的属性值 dump。
+ */
+export interface IAnimationKeyValueDump {
+    value: IAnimationValue;
+    default?: IAnimationValue;
+    extends?: string[];
+    readonly?: boolean;
+    type?: string;
+    visible?: boolean;
+}
+
+/**
+ * 曲线关键帧的插值和切线信息。
+ */
+export interface IAnimationCurveKeyData {
+    inTangent?: number;
+    inTangentWeight?: number;
+    outTangent?: number;
+    outTangentWeight?: number;
+    interpMode?: number;
+    tangentWeightMode?: number;
+    tangentMode?: number;
+    easingMethod?: number;
+    broken?: boolean;
+}
+
+/**
+ * 普通属性曲线中的关键帧。frame 使用 clip 的采样帧号，不是秒。
+ */
+export interface IAnimationCurveKeyDump extends IAnimationCurveKeyData {
+    frame: number;
+    dump: IAnimationKeyValueDump;
+    imgUrl?: string;
+}
+
+/**
+ * queryClip 返回的普通属性曲线 dump。
+ */
+export interface IAnimationCurveDump {
+    /** 相对动画 root 的节点路径。 */
+    nodePath: string;
+    /** 属性 key，例如 `position` 或 `cc.Sprite.color`。 */
+    key: string;
+    /** 曲线关键帧；没有可编辑关键帧时可能为 null。 */
+    keyframes: IAnimationCurveKeyDump[] | null;
+    category?: string;
+    type?: IAnimationPropertyType;
+    displayName?: string;
+    name?: string;
+    comp?: string;
+    menuName?: string;
+    preExtrap?: number;
+    postExtrap?: number;
+    isCurveSupport?: boolean;
+    parentPropKey?: string;
+    partKeys?: string[];
+}
+
+/**
+ * 定位动画目标节点。
+ * 传 rootPath/rootUuid 时直接使用该节点；传 nodePath/nodeUuid 时会向上查找最近的动画 root。
+ */
 export interface IAnimationTargetOptions {
+    /** 目标节点路径。 */
     nodePath?: string;
+    /** 目标节点 uuid。 */
     nodeUuid?: string;
+    /** 动画 root 节点路径。 */
     rootPath?: string;
+    /** 动画 root 节点 uuid。 */
     rootUuid?: string;
 }
 
+/**
+ * 进入动画编辑 session。
+ */
 export interface IAnimationEnterOptions {
+    /** 动画 root 节点路径。未传时从当前选择推导。 */
     rootPath?: string;
+    /** 动画 root 节点 uuid。 */
     rootUuid?: string;
+    /** 要编辑的 clip uuid。未传时使用 root 上的默认 clip。 */
     clipUuid?: string;
+    /** 退出时是否恢复进入前的 selection，默认 true。 */
     restoreSelectionOnExit?: boolean;
 }
 
+/**
+ * 退出动画编辑 session。
+ */
 export interface IAnimationExitOptions {
+    /** 退出前是否保存当前 clip。 */
     save?: boolean;
+    /** 是否恢复进入前的 selection，默认使用 enter 时的 restoreSelectionOnExit。 */
     restoreSelection?: boolean;
+    /** 是否恢复进入动画编辑前采样过的场景状态，默认 true。 */
     restoreSampledSceneState?: boolean;
 }
 
+/**
+ * 查询当前编辑时间时的 clip 选择。
+ */
 export interface IAnimationTimeOptions {
+    /** clip uuid；未传时使用当前 session 的编辑 clip。 */
     clipUuid?: string;
 }
 
+/**
+ * 查询 clip dump。
+ */
 export interface IAnimationQueryClipOptions extends IAnimationTargetOptions {
+    /** clip uuid；未传时使用当前 session 或 root 的默认 clip。 */
     clipUuid?: string;
 }
 
+/**
+ * 查询某一帧的属性采样值。
+ */
 export interface IAnimationQueryPropertyValueAtFrameOptions {
+    /** clip uuid；必须是当前编辑 clip。 */
     clipUuid?: string;
+    /** 目标节点路径；未传时使用当前动画 root。 */
     nodePath?: string;
+    /** 目标节点 uuid。 */
     nodeUuid?: string;
+    /** 属性 key，例如 `position` 或 `cc.Label.string`。 */
     propKey: string;
+    /** 要采样的帧号，不是秒。 */
     frame: number;
 }
 
+/**
+ * 设置当前编辑时间。
+ */
 export interface IAnimationSetTimeOptions {
+    /** 编辑时间，单位为秒。 */
     time: number;
 }
 
+/**
+ * 控制当前 clip 播放状态。
+ */
 export interface IAnimationPlayStateOptions {
+    /** 播放控制操作。 */
     operate: AnimationPlayOperation;
+    /** clip uuid；未传时使用当前 session 的编辑 clip。 */
     clipUuid?: string;
 }
 
+/**
+ * 切换当前动画编辑 clip。
+ */
 export interface IAnimationEditClipOptions {
+    /** 要切换到的 clip uuid，必须属于当前动画 root。 */
     clipUuid: string;
 }
 
+/**
+ * 动画 root 查询结果。
+ */
 export interface IAnimationRootResult {
     rootUuid: string;
     rootPath: string;
 }
 
+/**
+ * 动画 root 上可编辑的 clip 菜单项。
+ */
 export interface IAnimationClipMenuItem {
     uuid: string;
     name: string;
 }
 
+/**
+ * 动画事件。frame 使用采样帧号；保存骨骼 meta 时会按引擎格式写回。
+ */
 export interface IAnimationEventDump {
     frame: number;
     func: string;
-    params: unknown[];
+    params: IAnimationValue[];
 }
 
+/**
+ * Embedded player 中可播放的资源引用。
+ */
+export type IAnimationEmbeddedPlayable =
+    | { type: 'animation-clip'; clip?: string; path?: string }
+    | { type: 'particle-system'; path?: string };
+
+/**
+ * Embedded player dump。begin/end 使用采样帧号，不是秒。
+ */
+export interface IAnimationEmbeddedPlayerDump {
+    begin: number;
+    end: number;
+    reconciledSpeed: boolean;
+    playable?: IAnimationEmbeddedPlayable;
+    group: string;
+    displayName?: string;
+}
+
+/**
+ * Embedded player 分组轨道。
+ */
+export interface IAnimationEmbeddedPlayerGroup {
+    key: string;
+    name: string;
+    type: string;
+}
+
+/**
+ * 辅助曲线关键帧。frame 使用采样帧号，value 当前为 RealCurve 数值。
+ */
+export interface IAnimationAuxiliaryKeyDump extends IAnimationCurveKeyData {
+    frame: number;
+    value: number;
+}
+
+/**
+ * 辅助曲线 dump。
+ */
+export interface IAnimationAuxiliaryCurveDump {
+    keyframes: IAnimationAuxiliaryKeyDump[];
+    preExtrap: number;
+    postExtrap: number;
+}
+
+/**
+ * queryClip 返回的完整 clip 编辑数据。
+ */
 export interface IAnimationClipDump {
     name: string;
+    /** clip 时长，单位为秒。 */
     duration: number;
+    /** 每秒采样帧数。 */
     sample: number;
+    /** 播放速度倍率。 */
     speed: number;
+    /** Cocos AnimationClip.wrapMode 数值。 */
     wrapMode: number;
-    curves: unknown[];
+    /** 普通属性曲线。 */
+    curves: IAnimationCurveDump[];
+    /** 动画事件，frame 使用采样帧号。 */
     events: IAnimationEventDump[];
-    embeddedPlayers: unknown[];
-    embeddedPlayerGroups: unknown[];
+    /** Embedded player 列表，begin/end 使用采样帧号。 */
+    embeddedPlayers: IAnimationEmbeddedPlayerDump[];
+    /** Embedded player 分组轨道。 */
+    embeddedPlayerGroups: IAnimationEmbeddedPlayerGroup[];
+    /** 辅助曲线，以曲线名索引。 */
+    auxiliaryCurves: Record<string, IAnimationAuxiliaryCurveDump>;
+    /** 当前编辑时间，单位为秒。 */
     time: number;
+    /** 当前 clip 是否被锁定。 */
     isLock: boolean;
+    /** 是否来自骨骼动画资源。 */
+    isSkeleton: boolean;
+    /** 当前骨骼动画是否使用 baked animation。 */
     useBakedAnimation: boolean;
 }
 
+/**
+ * 动画 root 和 clip 列表信息。
+ */
 export interface IAnimationClipsInfo extends IAnimationRootResult {
     clipsMenu: IAnimationClipMenuItem[];
+    /** 默认或当前可编辑 clip uuid。 */
     defaultClip: string;
 }
 
+/**
+ * 打开动画编辑器需要的一次性 root 信息。
+ */
 export interface IAnimationRootInfo extends IAnimationClipsInfo {
-    nodeTreeDump: unknown;
+    /** 动画 root 的节点树 dump，对齐 Node service queryNodeTree 返回结构。 */
+    nodeTreeDump: INodeTreeItem | null;
+    /** 默认或当前可编辑 clip 的 dump。 */
     clipDump: IAnimationClipDump | null;
+    /** 当前编辑时间，单位为秒。 */
     time: number;
+    /** 当前播放状态。 */
     state: AnimationPlayState;
+    /** 当前动画 root 是否使用 baked animation。 */
     useBakedAnimation: boolean;
 }
 
+/**
+ * 当前动画编辑 session 状态。
+ */
 export interface IAnimationStateInfo {
+    /** 是否已经进入动画编辑 session。 */
     active: boolean;
+    /** 当前编辑器类型。 */
     editorType: AnimationEditorType;
+    /** 当前场景模式。 */
     mode: AnimationMode;
+    /** 当前动画 root uuid；未进入 session 时为空字符串。 */
     rootUuid: string;
+    /** 当前动画 root path；未进入 session 时为空字符串。 */
     rootPath: string;
+    /** 当前编辑 clip uuid；未进入 session 时为空字符串。 */
     clipUuid: string;
+    /** 当前编辑时间，单位为秒。 */
     time: number;
+    /** 当前播放状态。 */
     playState: AnimationPlayState;
+    /** 当前 selection paths。 */
     selection: string[];
+    /** 退出 session 时默认是否恢复进入前的 selection。 */
     restoreSelectionOnExit: boolean;
 }
 
+/**
+ * 可创建或编辑动画曲线的属性信息。
+ */
 export interface IAnimationPropertyInfo {
     name: string;
     key: string;
     displayName: string;
-    type: { value: string };
+    type: IAnimationPropertyType;
     menuName: string;
     comp?: string;
     category?: string;
 }
 
-export interface IAnimationOperation {
-    funcName: string;
-    args: unknown[];
-}
+/**
+ * applyOperation 使用的 typed operation。
+ *
+ * 所有 operation 都必须携带当前编辑的 clipUuid；clipUuid 不匹配时会返回 failure。
+ * frame、frames、offset、dstFrame 都使用采样帧号；setTime/queryTime 的 time 才使用秒。
+ * 支持的类型分为 clip 基础属性、事件、embedded player 和辅助曲线四类。
+ *
+ * @example
+ * ```ts
+ * await service.applyOperation({
+ *   operations: [
+ *     { type: 'changeSample', clipUuid, sample: 60 },
+ *     { type: 'addEvent', clipUuid, frame: 30, func: 'onHalf', params: ['value'] },
+ *   ],
+ * });
+ * ```
+ *
+ * @example
+ * ```ts
+ * await service.applyOperation({
+ *   operations: [
+ *     { type: 'addEmbeddedPlayerGroup', clipUuid, group: { key: 'fx', name: 'FX', type: 'particle-system' } },
+ *     { type: 'addAuxiliaryCurve', clipUuid, name: 'BlendWeight' },
+ *     { type: 'createAuxKey', clipUuid, name: 'BlendWeight', frame: 0, value: 1 },
+ *   ],
+ * });
+ * ```
+ */
+export type IAnimationOperation =
+    | { type: 'changeSample'; clipUuid: string; sample: number }
+    | { type: 'changeSpeed'; clipUuid: string; speed: number }
+    | { type: 'changeWrapMode'; clipUuid: string; wrapMode: number }
+    | { type: 'addEvent'; clipUuid: string; frame: number; func: string; params?: IAnimationValue[] }
+    | { type: 'deleteEvent'; clipUuid: string; frames: number[] }
+    | { type: 'updateEvent'; clipUuid: string; frames: number[]; events: IAnimationEventDump[] }
+    | { type: 'moveEvents'; clipUuid: string; frames: number[]; offset: number }
+    | { type: 'copyEventsTo'; clipUuid: string; frames: number[]; dstFrame: number }
+    | { type: 'addEmbeddedPlayer'; clipUuid: string; embeddedPlayer: IAnimationEmbeddedPlayerDump }
+    | { type: 'deleteEmbeddedPlayer'; clipUuid: string; embeddedPlayer: IAnimationEmbeddedPlayerDump }
+    | { type: 'updateEmbeddedPlayer'; clipUuid: string; embeddedPlayer: IAnimationEmbeddedPlayerDump; newEmbeddedPlayer: IAnimationEmbeddedPlayerDump }
+    | { type: 'clearEmbeddedPlayer'; clipUuid: string; group?: string }
+    | { type: 'addEmbeddedPlayerGroup'; clipUuid: string; group: IAnimationEmbeddedPlayerGroup }
+    | { type: 'removeEmbeddedPlayerGroup'; clipUuid: string; key: string }
+    | { type: 'clearEmbeddedPlayerGroup'; clipUuid: string; key: string }
+    | { type: 'addAuxiliaryCurve'; clipUuid: string; name: string }
+    | { type: 'removeAuxiliaryCurve'; clipUuid: string; name: string }
+    | { type: 'renameAuxiliaryCurve'; clipUuid: string; name: string; newName: string }
+    | { type: 'createAuxKey'; clipUuid: string; name: string; frame: number; value: number }
+    | { type: 'removeAuxKey'; clipUuid: string; name: string; frame: number }
+    | { type: 'moveAuxKeys'; clipUuid: string; name: string; frames: number[]; offset: number }
+    | { type: 'copyAuxKey'; clipUuid: string; name: string; frame: number; dstFrame: number };
 
+/**
+ * 批量执行动画编辑操作。
+ */
 export interface IAnimationOperationOptions {
+    /** 按顺序执行；任一操作失败时停止并返回 failure。 */
     operations: IAnimationOperation[];
+    /** 预留给 undo 录制；当前 scene-process 内部尚未接入完整 undo 语义。 */
     recordUndo?: boolean;
 }
 
+/**
+ * applyOperation 的执行结果。
+ */
 export interface IAnimationOperationResult {
     state: 'success' | 'failure';
-    result: unknown;
+    result: boolean;
     reason?: string;
 }
 
+/**
+ * Scene-process 内部 Animation service。
+ *
+ * 这个服务只在 scene-process 暴露，不走 MCP/API/main-process proxy。
+ * 调用顺序通常是：enter -> queryClip/queryProperties -> setTime/applyOperation -> save -> exit。
+ */
 export interface IAnimationService extends IServiceEvents {
+    /**
+     * 进入动画编辑 session，并采样到 0 秒。
+     */
     enter(options: IAnimationEnterOptions): Promise<IAnimationStateInfo>;
+    /**
+     * 退出动画编辑 session，可选择保存并恢复进入前的场景采样状态。
+     */
     exit(options: IAnimationExitOptions): Promise<IAnimationStateInfo>;
+    /**
+     * 查询当前动画编辑 session 状态；未进入 session 时 active 为 false。
+     */
     queryState(): Promise<IAnimationStateInfo>;
+    /**
+     * 查询目标节点所属的动画 root。
+     */
     queryRoot(options: IAnimationTargetOptions): Promise<IAnimationRootResult>;
+    /**
+     * 查询动画 root、节点树、默认 clip dump、时间和播放状态。
+     */
     queryRootInfo(options: IAnimationTargetOptions): Promise<IAnimationRootInfo>;
+    /**
+     * 查询指定 clip 的编辑 dump。
+     */
     queryClip(options: IAnimationQueryClipOptions): Promise<IAnimationClipDump>;
+    /**
+     * 查询动画 root 上的可编辑 clip 列表。
+     */
     queryClips(options: IAnimationTargetOptions): Promise<IAnimationClipsInfo>;
+    /**
+     * 查询目标节点上可创建动画曲线的属性。
+     */
     queryProperties(options: IAnimationTargetOptions): Promise<IAnimationPropertyInfo[]>;
+    /**
+     * 查询当前编辑时间，单位为秒。
+     */
     queryTime(options: IAnimationTimeOptions): Promise<number>;
-    queryPropertyValueAtFrame(options: IAnimationQueryPropertyValueAtFrameOptions): Promise<unknown>;
+    /**
+     * 在指定帧采样属性值；采样后会恢复原编辑时间。
+     */
+    queryPropertyValueAtFrame(options: IAnimationQueryPropertyValueAtFrameOptions): Promise<IAnimationValue>;
+    /**
+     * 设置当前编辑时间并采样场景，time 单位为秒。
+     */
     setTime(options: IAnimationSetTimeOptions): Promise<boolean>;
+    /**
+     * 控制当前 clip 播放状态。
+     */
     changePlayState(options: IAnimationPlayStateOptions): Promise<boolean>;
+    /**
+     * 切换当前编辑 clip，并重置编辑时间到 0 秒。
+     */
     changeEditClip(options: IAnimationEditClipOptions): Promise<boolean>;
+    /**
+     * 批量执行 typed animation operation。
+     */
     applyOperation(options: IAnimationOperationOptions): Promise<IAnimationOperationResult>;
+    /**
+     * 保存当前编辑 clip。普通 .anim 写 asset；骨骼动画写回 asset meta。
+     */
     save(): Promise<boolean>;
 }
 
+/**
+ * 去掉事件能力后的公开 service 形态。
+ */
 export type IPublicAnimationService = Omit<IAnimationService, keyof IServiceEvents>;

--- a/src/core/scene/common/animation.ts
+++ b/src/core/scene/common/animation.ts
@@ -1,0 +1,106 @@
+import type { IServiceEvents } from '../scene-process/service/core';
+
+export type AnimationMode = 'general' | 'prefab' | 'animation' | 'preview' | 'unknown';
+export type AnimationEditorType = 'scene' | 'prefab' | 'unknown';
+export type AnimationPlayState = 'stop' | 'playing' | 'pause';
+export type AnimationPlayOperation = 'play' | 'pause' | 'resume' | 'stop';
+
+export interface IAnimationTargetOptions {
+    nodePath?: string;
+    nodeUuid?: string;
+    rootPath?: string;
+    rootUuid?: string;
+}
+
+export interface IAnimationEnterOptions {
+    rootPath?: string;
+    rootUuid?: string;
+    clipUuid?: string;
+    restoreSelectionOnExit?: boolean;
+}
+
+export interface IAnimationExitOptions {
+    save?: boolean;
+    restoreSelection?: boolean;
+    restoreSampledSceneState?: boolean;
+}
+
+export interface IAnimationTimeOptions {
+    clipUuid?: string;
+}
+
+export interface IAnimationSetTimeOptions {
+    time: number;
+}
+
+export interface IAnimationPlayStateOptions {
+    operate: AnimationPlayOperation;
+    clipUuid?: string;
+}
+
+export interface IAnimationEditClipOptions {
+    clipUuid: string;
+}
+
+export interface IAnimationRootResult {
+    rootUuid: string;
+    rootPath: string;
+}
+
+export interface IAnimationClipMenuItem {
+    uuid: string;
+    name: string;
+}
+
+export interface IAnimationClipsInfo extends IAnimationRootResult {
+    clipsMenu: IAnimationClipMenuItem[];
+    defaultClip: string;
+}
+
+export interface IAnimationRootInfo extends IAnimationClipsInfo {
+    nodeTreeDump: unknown;
+    clipDump: unknown;
+    time: number;
+    state: AnimationPlayState;
+    useBakedAnimation: boolean;
+}
+
+export interface IAnimationStateInfo {
+    active: boolean;
+    editorType: AnimationEditorType;
+    mode: AnimationMode;
+    rootUuid: string;
+    rootPath: string;
+    clipUuid: string;
+    time: number;
+    playState: AnimationPlayState;
+    selection: string[];
+    restoreSelectionOnExit: boolean;
+}
+
+export interface IAnimationPropertyInfo {
+    name: string;
+    key: string;
+    displayName: string;
+    type: { value: string };
+    menuName: string;
+    comp?: string;
+    category?: string;
+}
+
+export interface IAnimationService extends IServiceEvents {
+    enter(options: IAnimationEnterOptions): Promise<IAnimationStateInfo>;
+    exit(options: IAnimationExitOptions): Promise<IAnimationStateInfo>;
+    queryState(): Promise<IAnimationStateInfo>;
+    queryRoot(options: IAnimationTargetOptions): Promise<IAnimationRootResult>;
+    queryRootInfo(options: IAnimationTargetOptions): Promise<IAnimationRootInfo>;
+    queryClips(options: IAnimationTargetOptions): Promise<IAnimationClipsInfo>;
+    queryProperties(options: IAnimationTargetOptions): Promise<IAnimationPropertyInfo[]>;
+    queryTime(options: IAnimationTimeOptions): Promise<number>;
+    setTime(options: IAnimationSetTimeOptions): Promise<boolean>;
+    changePlayState(options: IAnimationPlayStateOptions): Promise<boolean>;
+    changeEditClip(options: IAnimationEditClipOptions): Promise<boolean>;
+    save(): Promise<boolean>;
+}
+
+export type IPublicAnimationService = Omit<IAnimationService, keyof IServiceEvents>;

--- a/src/core/scene/common/animation.ts
+++ b/src/core/scene/common/animation.ts
@@ -29,6 +29,18 @@ export interface IAnimationTimeOptions {
     clipUuid?: string;
 }
 
+export interface IAnimationQueryClipOptions extends IAnimationTargetOptions {
+    clipUuid?: string;
+}
+
+export interface IAnimationQueryPropertyValueAtFrameOptions {
+    clipUuid?: string;
+    nodePath?: string;
+    nodeUuid?: string;
+    propKey: string;
+    frame: number;
+}
+
 export interface IAnimationSetTimeOptions {
     time: number;
 }
@@ -52,6 +64,27 @@ export interface IAnimationClipMenuItem {
     name: string;
 }
 
+export interface IAnimationEventDump {
+    frame: number;
+    func: string;
+    params: unknown[];
+}
+
+export interface IAnimationClipDump {
+    name: string;
+    duration: number;
+    sample: number;
+    speed: number;
+    wrapMode: number;
+    curves: unknown[];
+    events: IAnimationEventDump[];
+    embeddedPlayers: unknown[];
+    embeddedPlayerGroups: unknown[];
+    time: number;
+    isLock: boolean;
+    useBakedAnimation: boolean;
+}
+
 export interface IAnimationClipsInfo extends IAnimationRootResult {
     clipsMenu: IAnimationClipMenuItem[];
     defaultClip: string;
@@ -59,7 +92,7 @@ export interface IAnimationClipsInfo extends IAnimationRootResult {
 
 export interface IAnimationRootInfo extends IAnimationClipsInfo {
     nodeTreeDump: unknown;
-    clipDump: unknown;
+    clipDump: IAnimationClipDump | null;
     time: number;
     state: AnimationPlayState;
     useBakedAnimation: boolean;
@@ -88,18 +121,37 @@ export interface IAnimationPropertyInfo {
     category?: string;
 }
 
+export interface IAnimationOperation {
+    funcName: string;
+    args: unknown[];
+}
+
+export interface IAnimationOperationOptions {
+    operations: IAnimationOperation[];
+    recordUndo?: boolean;
+}
+
+export interface IAnimationOperationResult {
+    state: 'success' | 'failure';
+    result: unknown;
+    reason?: string;
+}
+
 export interface IAnimationService extends IServiceEvents {
     enter(options: IAnimationEnterOptions): Promise<IAnimationStateInfo>;
     exit(options: IAnimationExitOptions): Promise<IAnimationStateInfo>;
     queryState(): Promise<IAnimationStateInfo>;
     queryRoot(options: IAnimationTargetOptions): Promise<IAnimationRootResult>;
     queryRootInfo(options: IAnimationTargetOptions): Promise<IAnimationRootInfo>;
+    queryClip(options: IAnimationQueryClipOptions): Promise<IAnimationClipDump>;
     queryClips(options: IAnimationTargetOptions): Promise<IAnimationClipsInfo>;
     queryProperties(options: IAnimationTargetOptions): Promise<IAnimationPropertyInfo[]>;
     queryTime(options: IAnimationTimeOptions): Promise<number>;
+    queryPropertyValueAtFrame(options: IAnimationQueryPropertyValueAtFrameOptions): Promise<unknown>;
     setTime(options: IAnimationSetTimeOptions): Promise<boolean>;
     changePlayState(options: IAnimationPlayStateOptions): Promise<boolean>;
     changeEditClip(options: IAnimationEditClipOptions): Promise<boolean>;
+    applyOperation(options: IAnimationOperationOptions): Promise<IAnimationOperationResult>;
     save(): Promise<boolean>;
 }
 

--- a/src/core/scene/common/animation.ts
+++ b/src/core/scene/common/animation.ts
@@ -368,6 +368,8 @@ export interface IAnimationStateInfo {
     time: number;
     /** 当前播放状态。 */
     playState: AnimationPlayState;
+    /** 当前 animation authoring session 相对进入/保存 baseline 是否有未保存修改。 */
+    dirty: boolean;
     /** 当前 selection paths。 */
     selection: string[];
     /** 退出 session 时默认是否恢复进入前的 selection。 */

--- a/src/core/scene/common/animation.ts
+++ b/src/core/scene/common/animation.ts
@@ -488,6 +488,8 @@ export interface IAnimationOperationOptions {
     operations: IAnimationOperation[];
     /** 是否记录 undo/dirty；默认 true，显式传 false 时仅修改当前 clip，不写入 undo 栈。 */
     recordUndo?: boolean;
+    /** 明确消费外部属性 commit 时，将紧邻的 scene 属性 undo 合并进本次 animation undo。 */
+    absorbPreviousScenePropertyUndo?: boolean;
 }
 
 /**

--- a/src/core/scene/common/animation.ts
+++ b/src/core/scene/common/animation.ts
@@ -34,6 +34,7 @@ export type IAnimationValue = string | number | boolean | null | undefined | IAn
 export interface IAnimationPropertyType {
     value: string;
     extends?: string[];
+    enumList?: Array<{ name: string; value: number }>;
 }
 
 /**

--- a/src/core/scene/common/animation.ts
+++ b/src/core/scene/common/animation.ts
@@ -503,6 +503,13 @@ export interface IAnimationOperationResult {
     reason?: string;
 }
 
+export interface IAnimationSaveOptions {
+    /**
+     * 保存 clip 成功后同步保存当前 scene/prefab 资源，并用普通 editor save 语义清理 shared undo dirty。
+     */
+    saveScene?: boolean;
+}
+
 /**
  * Scene-process 内部 Animation service。
  *
@@ -571,9 +578,9 @@ export interface IAnimationService extends IServiceEvents {
      */
     applyOperation(options: IAnimationOperationOptions): Promise<IAnimationOperationResult>;
     /**
-     * 保存当前编辑 clip。普通 .anim 写 asset；骨骼动画写回 asset meta。
+     * 保存当前编辑 clip。普通 .anim 写 asset；骨骼动画写回 asset meta。saveScene 为 true 时同步保存当前 scene/prefab。
      */
-    save(): Promise<boolean>;
+    save(options?: IAnimationSaveOptions): Promise<boolean>;
 }
 
 /**

--- a/src/core/scene/common/animation.ts
+++ b/src/core/scene/common/animation.ts
@@ -420,7 +420,7 @@ export interface IAnimationPropertyInfo {
 }
 
 /**
- * applyOperation 使用的 typed operation。
+ * applyOperations 使用的 typed operation。
  *
  * 所有 operation 都必须携带当前编辑的 clipUuid；clipUuid 不匹配时会返回 failure。
  * frame、frames、offset、dstFrame 都使用采样帧号；setTime/queryTime 的 time 才使用秒。
@@ -428,7 +428,7 @@ export interface IAnimationPropertyInfo {
  *
  * @example
  * ```ts
- * await service.applyOperation({
+ * await service.applyOperations({
  *   operations: [
  *     { type: 'changeSample', clipUuid, sample: 60 },
  *     { type: 'addEvent', clipUuid, frame: 30, func: 'onHalf', params: ['value'] },
@@ -438,7 +438,7 @@ export interface IAnimationPropertyInfo {
  *
  * @example
  * ```ts
- * await service.applyOperation({
+ * await service.applyOperations({
  *   operations: [
  *     { type: 'addEmbeddedPlayerGroup', clipUuid, group: { key: 'fx', name: 'FX', type: 'particle-system' } },
  *     { type: 'addAuxiliaryCurve', clipUuid, name: 'BlendWeight' },
@@ -495,7 +495,7 @@ export interface IAnimationOperationOptions {
 }
 
 /**
- * applyOperation 的执行结果。
+ * applyOperations 的执行结果。
  */
 export interface IAnimationOperationResult {
     state: 'success' | 'failure';
@@ -514,7 +514,7 @@ export interface IAnimationSaveOptions {
  * Scene-process 内部 Animation service。
  *
  * 这个服务只在 scene-process 暴露，不走 MCP/API/main-process proxy。
- * 调用顺序通常是：enter -> queryClip/queryProperties -> setTime/applyOperation -> save -> exit。
+ * 调用顺序通常是：enter -> queryClip/queryProperties -> setTime/applyOperations -> save -> exit。
  */
 export interface IAnimationService extends IServiceEvents {
     /**
@@ -576,7 +576,7 @@ export interface IAnimationService extends IServiceEvents {
     /**
      * 批量执行 typed animation operation。
      */
-    applyOperation(options: IAnimationOperationOptions): Promise<IAnimationOperationResult>;
+    applyOperations(options: IAnimationOperationOptions): Promise<IAnimationOperationResult>;
     /**
      * 保存当前编辑 clip。普通 .anim 写 asset；骨骼动画写回 asset meta。saveScene 为 true 时同步保存当前 scene/prefab。
      */

--- a/src/core/scene/common/engine.ts
+++ b/src/core/scene/common/engine.ts
@@ -10,7 +10,12 @@ export interface IEngineEvents {
     'engine:ticked': [];
 }
 
-export interface IPublicEngineService extends Omit<IEngineService, 'initCustomLayer' | keyof IServiceEvents> {}
+export interface IPublicEngineService extends Omit<IEngineService,
+    'initCustomLayer' |
+    'enterAnimationMode' |
+    'exitAnimationMode' |
+    keyof IServiceEvents
+> {}
 
 export interface IEngineService extends IServiceEvents {
     /**
@@ -27,4 +32,8 @@ export interface IEngineService extends IServiceEvents {
      * 初始化自定义 Layer 配置
      */
     initCustomLayer(layers?: ICustomLayerConfig[]): Promise<void>;
+
+    enterAnimationMode(): void;
+
+    exitAnimationMode(): void;
 }

--- a/src/core/scene/common/index.ts
+++ b/src/core/scene/common/index.ts
@@ -7,6 +7,7 @@ export * from './script';
 export * from './component';
 export * from './asset';
 export * from './engine';
+export * from './animation';
 export * from './selection';
 export * from './operation';
 export * from './undo';

--- a/src/core/scene/common/message.ts
+++ b/src/core/scene/common/message.ts
@@ -8,6 +8,7 @@ import type { IGizmoEvents } from './gizmo';
 import type { ICameraEvents } from './camera';
 import type { ISceneViewEvents } from './scene-view';
 import type { IUndoEvents } from './undo';
+import type { IAnimationEvents } from './animation';
 
 /**
  * messageManager 不在已有接口中的补充事件
@@ -33,4 +34,5 @@ export interface IMessageManagerEvents extends
     ICameraEvents,
     ISceneViewEvents,
     IUndoEvents,
+    IAnimationEvents,
     ISceneEvents {}

--- a/src/core/scene/common/undo.ts
+++ b/src/core/scene/common/undo.ts
@@ -24,6 +24,11 @@ export interface IUndoOperationOptions {
     scope?: Partial<IUndoScope>;
 }
 
+export interface IUndoCheckpoint {
+    commandId: string | null;
+    generation: number;
+}
+
 export interface IUndoPushWithPreviousOptions {
     label?: string;
     type: string;
@@ -101,6 +106,15 @@ export interface IUndoService {
 
     /** 当前场景有未保存变更时返回 true。 */
     isDirty(): boolean;
+
+    /** 记录当前 undo cursor，用于业务层判断某个编辑 session 内的 scoped dirty。 */
+    createCheckpoint(): IUndoCheckpoint;
+
+    /** 当前 cursor 和 checkpoint 之间存在匹配 scope 的命令差异时返回 true。 */
+    hasScopedDifference(checkpoint: IUndoCheckpoint, scope: Partial<IUndoScope>): boolean;
+
+    /** 当前 cursor 和 checkpoint 之间存在不匹配 scope 的命令差异时返回 true。 */
+    hasDifferenceOutsideScope(checkpoint: IUndoCheckpoint, scope: Partial<IUndoScope>): boolean;
 
     /** 至少有一条可撤销命令时返回 true。 */
     canUndo(options?: IUndoOperationOptions): boolean;

--- a/src/core/scene/common/undo.ts
+++ b/src/core/scene/common/undo.ts
@@ -24,6 +24,14 @@ export interface IUndoOperationOptions {
     scope?: Partial<IUndoScope>;
 }
 
+export interface IUndoPushWithPreviousOptions {
+    label?: string;
+    type: string;
+    scope: IUndoScope;
+    previousScope?: Partial<IUndoScope>;
+    previousTypes?: string[];
+}
+
 export interface IUndoCommand {
     meta: IUndoCommandMeta;
     undo(): Promise<IUndoRedoResult>;
@@ -81,6 +89,9 @@ export interface IUndoService {
 
     /** 业务 service 显式推入可撤销命令的内部入口。 */
     push(command: IUndoCommand): void;
+
+    /** 将新命令与紧邻的当前栈顶命令合并；栈顶不匹配时退化为普通 push，不搜索历史栈。 */
+    pushWithPrevious(command: IUndoCommand, options: IUndoPushWithPreviousOptions): void;
 
     /** 清空整个 undo/redo 栈，内部生命周期 API。 */
     reset(): void;

--- a/src/core/scene/common/undo.ts
+++ b/src/core/scene/common/undo.ts
@@ -99,7 +99,7 @@ export interface IUndoService {
     /** 业务 service 显式推入可撤销命令的内部入口。 */
     push(command: IUndoCommand): void;
 
-    /** 将新命令与紧邻的当前栈顶命令合并；栈顶不匹配时退化为普通 push，不搜索历史栈。 */
+    /** 将新命令与紧邻栈顶的连续匹配命令合并；栈顶不匹配时退化为普通 push，不跨过不匹配命令搜索历史栈。 */
     pushWithPrevious(command: IUndoCommand, options: IUndoPushWithPreviousOptions): void;
 
     /** 清空整个 undo/redo 栈，内部生命周期 API。 */

--- a/src/core/scene/common/undo.ts
+++ b/src/core/scene/common/undo.ts
@@ -1,6 +1,8 @@
 export interface IUndoScope {
     assetUuid?: string;
     assetUrl?: string;
+    nodePath?: string;
+    propPath?: string;
     editorType?: 'scene' | 'prefab' | 'animation' | string;
     mode?: 'general' | 'prefab' | 'animation' | 'preview' | string;
 }
@@ -53,6 +55,8 @@ export interface IUndoBeginOptions {
     label?: string;
     /** 兼容旧调用点的别名，后续逐步迁移到 label。 */
     tag?: string;
+    /** 可选的命令作用域；用于上层在提交后做 scoped undo/吸收判断。 */
+    scope?: IUndoScope;
     /**
      * 自定义可撤销命令，内部自带 undo()/redo() 逻辑。
      * 传入后会跳过默认的属性快照模式，直接使用这个命令。

--- a/src/core/scene/common/undo.ts
+++ b/src/core/scene/common/undo.ts
@@ -20,6 +20,10 @@ export interface IUndoRedoResult {
     reason?: string;
 }
 
+export interface IUndoOperationOptions {
+    scope?: Partial<IUndoScope>;
+}
+
 export interface IUndoCommand {
     meta: IUndoCommandMeta;
     undo(): Promise<IUndoRedoResult>;
@@ -62,10 +66,10 @@ export interface IUndoService {
     cancelRecording(commandId: string): void;
 
     /** 撤销最近一条可撤销命令。 */
-    undo(): Promise<IUndoRedoResult>;
+    undo(options?: IUndoOperationOptions): Promise<IUndoRedoResult>;
 
     /** 重做最近撤销的一条命令。 */
-    redo(): Promise<IUndoRedoResult>;
+    redo(options?: IUndoOperationOptions): Promise<IUndoRedoResult>;
 
     beginGroup(options?: IUndoGroupOptions): string;
 
@@ -88,10 +92,10 @@ export interface IUndoService {
     isDirty(): boolean;
 
     /** 至少有一条可撤销命令时返回 true。 */
-    canUndo(): boolean;
+    canUndo(options?: IUndoOperationOptions): boolean;
 
     /** 至少有一条可重做命令时返回 true。 */
-    canRedo(): boolean;
+    canRedo(options?: IUndoOperationOptions): boolean;
 
     /**
      * 将当前 undo 栈位置标记为已保存状态。
@@ -111,10 +115,10 @@ export interface IUndoService {
 
 export interface IRedoService {
     /** 重做最近撤销的一条命令。 */
-    redo(): Promise<IUndoRedoResult>;
+    redo(options?: IUndoOperationOptions): Promise<IUndoRedoResult>;
 
     /** 至少有一条可重做命令时返回 true。 */
-    canRedo(): boolean;
+    canRedo(options?: IUndoOperationOptions): boolean;
 }
 
 /** 给外部代理过滤层使用的公开接口，只保留对外 API，刻意排除内部修改辅助方法。 */

--- a/src/core/scene/common/undo.ts
+++ b/src/core/scene/common/undo.ts
@@ -155,6 +155,7 @@ export type IPublicUndoService = Omit<
     IUndoService,
     | 'reset'
     | 'push'
+    | 'pushWithPrevious'
     | 'isApplying'
     | 'redo'
     | 'canRedo'

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -45,6 +45,7 @@ import { AnimationClipSnapshotCommand } from './animation/undo';
 import { IAnimationSession } from './animation/types';
 import { clipUuid, getClipSample } from './animation/utils';
 import { serializeAnimationPropertyValue } from './animation/property-value';
+import { AnimationServicePlayback } from './animation/service-playback';
 import { isAllowedSkeletonAnimationOperation, isAnimationOperationResult, shouldSyncClipDuration } from './animation/operation-policy';
 import { normalizeAnimationOperation } from './animation/operation-normalizer';
 import {
@@ -88,8 +89,21 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     );
     private _curEditTime = 0;
     private _playState: AnimationPlayState = 'stop';
-    private _playbackTimeBroadcastTimer: ReturnType<typeof setInterval> | null = null;
-    private _lastPlaybackBroadcastTime = Number.NaN;
+    private readonly _playback = new AnimationServicePlayback({
+        getCurrentState: () => this._session ? this._animationStates.get(this._session.clipUuid) : undefined,
+        getEditTime: () => this._curEditTime,
+        getPlayState: () => this._playState,
+        setEditTime: (time) => { this._curEditTime = time; },
+        setPlayState: (playState) => { this._playState = playState; },
+        enterAnimationMode: () => Service.Engine.enterAnimationMode(),
+        exitAnimationMode: () => Service.Engine.exitAnimationMode(),
+        repaintInEditMode: () => Service.Engine.repaintInEditMode(),
+        broadcastTimeChanged: (reason) => this._broadcastTimeChanged(reason),
+        broadcastStateChanged: async (reason) => {
+            const currentState = await this.queryState();
+            this._broadcastStateChanged(reason, currentState);
+        },
+    });
     private readonly _onAssetRefreshed = (uuid: string) => {
         void this._refreshCurrentClipAsset(uuid).catch((error) => {
             this._disposeSession();
@@ -345,32 +359,13 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
         switch (options.operate) {
             case 'play':
-                state.weight = 1;
-                if (state.isPlaying && state.isPaused) {
-                    state.resume();
-                } else {
-                    state.play();
-                }
-                this._playState = 'playing';
-                Service.Engine.enterAnimationMode();
-                this._startPlaybackTimeBroadcast();
+                this._playback.play(state);
                 break;
             case 'pause':
-                this._stopPlaybackTimeBroadcast();
-                state.pause();
-                this._curEditTime = state.current;
-                this._playState = 'pause';
-                Service.Engine.exitAnimationMode();
+                this._playback.pause(state);
                 break;
             case 'resume':
-                if (!state.isPlaying) {
-                    state.weight = 1;
-                    state.play();
-                }
-                state.resume();
-                this._playState = 'playing';
-                Service.Engine.enterAnimationMode();
-                this._startPlaybackTimeBroadcast();
+                this._playback.resume(state);
                 break;
             case 'stop':
                 await this._stopCurrent();
@@ -557,22 +552,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     private async _stopCurrent(): Promise<void> {
-        this._stopPlaybackTimeBroadcast();
-        if (!this._session) {
-            return;
-        }
-        const state = this._animationStates.get(this._session.clipUuid);
-        if (state) {
-            state.setTime(0);
-            if (!state.isPaused) {
-                state.pause();
-            }
-            state.sample();
-            state.stop();
-        }
-        this._curEditTime = 0;
-        this._playState = 'stop';
-        Service.Engine.exitAnimationMode();
+        await this._playback.stopCurrent();
     }
 
     private async _restoreFailedOperationSnapshot(clip: AnimationClip, snapshot: IAnimationClipSnapshot, rootNode: Node): Promise<void> {
@@ -624,9 +604,8 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     private _disposeSession(): void {
-        this._stopPlaybackTimeBroadcast();
+        this._playback.dispose();
         this._animationStates.clear();
-        Service.Engine.exitAnimationMode();
         this._session = null;
         this._curEditTime = 0;
         this._playState = 'stop';
@@ -663,59 +642,6 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             time: this._curEditTime,
             playState: this._playState,
         });
-    }
-
-    private _startPlaybackTimeBroadcast(): void {
-        this._stopPlaybackTimeBroadcast();
-        this._lastPlaybackBroadcastTime = Number.NaN;
-        this._playbackTimeBroadcastTimer = setInterval(() => {
-            this._broadcastPlaybackTimeTick();
-        }, 100);
-    }
-
-    private _stopPlaybackTimeBroadcast(): void {
-        if (this._playbackTimeBroadcastTimer) {
-            clearInterval(this._playbackTimeBroadcastTimer);
-            this._playbackTimeBroadcastTimer = null;
-        }
-    }
-
-    private _broadcastPlaybackTimeTick(): void {
-        if (!this._session || this._playState !== 'playing') {
-            this._stopPlaybackTimeBroadcast();
-            return;
-        }
-        const state = this._animationStates.get(this._session.clipUuid);
-        const time = state?.current;
-        if (!state || state.isPaused) {
-            this._stopPlaybackTimeBroadcast();
-            return;
-        }
-        if (!state.isPlaying) {
-            this._stopPlaybackTimeBroadcast();
-            const duration = Number.isFinite(state.duration) ? state.duration : this._curEditTime;
-            this._curEditTime = Math.max(0, duration);
-            state.weight = 1;
-            state.setTime(this._curEditTime);
-            state.sample();
-            this._playState = 'stop';
-            Service.Engine.exitAnimationMode();
-            void Service.Engine.repaintInEditMode();
-            this._broadcastTimeChanged('play-state');
-            void this.queryState()
-                .then((currentState) => this._broadcastStateChanged('play-state', currentState))
-                .catch((error) => console.error('[Animation] broadcast playback stop state failed:', error));
-            return;
-        }
-        if (typeof time !== 'number' || !Number.isFinite(time)) {
-            return;
-        }
-        if (Math.abs(time - this._lastPlaybackBroadcastTime) < 0.001) {
-            return;
-        }
-        this._curEditTime = time;
-        this._lastPlaybackBroadcastTime = time;
-        this._broadcastTimeChanged('play-state');
     }
 
     private _broadcastClipChanged(reason: AnimationEventReason): void {

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -20,6 +20,7 @@ import {
     IAnimationEditClipOptions,
     IAnimationEnterOptions,
     IAnimationExitOptions,
+    IAnimationOperation,
     IAnimationOperationOptions,
     IAnimationOperationResult,
     IAnimationPlayStateOptions,
@@ -72,6 +73,10 @@ function createPropertyInfo(name: string, type: string, displayName = name, comp
         menuName: displayName,
         comp,
     };
+}
+
+function isAnimationOperationResult(value: IAnimationOperation | IAnimationOperationResult): value is IAnimationOperationResult {
+    return (value as IAnimationOperationResult).state === 'success' || (value as IAnimationOperationResult).state === 'failure';
 }
 
 @register('Animation')
@@ -390,7 +395,13 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         const state = await this._getAnimationState(session.clipUuid);
         const shouldRecordUndo = options.recordUndo !== false;
         const before = shouldRecordUndo ? captureAnimationClipSnapshot(state.clip) : null;
-        for (const operation of options.operations) {
+        for (const inputOperation of options.operations) {
+            const normalized = await this._normalizeAnimationOperation(inputOperation, session.clipUuid);
+            if (isAnimationOperationResult(normalized)) {
+                return normalized;
+            }
+
+            const operation = normalized;
             const failure = validateAnimationOperation(operation, session.clipUuid);
             if (failure) {
                 return failure;
@@ -423,6 +434,45 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             state: 'success',
             result: true,
         };
+    }
+
+    private async _normalizeAnimationOperation(operation: IAnimationOperation, currentClipUuid: string): Promise<IAnimationOperation | IAnimationOperationResult> {
+        const type = (operation as any)?.type;
+        if (type !== 'createPropertyKey' && type !== 'updatePropertyKey') {
+            return operation;
+        }
+
+        const keyOperation = operation as Extract<IAnimationOperation, { type: 'createPropertyKey' | 'updatePropertyKey' }>;
+        const keyData = keyOperation.keyData ?? keyOperation.curveData;
+        if (keyOperation.value !== undefined) {
+            return keyData === keyOperation.keyData ? operation : { ...keyOperation, keyData };
+        }
+
+        try {
+            const sampled = await this.queryPropertyValueAtFrame({
+                clipUuid: keyOperation.clipUuid || currentClipUuid,
+                nodePath: keyOperation.nodePath,
+                nodeUuid: keyOperation.nodeUuid,
+                propKey: keyOperation.propKey,
+                frame: keyOperation.frame,
+            });
+            const value = this._extractSampledOperationValue(sampled, keyOperation.channel);
+            if (value === undefined) {
+                return {
+                    state: 'failure',
+                    result: false,
+                    reason: `Failed to sample animation property value: ${keyOperation.propKey}`,
+                };
+            }
+            return { ...keyOperation, keyData, value };
+        } catch (error) {
+            const normalized = error instanceof Error ? error : new Error(String(error));
+            return {
+                state: 'failure',
+                result: false,
+                reason: normalized.message,
+            };
+        }
     }
 
     async save(): Promise<boolean> {
@@ -759,6 +809,16 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         }
 
         return this._readPathValue(node, propKey);
+    }
+
+    private _extractSampledOperationValue(value: IAnimationValue, channel?: string): IAnimationValue {
+        if (!channel) {
+            return cloneValue(value);
+        }
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+            return undefined;
+        }
+        return cloneValue((value as Record<string, IAnimationValue>)[channel]);
     }
 
     private _getComponentNames(component: Component): string[] {

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -1014,7 +1014,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             return '';
         }
         const attr = CCClass.attr(ctor, prop);
-        if (!attr || attr.animatable === false || attr.readonly) {
+        if (!attr || attr.readonly || !this._isAnimablePropertyAttr(attr)) {
             return '';
         }
         const type = attr.type;
@@ -1038,6 +1038,16 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             return 'cc.String';
         }
         return '';
+    }
+
+    private _isAnimablePropertyAttr(attr: any): boolean {
+        if (attr.type === js.getClassName(Node)) {
+            return false;
+        }
+        if (attr.animatable !== undefined) {
+            return Boolean(attr.animatable);
+        }
+        return attr.visible === undefined ? true : Boolean(attr.visible);
     }
 
     private _readPropertyValue(node: Node, propKey: string): unknown {

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -467,6 +467,9 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         if (keyOperation.value !== undefined) {
             return keyData === keyOperation.keyData ? operation : { ...keyOperation, keyData };
         }
+        if (keyOperation.type === 'updatePropertyKey' && keyData) {
+            return keyData === keyOperation.keyData ? operation : { ...keyOperation, keyData };
+        }
 
         try {
             const sampled = await this.queryPropertyValueAtFrame({
@@ -742,11 +745,11 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             throw new Error(`current edit clip: '${session.clipUuid}' but you want to restore: '${uuid}'`);
         }
 
-        const rootNode = this._getSessionRootNode();
         const state = await this._getAnimationState(uuid);
-        await restoreAnimationClipSnapshot(state.clip, snapshot);
-        (state as any)._curveLoaded = false;
-        state.initialize(rootNode);
+        const clip = state.clip;
+        this._clearAnimationStates();
+        await restoreAnimationClipSnapshot(clip, snapshot);
+        await this._getAnimationState(uuid);
         await this.setTime({ time: this._curEditTime });
         this._broadcastClipChanged('undo-redo');
     }

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -34,12 +34,19 @@ import {
     IAnimationValue,
     NodeEventType,
 } from '../../common';
-import { BaseService, register, Service } from './core';
+import { BaseService, register, Service, ServiceEvents } from './core';
 import dumpUtil from './dump';
 import { Rpc } from '../rpc';
 import { createClipDump } from './animation/clip-dump';
+import {
+    animationClipSnapshotsEqual,
+    captureAnimationClipSnapshot,
+    restoreAnimationClipSnapshot,
+    type IAnimationClipSnapshot,
+} from './animation/clip-snapshot';
 import { applyClipOperation, validateAnimationOperation } from './animation/clip-operations';
 import { saveSkeletonAnimationMeta } from './animation/skeleton-meta';
+import { AnimationClipSnapshotCommand } from './animation/undo';
 import { IAnimationData, IAnimationSession } from './animation/types';
 import { cloneDump, cloneValue, clipUuid, getClipSample } from './animation/utils';
 
@@ -71,6 +78,17 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     private _animationStateMap = new Map<string, AnimationState>();
     private _curEditTime = 0;
     private _playState: AnimationPlayState = 'stop';
+    private readonly _onAssetRefreshed = (uuid: string) => {
+        void this._refreshCurrentClipAsset(uuid).catch((error) => {
+            this._disposeSession();
+            console.error('[Animation] refresh animation clip failed:', error);
+        });
+    };
+
+    constructor() {
+        super();
+        ServiceEvents?.on?.('asset-refresh', this._onAssetRefreshed);
+    }
 
     async enter(options: IAnimationEnterOptions): Promise<IAnimationStateInfo> {
         this._assertEditorOpened();
@@ -359,6 +377,8 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         }
 
         const state = await this._getAnimationState(session.clipUuid);
+        const shouldRecordUndo = options.recordUndo !== false;
+        const before = shouldRecordUndo ? captureAnimationClipSnapshot(state.clip) : null;
         for (const operation of options.operations) {
             const failure = validateAnimationOperation(operation, session.clipUuid);
             if (failure) {
@@ -375,7 +395,17 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             }
         }
 
+        (state as any)._curveLoaded = false;
         await this.setTime({ time: this._curEditTime });
+        const after = shouldRecordUndo ? captureAnimationClipSnapshot(state.clip) : null;
+        if (before && after && !animationClipSnapshotsEqual(before, after)) {
+            Service.Undo.push(new AnimationClipSnapshotCommand({
+                clipUuid: session.clipUuid,
+                before,
+                after,
+                applySnapshot: (snapshot) => this._restoreCurrentClipSnapshot(session.clipUuid, snapshot),
+            }));
+        }
         return {
             state: 'success',
             result: true,
@@ -401,6 +431,20 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             }]);
         }
         return true;
+    }
+
+    onAssetDeleted(uuid: string): void {
+        if (!this._session || this._session.clipUuid !== uuid) {
+            return;
+        }
+        void this.exit({ restoreSelection: false, restoreSampledSceneState: true }).catch((error) => {
+            this._disposeSession();
+            console.error('[Animation] exit after animation clip deletion failed:', error);
+        });
+    }
+
+    onEditorClosed(): void {
+        this._disposeSession();
     }
 
     private _assertEditorOpened(): void {
@@ -607,6 +651,37 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             }
         }
         this._animationStateMap.clear();
+    }
+
+    private async _restoreCurrentClipSnapshot(uuid: string, snapshot: IAnimationClipSnapshot): Promise<void> {
+        const session = this._requireSession();
+        if (uuid !== session.clipUuid) {
+            throw new Error(`current edit clip: '${session.clipUuid}' but you want to restore: '${uuid}'`);
+        }
+
+        const state = await this._getAnimationState(uuid);
+        await restoreAnimationClipSnapshot(state.clip, snapshot);
+        (state as any)._curveLoaded = false;
+        await this.setTime({ time: this._curEditTime });
+    }
+
+    private async _refreshCurrentClipAsset(uuid: string): Promise<void> {
+        if (!this._session || this._session.clipUuid !== uuid) {
+            return;
+        }
+
+        const time = this._curEditTime;
+        this._clearAnimationStates();
+        const state = await this._getAnimationState(uuid);
+        await this.setTime({ time: Math.min(time, state.duration) });
+    }
+
+    private _disposeSession(): void {
+        this._clearAnimationStates();
+        Service.Engine.exitAnimationMode();
+        this._session = null;
+        this._curEditTime = 0;
+        this._playState = 'stop';
     }
 
     private _queryComponentAnimableProperties(component: Component): IAnimationPropertyInfo[] {

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -104,6 +104,7 @@ function shouldSyncClipDuration(operation: IAnimationOperation): boolean {
         case 'copyAuxKey':
         case 'createPropertyKey':
         case 'updatePropertyKey':
+        case 'removePropertyCurve':
         case 'removePropertyKey':
         case 'removePropertyKeys':
         case 'movePropertyKeys':

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -2,7 +2,6 @@ import {
     Animation,
     AnimationClip,
     AnimationState,
-    CCClass,
     Component,
     Node,
     Scene,
@@ -56,6 +55,9 @@ import { captureAnimationSampledState, restoreAnimationSampledState } from './an
 import { AnimationClipSnapshotCommand } from './animation/undo';
 import { IAnimationData, IAnimationSession } from './animation/types';
 import { cloneValue, clipUuid, getClipSample } from './animation/utils';
+import type { IPropertyCurveMetadataContext } from './animation/property-curve';
+import { queryAnimationPropertyMetadata, queryComponentAnimableProperties } from './animation/property-metadata';
+import { normalizeProvidedAnimationPropertyOperationValue, serializeAnimationPropertyValue } from './animation/property-value';
 
 const NodeMgr = EditorExtends.Node;
 
@@ -336,7 +338,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             if (!comp || comp instanceof Animation) {
                 continue;
             }
-            properties.push(...this._queryComponentAnimableProperties(comp));
+            properties.push(...queryComponentAnimableProperties(comp));
         }
 
         return properties;
@@ -380,7 +382,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             this._curEditTime = previousTime;
             await Service.Engine.repaintInEditMode();
         }
-        return cloneValue(value) as IAnimationValue;
+        return serializeAnimationPropertyValue(value);
     }
 
     async queryAuxiliaryCurveValueAtFrame(options: IAnimationQueryAuxiliaryCurveValueAtFrameOptions) {
@@ -495,8 +497,9 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
         const rootNode = this._getSessionRootNode();
         const state = await this._getAnimationState(session.clipUuid);
+        const propertyMetadataContext = this._createPropertyCurveMetadataContext(rootNode);
         const shouldRecordUndo = options.recordUndo !== false;
-        const before = captureAnimationClipSnapshot(state.clip);
+        const before = captureAnimationClipSnapshot(state.clip, propertyMetadataContext);
         let shouldSyncDuration = false;
         let shouldRestoreOnFailure = false;
         for (const inputOperation of options.operations) {
@@ -519,7 +522,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
                 return skeletonFailure;
             }
 
-            const normalized = await this._normalizeAnimationOperation(inputOperation, session.clipUuid);
+            const normalized = await this._normalizeAnimationOperation(inputOperation, session.clipUuid, rootNode, session.rootPath);
             if (isAnimationOperationResult(normalized)) {
                 if (shouldRestoreOnFailure) {
                     await this._restoreFailedOperationSnapshot(state.clip, before, rootNode);
@@ -539,7 +542,11 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             let result = false;
             shouldRestoreOnFailure = true;
             try {
-                result = await applyClipOperation(state, operation, { rootNode, rootPath: session.rootPath });
+                result = await applyClipOperation(state, operation, {
+                    rootNode,
+                    rootPath: session.rootPath,
+                    queryPropertyMetadata: propertyMetadataContext.queryPropertyMetadata,
+                });
             } catch (error) {
                 const normalizedError = error instanceof Error ? error : new Error(String(error));
                 await this._restoreFailedOperationSnapshot(state.clip, before, rootNode);
@@ -567,7 +574,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         this._resetAnimationState(session.clipUuid);
         this._createAnimationState(session.clipUuid, state.clip);
         await this.setTime({ time: this._curEditTime });
-        const after = shouldRecordUndo ? captureAnimationClipSnapshot(state.clip) : null;
+        const after = shouldRecordUndo ? captureAnimationClipSnapshot(state.clip, propertyMetadataContext) : null;
         if (before && after && !animationClipSnapshotsEqual(before, after)) {
             Service.Undo.push(new AnimationClipSnapshotCommand({
                 clipUuid: session.clipUuid,
@@ -583,7 +590,12 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         };
     }
 
-    private async _normalizeAnimationOperation(operation: IAnimationOperation, currentClipUuid: string): Promise<IAnimationOperation | IAnimationOperationResult> {
+    private async _normalizeAnimationOperation(
+        operation: IAnimationOperation,
+        currentClipUuid: string,
+        rootNode: Node,
+        rootPath: string,
+    ): Promise<IAnimationOperation | IAnimationOperationResult> {
         const type = (operation as any)?.type;
         if (type === 'updatePropertyKeyData') {
             const keyOperation = operation as Extract<IAnimationOperation, { type: 'updatePropertyKeyData' }>;
@@ -597,7 +609,11 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         const keyOperation = operation as Extract<IAnimationOperation, { type: 'createPropertyKey' | 'updatePropertyKey' }>;
         const keyData = keyOperation.keyData ?? keyOperation.curveData;
         if (keyOperation.value !== undefined) {
-            return keyData === keyOperation.keyData ? operation : { ...keyOperation, keyData };
+            const value = await normalizeProvidedAnimationPropertyOperationValue(rootNode, rootPath, keyOperation, {
+                queryNodeByUuid: (uuid) => this._getNodeByUuid(uuid),
+                queryNodePath: (node) => this._getNodePath(node),
+            });
+            return { ...keyOperation, keyData, value };
         }
         if (keyOperation.type === 'updatePropertyKey' && keyData) {
             return {
@@ -843,7 +859,14 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         return createClipDump(clip, state, {
             isSkeleton: this._isSkeletonClip(clipUuid(clip), rootNode),
             useBakedAnimation: this._isUsingBakedAnimation(rootNode),
+            queryPropertyMetadata: (nodePath, propKey) => queryAnimationPropertyMetadata(rootNode, nodePath, propKey),
         });
+    }
+
+    private _createPropertyCurveMetadataContext(rootNode: Node): IPropertyCurveMetadataContext {
+        return {
+            queryPropertyMetadata: (nodePath, propKey) => queryAnimationPropertyMetadata(rootNode, nodePath, propKey),
+        };
     }
 
     private async _getAnimationState(uuid: string): Promise<AnimationState> {
@@ -1000,77 +1023,6 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         this._session = null;
         this._curEditTime = 0;
         this._playState = 'stop';
-    }
-
-    private _queryComponentAnimableProperties(component: Component): IAnimationPropertyInfo[] {
-        const ctor = component.constructor as any;
-        const props = Array.isArray(ctor.__props__) ? ctor.__props__ as string[] : [];
-        const compName = js.getClassName(component);
-        const result: IAnimationPropertyInfo[] = [];
-        for (const prop of props) {
-            const type = this._queryAnimablePropertyType(ctor, component as any, prop);
-            if (!type) {
-                continue;
-            }
-            result.push(createPropertyInfo(prop, type, `${compName}.${prop}`, compName));
-        }
-        return result;
-    }
-
-    private _queryAnimablePropertyType(ctor: Function, component: Record<string, unknown>, prop: string): string {
-        if (prop === 'type' || prop === '__scriptAsset') {
-            return '';
-        }
-        const attr = CCClass.attr(ctor, prop);
-        if (!attr || attr.readonly || !this._isAnimablePropertyAttr(attr)) {
-            return '';
-        }
-        const type = attr.type;
-        if (typeof type === 'string') {
-            return type;
-        }
-        if (type instanceof (CCClass.Attr as any).PrimitiveType) {
-            return type.name;
-        }
-        if (typeof type === 'function') {
-            return js.getClassName(type);
-        }
-        const value = component[prop];
-        if (typeof value === 'number') {
-            return 'cc.Number';
-        }
-        if (typeof value === 'boolean') {
-            return 'cc.Boolean';
-        }
-        if (typeof value === 'string') {
-            return 'cc.String';
-        }
-        if (value && typeof value === 'object') {
-            return this._queryAnimableObjectPropertyType(value);
-        }
-        return '';
-    }
-
-    private _queryAnimableObjectPropertyType(value: object): string {
-        if (value instanceof Node || value instanceof Component || Array.isArray(value)) {
-            return '';
-        }
-        const ctor = (value as { constructor?: Function }).constructor;
-        if (!ctor || ctor === Object) {
-            return '';
-        }
-        const type = js.getClassName(ctor);
-        return type && type !== 'Object' ? type : '';
-    }
-
-    private _isAnimablePropertyAttr(attr: any): boolean {
-        if (attr.type === js.getClassName(Node)) {
-            return false;
-        }
-        if (attr.animatable !== undefined) {
-            return Boolean(attr.animatable);
-        }
-        return attr.visible === undefined ? true : Boolean(attr.visible);
     }
 
     private _readPropertyValue(node: Node, propKey: string): unknown {

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -1,9 +1,9 @@
 import {
     Animation,
     AnimationClip,
-    AnimationState,
     Node,
 } from 'cc';
+import type { AnimationState } from 'cc';
 import {
     AnimationPlayState,
     AnimationEventReason,
@@ -29,7 +29,6 @@ import {
     NodeEventType,
 } from '../../common';
 import { BaseService, register, Service, ServiceEvents } from './core';
-import { Rpc } from '../rpc';
 import {
     animationClipSnapshotsEqual,
     captureAnimationClipSnapshot,
@@ -39,8 +38,9 @@ import {
 import { syncAnimationClipDuration } from './animation/clip-duration';
 import { applyClipOperation, validateAnimationOperation } from './animation/clip-operations';
 import { queryAuxiliaryCurveValueAtFrame } from './animation/auxiliary-curve';
-import { saveSkeletonAnimationMeta } from './animation/skeleton-meta';
 import { captureAnimationSampledState, restoreAnimationSampledState } from './animation/sampled-state';
+import { saveAnimationServiceClip } from './animation/service-save';
+import { AnimationStateRegistry } from './animation/state-registry';
 import { AnimationClipSnapshotCommand } from './animation/undo';
 import { IAnimationSession } from './animation/types';
 import { clipUuid, getClipSample } from './animation/utils';
@@ -82,7 +82,10 @@ import {
 @register('Animation')
 export class AnimationService extends BaseService<Record<string, any>> implements IAnimationService {
     private _session: IAnimationSession | null = null;
-    private _animationStateMap = new Map<string, AnimationState>();
+    private readonly _animationStates = new AnimationStateRegistry(
+        () => this._getSessionRootNode(),
+        async (uuid) => resolveAnimationClip(await queryNodeAnimationData(this._getSessionRootNode(), uuid), uuid),
+    );
     private _curEditTime = 0;
     private _playState: AnimationPlayState = 'stop';
     private _playbackTimeBroadcastTimer: ReturnType<typeof setInterval> | null = null;
@@ -151,7 +154,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             }
         }
 
-        this._clearAnimationStates();
+        this._animationStates.clear();
         Service.Engine.exitAnimationMode();
 
         const shouldRestoreSelection = options.restoreSelection ?? session.restoreSelectionOnExit;
@@ -231,7 +234,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         if (this._session) {
             const uuid = options.clipUuid || this._session.clipUuid;
             const state = isCurrentAnimationSessionClipQuery(this._session, options, uuid, hasTarget)
-                ? this._animationStateMap.get(uuid)
+                ? this._animationStates.get(uuid)
                 : undefined;
             if (state) {
                 return createAnimationServiceClipDump(this._getSessionRootNode(), state.clip, state);
@@ -241,7 +244,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         const { rootNode, clip } = await this._resolveClipForQuery(options);
         const uuid = clipUuid(clip);
         const state = this._session?.rootUuid === rootNode.uuid
-            ? this._animationStateMap.get(uuid)
+            ? this._animationStates.get(uuid)
             : undefined;
         return createAnimationServiceClipDump(rootNode, clip, state);
     }
@@ -260,7 +263,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         if (uuid === this._session.clipUuid) {
             return this._curEditTime;
         }
-        const state = this._animationStateMap.get(uuid);
+        const state = this._animationStates.get(uuid);
         return state?.current ?? this._curEditTime;
     }
 
@@ -485,8 +488,8 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         if (shouldSyncDuration) {
             syncAnimationClipDuration(state.clip);
         }
-        this._resetAnimationState(session.clipUuid);
-        this._createAnimationState(session.clipUuid, state.clip);
+        this._animationStates.reset(session.clipUuid);
+        this._animationStates.create(session.clipUuid, state.clip);
         await this.setTime({ time: this._curEditTime });
         const after = shouldRecordUndo ? captureAnimationClipSnapshot(state.clip, propertyMetadataContext) : null;
         if (before && after && !animationClipSnapshotsEqual(before, after)) {
@@ -507,22 +510,11 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     async save(): Promise<boolean> {
         const session = requireAnimationSession(this._session);
         const state = await this._getAnimationState(session.clipUuid);
-        if (isSkeletonClip(session.clipUuid, this._getSessionRootNode())) {
-            await saveSkeletonAnimationMeta(session.clipUuid, state.clip);
-            return true;
-        }
-
-        const content = EditorExtends.serialize(state.clip);
-        const assetInfo = await Rpc.getInstance().request('assetManager', 'queryAssetInfo', [session.clipUuid]);
-        if (assetInfo) {
-            await Rpc.getInstance().request('assetManager', 'saveAsset', [assetInfo.uuid, content]);
-        } else {
-            await Rpc.getInstance().request('assetManager', 'createAsset', [{
-                target: `db://assets/${state.clip.name}.anim`,
-                content,
-            }]);
-        }
-        return true;
+        return saveAnimationServiceClip({
+            session,
+            rootNode: this._getSessionRootNode(),
+            clip: state.clip,
+        });
     }
 
     onAssetDeleted(uuid: string): void {
@@ -561,13 +553,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
     private async _getAnimationState(uuid: string): Promise<AnimationState> {
         requireAnimationSession(this._session);
-        const existed = this._animationStateMap.get(uuid);
-        if (existed) {
-            return existed;
-        }
-
-        const clip = resolveAnimationClip(await queryNodeAnimationData(this._getSessionRootNode(), uuid), uuid);
-        return this._createAnimationState(uuid, clip);
+        return this._animationStates.getOrCreate(uuid);
     }
 
     private async _stopCurrent(): Promise<void> {
@@ -575,7 +561,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         if (!this._session) {
             return;
         }
-        const state = this._animationStateMap.get(this._session.clipUuid);
+        const state = this._animationStates.get(this._session.clipUuid);
         if (state) {
             state.setTime(0);
             if (!state.isPaused) {
@@ -589,30 +575,6 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         Service.Engine.exitAnimationMode();
     }
 
-    private _clearAnimationStates(): void {
-        for (const state of this._animationStateMap.values()) {
-            try {
-                state.destroy();
-            } catch (e) {
-                console.warn('[Animation] destroy animation state failed:', e);
-            }
-        }
-        this._animationStateMap.clear();
-    }
-
-    private _resetAnimationState(uuid: string): void {
-        const state = this._animationStateMap.get(uuid);
-        if (!state) {
-            return;
-        }
-        try {
-            state.destroy();
-        } catch (e) {
-            console.warn('[Animation] destroy animation state failed:', e);
-        }
-        this._animationStateMap.delete(uuid);
-    }
-
     private async _restoreFailedOperationSnapshot(clip: AnimationClip, snapshot: IAnimationClipSnapshot, rootNode: Node): Promise<void> {
         try {
             await restoreAnimationClipSnapshot(clip, snapshot);
@@ -620,7 +582,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             console.error('[Animation] restore failed operation snapshot failed:', error);
             throw error;
         }
-        const state = this._animationStateMap.get(clipUuid(clip));
+        const state = this._animationStates.get(clipUuid(clip));
         if (state) {
             (state as any)._curveLoaded = false;
             state.initialize(rootNode);
@@ -636,19 +598,11 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
         const state = await this._getAnimationState(uuid);
         const clip = state.clip;
-        this._resetAnimationState(uuid);
+        this._animationStates.reset(uuid);
         await restoreAnimationClipSnapshot(clip, snapshot);
-        this._createAnimationState(uuid, clip);
+        this._animationStates.create(uuid, clip);
         await this.setTime({ time: this._curEditTime });
         this._broadcastClipChanged('undo-redo');
-    }
-
-    private _createAnimationState(uuid: string, clip: AnimationClip): AnimationState {
-        const state = new AnimationState(clip);
-        (state as any)._curveLoaded = false;
-        state.initialize(this._getSessionRootNode());
-        this._animationStateMap.set(uuid, state);
-        return state;
     }
 
     private async _refreshCurrentClipAsset(uuid: string): Promise<void> {
@@ -663,15 +617,15 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         if (clip && animComp instanceof Animation) {
             rebindAnimationComponentClip(animComp, clip);
         }
-        this._resetAnimationState(uuid);
-        const state = await this._getAnimationState(uuid);
+        this._animationStates.reset(uuid);
+        await this._getAnimationState(uuid);
         await this.setTime({ time });
         this._broadcastClipChanged('asset-refresh');
     }
 
     private _disposeSession(): void {
         this._stopPlaybackTimeBroadcast();
-        this._clearAnimationStates();
+        this._animationStates.clear();
         Service.Engine.exitAnimationMode();
         this._session = null;
         this._curEditTime = 0;
@@ -731,7 +685,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             this._stopPlaybackTimeBroadcast();
             return;
         }
-        const state = this._animationStateMap.get(this._session.clipUuid);
+        const state = this._animationStates.get(this._session.clipUuid);
         const time = state?.current;
         if (!state || state.isPaused) {
             this._stopPlaybackTimeBroadcast();

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -151,6 +151,8 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     private _animationStateMap = new Map<string, AnimationState>();
     private _curEditTime = 0;
     private _playState: AnimationPlayState = 'stop';
+    private _playbackTimeBroadcastTimer: ReturnType<typeof setInterval> | null = null;
+    private _lastPlaybackBroadcastTime = Number.NaN;
     private readonly _onAssetRefreshed = (uuid: string) => {
         void this._refreshCurrentClipAsset(uuid).catch((error) => {
             this._disposeSession();
@@ -436,8 +438,10 @@ export class AnimationService extends BaseService<Record<string, any>> implement
                 }
                 this._playState = 'playing';
                 Service.Engine.enterAnimationMode();
+                this._startPlaybackTimeBroadcast();
                 break;
             case 'pause':
+                this._stopPlaybackTimeBroadcast();
                 state.pause();
                 this._curEditTime = state.current;
                 this._playState = 'pause';
@@ -451,6 +455,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
                 state.resume();
                 this._playState = 'playing';
                 Service.Engine.enterAnimationMode();
+                this._startPlaybackTimeBroadcast();
                 break;
             case 'stop':
                 await this._stopCurrent();
@@ -852,6 +857,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     private async _stopCurrent(): Promise<void> {
+        this._stopPlaybackTimeBroadcast();
         if (!this._session) {
             return;
         }
@@ -987,6 +993,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     private _disposeSession(): void {
+        this._stopPlaybackTimeBroadcast();
         this._clearAnimationStates();
         Service.Engine.exitAnimationMode();
         this._session = null;
@@ -1130,6 +1137,43 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             time: this._curEditTime,
             playState: this._playState,
         });
+    }
+
+    private _startPlaybackTimeBroadcast(): void {
+        this._stopPlaybackTimeBroadcast();
+        this._lastPlaybackBroadcastTime = Number.NaN;
+        this._playbackTimeBroadcastTimer = setInterval(() => {
+            this._broadcastPlaybackTimeTick();
+        }, 100);
+    }
+
+    private _stopPlaybackTimeBroadcast(): void {
+        if (this._playbackTimeBroadcastTimer) {
+            clearInterval(this._playbackTimeBroadcastTimer);
+            this._playbackTimeBroadcastTimer = null;
+        }
+    }
+
+    private _broadcastPlaybackTimeTick(): void {
+        if (!this._session || this._playState !== 'playing') {
+            this._stopPlaybackTimeBroadcast();
+            return;
+        }
+        const state = this._animationStateMap.get(this._session.clipUuid);
+        const time = state?.current;
+        if (!state?.isPlaying || state.isPaused) {
+            this._stopPlaybackTimeBroadcast();
+            return;
+        }
+        if (typeof time !== 'number' || !Number.isFinite(time)) {
+            return;
+        }
+        if (Math.abs(time - this._lastPlaybackBroadcastTime) < 0.001) {
+            return;
+        }
+        this._curEditTime = time;
+        this._lastPlaybackBroadcastTime = time;
+        this._broadcastTimeChanged('play-state');
     }
 
     private _broadcastClipChanged(reason: AnimationEventReason): void {

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -616,7 +616,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     private _createClipDump(rootNode: Node, clip: AnimationClip, state?: AnimationState): IAnimationClipDump {
-        return createClipDump(rootNode, clip, state, {
+        return createClipDump(clip, state, {
             isSkeleton: this._isSkeletonClip(clipUuid(clip), rootNode),
             useBakedAnimation: this._isUsingBakedAnimation(rootNode),
         });

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -12,6 +12,8 @@ import {
 } from 'cc';
 import {
     AnimationPlayState,
+    AnimationEventReason,
+    IAnimationClipEvent,
     IAnimationClipDump,
     IAnimationClipMenuItem,
     IAnimationClipsInfo,
@@ -120,7 +122,9 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         this._curEditTime = 0;
         await this._getAnimationState(uuid);
         await this.setTime({ time: 0 });
-        return await this.queryState();
+        const state = await this.queryState();
+        this._broadcastStateChanged('enter', state);
+        return state;
     }
 
     async exit(options: IAnimationExitOptions): Promise<IAnimationStateInfo> {
@@ -153,7 +157,9 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         this._curEditTime = 0;
         this._playState = 'stop';
         await Service.Engine.repaintInEditMode();
-        return await this.queryState();
+        const state = await this.queryState();
+        this._broadcastStateChanged('exit', state);
+        return state;
     }
 
     async queryState(): Promise<IAnimationStateInfo> {
@@ -311,6 +317,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         state.sample();
         this._curEditTime = playTime;
         await Service.Engine.repaintInEditMode();
+        this._broadcastTimeChanged('set-time');
         return true;
     }
 
@@ -352,6 +359,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         }
 
         await Service.Engine.repaintInEditMode();
+        this._broadcastStateChanged('play-state', await this.queryState());
         return true;
     }
 
@@ -367,6 +375,8 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         this._curEditTime = 0;
         await this._getAnimationState(options.clipUuid);
         await this.setTime({ time: 0 });
+        this._broadcastClipChanged('change-clip');
+        this._broadcastStateChanged('change-clip', await this.queryState());
         return true;
     }
 
@@ -376,6 +386,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             throw new Error('Animation operations must be an array.');
         }
 
+        const rootNode = this._getSessionRootNode();
         const state = await this._getAnimationState(session.clipUuid);
         const shouldRecordUndo = options.recordUndo !== false;
         const before = shouldRecordUndo ? captureAnimationClipSnapshot(state.clip) : null;
@@ -385,7 +396,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
                 return failure;
             }
 
-            const result = await applyClipOperation(state, operation);
+            const result = await applyClipOperation(state, operation, { rootNode, rootPath: session.rootPath });
             if (!result) {
                 return {
                     state: 'failure',
@@ -396,6 +407,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         }
 
         (state as any)._curveLoaded = false;
+        state.initialize(rootNode);
         await this.setTime({ time: this._curEditTime });
         const after = shouldRecordUndo ? captureAnimationClipSnapshot(state.clip) : null;
         if (before && after && !animationClipSnapshotsEqual(before, after)) {
@@ -406,6 +418,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
                 applySnapshot: (snapshot) => this._restoreCurrentClipSnapshot(session.clipUuid, snapshot),
             }));
         }
+        this._broadcastClipChanged('operation');
         return {
             state: 'success',
             result: true,
@@ -659,10 +672,13 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             throw new Error(`current edit clip: '${session.clipUuid}' but you want to restore: '${uuid}'`);
         }
 
+        const rootNode = this._getSessionRootNode();
         const state = await this._getAnimationState(uuid);
         await restoreAnimationClipSnapshot(state.clip, snapshot);
         (state as any)._curveLoaded = false;
+        state.initialize(rootNode);
         await this.setTime({ time: this._curEditTime });
+        this._broadcastClipChanged('undo-redo');
     }
 
     private async _refreshCurrentClipAsset(uuid: string): Promise<void> {
@@ -674,6 +690,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         this._clearAnimationStates();
         const state = await this._getAnimationState(uuid);
         await this.setTime({ time: Math.min(time, state.duration) });
+        this._broadcastClipChanged('asset-refresh');
     }
 
     private _disposeSession(): void {
@@ -784,6 +801,42 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             type: NodeEventType.NOTIFY_NODE_CHANGED,
             record: false,
         });
+    }
+
+    private _broadcastStateChanged(reason: AnimationEventReason, state: IAnimationStateInfo): void {
+        this.broadcast('animation:state-changed', { reason, state });
+    }
+
+    private _broadcastTimeChanged(reason: AnimationEventReason): void {
+        const event = this._createAnimationClipEvent(reason);
+        if (!event) {
+            return;
+        }
+        this.broadcast('animation:time-changed', {
+            ...event,
+            time: this._curEditTime,
+            playState: this._playState,
+        });
+    }
+
+    private _broadcastClipChanged(reason: AnimationEventReason): void {
+        const event = this._createAnimationClipEvent(reason);
+        if (!event) {
+            return;
+        }
+        this.broadcast('animation:clip-changed', event);
+    }
+
+    private _createAnimationClipEvent(reason: AnimationEventReason): IAnimationClipEvent | null {
+        if (!this._session) {
+            return null;
+        }
+        return {
+            reason,
+            rootUuid: this._session.rootUuid,
+            rootPath: this._session.rootPath,
+            clipUuid: this._session.clipUuid,
+        };
     }
 
     private _getSessionRootNode(): Node {

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -8,6 +8,7 @@ import {
     Scene,
     SkeletalAnimation,
     animation,
+    assetManager as ccAssetManager,
     js,
 } from 'cc';
 import {
@@ -24,6 +25,7 @@ import {
     IAnimationOperationOptions,
     IAnimationOperationResult,
     IAnimationPlayStateOptions,
+    IAnimationQueryAuxiliaryCurveValueAtFrameOptions,
     IAnimationPropertyInfo,
     IAnimationQueryClipOptions,
     IAnimationQueryPropertyValueAtFrameOptions,
@@ -38,7 +40,6 @@ import {
     NodeEventType,
 } from '../../common';
 import { BaseService, register, Service, ServiceEvents } from './core';
-import dumpUtil from './dump';
 import { Rpc } from '../rpc';
 import { createClipDump } from './animation/clip-dump';
 import {
@@ -49,10 +50,12 @@ import {
 } from './animation/clip-snapshot';
 import { syncAnimationClipDuration } from './animation/clip-duration';
 import { applyClipOperation, validateAnimationOperation } from './animation/clip-operations';
+import { queryAuxiliaryCurveValueAtFrame } from './animation/auxiliary-curve';
 import { saveSkeletonAnimationMeta } from './animation/skeleton-meta';
+import { captureAnimationSampledState, restoreAnimationSampledState } from './animation/sampled-state';
 import { AnimationClipSnapshotCommand } from './animation/undo';
 import { IAnimationData, IAnimationSession } from './animation/types';
-import { cloneDump, cloneValue, clipUuid, getClipSample } from './animation/utils';
+import { cloneValue, clipUuid, getClipSample } from './animation/utils';
 
 const NodeMgr = EditorExtends.Node;
 
@@ -82,12 +85,60 @@ function isAnimationOperationResult(value: IAnimationOperation | IAnimationOpera
 
 function shouldSyncClipDuration(operation: IAnimationOperation): boolean {
     switch (operation.type) {
+        case 'changeSample':
+        case 'addEvent':
+        case 'deleteEvent':
+        case 'updateEvent':
+        case 'moveEvents':
+        case 'copyEventsTo':
+        case 'addEmbeddedPlayer':
+        case 'deleteEmbeddedPlayer':
+        case 'updateEmbeddedPlayer':
+        case 'clearEmbeddedPlayer':
+        case 'removeEmbeddedPlayerGroup':
+        case 'clearEmbeddedPlayerGroup':
+        case 'removeAuxiliaryCurve':
+        case 'createAuxKey':
+        case 'removeAuxKey':
+        case 'moveAuxKeys':
+        case 'copyAuxKey':
         case 'createPropertyKey':
         case 'updatePropertyKey':
         case 'removePropertyKey':
         case 'removePropertyKeys':
         case 'movePropertyKeys':
         case 'copyPropertyKeysTo':
+            return true;
+        default:
+            return false;
+    }
+}
+
+function isAllowedSkeletonAnimationOperation(operation: IAnimationOperation): boolean {
+    switch (operation.type) {
+        case 'changeSample':
+        case 'changeSpeed':
+        case 'changeWrapMode':
+        case 'addEvent':
+        case 'deleteEvent':
+        case 'updateEvent':
+        case 'moveEvents':
+        case 'copyEventsTo':
+        case 'addEmbeddedPlayer':
+        case 'deleteEmbeddedPlayer':
+        case 'updateEmbeddedPlayer':
+        case 'clearEmbeddedPlayer':
+        case 'addEmbeddedPlayerGroup':
+        case 'removeEmbeddedPlayerGroup':
+        case 'clearEmbeddedPlayerGroup':
+        case 'addAuxiliaryCurve':
+        case 'removeAuxiliaryCurve':
+        case 'renameAuxiliaryCurve':
+        case 'createAuxKey':
+        case 'removeAuxKey':
+        case 'moveAuxKeys':
+        case 'copyAuxKey':
+        case 'updateAuxKeyData':
             return true;
         default:
             return false;
@@ -120,14 +171,13 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         }
 
         const rootNode = this._queryAnimationRootNode(this._resolveNode(options));
-        const animData = await this._queryNodeAnimationData(rootNode);
+        const animData = await this._queryNodeAnimationData(rootNode, options.clipUuid, { recoverClipBinding: true });
         const clip = this._resolveClip(animData, options.clipUuid);
         const uuid = clipUuid(clip);
         if (!uuid) {
             throw new Error('Animation clip uuid is empty.');
         }
 
-        const sampledRootDump = dumpUtil.dumpNode(rootNode, { includeComponents: true });
         this._session = {
             previousEditorType: Service.Editor.getCurrentEditorType(),
             previousSelection: Service.Selection.query(),
@@ -135,7 +185,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             rootUuid: rootNode.uuid,
             rootPath: this._getNodePath(rootNode),
             clipUuid: uuid,
-            sampledRootDump: sampledRootDump ? cloneDump(sampledRootDump) : null,
+            sampledRootState: captureAnimationSampledState(rootNode),
         };
 
         this._playState = 'stop';
@@ -157,10 +207,10 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         await this._stopCurrent();
 
         const shouldRestoreSampledState = options.restoreSampledSceneState ?? true;
-        if (shouldRestoreSampledState && session.sampledRootDump) {
+        if (shouldRestoreSampledState && session.sampledRootState) {
             const rootNode = this._getNodeByUuid(session.rootUuid);
             if (rootNode) {
-                await dumpUtil.restoreNode(rootNode, session.sampledRootDump);
+                await restoreAnimationSampledState(rootNode, session.sampledRootState);
                 this._emitNodeChanged(rootNode);
             }
         }
@@ -225,11 +275,12 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     async queryRootInfo(options: IAnimationTargetOptions): Promise<IAnimationRootInfo> {
         const rootNode = this._resolveRootNode(options);
         const clipsInfo = await this._queryClipsInfo(rootNode);
+        const defaultClipUuid = clipsInfo.defaultClip;
         return {
             ...clipsInfo,
             nodeTreeDump: await Service.Node.queryNodeTree({ path: clipsInfo.rootPath }),
-            clipDump: await this.queryClip({ rootUuid: rootNode.uuid, clipUuid: clipsInfo.defaultClip }),
-            time: this._session ? await this.queryTime({ clipUuid: clipsInfo.defaultClip }) : 0,
+            clipDump: defaultClipUuid ? await this.queryClip({ rootUuid: rootNode.uuid, clipUuid: defaultClipUuid }) : null,
+            time: this._session && defaultClipUuid ? await this.queryTime({ clipUuid: defaultClipUuid }) : 0,
             state: this._playState,
             useBakedAnimation: this._isUsingBakedAnimation(rootNode),
         };
@@ -241,9 +292,11 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
     async queryClip(options: IAnimationQueryClipOptions): Promise<IAnimationClipDump> {
         const hasTarget = Boolean(options.rootPath || options.rootUuid || options.nodePath || options.nodeUuid);
-        if (!hasTarget && this._session) {
+        if (this._session) {
             const uuid = options.clipUuid || this._session.clipUuid;
-            const state = this._animationStateMap.get(uuid);
+            const state = this._isCurrentSessionClipQuery(options, uuid, hasTarget)
+                ? this._animationStateMap.get(uuid)
+                : undefined;
             if (state) {
                 return this._createClipDump(this._getSessionRootNode(), state.clip, state);
             }
@@ -255,6 +308,19 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             ? this._animationStateMap.get(uuid)
             : undefined;
         return this._createClipDump(rootNode, clip, state);
+    }
+
+    private _isCurrentSessionClipQuery(options: IAnimationQueryClipOptions, clipUuid: string, hasTarget: boolean): boolean {
+        if (!this._session || clipUuid !== this._session.clipUuid) {
+            return false;
+        }
+        if (!hasTarget) {
+            return true;
+        }
+        return options.rootUuid === this._session.rootUuid
+            || options.rootPath === this._session.rootPath
+            || options.nodeUuid === this._session.rootUuid
+            || options.nodePath === this._session.rootPath;
     }
 
     async queryProperties(options: IAnimationTargetOptions): Promise<IAnimationPropertyInfo[]> {
@@ -314,6 +380,17 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         return cloneValue(value) as IAnimationValue;
     }
 
+    async queryAuxiliaryCurveValueAtFrame(options: IAnimationQueryAuxiliaryCurveValueAtFrameOptions) {
+        const session = this._requireSession();
+        const uuid = options.clipUuid || session.clipUuid;
+        if (uuid !== session.clipUuid) {
+            throw new Error(`current edit clip: '${session.clipUuid}' but you want to operate: '${uuid}'`);
+        }
+
+        const state = await this._getAnimationState(uuid);
+        return queryAuxiliaryCurveValueAtFrame(state.clip, options.name, options.frame);
+    }
+
     async setTime(options: IAnimationSetTimeOptions): Promise<boolean> {
         const session = this._requireSession();
         const state = await this._getAnimationState(session.clipUuid);
@@ -342,8 +419,12 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     async changePlayState(options: IAnimationPlayStateOptions): Promise<boolean> {
-        this._requireSession();
-        const state = await this._getAnimationState(options.clipUuid || this._session!.clipUuid);
+        const session = this._requireSession();
+        const uuid = options.clipUuid || session.clipUuid;
+        if (uuid !== session.clipUuid) {
+            throw new Error(`current edit clip: '${session.clipUuid}' but you want to operate: '${uuid}'`);
+        }
+        const state = await this._getAnimationState(uuid);
 
         switch (options.operate) {
             case 'play':
@@ -390,7 +471,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         }
 
         await this._stopCurrent();
-        this._resolveClip(await this._queryNodeAnimationData(this._getSessionRootNode()), options.clipUuid);
+        this._resolveClip(await this._queryNodeAnimationData(this._getSessionRootNode(), options.clipUuid, { recoverClipBinding: true }), options.clipUuid);
         session.clipUuid = options.clipUuid;
         this._curEditTime = 0;
         await this._getAnimationState(options.clipUuid);
@@ -409,27 +490,67 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         const rootNode = this._getSessionRootNode();
         const state = await this._getAnimationState(session.clipUuid);
         const shouldRecordUndo = options.recordUndo !== false;
-        const before = shouldRecordUndo ? captureAnimationClipSnapshot(state.clip) : null;
+        const before = captureAnimationClipSnapshot(state.clip);
         let shouldSyncDuration = false;
+        let shouldRestoreOnFailure = false;
         for (const inputOperation of options.operations) {
+            const inputFailure = validateAnimationOperation(inputOperation, session.clipUuid);
+            if (inputFailure) {
+                if (shouldRestoreOnFailure) {
+                    await this._restoreFailedOperationSnapshot(state.clip, before, rootNode);
+                }
+                return inputFailure;
+            }
+            if (this._isSkeletonClip(session.clipUuid, rootNode) && !isAllowedSkeletonAnimationOperation(inputOperation)) {
+                const skeletonFailure = {
+                    state: 'failure',
+                    result: false,
+                    reason: `Method '${inputOperation.type}' is not allowed in skeleton animation.`,
+                } as IAnimationOperationResult;
+                if (shouldRestoreOnFailure) {
+                    await this._restoreFailedOperationSnapshot(state.clip, before, rootNode);
+                }
+                return skeletonFailure;
+            }
+
             const normalized = await this._normalizeAnimationOperation(inputOperation, session.clipUuid);
             if (isAnimationOperationResult(normalized)) {
+                if (shouldRestoreOnFailure) {
+                    await this._restoreFailedOperationSnapshot(state.clip, before, rootNode);
+                }
                 return normalized;
             }
 
             const operation = normalized;
             const failure = validateAnimationOperation(operation, session.clipUuid);
             if (failure) {
+                if (shouldRestoreOnFailure) {
+                    await this._restoreFailedOperationSnapshot(state.clip, before, rootNode);
+                }
                 return failure;
             }
 
-            const result = await applyClipOperation(state, operation, { rootNode, rootPath: session.rootPath });
-            if (!result) {
+            let result = false;
+            shouldRestoreOnFailure = true;
+            try {
+                result = await applyClipOperation(state, operation, { rootNode, rootPath: session.rootPath });
+            } catch (error) {
+                const normalizedError = error instanceof Error ? error : new Error(String(error));
+                await this._restoreFailedOperationSnapshot(state.clip, before, rootNode);
                 return {
                     state: 'failure',
                     result: false,
-                    reason: `call method ${operation.type} failed`,
+                    reason: normalizedError.message,
                 };
+            }
+            if (!result) {
+                const failureResult = {
+                    state: 'failure',
+                    result: false,
+                    reason: `call method ${operation.type} failed`,
+                } as IAnimationOperationResult;
+                await this._restoreFailedOperationSnapshot(state.clip, before, rootNode);
+                return failureResult;
             }
             shouldSyncDuration = shouldSyncDuration || shouldSyncClipDuration(operation);
         }
@@ -458,6 +579,11 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
     private async _normalizeAnimationOperation(operation: IAnimationOperation, currentClipUuid: string): Promise<IAnimationOperation | IAnimationOperationResult> {
         const type = (operation as any)?.type;
+        if (type === 'updatePropertyKeyData') {
+            const keyOperation = operation as Extract<IAnimationOperation, { type: 'updatePropertyKeyData' }>;
+            const keyData = keyOperation.keyData ?? keyOperation.curveData;
+            return keyData === keyOperation.keyData ? operation : { ...keyOperation, keyData };
+        }
         if (type !== 'createPropertyKey' && type !== 'updatePropertyKey') {
             return operation;
         }
@@ -468,7 +594,11 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             return keyData === keyOperation.keyData ? operation : { ...keyOperation, keyData };
         }
         if (keyOperation.type === 'updatePropertyKey' && keyData) {
-            return keyData === keyOperation.keyData ? operation : { ...keyOperation, keyData };
+            return {
+                ...keyOperation,
+                type: 'updatePropertyKeyData',
+                keyData,
+            };
         }
 
         try {
@@ -630,7 +760,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         return node.getComponent(Animation);
     }
 
-    private async _queryNodeAnimationData(node: Node): Promise<IAnimationData> {
+    private async _queryNodeAnimationData(node: Node, preferredClipUuid?: string, options: { allowEmpty?: boolean; recoverClipBinding?: boolean } = {}): Promise<IAnimationData> {
         const animComp = this._queryAnimationComponent(node);
         if (!animComp) {
             throw new Error(`Animation component not found on node: ${this._getNodePath(node)}`);
@@ -641,6 +771,9 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         if (animComp instanceof Animation) {
             clips = (animComp.clips || []).filter((clip): clip is AnimationClip => Boolean(clip?.name));
             defaultClip = animComp.defaultClip || clips[0] || null;
+            if (defaultClip?.name) {
+                clips.push(defaultClip);
+            }
         } else {
             clips = (await this._visitAnimationClipsInController(animComp))
                 .filter((clip): clip is AnimationClip => Boolean(clip?.name));
@@ -651,7 +784,18 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         if (!defaultClip?.name) {
             defaultClip = clips[0] || null;
         }
+        if (options.recoverClipBinding && (clips.length === 0 || !defaultClip) && preferredClipUuid && animComp instanceof Animation) {
+            const recoveredClip = await this._loadAnimationClip(preferredClipUuid);
+            if (recoveredClip?.name) {
+                this._rebindAnimationComponentClip(animComp, recoveredClip);
+                clips = this._uniqAnimationClips((animComp.clips || []).filter((clip): clip is AnimationClip => Boolean(clip?.name)));
+                defaultClip = animComp.defaultClip?.name ? animComp.defaultClip : clips[0] || null;
+            }
+        }
         if (clips.length === 0 || !defaultClip) {
+            if (options.allowEmpty) {
+                return { node, animComp, clips, defaultClip };
+            }
             throw new Error(`Animation clips not found on node: ${this._getNodePath(node)}`);
         }
 
@@ -668,7 +812,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     private async _queryClipsInfo(rootNode: Node): Promise<IAnimationClipsInfo> {
-        const animData = await this._queryNodeAnimationData(rootNode);
+        const animData = await this._queryNodeAnimationData(rootNode, undefined, { allowEmpty: true });
         return {
             rootUuid: rootNode.uuid,
             rootPath: this._getNodePath(rootNode),
@@ -680,11 +824,12 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     private async _resolveClipForQuery(options: IAnimationQueryClipOptions): Promise<{ rootNode: Node; clip: AnimationClip }> {
         const hasTarget = Boolean(options.rootPath || options.rootUuid || options.nodePath || options.nodeUuid);
         const rootNode = hasTarget ? this._resolveRootNode(options) : this._getSessionRootNode();
-        const animData = await this._queryNodeAnimationData(rootNode);
         const defaultUuid = this._session?.rootUuid === rootNode.uuid ? this._session.clipUuid : undefined;
+        const targetUuid = options.clipUuid || defaultUuid;
+        const animData = await this._queryNodeAnimationData(rootNode, targetUuid);
         return {
             rootNode,
-            clip: this._resolveClip(animData, options.clipUuid || defaultUuid),
+            clip: this._resolveClip(animData, targetUuid),
         };
     }
 
@@ -702,12 +847,8 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             return existed;
         }
 
-        const clip = this._resolveClip(await this._queryNodeAnimationData(this._getSessionRootNode()), uuid);
-        const state = new AnimationState(clip);
-        (state as any)._curveLoaded = false;
-        state.initialize(this._getSessionRootNode());
-        this._animationStateMap.set(uuid, state);
-        return state;
+        const clip = this._resolveClip(await this._queryNodeAnimationData(this._getSessionRootNode(), uuid), uuid);
+        return this._createAnimationState(uuid, clip);
     }
 
     private async _stopCurrent(): Promise<void> {
@@ -739,6 +880,34 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         this._animationStateMap.clear();
     }
 
+    private _resetAnimationState(uuid: string): void {
+        const state = this._animationStateMap.get(uuid);
+        if (!state) {
+            return;
+        }
+        try {
+            state.destroy();
+        } catch (e) {
+            console.warn('[Animation] destroy animation state failed:', e);
+        }
+        this._animationStateMap.delete(uuid);
+    }
+
+    private async _restoreFailedOperationSnapshot(clip: AnimationClip, snapshot: IAnimationClipSnapshot, rootNode: Node): Promise<void> {
+        try {
+            await restoreAnimationClipSnapshot(clip, snapshot);
+        } catch (error) {
+            console.error('[Animation] restore failed operation snapshot failed:', error);
+            throw error;
+        }
+        const state = this._animationStateMap.get(clipUuid(clip));
+        if (state) {
+            (state as any)._curveLoaded = false;
+            state.initialize(rootNode);
+        }
+        await this.setTime({ time: this._curEditTime });
+    }
+
     private async _restoreCurrentClipSnapshot(uuid: string, snapshot: IAnimationClipSnapshot): Promise<void> {
         const session = this._requireSession();
         if (uuid !== session.clipUuid) {
@@ -747,11 +916,19 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
         const state = await this._getAnimationState(uuid);
         const clip = state.clip;
-        this._clearAnimationStates();
+        this._resetAnimationState(uuid);
         await restoreAnimationClipSnapshot(clip, snapshot);
-        await this._getAnimationState(uuid);
+        this._createAnimationState(uuid, clip);
         await this.setTime({ time: this._curEditTime });
         this._broadcastClipChanged('undo-redo');
+    }
+
+    private _createAnimationState(uuid: string, clip: AnimationClip): AnimationState {
+        const state = new AnimationState(clip);
+        (state as any)._curveLoaded = false;
+        state.initialize(this._getSessionRootNode());
+        this._animationStateMap.set(uuid, state);
+        return state;
     }
 
     private async _refreshCurrentClipAsset(uuid: string): Promise<void> {
@@ -760,10 +937,53 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         }
 
         const time = this._curEditTime;
-        this._clearAnimationStates();
+        const clip = await this._loadAnimationClip(uuid);
+        const rootNode = this._getSessionRootNode();
+        const animComp = this._queryAnimationComponent(rootNode);
+        if (clip && animComp instanceof Animation) {
+            this._rebindAnimationComponentClip(animComp, clip);
+        }
+        this._resetAnimationState(uuid);
         const state = await this._getAnimationState(uuid);
         await this.setTime({ time: Math.min(time, state.duration) });
         this._broadcastClipChanged('asset-refresh');
+    }
+
+    private _rebindAnimationComponentClip(animComp: Animation, clip: AnimationClip): void {
+        const uuid = clipUuid(clip);
+        const currentDefaultUuid = animComp.defaultClip ? clipUuid(animComp.defaultClip) : '';
+        let found = false;
+        const clips = (animComp.clips || []).map((item) => {
+            if (item && clipUuid(item) === uuid) {
+                found = true;
+                return clip;
+            }
+            return item;
+        });
+        if (!found) {
+            clips.push(clip);
+        }
+        animComp.clips = clips;
+        if (!currentDefaultUuid || currentDefaultUuid === uuid) {
+            animComp.defaultClip = clip;
+        }
+    }
+
+    private async _loadAnimationClip(uuid: string): Promise<AnimationClip | null> {
+        const cached = ccAssetManager.assets.get(uuid);
+        if (cached instanceof AnimationClip) {
+            return cached;
+        }
+
+        return await new Promise((resolve, reject) => {
+            ccAssetManager.loadAny(uuid, (error, asset: AnimationClip) => {
+                if (error) {
+                    reject(error);
+                    return;
+                }
+                resolve(asset instanceof AnimationClip ? asset : null);
+            });
+        });
     }
 
     private _disposeSession(): void {

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -47,6 +47,7 @@ import {
     restoreAnimationClipSnapshot,
     type IAnimationClipSnapshot,
 } from './animation/clip-snapshot';
+import { syncAnimationClipDuration } from './animation/clip-duration';
 import { applyClipOperation, validateAnimationOperation } from './animation/clip-operations';
 import { saveSkeletonAnimationMeta } from './animation/skeleton-meta';
 import { AnimationClipSnapshotCommand } from './animation/undo';
@@ -77,6 +78,20 @@ function createPropertyInfo(name: string, type: string, displayName = name, comp
 
 function isAnimationOperationResult(value: IAnimationOperation | IAnimationOperationResult): value is IAnimationOperationResult {
     return (value as IAnimationOperationResult).state === 'success' || (value as IAnimationOperationResult).state === 'failure';
+}
+
+function shouldSyncClipDuration(operation: IAnimationOperation): boolean {
+    switch (operation.type) {
+        case 'createPropertyKey':
+        case 'updatePropertyKey':
+        case 'removePropertyKey':
+        case 'removePropertyKeys':
+        case 'movePropertyKeys':
+        case 'copyPropertyKeysTo':
+            return true;
+        default:
+            return false;
+    }
 }
 
 @register('Animation')
@@ -395,6 +410,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         const state = await this._getAnimationState(session.clipUuid);
         const shouldRecordUndo = options.recordUndo !== false;
         const before = shouldRecordUndo ? captureAnimationClipSnapshot(state.clip) : null;
+        let shouldSyncDuration = false;
         for (const inputOperation of options.operations) {
             const normalized = await this._normalizeAnimationOperation(inputOperation, session.clipUuid);
             if (isAnimationOperationResult(normalized)) {
@@ -415,8 +431,12 @@ export class AnimationService extends BaseService<Record<string, any>> implement
                     reason: `call method ${operation.type} failed`,
                 };
             }
+            shouldSyncDuration = shouldSyncDuration || shouldSyncClipDuration(operation);
         }
 
+        if (shouldSyncDuration) {
+            syncAnimationClipDuration(state.clip);
+        }
         (state as any)._curveLoaded = false;
         state.initialize(rootNode);
         await this.setTime({ time: this._curEditTime });

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -13,7 +13,6 @@ import {
     IAnimationEditClipOptions,
     IAnimationEnterOptions,
     IAnimationExitOptions,
-    IAnimationOperation,
     IAnimationOperationOptions,
     IAnimationOperationResult,
     IAnimationPlayStateOptions,
@@ -50,9 +49,10 @@ import { IAnimationSession } from './animation/types';
 import { clipUuid, getClipSample } from './animation/utils';
 import type { IPropertyCurveMetadataContext } from './animation/property-curve';
 import { queryAnimationPropertyMetadata, queryComponentAnimableProperties } from './animation/property-metadata';
-import { normalizeProvidedAnimationPropertyOperationValue, serializeAnimationPropertyValue } from './animation/property-value';
+import { serializeAnimationPropertyValue } from './animation/property-value';
 import { ACTIVE_PROPERTY, DEFAULT_PROPERTIES } from './animation/property-menu';
 import { isAllowedSkeletonAnimationOperation, isAnimationOperationResult, shouldSyncClipDuration } from './animation/operation-policy';
+import { normalizeAnimationOperation } from './animation/operation-normalizer';
 import {
     loadAnimationClip,
     queryAnimationClipsInfo,
@@ -61,7 +61,6 @@ import {
     resolveAnimationClip,
 } from './animation/clip-library';
 import {
-    extractSampledOperationValue,
     getAnimationMode,
     getNodeByPath,
     getNodeByUuid,
@@ -448,7 +447,12 @@ export class AnimationService extends BaseService<Record<string, any>> implement
                 return skeletonFailure;
             }
 
-            const normalized = await this._normalizeAnimationOperation(inputOperation, session.clipUuid, rootNode, session.rootPath);
+            const normalized = await normalizeAnimationOperation(inputOperation, {
+                currentClipUuid: session.clipUuid,
+                rootNode,
+                rootPath: session.rootPath,
+                queryPropertyValueAtFrame: (queryOptions) => this.queryPropertyValueAtFrame(queryOptions),
+            });
             if (isAnimationOperationResult(normalized)) {
                 if (shouldRestoreOnFailure) {
                     await this._restoreFailedOperationSnapshot(state.clip, before, rootNode);
@@ -514,66 +518,6 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             state: 'success',
             result: true,
         };
-    }
-
-    private async _normalizeAnimationOperation(
-        operation: IAnimationOperation,
-        currentClipUuid: string,
-        rootNode: Node,
-        rootPath: string,
-    ): Promise<IAnimationOperation | IAnimationOperationResult> {
-        const type = (operation as any)?.type;
-        if (type === 'updatePropertyKeyData') {
-            const keyOperation = operation as Extract<IAnimationOperation, { type: 'updatePropertyKeyData' }>;
-            const keyData = keyOperation.keyData ?? keyOperation.curveData;
-            return keyData === keyOperation.keyData ? operation : { ...keyOperation, keyData };
-        }
-        if (type !== 'createPropertyKey' && type !== 'updatePropertyKey') {
-            return operation;
-        }
-
-        const keyOperation = operation as Extract<IAnimationOperation, { type: 'createPropertyKey' | 'updatePropertyKey' }>;
-        const keyData = keyOperation.keyData ?? keyOperation.curveData;
-        if (keyOperation.value !== undefined) {
-            const value = await normalizeProvidedAnimationPropertyOperationValue(rootNode, rootPath, keyOperation, {
-                queryNodeByUuid: (uuid) => getNodeByUuid(uuid),
-                queryNodePath: (node) => getNodePath(node),
-            });
-            return { ...keyOperation, keyData, value };
-        }
-        if (keyOperation.type === 'updatePropertyKey' && keyData) {
-            return {
-                ...keyOperation,
-                type: 'updatePropertyKeyData',
-                keyData,
-            };
-        }
-
-        try {
-            const sampled = await this.queryPropertyValueAtFrame({
-                clipUuid: keyOperation.clipUuid || currentClipUuid,
-                nodePath: keyOperation.nodePath,
-                nodeUuid: keyOperation.nodeUuid,
-                propKey: keyOperation.propKey,
-                frame: keyOperation.frame,
-            });
-            const value = extractSampledOperationValue(sampled, keyOperation.channel);
-            if (value === undefined) {
-                return {
-                    state: 'failure',
-                    result: false,
-                    reason: `Failed to sample animation property value: ${keyOperation.propKey}`,
-                };
-            }
-            return { ...keyOperation, keyData, value };
-        } catch (error) {
-            const normalized = error instanceof Error ? error : new Error(String(error));
-            return {
-                state: 'failure',
-                result: false,
-                reason: normalized.message,
-            };
-        }
     }
 
     async save(): Promise<boolean> {

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -273,7 +273,11 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         if (!this._session) {
             return 0;
         }
-        const state = this._animationStateMap.get(options.clipUuid || this._session.clipUuid);
+        const uuid = options.clipUuid || this._session.clipUuid;
+        if (uuid === this._session.clipUuid) {
+            return this._curEditTime;
+        }
+        const state = this._animationStateMap.get(uuid);
         return state?.current ?? this._curEditTime;
     }
 
@@ -325,15 +329,12 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         const session = this._requireSession();
         const state = await this._getAnimationState(session.clipUuid);
         let playTime = options.time;
-        if (playTime > state.duration) {
-            playTime = state.duration;
-        }
         if (playTime < 0) {
             playTime = 0;
         }
 
         if (((state.clip.wrapMode & AnimationClip.WrapMode.Reverse) === AnimationClip.WrapMode.Reverse)) {
-            playTime = state.duration - playTime;
+            playTime = state.duration - Math.min(playTime, state.duration);
         }
 
         state.weight = 1;

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -1161,8 +1161,24 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         }
         const state = this._animationStateMap.get(this._session.clipUuid);
         const time = state?.current;
-        if (!state?.isPlaying || state.isPaused) {
+        if (!state || state.isPaused) {
             this._stopPlaybackTimeBroadcast();
+            return;
+        }
+        if (!state.isPlaying) {
+            this._stopPlaybackTimeBroadcast();
+            const duration = Number.isFinite(state.duration) ? state.duration : this._curEditTime;
+            this._curEditTime = Math.max(0, duration);
+            state.weight = 1;
+            state.setTime(this._curEditTime);
+            state.sample();
+            this._playState = 'stop';
+            Service.Engine.exitAnimationMode();
+            void Service.Engine.repaintInEditMode();
+            this._broadcastTimeChanged('play-state');
+            void this.queryState()
+                .then((currentState) => this._broadcastStateChanged('play-state', currentState))
+                .catch((error) => console.error('[Animation] broadcast playback stop state failed:', error));
             return;
         }
         if (typeof time !== 'number' || !Number.isFinite(time)) {

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -1,0 +1,642 @@
+import {
+    Animation,
+    AnimationClip,
+    AnimationState,
+    CCClass,
+    Component,
+    Node,
+    Scene,
+    SkeletalAnimation,
+    animation,
+    js,
+} from 'cc';
+import {
+    AnimationPlayState,
+    IAnimationClipMenuItem,
+    IAnimationClipsInfo,
+    IAnimationEditClipOptions,
+    IAnimationEnterOptions,
+    IAnimationExitOptions,
+    IAnimationPlayStateOptions,
+    IAnimationPropertyInfo,
+    IAnimationRootInfo,
+    IAnimationRootResult,
+    IAnimationService,
+    IAnimationSetTimeOptions,
+    IAnimationStateInfo,
+    IAnimationTargetOptions,
+    IAnimationTimeOptions,
+    NodeEventType,
+} from '../../common';
+import { BaseService, register, Service } from './core';
+import dumpUtil from './dump';
+import { Rpc } from '../rpc';
+
+const NodeMgr = EditorExtends.Node;
+
+interface IAnimationData {
+    node: Node;
+    animComp: Animation | animation.AnimationController;
+    clips: AnimationClip[];
+    defaultClip: AnimationClip | null;
+}
+
+interface IAnimationSession {
+    previousEditorType: 'scene' | 'prefab' | 'unknown';
+    previousSelection: string[];
+    restoreSelectionOnExit: boolean;
+    rootUuid: string;
+    rootPath: string;
+    clipUuid: string;
+    sampledRootDump: unknown;
+}
+
+const DEFAULT_PROPERTIES: IAnimationPropertyInfo[] = [
+    createPropertyInfo('position', 'cc.Vec3'),
+    createPropertyInfo('eulerAngles', 'cc.Vec3', 'rotation(eulerAngles)'),
+    createPropertyInfo('rotation', 'cc.Quat', 'rotation(quaternion)'),
+    createPropertyInfo('scale', 'cc.Vec3'),
+];
+
+const ACTIVE_PROPERTY = createPropertyInfo('active', 'cc.Boolean');
+
+function createPropertyInfo(name: string, type: string, displayName = name, comp?: string): IAnimationPropertyInfo {
+    return {
+        name,
+        key: comp ? `${comp}.${name}` : name,
+        displayName,
+        type: { value: type },
+        menuName: displayName,
+        comp,
+    };
+}
+
+function cloneDump<T>(dump: T): T {
+    return JSON.parse(JSON.stringify(dump)) as T;
+}
+
+function clipUuid(clip: AnimationClip | null | undefined): string {
+    return ((clip as any)?._uuid || (clip as any)?.uuid || '') as string;
+}
+
+@register('Animation')
+export class AnimationService extends BaseService<Record<string, any>> implements IAnimationService {
+    private _session: IAnimationSession | null = null;
+    private _animationStateMap = new Map<string, AnimationState>();
+    private _curEditTime = 0;
+    private _playState: AnimationPlayState = 'stop';
+
+    async enter(options: IAnimationEnterOptions): Promise<IAnimationStateInfo> {
+        this._assertEditorOpened();
+
+        if (this._session) {
+            await this.exit({ restoreSelection: false, restoreSampledSceneState: true });
+        }
+
+        const rootNode = this._queryAnimationRootNode(this._resolveNode(options));
+        const animData = await this._queryNodeAnimationData(rootNode);
+        const clip = this._resolveClip(animData, options.clipUuid);
+        const uuid = clipUuid(clip);
+        if (!uuid) {
+            throw new Error('Animation clip uuid is empty.');
+        }
+
+        const sampledRootDump = dumpUtil.dumpNode(rootNode, { includeComponents: true });
+        this._session = {
+            previousEditorType: Service.Editor.getCurrentEditorType(),
+            previousSelection: Service.Selection.query(),
+            restoreSelectionOnExit: options.restoreSelectionOnExit ?? true,
+            rootUuid: rootNode.uuid,
+            rootPath: this._getNodePath(rootNode),
+            clipUuid: uuid,
+            sampledRootDump: sampledRootDump ? cloneDump(sampledRootDump) : null,
+        };
+
+        this._playState = 'stop';
+        this._curEditTime = 0;
+        await this._getAnimationState(uuid);
+        await this.setTime({ time: 0 });
+        return await this.queryState();
+    }
+
+    async exit(options: IAnimationExitOptions): Promise<IAnimationStateInfo> {
+        const session = this._requireSession();
+
+        if (options.save) {
+            await this.save();
+        }
+
+        await this._stopCurrent();
+
+        const shouldRestoreSampledState = options.restoreSampledSceneState ?? true;
+        if (shouldRestoreSampledState && session.sampledRootDump) {
+            const rootNode = this._getNodeByUuid(session.rootUuid);
+            if (rootNode) {
+                await dumpUtil.restoreNode(rootNode, session.sampledRootDump);
+                this._emitNodeChanged(rootNode);
+            }
+        }
+
+        this._clearAnimationStates();
+        Service.Engine.exitAnimationMode();
+
+        const shouldRestoreSelection = options.restoreSelection ?? session.restoreSelectionOnExit;
+        if (shouldRestoreSelection) {
+            this._restoreSelection(session.previousSelection);
+        }
+
+        this._session = null;
+        this._curEditTime = 0;
+        this._playState = 'stop';
+        await Service.Engine.repaintInEditMode();
+        return await this.queryState();
+    }
+
+    async queryState(): Promise<IAnimationStateInfo> {
+        const editorType = Service.Editor.getCurrentEditorType();
+        const selection = Service.Selection.query();
+        if (!this._session) {
+            return {
+                active: false,
+                editorType,
+                mode: this._getMode(editorType),
+                rootUuid: '',
+                rootPath: '',
+                clipUuid: '',
+                time: 0,
+                playState: 'stop',
+                selection,
+                restoreSelectionOnExit: true,
+            };
+        }
+
+        return {
+            active: true,
+            editorType,
+            mode: 'animation',
+            rootUuid: this._session.rootUuid,
+            rootPath: this._session.rootPath,
+            clipUuid: this._session.clipUuid,
+            time: this._curEditTime,
+            playState: this._playState,
+            selection,
+            restoreSelectionOnExit: this._session.restoreSelectionOnExit,
+        };
+    }
+
+    async queryRoot(options: IAnimationTargetOptions): Promise<IAnimationRootResult> {
+        const rootNode = this._queryAnimationRootNode(this._resolveNode(options));
+        return {
+            rootUuid: rootNode.uuid,
+            rootPath: this._getNodePath(rootNode),
+        };
+    }
+
+    async queryRootInfo(options: IAnimationTargetOptions): Promise<IAnimationRootInfo> {
+        const rootNode = this._resolveRootNode(options);
+        const clipsInfo = await this._queryClipsInfo(rootNode);
+        return {
+            ...clipsInfo,
+            nodeTreeDump: await Service.Node.queryNodeTree({ path: clipsInfo.rootPath }),
+            clipDump: null,
+            time: this._session ? await this.queryTime({ clipUuid: clipsInfo.defaultClip }) : 0,
+            state: this._playState,
+            useBakedAnimation: this._isUsingBakedAnimation(rootNode),
+        };
+    }
+
+    async queryClips(options: IAnimationTargetOptions): Promise<IAnimationClipsInfo> {
+        return await this._queryClipsInfo(this._resolveRootNode(options));
+    }
+
+    async queryProperties(options: IAnimationTargetOptions): Promise<IAnimationPropertyInfo[]> {
+        const node = this._resolveNode(options);
+        const root = this._session ? this._getNodeByUuid(this._session.rootUuid) : this._queryAnimationRootNode(node);
+        const isChild = Boolean(root && root !== node);
+        const properties = isChild ? [ACTIVE_PROPERTY, ...DEFAULT_PROPERTIES] : [...DEFAULT_PROPERTIES];
+
+        for (const comp of node.components) {
+            if (!comp || comp instanceof Animation) {
+                continue;
+            }
+            properties.push(...this._queryComponentAnimableProperties(comp));
+        }
+
+        return properties;
+    }
+
+    async queryTime(options: IAnimationTimeOptions): Promise<number> {
+        if (!this._session) {
+            return 0;
+        }
+        const state = this._animationStateMap.get(options.clipUuid || this._session.clipUuid);
+        return state?.current ?? this._curEditTime;
+    }
+
+    async setTime(options: IAnimationSetTimeOptions): Promise<boolean> {
+        const session = this._requireSession();
+        const state = await this._getAnimationState(session.clipUuid);
+        let playTime = options.time;
+        if (playTime > state.duration) {
+            playTime = state.duration;
+        }
+        if (playTime < 0) {
+            playTime = 0;
+        }
+
+        if (((state.clip.wrapMode & AnimationClip.WrapMode.Reverse) === AnimationClip.WrapMode.Reverse)) {
+            playTime = state.duration - playTime;
+        }
+
+        state.weight = 1;
+        state.setTime(playTime);
+        if (!state.isPaused) {
+            state.pause();
+        }
+        state.sample();
+        this._curEditTime = playTime;
+        await Service.Engine.repaintInEditMode();
+        return true;
+    }
+
+    async changePlayState(options: IAnimationPlayStateOptions): Promise<boolean> {
+        this._requireSession();
+        const state = await this._getAnimationState(options.clipUuid || this._session!.clipUuid);
+
+        switch (options.operate) {
+            case 'play':
+                state.weight = 1;
+                if (state.isPlaying && state.isPaused) {
+                    state.resume();
+                } else {
+                    state.play();
+                }
+                this._playState = 'playing';
+                Service.Engine.enterAnimationMode();
+                break;
+            case 'pause':
+                state.pause();
+                this._curEditTime = state.current;
+                this._playState = 'pause';
+                Service.Engine.exitAnimationMode();
+                break;
+            case 'resume':
+                if (!state.isPlaying) {
+                    state.weight = 1;
+                    state.play();
+                }
+                state.resume();
+                this._playState = 'playing';
+                Service.Engine.enterAnimationMode();
+                break;
+            case 'stop':
+                await this._stopCurrent();
+                break;
+            default:
+                throw new Error(`Unsupported animation play operation: ${String(options.operate)}`);
+        }
+
+        await Service.Engine.repaintInEditMode();
+        return true;
+    }
+
+    async changeEditClip(options: IAnimationEditClipOptions): Promise<boolean> {
+        const session = this._requireSession();
+        if (options.clipUuid === session.clipUuid) {
+            return true;
+        }
+
+        await this._stopCurrent();
+        this._resolveClip(await this._queryNodeAnimationData(this._getSessionRootNode()), options.clipUuid);
+        session.clipUuid = options.clipUuid;
+        this._curEditTime = 0;
+        await this._getAnimationState(options.clipUuid);
+        await this.setTime({ time: 0 });
+        return true;
+    }
+
+    async save(): Promise<boolean> {
+        const session = this._requireSession();
+        if (this._isSkeletonClip(session.clipUuid)) {
+            throw new Error('Saving skeleton animation metadata is not implemented yet.');
+        }
+
+        const state = await this._getAnimationState(session.clipUuid);
+        const content = EditorExtends.serialize(state.clip);
+        const assetInfo = await Rpc.getInstance().request('assetManager', 'queryAssetInfo', [session.clipUuid]);
+        if (assetInfo) {
+            await Rpc.getInstance().request('assetManager', 'saveAsset', [assetInfo.uuid, content]);
+        } else {
+            await Rpc.getInstance().request('assetManager', 'createAsset', [{
+                target: `db://assets/${state.clip.name}.anim`,
+                content,
+            }]);
+        }
+        return true;
+    }
+
+    private _assertEditorOpened(): void {
+        if (!Service.Editor.getRootNode()) {
+            throw new Error('Animation editor requires an opened scene or prefab.');
+        }
+    }
+
+    private _requireSession(): IAnimationSession {
+        if (!this._session) {
+            throw new Error('Animation editing session is not active.');
+        }
+        return this._session;
+    }
+
+    private _getMode(editorType: 'scene' | 'prefab' | 'unknown') {
+        if (editorType === 'scene') {
+            return 'general';
+        }
+        if (editorType === 'prefab') {
+            return 'prefab';
+        }
+        return 'unknown';
+    }
+
+    private _resolveRootNode(options: IAnimationTargetOptions): Node {
+        const node = this._resolveNode(options);
+        return options.rootPath || options.rootUuid ? node : this._queryAnimationRootNode(node);
+    }
+
+    private _resolveNode(options: IAnimationTargetOptions | IAnimationEnterOptions): Node {
+        this._assertEditorOpened();
+        const uuid = 'rootUuid' in options ? options.rootUuid : undefined;
+        const path = 'rootPath' in options ? options.rootPath : undefined;
+        const nodeUuid = 'nodeUuid' in options ? options.nodeUuid : undefined;
+        const nodePath = 'nodePath' in options ? options.nodePath : undefined;
+        const target = this._getNodeByUuid(uuid || nodeUuid || '') || this._getNodeByPath(path || nodePath || '');
+        if (target) {
+            return target;
+        }
+
+        const selection = Service.Selection.query();
+        if (selection.length > 0) {
+            const selected = this._getNodeByPath(selection[0]);
+            if (selected) {
+                return selected;
+            }
+        }
+
+        throw new Error('Animation target node is required.');
+    }
+
+    private _queryAnimationRootNode(node: Node): Node {
+        let current: Node | null = node;
+        const editorRoot = Service.Editor.getRootNode();
+        while (current) {
+            if (this._queryAnimationComponent(current)) {
+                return current;
+            }
+            if (current === editorRoot || current.parent instanceof Scene) {
+                break;
+            }
+            current = current.parent;
+        }
+        return node;
+    }
+
+    private _queryAnimationComponent(node: Node): Animation | animation.AnimationController | null {
+        const controllerCtor = (animation as any).AnimationController;
+        const controller = controllerCtor ? node.getComponent(controllerCtor) : null;
+        if (controller) {
+            return controller as animation.AnimationController;
+        }
+        return node.getComponent(Animation);
+    }
+
+    private async _queryNodeAnimationData(node: Node): Promise<IAnimationData> {
+        const animComp = this._queryAnimationComponent(node);
+        if (!animComp) {
+            throw new Error(`Animation component not found on node: ${this._getNodePath(node)}`);
+        }
+
+        let clips: AnimationClip[] = [];
+        let defaultClip: AnimationClip | null = null;
+        if (animComp instanceof Animation) {
+            clips = (animComp.clips || []).filter((clip): clip is AnimationClip => Boolean(clip?.name));
+            defaultClip = animComp.defaultClip || clips[0] || null;
+        } else {
+            clips = (await this._visitAnimationClipsInController(animComp))
+                .filter((clip): clip is AnimationClip => Boolean(clip?.name));
+            defaultClip = clips[0] || null;
+        }
+
+        clips = this._uniqAnimationClips(clips);
+        if (!defaultClip?.name) {
+            defaultClip = clips[0] || null;
+        }
+        if (clips.length === 0 || !defaultClip) {
+            throw new Error(`Animation clips not found on node: ${this._getNodePath(node)}`);
+        }
+
+        return { node, animComp, clips, defaultClip };
+    }
+
+    private _resolveClip(animData: IAnimationData, uuid?: string): AnimationClip {
+        const targetUuid = uuid || clipUuid(animData.defaultClip);
+        const clip = animData.clips.find((item) => clipUuid(item) === targetUuid);
+        if (!clip) {
+            throw new Error(`Animation clip not found: ${targetUuid}`);
+        }
+        return clip;
+    }
+
+    private async _queryClipsInfo(rootNode: Node): Promise<IAnimationClipsInfo> {
+        const animData = await this._queryNodeAnimationData(rootNode);
+        return {
+            rootUuid: rootNode.uuid,
+            rootPath: this._getNodePath(rootNode),
+            clipsMenu: this._decodeClipsMenu(animData.clips),
+            defaultClip: clipUuid(animData.defaultClip),
+        };
+    }
+
+    private async _getAnimationState(uuid: string): Promise<AnimationState> {
+        const session = this._requireSession();
+        const existed = this._animationStateMap.get(uuid);
+        if (existed) {
+            return existed;
+        }
+
+        const clip = this._resolveClip(await this._queryNodeAnimationData(this._getSessionRootNode()), uuid);
+        const state = new AnimationState(clip);
+        (state as any)._curveLoaded = false;
+        state.initialize(this._getSessionRootNode());
+        this._animationStateMap.set(uuid, state);
+        return state;
+    }
+
+    private async _stopCurrent(): Promise<void> {
+        if (!this._session) {
+            return;
+        }
+        const state = this._animationStateMap.get(this._session.clipUuid);
+        if (state) {
+            state.setTime(0);
+            if (!state.isPaused) {
+                state.pause();
+            }
+            state.sample();
+            state.stop();
+        }
+        this._curEditTime = 0;
+        this._playState = 'stop';
+        Service.Engine.exitAnimationMode();
+    }
+
+    private _clearAnimationStates(): void {
+        for (const state of this._animationStateMap.values()) {
+            try {
+                state.destroy();
+            } catch (e) {
+                console.warn('[Animation] destroy animation state failed:', e);
+            }
+        }
+        this._animationStateMap.clear();
+    }
+
+    private _queryComponentAnimableProperties(component: Component): IAnimationPropertyInfo[] {
+        const ctor = component.constructor as any;
+        const props = Array.isArray(ctor.__props__) ? ctor.__props__ as string[] : [];
+        const compName = js.getClassName(component);
+        const result: IAnimationPropertyInfo[] = [];
+        for (const prop of props) {
+            const type = this._queryAnimablePropertyType(ctor, component as any, prop);
+            if (!type) {
+                continue;
+            }
+            result.push(createPropertyInfo(prop, type, `${compName}.${prop}`, compName));
+        }
+        return result;
+    }
+
+    private _queryAnimablePropertyType(ctor: Function, component: Record<string, unknown>, prop: string): string {
+        if (prop === 'type' || prop === '__scriptAsset') {
+            return '';
+        }
+        const attr = CCClass.attr(ctor, prop);
+        if (!attr || attr.animatable === false || attr.readonly) {
+            return '';
+        }
+        const type = attr.type;
+        if (typeof type === 'string') {
+            return type;
+        }
+        if (type instanceof (CCClass.Attr as any).PrimitiveType) {
+            return type.name;
+        }
+        if (typeof type === 'function') {
+            return js.getClassName(type);
+        }
+        const value = component[prop];
+        if (typeof value === 'number') {
+            return 'cc.Number';
+        }
+        if (typeof value === 'boolean') {
+            return 'cc.Boolean';
+        }
+        if (typeof value === 'string') {
+            return 'cc.String';
+        }
+        return '';
+    }
+
+    private _restoreSelection(selection: string[]): void {
+        Service.Selection.clear();
+        for (const path of selection.slice().reverse()) {
+            if (this._getNodeByPath(path)) {
+                Service.Selection.select(path);
+            }
+        }
+    }
+
+    private _emitNodeChanged(node: Node): void {
+        this.emit('node:change', node, {
+            source: 'editor',
+            type: NodeEventType.NOTIFY_NODE_CHANGED,
+            record: false,
+        });
+    }
+
+    private _getSessionRootNode(): Node {
+        const session = this._requireSession();
+        const rootNode = this._getNodeByUuid(session.rootUuid);
+        if (!rootNode) {
+            throw new Error(`Animation root node not found: ${session.rootUuid}`);
+        }
+        return rootNode;
+    }
+
+    private _getNodeByUuid(uuid: string): Node | null {
+        if (!uuid) {
+            return null;
+        }
+        return NodeMgr.getNode(uuid) || null;
+    }
+
+    private _getNodeByPath(path: string): Node | null {
+        if (!path) {
+            return null;
+        }
+        return NodeMgr.getNodeByPath(path) || null;
+    }
+
+    private _getNodePath(node: Node): string {
+        return NodeMgr.getNodePath(node) || '';
+    }
+
+    private _decodeClipsMenu(clips: AnimationClip[]): IAnimationClipMenuItem[] {
+        return clips.map((clip) => ({
+            uuid: clipUuid(clip),
+            name: clip.name,
+        }));
+    }
+
+    private _uniqAnimationClips(clips: AnimationClip[]): AnimationClip[] {
+        const seen = new Set<string>();
+        const result: AnimationClip[] = [];
+        for (const clip of clips) {
+            const uuid = clipUuid(clip);
+            if (!uuid || seen.has(uuid)) {
+                continue;
+            }
+            seen.add(uuid);
+            result.push(clip);
+        }
+        return result;
+    }
+
+    private async _visitAnimationClipsInController(controller: animation.AnimationController): Promise<AnimationClip[]> {
+        const system = (globalThis as any).System;
+        if (system?.import) {
+            const mod = await system.import('cc/editor/new-gen-anim');
+            if (typeof mod?.visitAnimationClipsInController === 'function') {
+                return Array.from(mod.visitAnimationClipsInController(controller) as Iterable<AnimationClip>);
+            }
+        }
+
+        const mod = await import('cc/editor/new-gen-anim');
+        if (typeof mod.visitAnimationClipsInController !== 'function') {
+            throw new Error('visitAnimationClipsInController is not available.');
+        }
+        return Array.from(mod.visitAnimationClipsInController(controller) as Iterable<AnimationClip>);
+    }
+
+    private _isUsingBakedAnimation(rootNode: Node): boolean {
+        const animComp = this._queryAnimationComponent(rootNode);
+        return animComp instanceof SkeletalAnimation && Boolean(animComp.useBakedAnimation);
+    }
+
+    private _isSkeletonClip(uuid: string): boolean {
+        if (uuid.includes('@')) {
+            return true;
+        }
+        const rootNode = this._session ? this._getNodeByUuid(this._session.rootUuid) : null;
+        return Boolean(rootNode && this._queryAnimationComponent(rootNode) instanceof SkeletalAnimation);
+    }
+}

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -558,8 +558,8 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         if (shouldSyncDuration) {
             syncAnimationClipDuration(state.clip);
         }
-        (state as any)._curveLoaded = false;
-        state.initialize(rootNode);
+        this._resetAnimationState(session.clipUuid);
+        this._createAnimationState(session.clipUuid, state.clip);
         await this.setTime({ time: this._curEditTime });
         const after = shouldRecordUndo ? captureAnimationClipSnapshot(state.clip) : null;
         if (before && after && !animationClipSnapshotsEqual(before, after)) {

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -2,20 +2,13 @@ import {
     Animation,
     AnimationClip,
     AnimationState,
-    Component,
     Node,
-    Scene,
-    SkeletalAnimation,
-    animation,
-    assetManager as ccAssetManager,
-    js,
 } from 'cc';
 import {
     AnimationPlayState,
     AnimationEventReason,
     IAnimationClipEvent,
     IAnimationClipDump,
-    IAnimationClipMenuItem,
     IAnimationClipsInfo,
     IAnimationEditClipOptions,
     IAnimationEnterOptions,
@@ -53,100 +46,32 @@ import { queryAuxiliaryCurveValueAtFrame } from './animation/auxiliary-curve';
 import { saveSkeletonAnimationMeta } from './animation/skeleton-meta';
 import { captureAnimationSampledState, restoreAnimationSampledState } from './animation/sampled-state';
 import { AnimationClipSnapshotCommand } from './animation/undo';
-import { IAnimationData, IAnimationSession } from './animation/types';
-import { cloneValue, clipUuid, getClipSample } from './animation/utils';
+import { IAnimationSession } from './animation/types';
+import { clipUuid, getClipSample } from './animation/utils';
 import type { IPropertyCurveMetadataContext } from './animation/property-curve';
 import { queryAnimationPropertyMetadata, queryComponentAnimableProperties } from './animation/property-metadata';
 import { normalizeProvidedAnimationPropertyOperationValue, serializeAnimationPropertyValue } from './animation/property-value';
-
-const NodeMgr = EditorExtends.Node;
-
-const DEFAULT_PROPERTIES: IAnimationPropertyInfo[] = [
-    createPropertyInfo('position', 'cc.Vec3'),
-    createPropertyInfo('eulerAngles', 'cc.Vec3', 'rotation(eulerAngles)'),
-    createPropertyInfo('rotation', 'cc.Quat', 'rotation(quaternion)'),
-    createPropertyInfo('scale', 'cc.Vec3'),
-];
-
-const ACTIVE_PROPERTY = createPropertyInfo('active', 'cc.Boolean');
-
-function createPropertyInfo(name: string, type: string, displayName = name, comp?: string): IAnimationPropertyInfo {
-    return {
-        name,
-        key: comp ? `${comp}.${name}` : name,
-        displayName,
-        type: { value: type },
-        menuName: displayName,
-        comp,
-    };
-}
-
-function isAnimationOperationResult(value: IAnimationOperation | IAnimationOperationResult): value is IAnimationOperationResult {
-    return (value as IAnimationOperationResult).state === 'success' || (value as IAnimationOperationResult).state === 'failure';
-}
-
-function shouldSyncClipDuration(operation: IAnimationOperation): boolean {
-    switch (operation.type) {
-        case 'changeSample':
-        case 'addEvent':
-        case 'deleteEvent':
-        case 'updateEvent':
-        case 'moveEvents':
-        case 'copyEventsTo':
-        case 'addEmbeddedPlayer':
-        case 'deleteEmbeddedPlayer':
-        case 'updateEmbeddedPlayer':
-        case 'clearEmbeddedPlayer':
-        case 'removeEmbeddedPlayerGroup':
-        case 'clearEmbeddedPlayerGroup':
-        case 'removeAuxiliaryCurve':
-        case 'createAuxKey':
-        case 'removeAuxKey':
-        case 'moveAuxKeys':
-        case 'copyAuxKey':
-        case 'createPropertyKey':
-        case 'updatePropertyKey':
-        case 'removePropertyCurve':
-        case 'removePropertyKey':
-        case 'removePropertyKeys':
-        case 'movePropertyKeys':
-        case 'copyPropertyKeysTo':
-            return true;
-        default:
-            return false;
-    }
-}
-
-function isAllowedSkeletonAnimationOperation(operation: IAnimationOperation): boolean {
-    switch (operation.type) {
-        case 'changeSample':
-        case 'changeSpeed':
-        case 'changeWrapMode':
-        case 'addEvent':
-        case 'deleteEvent':
-        case 'updateEvent':
-        case 'moveEvents':
-        case 'copyEventsTo':
-        case 'addEmbeddedPlayer':
-        case 'deleteEmbeddedPlayer':
-        case 'updateEmbeddedPlayer':
-        case 'clearEmbeddedPlayer':
-        case 'addEmbeddedPlayerGroup':
-        case 'removeEmbeddedPlayerGroup':
-        case 'clearEmbeddedPlayerGroup':
-        case 'addAuxiliaryCurve':
-        case 'removeAuxiliaryCurve':
-        case 'renameAuxiliaryCurve':
-        case 'createAuxKey':
-        case 'removeAuxKey':
-        case 'moveAuxKeys':
-        case 'copyAuxKey':
-        case 'updateAuxKeyData':
-            return true;
-        default:
-            return false;
-    }
-}
+import { ACTIVE_PROPERTY, DEFAULT_PROPERTIES } from './animation/property-menu';
+import { isAllowedSkeletonAnimationOperation, isAnimationOperationResult, shouldSyncClipDuration } from './animation/operation-policy';
+import {
+    loadAnimationClip,
+    queryAnimationClipsInfo,
+    queryNodeAnimationData,
+    rebindAnimationComponentClip,
+    resolveAnimationClip,
+} from './animation/clip-library';
+import {
+    extractSampledOperationValue,
+    getAnimationMode,
+    getNodeByPath,
+    getNodeByUuid,
+    getNodePath,
+    isSkeletonClip,
+    isUsingBakedAnimation,
+    queryAnimationComponent,
+    queryAnimationRootNode,
+    readPropertyValue,
+} from './animation/scene-node';
 
 @register('Animation')
 export class AnimationService extends BaseService<Record<string, any>> implements IAnimationService {
@@ -175,9 +100,9 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             await this.exit({ restoreSelection: false, restoreSampledSceneState: true });
         }
 
-        const rootNode = this._queryAnimationRootNode(this._resolveNode(options));
-        const animData = await this._queryNodeAnimationData(rootNode, options.clipUuid, { recoverClipBinding: true });
-        const clip = this._resolveClip(animData, options.clipUuid);
+        const rootNode = queryAnimationRootNode(this._resolveNode(options), Service.Editor.getRootNode());
+        const animData = await queryNodeAnimationData(rootNode, options.clipUuid, { recoverClipBinding: true });
+        const clip = resolveAnimationClip(animData, options.clipUuid);
         const uuid = clipUuid(clip);
         if (!uuid) {
             throw new Error('Animation clip uuid is empty.');
@@ -188,7 +113,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             previousSelection: Service.Selection.query(),
             restoreSelectionOnExit: options.restoreSelectionOnExit ?? true,
             rootUuid: rootNode.uuid,
-            rootPath: this._getNodePath(rootNode),
+            rootPath: getNodePath(rootNode),
             clipUuid: uuid,
             sampledRootState: captureAnimationSampledState(rootNode),
         };
@@ -213,7 +138,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
         const shouldRestoreSampledState = options.restoreSampledSceneState ?? true;
         if (shouldRestoreSampledState && session.sampledRootState) {
-            const rootNode = this._getNodeByUuid(session.rootUuid);
+            const rootNode = getNodeByUuid(session.rootUuid);
             if (rootNode) {
                 await restoreAnimationSampledState(rootNode, session.sampledRootState);
                 this._emitNodeChanged(rootNode);
@@ -244,7 +169,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             return {
                 active: false,
                 editorType,
-                mode: this._getMode(editorType),
+                mode: getAnimationMode(editorType),
                 rootUuid: '',
                 rootPath: '',
                 clipUuid: '',
@@ -270,16 +195,16 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     async queryRoot(options: IAnimationTargetOptions): Promise<IAnimationRootResult> {
-        const rootNode = this._queryAnimationRootNode(this._resolveNode(options));
+        const rootNode = queryAnimationRootNode(this._resolveNode(options), Service.Editor.getRootNode());
         return {
             rootUuid: rootNode.uuid,
-            rootPath: this._getNodePath(rootNode),
+            rootPath: getNodePath(rootNode),
         };
     }
 
     async queryRootInfo(options: IAnimationTargetOptions): Promise<IAnimationRootInfo> {
         const rootNode = this._resolveRootNode(options);
-        const clipsInfo = await this._queryClipsInfo(rootNode);
+        const clipsInfo = await queryAnimationClipsInfo(rootNode);
         const defaultClipUuid = clipsInfo.defaultClip;
         return {
             ...clipsInfo,
@@ -287,12 +212,12 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             clipDump: defaultClipUuid ? await this.queryClip({ rootUuid: rootNode.uuid, clipUuid: defaultClipUuid }) : null,
             time: this._session && defaultClipUuid ? await this.queryTime({ clipUuid: defaultClipUuid }) : 0,
             state: this._playState,
-            useBakedAnimation: this._isUsingBakedAnimation(rootNode),
+            useBakedAnimation: isUsingBakedAnimation(rootNode),
         };
     }
 
     async queryClips(options: IAnimationTargetOptions): Promise<IAnimationClipsInfo> {
-        return await this._queryClipsInfo(this._resolveRootNode(options));
+        return await queryAnimationClipsInfo(this._resolveRootNode(options));
     }
 
     async queryClip(options: IAnimationQueryClipOptions): Promise<IAnimationClipDump> {
@@ -330,7 +255,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
     async queryProperties(options: IAnimationTargetOptions): Promise<IAnimationPropertyInfo[]> {
         const node = this._resolveNode(options);
-        const root = this._session ? this._getNodeByUuid(this._session.rootUuid) : this._queryAnimationRootNode(node);
+        const root = this._session ? getNodeByUuid(this._session.rootUuid) : queryAnimationRootNode(node, Service.Editor.getRootNode());
         const isChild = Boolean(root && root !== node);
         const properties = isChild ? [ACTIVE_PROPERTY, ...DEFAULT_PROPERTIES] : [...DEFAULT_PROPERTIES];
 
@@ -372,7 +297,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             state.sample();
 
             const node = this._resolveFrameQueryNode(options);
-            value = this._readPropertyValue(node, options.propKey);
+            value = readPropertyValue(node, options.propKey);
         } finally {
             state.setTime(previousTime);
             if (!state.isPaused) {
@@ -479,7 +404,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         }
 
         await this._stopCurrent();
-        this._resolveClip(await this._queryNodeAnimationData(this._getSessionRootNode(), options.clipUuid, { recoverClipBinding: true }), options.clipUuid);
+        resolveAnimationClip(await queryNodeAnimationData(this._getSessionRootNode(), options.clipUuid, { recoverClipBinding: true }), options.clipUuid);
         session.clipUuid = options.clipUuid;
         this._curEditTime = 0;
         await this._getAnimationState(options.clipUuid);
@@ -510,7 +435,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
                 }
                 return inputFailure;
             }
-            if (this._isSkeletonClip(session.clipUuid, rootNode) && !isAllowedSkeletonAnimationOperation(inputOperation)) {
+            if (isSkeletonClip(session.clipUuid, rootNode) && !isAllowedSkeletonAnimationOperation(inputOperation)) {
                 const skeletonFailure = {
                     state: 'failure',
                     result: false,
@@ -610,8 +535,8 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         const keyData = keyOperation.keyData ?? keyOperation.curveData;
         if (keyOperation.value !== undefined) {
             const value = await normalizeProvidedAnimationPropertyOperationValue(rootNode, rootPath, keyOperation, {
-                queryNodeByUuid: (uuid) => this._getNodeByUuid(uuid),
-                queryNodePath: (node) => this._getNodePath(node),
+                queryNodeByUuid: (uuid) => getNodeByUuid(uuid),
+                queryNodePath: (node) => getNodePath(node),
             });
             return { ...keyOperation, keyData, value };
         }
@@ -631,7 +556,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
                 propKey: keyOperation.propKey,
                 frame: keyOperation.frame,
             });
-            const value = this._extractSampledOperationValue(sampled, keyOperation.channel);
+            const value = extractSampledOperationValue(sampled, keyOperation.channel);
             if (value === undefined) {
                 return {
                     state: 'failure',
@@ -653,7 +578,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     async save(): Promise<boolean> {
         const session = this._requireSession();
         const state = await this._getAnimationState(session.clipUuid);
-        if (this._isSkeletonClip(session.clipUuid, this._getSessionRootNode())) {
+        if (isSkeletonClip(session.clipUuid, this._getSessionRootNode())) {
             await saveSkeletonAnimationMeta(session.clipUuid, state.clip);
             return true;
         }
@@ -698,19 +623,9 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         return this._session;
     }
 
-    private _getMode(editorType: 'scene' | 'prefab' | 'unknown') {
-        if (editorType === 'scene') {
-            return 'general';
-        }
-        if (editorType === 'prefab') {
-            return 'prefab';
-        }
-        return 'unknown';
-    }
-
     private _resolveRootNode(options: IAnimationTargetOptions): Node {
         const node = this._resolveNode(options);
-        return options.rootPath || options.rootUuid ? node : this._queryAnimationRootNode(node);
+        return options.rootPath || options.rootUuid ? node : queryAnimationRootNode(node, Service.Editor.getRootNode());
     }
 
     private _resolveNode(options: IAnimationTargetOptions | IAnimationEnterOptions): Node {
@@ -719,14 +634,14 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         const path = 'rootPath' in options ? options.rootPath : undefined;
         const nodeUuid = 'nodeUuid' in options ? options.nodeUuid : undefined;
         const nodePath = 'nodePath' in options ? options.nodePath : undefined;
-        const target = this._getNodeByUuid(uuid || nodeUuid || '') || this._getNodeByPath(path || nodePath || '');
+        const target = getNodeByUuid(uuid || nodeUuid || '') || getNodeByPath(path || nodePath || '');
         if (target) {
             return target;
         }
 
         const selection = Service.Selection.query();
         if (selection.length > 0) {
-            const selected = this._getNodeByPath(selection[0]);
+            const selected = getNodeByPath(selection[0]);
             if (selected) {
                 return selected;
             }
@@ -737,19 +652,19 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
     private _resolveFrameQueryNode(options: IAnimationQueryPropertyValueAtFrameOptions): Node {
         const session = this._requireSession();
-        const nodeByUuid = this._getNodeByUuid(options.nodeUuid || '');
+        const nodeByUuid = getNodeByUuid(options.nodeUuid || '');
         if (nodeByUuid) {
             return nodeByUuid;
         }
 
         const path = options.nodePath || session.rootPath;
-        const nodeByPath = this._getNodeByPath(path);
+        const nodeByPath = getNodeByPath(path);
         if (nodeByPath) {
             return nodeByPath;
         }
 
         if (options.nodePath && !options.nodePath.startsWith(session.rootPath)) {
-            const relativeNode = this._getNodeByPath(`${session.rootPath}/${options.nodePath}`);
+            const relativeNode = getNodeByPath(`${session.rootPath}/${options.nodePath}`);
             if (relativeNode) {
                 return relativeNode;
             }
@@ -758,107 +673,22 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         throw new Error(`Animation target node is required: ${path}`);
     }
 
-    private _queryAnimationRootNode(node: Node): Node {
-        let current: Node | null = node;
-        const editorRoot = Service.Editor.getRootNode();
-        while (current) {
-            if (this._queryAnimationComponent(current)) {
-                return current;
-            }
-            if (current === editorRoot || current.parent instanceof Scene) {
-                break;
-            }
-            current = current.parent;
-        }
-        return node;
-    }
-
-    private _queryAnimationComponent(node: Node): Animation | animation.AnimationController | null {
-        const controllerCtor = (animation as any).AnimationController;
-        const controller = controllerCtor ? node.getComponent(controllerCtor) : null;
-        if (controller) {
-            return controller as animation.AnimationController;
-        }
-        return node.getComponent(Animation);
-    }
-
-    private async _queryNodeAnimationData(node: Node, preferredClipUuid?: string, options: { allowEmpty?: boolean; recoverClipBinding?: boolean } = {}): Promise<IAnimationData> {
-        const animComp = this._queryAnimationComponent(node);
-        if (!animComp) {
-            throw new Error(`Animation component not found on node: ${this._getNodePath(node)}`);
-        }
-
-        let clips: AnimationClip[] = [];
-        let defaultClip: AnimationClip | null = null;
-        if (animComp instanceof Animation) {
-            clips = (animComp.clips || []).filter((clip): clip is AnimationClip => Boolean(clip?.name));
-            defaultClip = animComp.defaultClip || clips[0] || null;
-            if (defaultClip?.name) {
-                clips.push(defaultClip);
-            }
-        } else {
-            clips = (await this._visitAnimationClipsInController(animComp))
-                .filter((clip): clip is AnimationClip => Boolean(clip?.name));
-            defaultClip = clips[0] || null;
-        }
-
-        clips = this._uniqAnimationClips(clips);
-        if (!defaultClip?.name) {
-            defaultClip = clips[0] || null;
-        }
-        if (options.recoverClipBinding && (clips.length === 0 || !defaultClip) && preferredClipUuid && animComp instanceof Animation) {
-            const recoveredClip = await this._loadAnimationClip(preferredClipUuid);
-            if (recoveredClip?.name) {
-                this._rebindAnimationComponentClip(animComp, recoveredClip);
-                clips = this._uniqAnimationClips((animComp.clips || []).filter((clip): clip is AnimationClip => Boolean(clip?.name)));
-                defaultClip = animComp.defaultClip?.name ? animComp.defaultClip : clips[0] || null;
-            }
-        }
-        if (clips.length === 0 || !defaultClip) {
-            if (options.allowEmpty) {
-                return { node, animComp, clips, defaultClip };
-            }
-            throw new Error(`Animation clips not found on node: ${this._getNodePath(node)}`);
-        }
-
-        return { node, animComp, clips, defaultClip };
-    }
-
-    private _resolveClip(animData: IAnimationData, uuid?: string): AnimationClip {
-        const targetUuid = uuid || clipUuid(animData.defaultClip);
-        const clip = animData.clips.find((item) => clipUuid(item) === targetUuid);
-        if (!clip) {
-            throw new Error(`Animation clip not found: ${targetUuid}`);
-        }
-        return clip;
-    }
-
-    private async _queryClipsInfo(rootNode: Node): Promise<IAnimationClipsInfo> {
-        const animData = await this._queryNodeAnimationData(rootNode, undefined, { allowEmpty: true });
-        return {
-            rootUuid: rootNode.uuid,
-            rootPath: this._getNodePath(rootNode),
-            clipsMenu: this._decodeClipsMenu(animData.clips),
-            defaultClip: clipUuid(animData.defaultClip),
-        };
-    }
-
     private async _resolveClipForQuery(options: IAnimationQueryClipOptions): Promise<{ rootNode: Node; clip: AnimationClip }> {
         const hasTarget = Boolean(options.rootPath || options.rootUuid || options.nodePath || options.nodeUuid);
         const rootNode = hasTarget ? this._resolveRootNode(options) : this._getSessionRootNode();
         const defaultUuid = this._session?.rootUuid === rootNode.uuid ? this._session.clipUuid : undefined;
         const targetUuid = options.clipUuid || defaultUuid;
-        const animData = await this._queryNodeAnimationData(rootNode, targetUuid);
+        const animData = await queryNodeAnimationData(rootNode, targetUuid);
         return {
             rootNode,
-            clip: this._resolveClip(animData, targetUuid),
+            clip: resolveAnimationClip(animData, targetUuid),
         };
     }
 
     private _createClipDump(rootNode: Node, clip: AnimationClip, state?: AnimationState): IAnimationClipDump {
         return createClipDump(clip, state, {
-            isSkeleton: this._isSkeletonClip(clipUuid(clip), rootNode),
-            useBakedAnimation: this._isUsingBakedAnimation(rootNode),
+            isSkeleton: isSkeletonClip(clipUuid(clip), rootNode),
+            useBakedAnimation: isUsingBakedAnimation(rootNode),
             queryPropertyMetadata: (nodePath, propKey) => queryAnimationPropertyMetadata(rootNode, nodePath, propKey),
         });
     }
@@ -876,7 +706,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             return existed;
         }
 
-        const clip = this._resolveClip(await this._queryNodeAnimationData(this._getSessionRootNode(), uuid), uuid);
+        const clip = resolveAnimationClip(await queryNodeAnimationData(this._getSessionRootNode(), uuid), uuid);
         return this._createAnimationState(uuid, clip);
     }
 
@@ -967,53 +797,16 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         }
 
         const time = this._curEditTime;
-        const clip = await this._loadAnimationClip(uuid);
+        const clip = await loadAnimationClip(uuid);
         const rootNode = this._getSessionRootNode();
-        const animComp = this._queryAnimationComponent(rootNode);
+        const animComp = queryAnimationComponent(rootNode);
         if (clip && animComp instanceof Animation) {
-            this._rebindAnimationComponentClip(animComp, clip);
+            rebindAnimationComponentClip(animComp, clip);
         }
         this._resetAnimationState(uuid);
         const state = await this._getAnimationState(uuid);
         await this.setTime({ time: Math.min(time, state.duration) });
         this._broadcastClipChanged('asset-refresh');
-    }
-
-    private _rebindAnimationComponentClip(animComp: Animation, clip: AnimationClip): void {
-        const uuid = clipUuid(clip);
-        const currentDefaultUuid = animComp.defaultClip ? clipUuid(animComp.defaultClip) : '';
-        let found = false;
-        const clips = (animComp.clips || []).map((item) => {
-            if (item && clipUuid(item) === uuid) {
-                found = true;
-                return clip;
-            }
-            return item;
-        });
-        if (!found) {
-            clips.push(clip);
-        }
-        animComp.clips = clips;
-        if (!currentDefaultUuid || currentDefaultUuid === uuid) {
-            animComp.defaultClip = clip;
-        }
-    }
-
-    private async _loadAnimationClip(uuid: string): Promise<AnimationClip | null> {
-        const cached = ccAssetManager.assets.get(uuid);
-        if (cached instanceof AnimationClip) {
-            return cached;
-        }
-
-        return await new Promise((resolve, reject) => {
-            ccAssetManager.loadAny(uuid, (error, asset: AnimationClip) => {
-                if (error) {
-                    reject(error);
-                    return;
-                }
-                resolve(asset instanceof AnimationClip ? asset : null);
-            });
-        });
     }
 
     private _disposeSession(): void {
@@ -1025,59 +818,10 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         this._playState = 'stop';
     }
 
-    private _readPropertyValue(node: Node, propKey: string): unknown {
-        for (const component of node.components) {
-            const names = this._getComponentNames(component);
-            for (const name of names) {
-                const prefix = `${name}.`;
-                if (name && propKey.startsWith(prefix)) {
-                    return this._readPathValue(component, propKey.slice(prefix.length));
-                }
-            }
-        }
-
-        return this._readPathValue(node, propKey);
-    }
-
-    private _extractSampledOperationValue(value: IAnimationValue, channel?: string): IAnimationValue {
-        if (!channel) {
-            return cloneValue(value);
-        }
-        if (!value || typeof value !== 'object' || Array.isArray(value)) {
-            return undefined;
-        }
-        return cloneValue((value as Record<string, IAnimationValue>)[channel]);
-    }
-
-    private _getComponentNames(component: Component): string[] {
-        const names = [
-            js.getClassName(component),
-            (component as any).__className,
-            (component as any).constructor?.__className,
-            (component as any).constructor?.name,
-        ];
-        return names.filter((name, index): name is string => typeof name === 'string' && name.length > 0 && names.indexOf(name) === index);
-    }
-
-    private _readPathValue(target: unknown, path: string): unknown {
-        if (!path) {
-            return target;
-        }
-
-        let value = target as any;
-        for (const key of path.split('.')) {
-            if (value === null || value === undefined) {
-                return undefined;
-            }
-            value = value[key];
-        }
-        return value;
-    }
-
     private _restoreSelection(selection: string[]): void {
         Service.Selection.clear();
         for (const path of selection.slice().reverse()) {
-            if (this._getNodeByPath(path)) {
+            if (getNodeByPath(path)) {
                 Service.Selection.select(path);
             }
         }
@@ -1182,78 +926,11 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
     private _getSessionRootNode(): Node {
         const session = this._requireSession();
-        const rootNode = this._getNodeByUuid(session.rootUuid);
+        const rootNode = getNodeByUuid(session.rootUuid);
         if (!rootNode) {
             throw new Error(`Animation root node not found: ${session.rootUuid}`);
         }
         return rootNode;
     }
 
-    private _getNodeByUuid(uuid: string): Node | null {
-        if (!uuid) {
-            return null;
-        }
-        return NodeMgr.getNode(uuid) || null;
-    }
-
-    private _getNodeByPath(path: string): Node | null {
-        if (!path) {
-            return null;
-        }
-        return NodeMgr.getNodeByPath(path) || null;
-    }
-
-    private _getNodePath(node: Node): string {
-        return NodeMgr.getNodePath(node) || '';
-    }
-
-    private _decodeClipsMenu(clips: AnimationClip[]): IAnimationClipMenuItem[] {
-        return clips.map((clip) => ({
-            uuid: clipUuid(clip),
-            name: clip.name,
-        }));
-    }
-
-    private _uniqAnimationClips(clips: AnimationClip[]): AnimationClip[] {
-        const seen = new Set<string>();
-        const result: AnimationClip[] = [];
-        for (const clip of clips) {
-            const uuid = clipUuid(clip);
-            if (!uuid || seen.has(uuid)) {
-                continue;
-            }
-            seen.add(uuid);
-            result.push(clip);
-        }
-        return result;
-    }
-
-    private async _visitAnimationClipsInController(controller: animation.AnimationController): Promise<AnimationClip[]> {
-        const system = (globalThis as any).System;
-        if (system?.import) {
-            const mod = await system.import('cc/editor/new-gen-anim');
-            if (typeof mod?.visitAnimationClipsInController === 'function') {
-                return Array.from(mod.visitAnimationClipsInController(controller) as Iterable<AnimationClip>);
-            }
-        }
-
-        const mod = await import('cc/editor/new-gen-anim');
-        if (typeof mod.visitAnimationClipsInController !== 'function') {
-            throw new Error('visitAnimationClipsInController is not available.');
-        }
-        return Array.from(mod.visitAnimationClipsInController(controller) as Iterable<AnimationClip>);
-    }
-
-    private _isUsingBakedAnimation(rootNode: Node): boolean {
-        const animComp = this._queryAnimationComponent(rootNode);
-        return animComp instanceof SkeletalAnimation && Boolean(animComp.useBakedAnimation);
-    }
-
-    private _isSkeletonClip(uuid: string, rootNode?: Node): boolean {
-        if (uuid.includes('@')) {
-            return true;
-        }
-        const targetRootNode = rootNode || (this._session ? this._getNodeByUuid(this._session.rootUuid) : null);
-        return Boolean(targetRootNode && this._queryAnimationComponent(targetRootNode) instanceof SkeletalAnimation);
-    }
 }

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -1044,7 +1044,22 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         if (typeof value === 'string') {
             return 'cc.String';
         }
+        if (value && typeof value === 'object') {
+            return this._queryAnimableObjectPropertyType(value);
+        }
         return '';
+    }
+
+    private _queryAnimableObjectPropertyType(value: object): string {
+        if (value instanceof Node || value instanceof Component || Array.isArray(value)) {
+            return '';
+        }
+        const ctor = (value as { constructor?: Function }).constructor;
+        if (!ctor || ctor === Object) {
+            return '';
+        }
+        const type = js.getClassName(ctor);
+        return type && type !== 'Object' ? type : '';
     }
 
     private _isAnimablePropertyAttr(attr: any): boolean {

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -12,13 +12,19 @@ import {
 } from 'cc';
 import {
     AnimationPlayState,
+    IAnimationClipDump,
     IAnimationClipMenuItem,
     IAnimationClipsInfo,
     IAnimationEditClipOptions,
     IAnimationEnterOptions,
     IAnimationExitOptions,
+    IAnimationOperation,
+    IAnimationOperationOptions,
+    IAnimationOperationResult,
     IAnimationPlayStateOptions,
     IAnimationPropertyInfo,
+    IAnimationQueryClipOptions,
+    IAnimationQueryPropertyValueAtFrameOptions,
     IAnimationRootInfo,
     IAnimationRootResult,
     IAnimationService,
@@ -73,6 +79,16 @@ function createPropertyInfo(name: string, type: string, displayName = name, comp
 
 function cloneDump<T>(dump: T): T {
     return JSON.parse(JSON.stringify(dump)) as T;
+}
+
+function cloneValue<T>(value: T): T {
+    if (value === null || value === undefined) {
+        return value;
+    }
+    if (typeof value !== 'object') {
+        return value;
+    }
+    return cloneDump(value);
 }
 
 function clipUuid(clip: AnimationClip | null | undefined): string {
@@ -198,7 +214,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         return {
             ...clipsInfo,
             nodeTreeDump: await Service.Node.queryNodeTree({ path: clipsInfo.rootPath }),
-            clipDump: null,
+            clipDump: await this.queryClip({ rootUuid: rootNode.uuid, clipUuid: clipsInfo.defaultClip }),
             time: this._session ? await this.queryTime({ clipUuid: clipsInfo.defaultClip }) : 0,
             state: this._playState,
             useBakedAnimation: this._isUsingBakedAnimation(rootNode),
@@ -207,6 +223,24 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
     async queryClips(options: IAnimationTargetOptions): Promise<IAnimationClipsInfo> {
         return await this._queryClipsInfo(this._resolveRootNode(options));
+    }
+
+    async queryClip(options: IAnimationQueryClipOptions): Promise<IAnimationClipDump> {
+        const hasTarget = Boolean(options.rootPath || options.rootUuid || options.nodePath || options.nodeUuid);
+        if (!hasTarget && this._session) {
+            const uuid = options.clipUuid || this._session.clipUuid;
+            const state = this._animationStateMap.get(uuid);
+            if (state) {
+                return this._createClipDump(this._getSessionRootNode(), state.clip, state);
+            }
+        }
+
+        const { rootNode, clip } = await this._resolveClipForQuery(options);
+        const uuid = clipUuid(clip);
+        const state = this._session?.rootUuid === rootNode.uuid
+            ? this._animationStateMap.get(uuid)
+            : undefined;
+        return this._createClipDump(rootNode, clip, state);
     }
 
     async queryProperties(options: IAnimationTargetOptions): Promise<IAnimationPropertyInfo[]> {
@@ -231,6 +265,39 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         }
         const state = this._animationStateMap.get(options.clipUuid || this._session.clipUuid);
         return state?.current ?? this._curEditTime;
+    }
+
+    async queryPropertyValueAtFrame(options: IAnimationQueryPropertyValueAtFrameOptions): Promise<unknown> {
+        const session = this._requireSession();
+        const uuid = options.clipUuid || session.clipUuid;
+        if (uuid !== session.clipUuid) {
+            throw new Error(`current edit clip: '${session.clipUuid}' but you want to operate: '${uuid}'`);
+        }
+
+        const state = await this._getAnimationState(uuid);
+        const previousTime = state.current ?? this._curEditTime;
+        const sample = this._getClipSample(state.clip);
+        let value: unknown;
+        try {
+            state.weight = 1;
+            state.setTime(options.frame / sample);
+            if (!state.isPaused) {
+                state.pause();
+            }
+            state.sample();
+
+            const node = this._resolveFrameQueryNode(options);
+            value = this._readPropertyValue(node, options.propKey);
+        } finally {
+            state.setTime(previousTime);
+            if (!state.isPaused) {
+                state.pause();
+            }
+            state.sample();
+            this._curEditTime = previousTime;
+            await Service.Engine.repaintInEditMode();
+        }
+        return cloneValue(value);
     }
 
     async setTime(options: IAnimationSetTimeOptions): Promise<boolean> {
@@ -315,6 +382,37 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         return true;
     }
 
+    async applyOperation(options: IAnimationOperationOptions): Promise<IAnimationOperationResult> {
+        const session = this._requireSession();
+        if (!Array.isArray(options.operations)) {
+            throw new Error('Animation operations must be an array.');
+        }
+
+        const state = await this._getAnimationState(session.clipUuid);
+        for (const operation of options.operations) {
+            const failure = this._validateAnimationOperation(operation, session.clipUuid);
+            if (failure) {
+                return failure;
+            }
+
+            const args = operation.args.slice(1);
+            const result = this._applyClipOperation(state, operation.funcName, args);
+            if (!result) {
+                return {
+                    state: 'failure',
+                    result: false,
+                    reason: `call method ${operation.funcName} failed`,
+                };
+            }
+        }
+
+        await this.setTime({ time: this._curEditTime });
+        return {
+            state: 'success',
+            result: true,
+        };
+    }
+
     async save(): Promise<boolean> {
         const session = this._requireSession();
         if (this._isSkeletonClip(session.clipUuid)) {
@@ -383,6 +481,29 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         }
 
         throw new Error('Animation target node is required.');
+    }
+
+    private _resolveFrameQueryNode(options: IAnimationQueryPropertyValueAtFrameOptions): Node {
+        const session = this._requireSession();
+        const nodeByUuid = this._getNodeByUuid(options.nodeUuid || '');
+        if (nodeByUuid) {
+            return nodeByUuid;
+        }
+
+        const path = options.nodePath || session.rootPath;
+        const nodeByPath = this._getNodeByPath(path);
+        if (nodeByPath) {
+            return nodeByPath;
+        }
+
+        if (options.nodePath && !options.nodePath.startsWith(session.rootPath)) {
+            const relativeNode = this._getNodeByPath(`${session.rootPath}/${options.nodePath}`);
+            if (relativeNode) {
+                return relativeNode;
+            }
+        }
+
+        throw new Error(`Animation target node is required: ${path}`);
     }
 
     private _queryAnimationRootNode(node: Node): Node {
@@ -456,6 +577,40 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         };
     }
 
+    private async _resolveClipForQuery(options: IAnimationQueryClipOptions): Promise<{ rootNode: Node; clip: AnimationClip }> {
+        const hasTarget = Boolean(options.rootPath || options.rootUuid || options.nodePath || options.nodeUuid);
+        const rootNode = hasTarget ? this._resolveRootNode(options) : this._getSessionRootNode();
+        const animData = await this._queryNodeAnimationData(rootNode);
+        const defaultUuid = this._session?.rootUuid === rootNode.uuid ? this._session.clipUuid : undefined;
+        return {
+            rootNode,
+            clip: this._resolveClip(animData, options.clipUuid || defaultUuid),
+        };
+    }
+
+    private _createClipDump(rootNode: Node, clip: AnimationClip, state?: AnimationState): IAnimationClipDump {
+        const sample = this._getClipSample(clip);
+        const events = Array.isArray((clip as any).events) ? (clip as any).events : [];
+        return {
+            name: clip.name,
+            duration: Number((clip as any).duration) || 0,
+            sample,
+            speed: Number((clip as any).speed) || 0,
+            wrapMode: Number((clip as any).wrapMode) || 0,
+            curves: [],
+            events: events.map((event: any) => ({
+                frame: Math.round((Number(event.frame) || 0) * sample),
+                func: event.func || '',
+                params: Array.isArray(event.params) ? cloneValue(event.params) : [],
+            })),
+            embeddedPlayers: [],
+            embeddedPlayerGroups: [],
+            time: state?.current ?? 0,
+            isLock: false,
+            useBakedAnimation: this._isUsingBakedAnimation(rootNode),
+        };
+    }
+
     private async _getAnimationState(uuid: string): Promise<AnimationState> {
         const session = this._requireSession();
         const existed = this._animationStateMap.get(uuid);
@@ -469,6 +624,249 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         state.initialize(this._getSessionRootNode());
         this._animationStateMap.set(uuid, state);
         return state;
+    }
+
+    private _validateAnimationOperation(operation: IAnimationOperation, currentClipUuid: string): IAnimationOperationResult | null {
+        if (!operation || typeof operation.funcName !== 'string' || !Array.isArray(operation.args)) {
+            return {
+                state: 'failure',
+                result: false,
+                reason: 'Animation operation is invalid.',
+            };
+        }
+
+        const targetClipUuid = operation.args[0];
+        if (targetClipUuid !== currentClipUuid) {
+            return {
+                state: 'failure',
+                result: false,
+                reason: `current edit clip: '${currentClipUuid}' but you want to operate: '${String(targetClipUuid)}'`,
+            };
+        }
+
+        if (!this._isSupportedClipOperation(operation.funcName)) {
+            return {
+                state: 'failure',
+                result: false,
+                reason: `Method '${operation.funcName}' does not exist to manipulate the animation.`,
+            };
+        }
+
+        return null;
+    }
+
+    private _isSupportedClipOperation(funcName: string): boolean {
+        return [
+            'changeSample',
+            'changeSpeed',
+            'changeWrapMode',
+            'addEvent',
+            'deleteEvent',
+            'updateEvent',
+            'moveEvents',
+            'copyEventsTo',
+        ].includes(funcName);
+    }
+
+    private _applyClipOperation(state: AnimationState, funcName: string, args: unknown[]): boolean {
+        const clip = state.clip;
+        switch (funcName) {
+            case 'changeSample':
+                return this._changeClipSample(clip, args[0]);
+            case 'changeSpeed':
+                return this._changeClipSpeed(clip, args[0]);
+            case 'changeWrapMode':
+                return this._changeClipWrapMode(clip, args[0]);
+            case 'addEvent':
+                return this._addClipEvent(clip, args[0], args[1], args[2], true);
+            case 'deleteEvent':
+                return this._deleteClipEvents(clip, args[0], true);
+            case 'updateEvent':
+                return this._updateClipEvents(clip, args[0], args[1]);
+            case 'moveEvents':
+                return this._moveClipEvents(clip, args[0], args[1]);
+            case 'copyEventsTo':
+                return this._copyClipEventsTo(clip, args[0], args[1]);
+            default:
+                return false;
+        }
+    }
+
+    private _changeClipSample(clip: AnimationClip, value: unknown): boolean {
+        let sample = Math.round(Number(value));
+        if (!Number.isFinite(sample) || sample < 1) {
+            sample = 1;
+        }
+
+        const oldSample = this._getClipSample(clip);
+        const events = this._queryClipEvents(clip);
+        if (events) {
+            for (const event of events) {
+                const frame = Math.round((Number(event.frame) || 0) * oldSample);
+                event.frame = frame / sample;
+            }
+        }
+
+        (clip as any).sample = sample;
+        this._updateClipEventData(clip);
+        return true;
+    }
+
+    private _changeClipSpeed(clip: AnimationClip, value: unknown): boolean {
+        const speed = Number(value);
+        if (!Number.isFinite(speed)) {
+            return false;
+        }
+        (clip as any).speed = speed;
+        return true;
+    }
+
+    private _changeClipWrapMode(clip: AnimationClip, value: unknown): boolean {
+        const wrapMode = Number(value);
+        (clip as any).wrapMode = Number.isFinite(wrapMode) ? wrapMode : 0;
+        return true;
+    }
+
+    private _addClipEvent(clip: AnimationClip, frameValue: unknown, funcName: unknown, paramsValue: unknown, updateEventData: boolean): boolean {
+        const frame = Number(frameValue);
+        if (!Number.isFinite(frame) || frame < 0) {
+            return false;
+        }
+
+        const events = this._ensureClipEvents(clip);
+        events.push({
+            frame: frame / this._getClipSample(clip),
+            func: typeof funcName === 'string' ? funcName : '',
+            params: Array.isArray(paramsValue) ? cloneValue(paramsValue) : [],
+        });
+        events.sort((a, b) => Number(a.frame) - Number(b.frame));
+
+        if (updateEventData) {
+            this._updateClipEventData(clip);
+        }
+        return true;
+    }
+
+    private _deleteClipEvents(clip: AnimationClip, framesValue: unknown, updateEventData: boolean): boolean {
+        const events = this._queryClipEvents(clip);
+        if (!events) {
+            return false;
+        }
+
+        const frames = this._normalizeFrames(framesValue);
+        const sample = this._getClipSample(clip);
+        for (let i = events.length - 1; i >= 0; i--) {
+            const frame = Math.round((Number(events[i].frame) || 0) * sample);
+            if (frames.includes(frame)) {
+                events.splice(i, 1);
+            }
+        }
+
+        if (updateEventData) {
+            this._updateClipEventData(clip);
+        }
+        return true;
+    }
+
+    private _updateClipEvents(clip: AnimationClip, framesValue: unknown, eventsValue: unknown): boolean {
+        const frames = this._normalizeFrames(framesValue);
+        if (frames.length === 0) {
+            return false;
+        }
+
+        const newEvents = Array.isArray(eventsValue) ? eventsValue : [];
+        for (const frame of frames) {
+            if (!this._deleteClipEvents(clip, [frame], false)) {
+                return false;
+            }
+            for (const event of newEvents) {
+                this._addClipEvent(clip, frame, (event as any)?.func, (event as any)?.params, false);
+            }
+        }
+
+        this._updateClipEventData(clip);
+        return true;
+    }
+
+    private _moveClipEvents(clip: AnimationClip, framesValue: unknown, offsetValue: unknown): boolean {
+        const events = this._queryClipEvents(clip);
+        if (!events) {
+            return false;
+        }
+
+        const frames = this._normalizeFrames(framesValue);
+        const offset = Number(offsetValue);
+        if (!Number.isFinite(offset)) {
+            return false;
+        }
+
+        const sample = this._getClipSample(clip);
+        for (const event of events) {
+            const frame = Math.round((Number(event.frame) || 0) * sample);
+            if (frames.includes(frame)) {
+                event.frame = Math.max(0, frame + offset) / sample;
+            }
+        }
+
+        events.sort((a, b) => Number(a.frame) - Number(b.frame));
+        this._updateClipEventData(clip);
+        return true;
+    }
+
+    private _copyClipEventsTo(clip: AnimationClip, framesValue: unknown, dstFrameValue: unknown): boolean {
+        const events = this._queryClipEvents(clip);
+        if (!events) {
+            return false;
+        }
+
+        const frames = this._normalizeFrames(framesValue).sort((a, b) => a - b);
+        const dstFrame = Number(dstFrameValue);
+        if (frames.length === 0 || !Number.isFinite(dstFrame)) {
+            return false;
+        }
+
+        const sample = this._getClipSample(clip);
+        const baseFrame = frames[0];
+        const matched = events
+            .filter((event) => frames.includes(Math.round((Number(event.frame) || 0) * sample)))
+            .map((event) => ({
+                frame: Math.max(0, Math.round((Number(event.frame) || 0) * sample) - baseFrame + dstFrame),
+                func: event.func,
+                params: cloneValue(event.params || []),
+            }));
+
+        for (const event of matched) {
+            this._addClipEvent(clip, event.frame, event.func, event.params, false);
+        }
+
+        this._updateClipEventData(clip);
+        return true;
+    }
+
+    private _queryClipEvents(clip: AnimationClip): any[] | null {
+        const events = (clip as any).events;
+        return Array.isArray(events) ? events : null;
+    }
+
+    private _ensureClipEvents(clip: AnimationClip): any[] {
+        if (!Array.isArray((clip as any).events)) {
+            (clip as any).events = [];
+        }
+        return (clip as any).events;
+    }
+
+    private _normalizeFrames(value: unknown): number[] {
+        const values = Array.isArray(value) ? value : [value];
+        return values
+            .map((item) => Number(item))
+            .filter((item) => Number.isFinite(item))
+            .map((item) => Math.round(item));
+    }
+
+    private _updateClipEventData(clip: AnimationClip): void {
+        if (typeof (clip as any).updateEventDatas === 'function') {
+            (clip as any).updateEventDatas();
+        }
     }
 
     private async _stopCurrent(): Promise<void> {
@@ -544,6 +942,50 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             return 'cc.String';
         }
         return '';
+    }
+
+    private _getClipSample(clip: AnimationClip): number {
+        const sample = Number((clip as any).sample);
+        return Number.isFinite(sample) && sample > 0 ? sample : 1;
+    }
+
+    private _readPropertyValue(node: Node, propKey: string): unknown {
+        for (const component of node.components) {
+            const names = this._getComponentNames(component);
+            for (const name of names) {
+                const prefix = `${name}.`;
+                if (name && propKey.startsWith(prefix)) {
+                    return this._readPathValue(component, propKey.slice(prefix.length));
+                }
+            }
+        }
+
+        return this._readPathValue(node, propKey);
+    }
+
+    private _getComponentNames(component: Component): string[] {
+        const names = [
+            js.getClassName(component),
+            (component as any).__className,
+            (component as any).constructor?.__className,
+            (component as any).constructor?.name,
+        ];
+        return names.filter((name, index): name is string => typeof name === 'string' && name.length > 0 && names.indexOf(name) === index);
+    }
+
+    private _readPathValue(target: unknown, path: string): unknown {
+        if (!path) {
+            return target;
+        }
+
+        let value = target as any;
+        for (const key of path.split('.')) {
+            if (value === null || value === undefined) {
+                return undefined;
+            }
+            value = value[key];
+        }
+        return value;
     }
 
     private _restoreSelection(selection: string[]): void {

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -7,7 +7,6 @@ import {
 import {
     AnimationPlayState,
     AnimationEventReason,
-    IAnimationClipEvent,
     IAnimationClipDump,
     IAnimationClipsInfo,
     IAnimationEditClipOptions,
@@ -17,7 +16,6 @@ import {
     IAnimationOperationResult,
     IAnimationPlayStateOptions,
     IAnimationQueryAuxiliaryCurveValueAtFrameOptions,
-    IAnimationPropertyInfo,
     IAnimationQueryClipOptions,
     IAnimationQueryPropertyValueAtFrameOptions,
     IAnimationRootInfo,
@@ -32,7 +30,6 @@ import {
 } from '../../common';
 import { BaseService, register, Service, ServiceEvents } from './core';
 import { Rpc } from '../rpc';
-import { createClipDump } from './animation/clip-dump';
 import {
     animationClipSnapshotsEqual,
     captureAnimationClipSnapshot,
@@ -47,10 +44,7 @@ import { captureAnimationSampledState, restoreAnimationSampledState } from './an
 import { AnimationClipSnapshotCommand } from './animation/undo';
 import { IAnimationSession } from './animation/types';
 import { clipUuid, getClipSample } from './animation/utils';
-import type { IPropertyCurveMetadataContext } from './animation/property-curve';
-import { queryAnimationPropertyMetadata, queryComponentAnimableProperties } from './animation/property-metadata';
 import { serializeAnimationPropertyValue } from './animation/property-value';
-import { ACTIVE_PROPERTY, DEFAULT_PROPERTIES } from './animation/property-menu';
 import { isAllowedSkeletonAnimationOperation, isAnimationOperationResult, shouldSyncClipDuration } from './animation/operation-policy';
 import { normalizeAnimationOperation } from './animation/operation-normalizer';
 import {
@@ -71,6 +65,19 @@ import {
     queryAnimationRootNode,
     readPropertyValue,
 } from './animation/scene-node';
+import {
+    assertAnimationEditorOpened,
+    createAnimationPropertyCurveMetadataContext,
+    createAnimationServiceClipDump,
+    createAnimationServiceClipEvent,
+    getAnimationSessionRootNode,
+    isCurrentAnimationSessionClipQuery,
+    queryAnimationServiceProperties,
+    requireAnimationSession,
+    resolveAnimationFrameQueryNode,
+    resolveAnimationRootTarget,
+    resolveAnimationTargetNode,
+} from './animation/service-target';
 
 @register('Animation')
 export class AnimationService extends BaseService<Record<string, any>> implements IAnimationService {
@@ -93,7 +100,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     async enter(options: IAnimationEnterOptions): Promise<IAnimationStateInfo> {
-        this._assertEditorOpened();
+        assertAnimationEditorOpened(Service.Editor.getRootNode());
 
         if (this._session) {
             await this.exit({ restoreSelection: false, restoreSampledSceneState: true });
@@ -127,7 +134,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     async exit(options: IAnimationExitOptions): Promise<IAnimationStateInfo> {
-        const session = this._requireSession();
+        const session = requireAnimationSession(this._session);
 
         if (options.save) {
             await this.save();
@@ -223,11 +230,11 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         const hasTarget = Boolean(options.rootPath || options.rootUuid || options.nodePath || options.nodeUuid);
         if (this._session) {
             const uuid = options.clipUuid || this._session.clipUuid;
-            const state = this._isCurrentSessionClipQuery(options, uuid, hasTarget)
+            const state = isCurrentAnimationSessionClipQuery(this._session, options, uuid, hasTarget)
                 ? this._animationStateMap.get(uuid)
                 : undefined;
             if (state) {
-                return this._createClipDump(this._getSessionRootNode(), state.clip, state);
+                return createAnimationServiceClipDump(this._getSessionRootNode(), state.clip, state);
             }
         }
 
@@ -236,36 +243,13 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         const state = this._session?.rootUuid === rootNode.uuid
             ? this._animationStateMap.get(uuid)
             : undefined;
-        return this._createClipDump(rootNode, clip, state);
+        return createAnimationServiceClipDump(rootNode, clip, state);
     }
 
-    private _isCurrentSessionClipQuery(options: IAnimationQueryClipOptions, clipUuid: string, hasTarget: boolean): boolean {
-        if (!this._session || clipUuid !== this._session.clipUuid) {
-            return false;
-        }
-        if (!hasTarget) {
-            return true;
-        }
-        return options.rootUuid === this._session.rootUuid
-            || options.rootPath === this._session.rootPath
-            || options.nodeUuid === this._session.rootUuid
-            || options.nodePath === this._session.rootPath;
-    }
-
-    async queryProperties(options: IAnimationTargetOptions): Promise<IAnimationPropertyInfo[]> {
+    async queryProperties(options: IAnimationTargetOptions) {
         const node = this._resolveNode(options);
         const root = this._session ? getNodeByUuid(this._session.rootUuid) : queryAnimationRootNode(node, Service.Editor.getRootNode());
-        const isChild = Boolean(root && root !== node);
-        const properties = isChild ? [ACTIVE_PROPERTY, ...DEFAULT_PROPERTIES] : [...DEFAULT_PROPERTIES];
-
-        for (const comp of node.components) {
-            if (!comp || comp instanceof Animation) {
-                continue;
-            }
-            properties.push(...queryComponentAnimableProperties(comp));
-        }
-
-        return properties;
+        return queryAnimationServiceProperties(node, root);
     }
 
     async queryTime(options: IAnimationTimeOptions): Promise<number> {
@@ -281,7 +265,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     async queryPropertyValueAtFrame(options: IAnimationQueryPropertyValueAtFrameOptions): Promise<IAnimationValue> {
-        const session = this._requireSession();
+        const session = requireAnimationSession(this._session);
         const uuid = options.clipUuid || session.clipUuid;
         if (uuid !== session.clipUuid) {
             throw new Error(`current edit clip: '${session.clipUuid}' but you want to operate: '${uuid}'`);
@@ -299,7 +283,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             }
             state.sample();
 
-            const node = this._resolveFrameQueryNode(options);
+            const node = resolveAnimationFrameQueryNode(options, session);
             value = readPropertyValue(node, options.propKey);
         } finally {
             state.setTime(previousTime);
@@ -314,7 +298,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     async queryAuxiliaryCurveValueAtFrame(options: IAnimationQueryAuxiliaryCurveValueAtFrameOptions) {
-        const session = this._requireSession();
+        const session = requireAnimationSession(this._session);
         const uuid = options.clipUuid || session.clipUuid;
         if (uuid !== session.clipUuid) {
             throw new Error(`current edit clip: '${session.clipUuid}' but you want to operate: '${uuid}'`);
@@ -325,7 +309,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     async setTime(options: IAnimationSetTimeOptions): Promise<boolean> {
-        const session = this._requireSession();
+        const session = requireAnimationSession(this._session);
         const state = await this._getAnimationState(session.clipUuid);
         let playTime = options.time;
         if (playTime < 0) {
@@ -349,7 +333,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     async changePlayState(options: IAnimationPlayStateOptions): Promise<boolean> {
-        const session = this._requireSession();
+        const session = requireAnimationSession(this._session);
         const uuid = options.clipUuid || session.clipUuid;
         if (uuid !== session.clipUuid) {
             throw new Error(`current edit clip: '${session.clipUuid}' but you want to operate: '${uuid}'`);
@@ -398,7 +382,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     async changeEditClip(options: IAnimationEditClipOptions): Promise<boolean> {
-        const session = this._requireSession();
+        const session = requireAnimationSession(this._session);
         if (options.clipUuid === session.clipUuid) {
             return true;
         }
@@ -415,14 +399,14 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     async applyOperation(options: IAnimationOperationOptions): Promise<IAnimationOperationResult> {
-        const session = this._requireSession();
+        const session = requireAnimationSession(this._session);
         if (!Array.isArray(options.operations)) {
             throw new Error('Animation operations must be an array.');
         }
 
         const rootNode = this._getSessionRootNode();
         const state = await this._getAnimationState(session.clipUuid);
-        const propertyMetadataContext = this._createPropertyCurveMetadataContext(rootNode);
+        const propertyMetadataContext = createAnimationPropertyCurveMetadataContext(rootNode);
         const shouldRecordUndo = options.recordUndo !== false;
         const before = captureAnimationClipSnapshot(state.clip, propertyMetadataContext);
         let shouldSyncDuration = false;
@@ -521,7 +505,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     async save(): Promise<boolean> {
-        const session = this._requireSession();
+        const session = requireAnimationSession(this._session);
         const state = await this._getAnimationState(session.clipUuid);
         if (isSkeletonClip(session.clipUuid, this._getSessionRootNode())) {
             await saveSkeletonAnimationMeta(session.clipUuid, state.clip);
@@ -555,67 +539,12 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         this._disposeSession();
     }
 
-    private _assertEditorOpened(): void {
-        if (!Service.Editor.getRootNode()) {
-            throw new Error('Animation editor requires an opened scene or prefab.');
-        }
-    }
-
-    private _requireSession(): IAnimationSession {
-        if (!this._session) {
-            throw new Error('Animation editing session is not active.');
-        }
-        return this._session;
-    }
-
     private _resolveRootNode(options: IAnimationTargetOptions): Node {
-        const node = this._resolveNode(options);
-        return options.rootPath || options.rootUuid ? node : queryAnimationRootNode(node, Service.Editor.getRootNode());
+        return resolveAnimationRootTarget(options, Service.Editor.getRootNode(), Service.Selection.query());
     }
 
     private _resolveNode(options: IAnimationTargetOptions | IAnimationEnterOptions): Node {
-        this._assertEditorOpened();
-        const uuid = 'rootUuid' in options ? options.rootUuid : undefined;
-        const path = 'rootPath' in options ? options.rootPath : undefined;
-        const nodeUuid = 'nodeUuid' in options ? options.nodeUuid : undefined;
-        const nodePath = 'nodePath' in options ? options.nodePath : undefined;
-        const target = getNodeByUuid(uuid || nodeUuid || '') || getNodeByPath(path || nodePath || '');
-        if (target) {
-            return target;
-        }
-
-        const selection = Service.Selection.query();
-        if (selection.length > 0) {
-            const selected = getNodeByPath(selection[0]);
-            if (selected) {
-                return selected;
-            }
-        }
-
-        throw new Error('Animation target node is required.');
-    }
-
-    private _resolveFrameQueryNode(options: IAnimationQueryPropertyValueAtFrameOptions): Node {
-        const session = this._requireSession();
-        const nodeByUuid = getNodeByUuid(options.nodeUuid || '');
-        if (nodeByUuid) {
-            return nodeByUuid;
-        }
-
-        const path = options.nodePath || session.rootPath;
-        const nodeByPath = getNodeByPath(path);
-        if (nodeByPath) {
-            return nodeByPath;
-        }
-
-        if (options.nodePath && !options.nodePath.startsWith(session.rootPath)) {
-            const relativeNode = getNodeByPath(`${session.rootPath}/${options.nodePath}`);
-            if (relativeNode) {
-                return relativeNode;
-            }
-        }
-
-        throw new Error(`Animation target node is required: ${path}`);
+        return resolveAnimationTargetNode(options, Service.Editor.getRootNode(), Service.Selection.query());
     }
 
     private async _resolveClipForQuery(options: IAnimationQueryClipOptions): Promise<{ rootNode: Node; clip: AnimationClip }> {
@@ -630,22 +559,8 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         };
     }
 
-    private _createClipDump(rootNode: Node, clip: AnimationClip, state?: AnimationState): IAnimationClipDump {
-        return createClipDump(clip, state, {
-            isSkeleton: isSkeletonClip(clipUuid(clip), rootNode),
-            useBakedAnimation: isUsingBakedAnimation(rootNode),
-            queryPropertyMetadata: (nodePath, propKey) => queryAnimationPropertyMetadata(rootNode, nodePath, propKey),
-        });
-    }
-
-    private _createPropertyCurveMetadataContext(rootNode: Node): IPropertyCurveMetadataContext {
-        return {
-            queryPropertyMetadata: (nodePath, propKey) => queryAnimationPropertyMetadata(rootNode, nodePath, propKey),
-        };
-    }
-
     private async _getAnimationState(uuid: string): Promise<AnimationState> {
-        const session = this._requireSession();
+        requireAnimationSession(this._session);
         const existed = this._animationStateMap.get(uuid);
         if (existed) {
             return existed;
@@ -714,7 +629,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     private async _restoreCurrentClipSnapshot(uuid: string, snapshot: IAnimationClipSnapshot): Promise<void> {
-        const session = this._requireSession();
+        const session = requireAnimationSession(this._session);
         if (uuid !== session.clipUuid) {
             throw new Error(`current edit clip: '${session.clipUuid}' but you want to restore: '${uuid}'`);
         }
@@ -785,7 +700,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     private _broadcastTimeChanged(reason: AnimationEventReason): void {
-        const event = this._createAnimationClipEvent(reason);
+        const event = createAnimationServiceClipEvent(this._session, reason);
         if (!event) {
             return;
         }
@@ -850,32 +765,15 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     private _broadcastClipChanged(reason: AnimationEventReason): void {
-        const event = this._createAnimationClipEvent(reason);
+        const event = createAnimationServiceClipEvent(this._session, reason);
         if (!event) {
             return;
         }
         this.broadcast('animation:clip-changed', event);
     }
 
-    private _createAnimationClipEvent(reason: AnimationEventReason): IAnimationClipEvent | null {
-        if (!this._session) {
-            return null;
-        }
-        return {
-            reason,
-            rootUuid: this._session.rootUuid,
-            rootPath: this._session.rootPath,
-            clipUuid: this._session.clipUuid,
-        };
-    }
-
     private _getSessionRootNode(): Node {
-        const session = this._requireSession();
-        const rootNode = getNodeByUuid(session.rootUuid);
-        if (!rootNode) {
-            throw new Error(`Animation root node not found: ${session.rootUuid}`);
-        }
-        return rootNode;
+        return getAnimationSessionRootNode(requireAnimationSession(this._session));
     }
 
 }

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -18,7 +18,6 @@ import {
     IAnimationEditClipOptions,
     IAnimationEnterOptions,
     IAnimationExitOptions,
-    IAnimationOperation,
     IAnimationOperationOptions,
     IAnimationOperationResult,
     IAnimationPlayStateOptions,
@@ -32,30 +31,19 @@ import {
     IAnimationStateInfo,
     IAnimationTargetOptions,
     IAnimationTimeOptions,
+    IAnimationValue,
     NodeEventType,
 } from '../../common';
 import { BaseService, register, Service } from './core';
 import dumpUtil from './dump';
 import { Rpc } from '../rpc';
+import { createClipDump } from './animation/clip-dump';
+import { applyClipOperation, validateAnimationOperation } from './animation/clip-operations';
+import { saveSkeletonAnimationMeta } from './animation/skeleton-meta';
+import { IAnimationData, IAnimationSession } from './animation/types';
+import { cloneDump, cloneValue, clipUuid, getClipSample } from './animation/utils';
 
 const NodeMgr = EditorExtends.Node;
-
-interface IAnimationData {
-    node: Node;
-    animComp: Animation | animation.AnimationController;
-    clips: AnimationClip[];
-    defaultClip: AnimationClip | null;
-}
-
-interface IAnimationSession {
-    previousEditorType: 'scene' | 'prefab' | 'unknown';
-    previousSelection: string[];
-    restoreSelectionOnExit: boolean;
-    rootUuid: string;
-    rootPath: string;
-    clipUuid: string;
-    sampledRootDump: unknown;
-}
 
 const DEFAULT_PROPERTIES: IAnimationPropertyInfo[] = [
     createPropertyInfo('position', 'cc.Vec3'),
@@ -75,24 +63,6 @@ function createPropertyInfo(name: string, type: string, displayName = name, comp
         menuName: displayName,
         comp,
     };
-}
-
-function cloneDump<T>(dump: T): T {
-    return JSON.parse(JSON.stringify(dump)) as T;
-}
-
-function cloneValue<T>(value: T): T {
-    if (value === null || value === undefined) {
-        return value;
-    }
-    if (typeof value !== 'object') {
-        return value;
-    }
-    return cloneDump(value);
-}
-
-function clipUuid(clip: AnimationClip | null | undefined): string {
-    return ((clip as any)?._uuid || (clip as any)?.uuid || '') as string;
 }
 
 @register('Animation')
@@ -267,7 +237,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         return state?.current ?? this._curEditTime;
     }
 
-    async queryPropertyValueAtFrame(options: IAnimationQueryPropertyValueAtFrameOptions): Promise<unknown> {
+    async queryPropertyValueAtFrame(options: IAnimationQueryPropertyValueAtFrameOptions): Promise<IAnimationValue> {
         const session = this._requireSession();
         const uuid = options.clipUuid || session.clipUuid;
         if (uuid !== session.clipUuid) {
@@ -276,7 +246,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
         const state = await this._getAnimationState(uuid);
         const previousTime = state.current ?? this._curEditTime;
-        const sample = this._getClipSample(state.clip);
+        const sample = getClipSample(state.clip);
         let value: unknown;
         try {
             state.weight = 1;
@@ -297,7 +267,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             this._curEditTime = previousTime;
             await Service.Engine.repaintInEditMode();
         }
-        return cloneValue(value);
+        return cloneValue(value) as IAnimationValue;
     }
 
     async setTime(options: IAnimationSetTimeOptions): Promise<boolean> {
@@ -390,18 +360,17 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
         const state = await this._getAnimationState(session.clipUuid);
         for (const operation of options.operations) {
-            const failure = this._validateAnimationOperation(operation, session.clipUuid);
+            const failure = validateAnimationOperation(operation, session.clipUuid);
             if (failure) {
                 return failure;
             }
 
-            const args = operation.args.slice(1);
-            const result = this._applyClipOperation(state, operation.funcName, args);
+            const result = await applyClipOperation(state, operation);
             if (!result) {
                 return {
                     state: 'failure',
                     result: false,
-                    reason: `call method ${operation.funcName} failed`,
+                    reason: `call method ${operation.type} failed`,
                 };
             }
         }
@@ -415,11 +384,12 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
     async save(): Promise<boolean> {
         const session = this._requireSession();
-        if (this._isSkeletonClip(session.clipUuid)) {
-            throw new Error('Saving skeleton animation metadata is not implemented yet.');
+        const state = await this._getAnimationState(session.clipUuid);
+        if (this._isSkeletonClip(session.clipUuid, this._getSessionRootNode())) {
+            await saveSkeletonAnimationMeta(session.clipUuid, state.clip);
+            return true;
         }
 
-        const state = await this._getAnimationState(session.clipUuid);
         const content = EditorExtends.serialize(state.clip);
         const assetInfo = await Rpc.getInstance().request('assetManager', 'queryAssetInfo', [session.clipUuid]);
         if (assetInfo) {
@@ -589,26 +559,10 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     private _createClipDump(rootNode: Node, clip: AnimationClip, state?: AnimationState): IAnimationClipDump {
-        const sample = this._getClipSample(clip);
-        const events = Array.isArray((clip as any).events) ? (clip as any).events : [];
-        return {
-            name: clip.name,
-            duration: Number((clip as any).duration) || 0,
-            sample,
-            speed: Number((clip as any).speed) || 0,
-            wrapMode: Number((clip as any).wrapMode) || 0,
-            curves: [],
-            events: events.map((event: any) => ({
-                frame: Math.round((Number(event.frame) || 0) * sample),
-                func: event.func || '',
-                params: Array.isArray(event.params) ? cloneValue(event.params) : [],
-            })),
-            embeddedPlayers: [],
-            embeddedPlayerGroups: [],
-            time: state?.current ?? 0,
-            isLock: false,
+        return createClipDump(rootNode, clip, state, {
+            isSkeleton: this._isSkeletonClip(clipUuid(clip), rootNode),
             useBakedAnimation: this._isUsingBakedAnimation(rootNode),
-        };
+        });
     }
 
     private async _getAnimationState(uuid: string): Promise<AnimationState> {
@@ -624,249 +578,6 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         state.initialize(this._getSessionRootNode());
         this._animationStateMap.set(uuid, state);
         return state;
-    }
-
-    private _validateAnimationOperation(operation: IAnimationOperation, currentClipUuid: string): IAnimationOperationResult | null {
-        if (!operation || typeof operation.funcName !== 'string' || !Array.isArray(operation.args)) {
-            return {
-                state: 'failure',
-                result: false,
-                reason: 'Animation operation is invalid.',
-            };
-        }
-
-        const targetClipUuid = operation.args[0];
-        if (targetClipUuid !== currentClipUuid) {
-            return {
-                state: 'failure',
-                result: false,
-                reason: `current edit clip: '${currentClipUuid}' but you want to operate: '${String(targetClipUuid)}'`,
-            };
-        }
-
-        if (!this._isSupportedClipOperation(operation.funcName)) {
-            return {
-                state: 'failure',
-                result: false,
-                reason: `Method '${operation.funcName}' does not exist to manipulate the animation.`,
-            };
-        }
-
-        return null;
-    }
-
-    private _isSupportedClipOperation(funcName: string): boolean {
-        return [
-            'changeSample',
-            'changeSpeed',
-            'changeWrapMode',
-            'addEvent',
-            'deleteEvent',
-            'updateEvent',
-            'moveEvents',
-            'copyEventsTo',
-        ].includes(funcName);
-    }
-
-    private _applyClipOperation(state: AnimationState, funcName: string, args: unknown[]): boolean {
-        const clip = state.clip;
-        switch (funcName) {
-            case 'changeSample':
-                return this._changeClipSample(clip, args[0]);
-            case 'changeSpeed':
-                return this._changeClipSpeed(clip, args[0]);
-            case 'changeWrapMode':
-                return this._changeClipWrapMode(clip, args[0]);
-            case 'addEvent':
-                return this._addClipEvent(clip, args[0], args[1], args[2], true);
-            case 'deleteEvent':
-                return this._deleteClipEvents(clip, args[0], true);
-            case 'updateEvent':
-                return this._updateClipEvents(clip, args[0], args[1]);
-            case 'moveEvents':
-                return this._moveClipEvents(clip, args[0], args[1]);
-            case 'copyEventsTo':
-                return this._copyClipEventsTo(clip, args[0], args[1]);
-            default:
-                return false;
-        }
-    }
-
-    private _changeClipSample(clip: AnimationClip, value: unknown): boolean {
-        let sample = Math.round(Number(value));
-        if (!Number.isFinite(sample) || sample < 1) {
-            sample = 1;
-        }
-
-        const oldSample = this._getClipSample(clip);
-        const events = this._queryClipEvents(clip);
-        if (events) {
-            for (const event of events) {
-                const frame = Math.round((Number(event.frame) || 0) * oldSample);
-                event.frame = frame / sample;
-            }
-        }
-
-        (clip as any).sample = sample;
-        this._updateClipEventData(clip);
-        return true;
-    }
-
-    private _changeClipSpeed(clip: AnimationClip, value: unknown): boolean {
-        const speed = Number(value);
-        if (!Number.isFinite(speed)) {
-            return false;
-        }
-        (clip as any).speed = speed;
-        return true;
-    }
-
-    private _changeClipWrapMode(clip: AnimationClip, value: unknown): boolean {
-        const wrapMode = Number(value);
-        (clip as any).wrapMode = Number.isFinite(wrapMode) ? wrapMode : 0;
-        return true;
-    }
-
-    private _addClipEvent(clip: AnimationClip, frameValue: unknown, funcName: unknown, paramsValue: unknown, updateEventData: boolean): boolean {
-        const frame = Number(frameValue);
-        if (!Number.isFinite(frame) || frame < 0) {
-            return false;
-        }
-
-        const events = this._ensureClipEvents(clip);
-        events.push({
-            frame: frame / this._getClipSample(clip),
-            func: typeof funcName === 'string' ? funcName : '',
-            params: Array.isArray(paramsValue) ? cloneValue(paramsValue) : [],
-        });
-        events.sort((a, b) => Number(a.frame) - Number(b.frame));
-
-        if (updateEventData) {
-            this._updateClipEventData(clip);
-        }
-        return true;
-    }
-
-    private _deleteClipEvents(clip: AnimationClip, framesValue: unknown, updateEventData: boolean): boolean {
-        const events = this._queryClipEvents(clip);
-        if (!events) {
-            return false;
-        }
-
-        const frames = this._normalizeFrames(framesValue);
-        const sample = this._getClipSample(clip);
-        for (let i = events.length - 1; i >= 0; i--) {
-            const frame = Math.round((Number(events[i].frame) || 0) * sample);
-            if (frames.includes(frame)) {
-                events.splice(i, 1);
-            }
-        }
-
-        if (updateEventData) {
-            this._updateClipEventData(clip);
-        }
-        return true;
-    }
-
-    private _updateClipEvents(clip: AnimationClip, framesValue: unknown, eventsValue: unknown): boolean {
-        const frames = this._normalizeFrames(framesValue);
-        if (frames.length === 0) {
-            return false;
-        }
-
-        const newEvents = Array.isArray(eventsValue) ? eventsValue : [];
-        for (const frame of frames) {
-            if (!this._deleteClipEvents(clip, [frame], false)) {
-                return false;
-            }
-            for (const event of newEvents) {
-                this._addClipEvent(clip, frame, (event as any)?.func, (event as any)?.params, false);
-            }
-        }
-
-        this._updateClipEventData(clip);
-        return true;
-    }
-
-    private _moveClipEvents(clip: AnimationClip, framesValue: unknown, offsetValue: unknown): boolean {
-        const events = this._queryClipEvents(clip);
-        if (!events) {
-            return false;
-        }
-
-        const frames = this._normalizeFrames(framesValue);
-        const offset = Number(offsetValue);
-        if (!Number.isFinite(offset)) {
-            return false;
-        }
-
-        const sample = this._getClipSample(clip);
-        for (const event of events) {
-            const frame = Math.round((Number(event.frame) || 0) * sample);
-            if (frames.includes(frame)) {
-                event.frame = Math.max(0, frame + offset) / sample;
-            }
-        }
-
-        events.sort((a, b) => Number(a.frame) - Number(b.frame));
-        this._updateClipEventData(clip);
-        return true;
-    }
-
-    private _copyClipEventsTo(clip: AnimationClip, framesValue: unknown, dstFrameValue: unknown): boolean {
-        const events = this._queryClipEvents(clip);
-        if (!events) {
-            return false;
-        }
-
-        const frames = this._normalizeFrames(framesValue).sort((a, b) => a - b);
-        const dstFrame = Number(dstFrameValue);
-        if (frames.length === 0 || !Number.isFinite(dstFrame)) {
-            return false;
-        }
-
-        const sample = this._getClipSample(clip);
-        const baseFrame = frames[0];
-        const matched = events
-            .filter((event) => frames.includes(Math.round((Number(event.frame) || 0) * sample)))
-            .map((event) => ({
-                frame: Math.max(0, Math.round((Number(event.frame) || 0) * sample) - baseFrame + dstFrame),
-                func: event.func,
-                params: cloneValue(event.params || []),
-            }));
-
-        for (const event of matched) {
-            this._addClipEvent(clip, event.frame, event.func, event.params, false);
-        }
-
-        this._updateClipEventData(clip);
-        return true;
-    }
-
-    private _queryClipEvents(clip: AnimationClip): any[] | null {
-        const events = (clip as any).events;
-        return Array.isArray(events) ? events : null;
-    }
-
-    private _ensureClipEvents(clip: AnimationClip): any[] {
-        if (!Array.isArray((clip as any).events)) {
-            (clip as any).events = [];
-        }
-        return (clip as any).events;
-    }
-
-    private _normalizeFrames(value: unknown): number[] {
-        const values = Array.isArray(value) ? value : [value];
-        return values
-            .map((item) => Number(item))
-            .filter((item) => Number.isFinite(item))
-            .map((item) => Math.round(item));
-    }
-
-    private _updateClipEventData(clip: AnimationClip): void {
-        if (typeof (clip as any).updateEventDatas === 'function') {
-            (clip as any).updateEventDatas();
-        }
     }
 
     private async _stopCurrent(): Promise<void> {
@@ -942,11 +653,6 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             return 'cc.String';
         }
         return '';
-    }
-
-    private _getClipSample(clip: AnimationClip): number {
-        const sample = Number((clip as any).sample);
-        return Number.isFinite(sample) && sample > 0 ? sample : 1;
     }
 
     private _readPropertyValue(node: Node, propKey: string): unknown {
@@ -1074,11 +780,11 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         return animComp instanceof SkeletalAnimation && Boolean(animComp.useBakedAnimation);
     }
 
-    private _isSkeletonClip(uuid: string): boolean {
+    private _isSkeletonClip(uuid: string, rootNode?: Node): boolean {
         if (uuid.includes('@')) {
             return true;
         }
-        const rootNode = this._session ? this._getNodeByUuid(this._session.rootUuid) : null;
-        return Boolean(rootNode && this._queryAnimationComponent(rootNode) instanceof SkeletalAnimation);
+        const targetRootNode = rootNode || (this._session ? this._getNodeByUuid(this._session.rootUuid) : null);
+        return Boolean(targetRootNode && this._queryAnimationComponent(targetRootNode) instanceof SkeletalAnimation);
     }
 }

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -289,7 +289,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         }
 
         const state = await this._getAnimationState(uuid);
-        const previousTime = state.current ?? this._curEditTime;
+        const previousTime = this._curEditTime;
         const sample = getClipSample(state.clip);
         let value: unknown;
         try {
@@ -806,7 +806,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         }
         this._resetAnimationState(uuid);
         const state = await this._getAnimationState(uuid);
-        await this.setTime({ time: Math.min(time, state.duration) });
+        await this.setTime({ time });
         this._broadcastClipChanged('asset-refresh');
     }
 

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -46,7 +46,7 @@ import { saveAnimationServiceClip } from './animation/service-save';
 import { AnimationStateRegistry } from './animation/state-registry';
 import { AnimationClipSnapshotCommand } from './animation/undo';
 import { IAnimationSession } from './animation/types';
-import { clipUuid, getClipSample } from './animation/utils';
+import { clipUuid, ensureClipEvents, getClipSample } from './animation/utils';
 import { serializeAnimationPropertyValue } from './animation/property-value';
 import { AnimationServicePlayback } from './animation/service-playback';
 import { isAllowedSkeletonAnimationOperation, isAnimationOperationResult, shouldSyncClipDuration } from './animation/operation-policy';
@@ -561,12 +561,14 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     async save(options: IAnimationSaveOptions = {}): Promise<boolean> {
         const session = requireAnimationSession(this._session);
         const state = await this._getAnimationState(session.clipUuid);
+        const rootNode = this._getSessionRootNode();
+        ensureClipEvents(state.clip);
         this._markSelfSavedClipRefresh(session.clipUuid);
         let saved = false;
         try {
             saved = await saveAnimationServiceClip({
                 session,
-                rootNode: this._getSessionRootNode(),
+                rootNode,
                 clip: state.clip,
             });
         } catch (error) {
@@ -574,6 +576,10 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             throw error;
         }
         if (saved) {
+            const animComp = queryAnimationComponent(rootNode);
+            if (animComp instanceof Animation) {
+                rebindAnimationComponentClip(animComp, state.clip);
+            }
             this._markSelfSavedClipRefresh(session.clipUuid);
             if (options.saveScene === true) {
                 await this._saveSceneForAnimationSession(session);

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -26,6 +26,7 @@ import {
     IAnimationTargetOptions,
     IAnimationTimeOptions,
     IAnimationValue,
+    IUndoScope,
     NodeEventType,
 } from '../../common';
 import { BaseService, register, Service, ServiceEvents } from './core';
@@ -139,6 +140,8 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             rootPath: getNodePath(rootNode),
             clipUuid: uuid,
             sampledRootState: captureAnimationSampledState(rootNode),
+            undoBaseline: Service.Undo.createCheckpoint(),
+            globalDirtyAtEnter: Service.Undo.isDirty(),
         };
 
         this._playState = 'stop';
@@ -198,6 +201,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
                 clipUuid: '',
                 time: 0,
                 playState: 'stop',
+                dirty: false,
                 selection,
                 restoreSelectionOnExit: true,
             };
@@ -212,6 +216,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             clipUuid: this._session.clipUuid,
             time: this._curEditTime,
             playState: this._playState,
+            dirty: this._isAnimationSessionDirty(this._session),
             selection,
             restoreSelectionOnExit: this._session.restoreSelectionOnExit,
         };
@@ -520,11 +525,21 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     async save(): Promise<boolean> {
         const session = requireAnimationSession(this._session);
         const state = await this._getAnimationState(session.clipUuid);
-        return saveAnimationServiceClip({
+        const saved = await saveAnimationServiceClip({
             session,
             rootNode: this._getSessionRootNode(),
             clip: state.clip,
         });
+        if (saved) {
+            const animationScope = this._createAnimationUndoScope(session.clipUuid);
+            const hasNonAnimationDifference = Service.Undo.hasDifferenceOutsideScope(session.undoBaseline, animationScope);
+            if (!session.globalDirtyAtEnter && !hasNonAnimationDifference) {
+                Service.Undo.markSaved();
+            }
+            session.undoBaseline = Service.Undo.createCheckpoint();
+            session.globalDirtyAtEnter = Service.Undo.isDirty();
+        }
+        return saved;
     }
 
     onAssetDeleted(uuid: string): void {
@@ -669,6 +684,18 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
     private _getSessionRootNode(): Node {
         return getAnimationSessionRootNode(requireAnimationSession(this._session));
+    }
+
+    private _isAnimationSessionDirty(session: IAnimationSession): boolean {
+        return Service.Undo.hasScopedDifference(session.undoBaseline, this._createAnimationUndoScope(session.clipUuid));
+    }
+
+    private _createAnimationUndoScope(clipUuid: string): Partial<IUndoScope> {
+        return {
+            assetUuid: clipUuid,
+            editorType: 'animation',
+            mode: 'animation',
+        };
     }
 
 }

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -15,6 +15,7 @@ import {
     IAnimationOperation,
     IAnimationOperationOptions,
     IAnimationOperationResult,
+    IAnimationSaveOptions,
     IAnimationPlayStateOptions,
     IAnimationQueryAuxiliaryCurveValueAtFrameOptions,
     IAnimationQueryClipOptions,
@@ -557,7 +558,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         };
     }
 
-    async save(): Promise<boolean> {
+    async save(options: IAnimationSaveOptions = {}): Promise<boolean> {
         const session = requireAnimationSession(this._session);
         const state = await this._getAnimationState(session.clipUuid);
         this._markSelfSavedClipRefresh(session.clipUuid);
@@ -574,10 +575,14 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         }
         if (saved) {
             this._markSelfSavedClipRefresh(session.clipUuid);
-            const animationScope = this._createAnimationUndoScope(session.clipUuid);
-            const hasNonAnimationDifference = Service.Undo.hasDifferenceOutsideScope(session.undoBaseline, animationScope);
-            if (!session.globalDirtyAtEnter && !hasNonAnimationDifference) {
-                Service.Undo.markSaved();
+            if (options.saveScene === true) {
+                await this._saveSceneForAnimationSession(session);
+            } else {
+                const animationScope = this._createAnimationUndoScope(session.clipUuid);
+                const hasNonAnimationDifference = Service.Undo.hasDifferenceOutsideScope(session.undoBaseline, animationScope);
+                if (!session.globalDirtyAtEnter && !hasNonAnimationDifference) {
+                    Service.Undo.markSaved();
+                }
             }
             session.undoBaseline = Service.Undo.createCheckpoint();
             session.globalDirtyAtEnter = Service.Undo.isDirty();
@@ -752,6 +757,23 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             return;
         }
         this.broadcast('animation:clip-changed', event);
+    }
+
+    private async _saveSceneForAnimationSession(session: IAnimationSession): Promise<void> {
+        const rootNode = getNodeByUuid(session.rootUuid);
+        if (!rootNode || !session.sampledRootState) {
+            await Service.Editor.save({});
+            return;
+        }
+
+        const editTime = this._curEditTime;
+        await this._stopCurrent();
+        await restoreAnimationSampledState(rootNode, session.sampledRootState);
+        try {
+            await Service.Editor.save({});
+        } finally {
+            await this.setTime({ time: editTime });
+        }
     }
 
     private _getSessionRootNode(): Node {

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -432,7 +432,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         return true;
     }
 
-    async applyOperation(options: IAnimationOperationOptions): Promise<IAnimationOperationResult> {
+    async applyOperations(options: IAnimationOperationOptions): Promise<IAnimationOperationResult> {
         const session = requireAnimationSession(this._session);
         if (!Array.isArray(options.operations)) {
             throw new Error('Animation operations must be an array.');

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -651,7 +651,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         if (!this._session || this._session.clipUuid !== uuid) {
             return;
         }
-        if (this._consumeSelfSavedClipRefresh(uuid)) {
+        if (this._shouldSuppressSelfSavedClipRefresh(uuid)) {
             return;
         }
 
@@ -738,13 +738,16 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         this._selfSavedClipRefreshes.set(uuid, Date.now());
     }
 
-    private _consumeSelfSavedClipRefresh(uuid: string): boolean {
+    private _shouldSuppressSelfSavedClipRefresh(uuid: string): boolean {
         const savedAt = this._selfSavedClipRefreshes.get(uuid);
         if (savedAt === undefined) {
             return false;
         }
+        if (Date.now() - savedAt <= SELF_SAVE_ASSET_REFRESH_SUPPRESSION_MS) {
+            return true;
+        }
         this._selfSavedClipRefreshes.delete(uuid);
-        return Date.now() - savedAt <= SELF_SAVE_ASSET_REFRESH_SUPPRESSION_MS;
+        return false;
     }
 
     private _createPreviousScenePropertyUndoScope(rootPath: string, operations: IAnimationOperation[]): Partial<IUndoScope> | null {

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -527,7 +527,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
                         mode: 'animation',
                     },
                     previousScope,
-                    previousTypes: ['node:set-property', 'component:set-property'],
+                    previousTypes: ['node:set-property', 'component:set-property', 'recording:snapshot'],
                 });
             } else {
                 Service.Undo.push(undoCommand);

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -488,12 +488,27 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         await this.setTime({ time: this._curEditTime });
         const after = shouldRecordUndo ? captureAnimationClipSnapshot(state.clip, propertyMetadataContext) : null;
         if (before && after && !animationClipSnapshotsEqual(before, after)) {
-            Service.Undo.push(new AnimationClipSnapshotCommand({
+            const undoCommand = new AnimationClipSnapshotCommand({
                 clipUuid: session.clipUuid,
                 before,
                 after,
                 applySnapshot: (snapshot) => this._restoreCurrentClipSnapshot(session.clipUuid, snapshot),
-            }));
+            });
+            if (options.absorbPreviousScenePropertyUndo === true) {
+                Service.Undo.pushWithPrevious(undoCommand, {
+                    label: 'Animation Property Commit',
+                    type: 'animation:property-commit',
+                    scope: {
+                        assetUuid: session.clipUuid,
+                        editorType: 'animation',
+                        mode: 'animation',
+                    },
+                    previousScope: { editorType: 'scene' },
+                    previousTypes: ['node:set-property', 'component:set-property'],
+                });
+            } else {
+                Service.Undo.push(undoCommand);
+            }
         }
         this._broadcastClipChanged('operation');
         return {

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -303,7 +303,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         const wasPlaying = state.isPlaying;
         const wasPaused = state.isPaused;
         const sample = getClipSample(state.clip);
-        let value: unknown;
+        let value: IAnimationValue;
         try {
             state.weight = 1;
             state.setTime(options.frame / sample);
@@ -313,7 +313,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             state.sample();
 
             const node = resolveAnimationFrameQueryNode(options, session);
-            value = readPropertyValue(node, options.propKey);
+            value = serializeAnimationPropertyValue(readPropertyValue(node, options.propKey));
         } finally {
             state.setTime(wasPlaying ? previousStateTime : previousTime);
             if (wasPlaying && !wasPaused) {
@@ -328,7 +328,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             this._curEditTime = previousTime;
             await Service.Engine.repaintInEditMode();
         }
-        return serializeAnimationPropertyValue(value);
+        return value;
     }
 
     async queryAuxiliaryCurveValueAtFrame(options: IAnimationQueryAuxiliaryCurveValueAtFrameOptions) {

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -236,6 +236,20 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
     async queryRootInfo(options: IAnimationTargetOptions): Promise<IAnimationRootInfo> {
         const rootNode = this._resolveRootNode(options);
+        if (!queryAnimationComponent(rootNode)) {
+            const rootPath = getNodePath(rootNode);
+            return {
+                rootUuid: rootNode.uuid,
+                rootPath,
+                clipsMenu: [],
+                defaultClip: '',
+                nodeTreeDump: await Service.Node.queryNodeTree({ path: rootPath }),
+                clipDump: null,
+                time: 0,
+                state: 'stop',
+                useBakedAnimation: false,
+            };
+        }
         const clipsInfo = await queryAnimationClipsInfo(rootNode);
         const activeSession = this._session?.rootUuid === rootNode.uuid ? this._session : null;
         const clipUuid = activeSession?.clipUuid || clipsInfo.defaultClip;
@@ -617,17 +631,12 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     private async _restoreFailedOperationSnapshot(clip: AnimationClip, snapshot: IAnimationClipSnapshot, _rootNode: Node): Promise<void> {
+        const uuid = clipUuid(clip);
         try {
-            await restoreAnimationClipSnapshot(clip, snapshot);
+            await this._restoreClipSnapshotWithStateRecreation(uuid, clip, snapshot);
         } catch (error) {
             console.error('[Animation] restore failed operation snapshot failed:', error);
             throw error;
-        }
-        const uuid = clipUuid(clip);
-        const state = this._animationStates.get(uuid);
-        if (state) {
-            this._animationStates.reset(uuid);
-            this._animationStates.create(uuid, clip);
         }
         await this.setTime({ time: this._curEditTime });
     }
@@ -640,11 +649,32 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
         const state = await this._getAnimationState(uuid);
         const clip = state.clip;
-        await restoreAnimationClipSnapshot(clip, snapshot);
-        this._animationStates.reset(uuid);
-        this._animationStates.create(uuid, clip);
+        await this._restoreClipSnapshotWithStateRecreation(uuid, clip, snapshot, true);
         await this.setTime({ time: this._curEditTime });
         this._broadcastClipChanged('undo-redo');
+    }
+
+    private async _restoreClipSnapshotWithStateRecreation(
+        uuid: string,
+        clip: AnimationClip,
+        snapshot: IAnimationClipSnapshot,
+        shouldRecreateState = Boolean(this._animationStates.get(uuid)),
+    ): Promise<void> {
+        if (shouldRecreateState) {
+            // Destroy the old state before replacing clip tracks; destroy() may touch curves it initialized.
+            this._animationStates.reset(uuid);
+        }
+        try {
+            await restoreAnimationClipSnapshot(clip, snapshot);
+        } catch (error) {
+            if (shouldRecreateState) {
+                this._animationStates.create(uuid, clip);
+            }
+            throw error;
+        }
+        if (shouldRecreateState) {
+            this._animationStates.create(uuid, clip);
+        }
     }
 
     private async _refreshCurrentClipAsset(uuid: string): Promise<void> {
@@ -657,6 +687,12 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
         const time = this._curEditTime;
         const clip = await loadAnimationClip(uuid);
+        if (!this._session || this._session.clipUuid !== uuid) {
+            return;
+        }
+        if (this._shouldSuppressSelfSavedClipRefresh(uuid)) {
+            return;
+        }
         const rootNode = this._getSessionRootNode();
         const animComp = queryAnimationComponent(rootNode);
         if (clip && animComp instanceof Animation) {

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -12,6 +12,7 @@ import {
     IAnimationEditClipOptions,
     IAnimationEnterOptions,
     IAnimationExitOptions,
+    IAnimationOperation,
     IAnimationOperationOptions,
     IAnimationOperationResult,
     IAnimationPlayStateOptions,
@@ -233,13 +234,14 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     async queryRootInfo(options: IAnimationTargetOptions): Promise<IAnimationRootInfo> {
         const rootNode = this._resolveRootNode(options);
         const clipsInfo = await queryAnimationClipsInfo(rootNode);
-        const defaultClipUuid = clipsInfo.defaultClip;
+        const activeSession = this._session?.rootUuid === rootNode.uuid ? this._session : null;
+        const clipUuid = activeSession?.clipUuid || clipsInfo.defaultClip;
         return {
             ...clipsInfo,
             nodeTreeDump: await Service.Node.queryNodeTree({ path: clipsInfo.rootPath }),
-            clipDump: defaultClipUuid ? await this.queryClip({ rootUuid: rootNode.uuid, clipUuid: defaultClipUuid }) : null,
-            time: this._session && defaultClipUuid ? await this.queryTime({ clipUuid: defaultClipUuid }) : 0,
-            state: this._playState,
+            clipDump: clipUuid ? await this.queryClip({ rootUuid: rootNode.uuid, clipUuid }) : null,
+            time: activeSession && clipUuid ? await this.queryTime({ clipUuid }) : 0,
+            state: activeSession ? this._playState : 'stop',
             useBakedAnimation: isUsingBakedAnimation(rootNode),
         };
     }
@@ -283,7 +285,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             return this._curEditTime;
         }
         const state = this._animationStates.get(uuid);
-        return state?.current ?? this._curEditTime;
+        return state?.current ?? 0;
     }
 
     async queryPropertyValueAtFrame(options: IAnimationQueryPropertyValueAtFrameOptions): Promise<IAnimationValue> {
@@ -295,6 +297,11 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
         const state = await this._getAnimationState(uuid);
         const previousTime = this._curEditTime;
+        const previousStateTime = typeof state.current === 'number' && Number.isFinite(state.current)
+            ? state.current
+            : previousTime;
+        const wasPlaying = state.isPlaying;
+        const wasPaused = state.isPaused;
         const sample = getClipSample(state.clip);
         let value: unknown;
         try {
@@ -308,11 +315,16 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             const node = resolveAnimationFrameQueryNode(options, session);
             value = readPropertyValue(node, options.propKey);
         } finally {
-            state.setTime(previousTime);
-            if (!state.isPaused) {
+            state.setTime(wasPlaying ? previousStateTime : previousTime);
+            if (wasPlaying && !wasPaused) {
+                state.sample();
+                state.resume();
+            } else if (!state.isPaused) {
                 state.pause();
+                state.sample();
+            } else {
+                state.sample();
             }
-            state.sample();
             this._curEditTime = previousTime;
             await Service.Engine.repaintInEditMode();
         }
@@ -333,22 +345,23 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     async setTime(options: IAnimationSetTimeOptions): Promise<boolean> {
         const session = requireAnimationSession(this._session);
         const state = await this._getAnimationState(session.clipUuid);
-        let playTime = options.time;
-        if (playTime < 0) {
-            playTime = 0;
+        let editTime = options.time;
+        if (editTime < 0) {
+            editTime = 0;
         }
+        let sampleTime = editTime;
 
         if (((state.clip.wrapMode & AnimationClip.WrapMode.Reverse) === AnimationClip.WrapMode.Reverse)) {
-            playTime = state.duration - Math.min(playTime, state.duration);
+            sampleTime = state.duration - Math.min(editTime, state.duration);
         }
 
         state.weight = 1;
-        state.setTime(playTime);
+        state.setTime(sampleTime);
         if (!state.isPaused) {
             state.pause();
         }
         state.sample();
-        this._curEditTime = playTime;
+        this._curEditTime = editTime;
         await Service.Engine.repaintInEditMode();
         this._broadcastTimeChanged('set-time');
         return true;
@@ -412,6 +425,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         const propertyMetadataContext = createAnimationPropertyCurveMetadataContext(rootNode);
         const shouldRecordUndo = options.recordUndo !== false;
         const before = captureAnimationClipSnapshot(state.clip, propertyMetadataContext);
+        const appliedOperations: IAnimationOperation[] = [];
         let shouldSyncDuration = false;
         let shouldRestoreOnFailure = false;
         for (const inputOperation of options.operations) {
@@ -482,6 +496,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
                 await this._restoreFailedOperationSnapshot(state.clip, before, rootNode);
                 return failureResult;
             }
+            appliedOperations.push(operation);
             shouldSyncDuration = shouldSyncDuration || shouldSyncClipDuration(operation);
         }
 
@@ -499,7 +514,10 @@ export class AnimationService extends BaseService<Record<string, any>> implement
                 after,
                 applySnapshot: (snapshot) => this._restoreCurrentClipSnapshot(session.clipUuid, snapshot),
             });
-            if (options.absorbPreviousScenePropertyUndo === true) {
+            const previousScope = options.absorbPreviousScenePropertyUndo === true
+                ? this._createPreviousScenePropertyUndoScope(session.rootPath, appliedOperations)
+                : null;
+            if (previousScope) {
                 Service.Undo.pushWithPrevious(undoCommand, {
                     label: 'Animation Property Commit',
                     type: 'animation:property-commit',
@@ -508,7 +526,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
                         editorType: 'animation',
                         mode: 'animation',
                     },
-                    previousScope: { editorType: 'scene' },
+                    previousScope,
                     previousTypes: ['node:set-property', 'component:set-property'],
                 });
             } else {
@@ -585,17 +603,18 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         await this._playback.stopCurrent();
     }
 
-    private async _restoreFailedOperationSnapshot(clip: AnimationClip, snapshot: IAnimationClipSnapshot, rootNode: Node): Promise<void> {
+    private async _restoreFailedOperationSnapshot(clip: AnimationClip, snapshot: IAnimationClipSnapshot, _rootNode: Node): Promise<void> {
         try {
             await restoreAnimationClipSnapshot(clip, snapshot);
         } catch (error) {
             console.error('[Animation] restore failed operation snapshot failed:', error);
             throw error;
         }
-        const state = this._animationStates.get(clipUuid(clip));
+        const uuid = clipUuid(clip);
+        const state = this._animationStates.get(uuid);
         if (state) {
-            (state as any)._curveLoaded = false;
-            state.initialize(rootNode);
+            this._animationStates.reset(uuid);
+            this._animationStates.create(uuid, clip);
         }
         await this.setTime({ time: this._curEditTime });
     }
@@ -608,8 +627,8 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
         const state = await this._getAnimationState(uuid);
         const clip = state.clip;
-        this._animationStates.reset(uuid);
         await restoreAnimationClipSnapshot(clip, snapshot);
+        this._animationStates.reset(uuid);
         this._animationStates.create(uuid, clip);
         await this.setTime({ time: this._curEditTime });
         this._broadcastClipChanged('undo-redo');
@@ -698,4 +717,51 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         };
     }
 
+    private _createPreviousScenePropertyUndoScope(rootPath: string, operations: IAnimationOperation[]): Partial<IUndoScope> | null {
+        if (operations.length === 0) {
+            return null;
+        }
+        const targets = new Map<string, { nodePath: string; propPath: string }>();
+        for (const operation of operations) {
+            if (!('propKey' in operation)) {
+                return null;
+            }
+            const nodePath = this._resolveScenePropertyNodePath(rootPath, operation);
+            if (!nodePath) {
+                return null;
+            }
+            const target = { nodePath, propPath: operation.propKey };
+            targets.set(`${target.nodePath}\n${target.propPath}`, target);
+        }
+        if (targets.size !== 1) {
+            return null;
+        }
+        const [target] = targets.values();
+        return {
+            editorType: 'scene',
+            nodePath: target.nodePath,
+            propPath: target.propPath,
+        };
+    }
+
+    private _resolveScenePropertyNodePath(rootPath: string, operation: { nodePath?: string; nodeUuid?: string }): string | null {
+        if (operation.nodeUuid) {
+            const node = getNodeByUuid(operation.nodeUuid);
+            return node ? getNodePath(node) : null;
+        }
+        const normalizedRootPath = normalizeSceneNodePath(rootPath);
+        const normalizedNodePath = normalizeSceneNodePath(operation.nodePath || '');
+        if (!normalizedNodePath || normalizedNodePath === normalizedRootPath) {
+            return normalizedRootPath;
+        }
+        if (normalizedRootPath && normalizedNodePath.startsWith(`${normalizedRootPath}/`)) {
+            return normalizedNodePath;
+        }
+        return normalizedRootPath ? `${normalizedRootPath}/${normalizedNodePath}` : normalizedNodePath;
+    }
+
+}
+
+function normalizeSceneNodePath(path: string): string {
+    return String(path || '').replace(/^\/+|\/+$/g, '');
 }

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -82,6 +82,8 @@ import {
     resolveAnimationTargetNode,
 } from './animation/service-target';
 
+const SELF_SAVE_ASSET_REFRESH_SUPPRESSION_MS = 5000;
+
 @register('Animation')
 export class AnimationService extends BaseService<Record<string, any>> implements IAnimationService {
     private _session: IAnimationSession | null = null;
@@ -91,6 +93,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     );
     private _curEditTime = 0;
     private _playState: AnimationPlayState = 'stop';
+    private readonly _selfSavedClipRefreshes = new Map<string, number>();
     private readonly _playback = new AnimationServicePlayback({
         getCurrentState: () => this._session ? this._animationStates.get(this._session.clipUuid) : undefined,
         getEditTime: () => this._curEditTime,
@@ -543,12 +546,20 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     async save(): Promise<boolean> {
         const session = requireAnimationSession(this._session);
         const state = await this._getAnimationState(session.clipUuid);
-        const saved = await saveAnimationServiceClip({
-            session,
-            rootNode: this._getSessionRootNode(),
-            clip: state.clip,
-        });
+        this._markSelfSavedClipRefresh(session.clipUuid);
+        let saved = false;
+        try {
+            saved = await saveAnimationServiceClip({
+                session,
+                rootNode: this._getSessionRootNode(),
+                clip: state.clip,
+            });
+        } catch (error) {
+            this._selfSavedClipRefreshes.delete(session.clipUuid);
+            throw error;
+        }
         if (saved) {
+            this._markSelfSavedClipRefresh(session.clipUuid);
             const animationScope = this._createAnimationUndoScope(session.clipUuid);
             const hasNonAnimationDifference = Service.Undo.hasDifferenceOutsideScope(session.undoBaseline, animationScope);
             if (!session.globalDirtyAtEnter && !hasNonAnimationDifference) {
@@ -556,6 +567,8 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             }
             session.undoBaseline = Service.Undo.createCheckpoint();
             session.globalDirtyAtEnter = Service.Undo.isDirty();
+        } else {
+            this._selfSavedClipRefreshes.delete(session.clipUuid);
         }
         return saved;
     }
@@ -638,6 +651,9 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         if (!this._session || this._session.clipUuid !== uuid) {
             return;
         }
+        if (this._consumeSelfSavedClipRefresh(uuid)) {
+            return;
+        }
 
         const time = this._curEditTime;
         const clip = await loadAnimationClip(uuid);
@@ -655,6 +671,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     private _disposeSession(): void {
         this._playback.dispose();
         this._animationStates.clear();
+        this._selfSavedClipRefreshes.clear();
         this._session = null;
         this._curEditTime = 0;
         this._playState = 'stop';
@@ -715,6 +732,19 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             editorType: 'animation',
             mode: 'animation',
         };
+    }
+
+    private _markSelfSavedClipRefresh(uuid: string): void {
+        this._selfSavedClipRefreshes.set(uuid, Date.now());
+    }
+
+    private _consumeSelfSavedClipRefresh(uuid: string): boolean {
+        const savedAt = this._selfSavedClipRefreshes.get(uuid);
+        if (savedAt === undefined) {
+            return false;
+        }
+        this._selfSavedClipRefreshes.delete(uuid);
+        return Date.now() - savedAt <= SELF_SAVE_ASSET_REFRESH_SUPPRESSION_MS;
     }
 
     private _createPreviousScenePropertyUndoScope(rootPath: string, operations: IAnimationOperation[]): Partial<IUndoScope> | null {

--- a/src/core/scene/scene-process/service/animation/asset-value.ts
+++ b/src/core/scene/scene-process/service/animation/asset-value.ts
@@ -1,0 +1,52 @@
+import { Asset, assetManager as ccAssetManager, js } from 'cc';
+
+export interface IAnimationAssetMetadata {
+    type: { value: string };
+    valueCtor?: new () => unknown;
+}
+
+export function isAnimationAssetValue(value: unknown): value is Asset {
+    return value instanceof Asset;
+}
+
+export function serializeAnimationAssetValue(value: Asset): { uuid: string } | null {
+    const uuid = queryAnimationAssetUuid(value);
+    return uuid ? { uuid } : null;
+}
+
+export function queryAnimationAssetUuid(value: unknown): string {
+    if (!value || typeof value !== 'object') {
+        return '';
+    }
+    const record = value as Record<string, unknown>;
+    const uuid = record.uuid || record._uuid || record.__uuid__;
+    return typeof uuid === 'string' ? uuid : '';
+}
+
+export function queryAnimationAssetCtor(metadata: IAnimationAssetMetadata | null | undefined): (new () => Asset) | null {
+    const ctor = metadata?.valueCtor || (metadata?.type?.value ? js.getClassByName(metadata.type.value) : null);
+    if (typeof ctor !== 'function') {
+        return null;
+    }
+    return ctor === Asset || ctor.prototype instanceof Asset ? ctor as new () => Asset : null;
+}
+
+export function createAnimationAssetPlaceholder(assetCtor: new () => Asset, uuid: string): Asset {
+    const asset = new assetCtor();
+    asset.initDefault(uuid);
+    return asset;
+}
+
+export async function loadAnimationAssetValue(assetCtor: new () => Asset, uuid: string): Promise<Asset> {
+    const asset = await new Promise<Asset | null>((resolve) => {
+        ccAssetManager.loadAny(uuid, (error: Error | null, loaded: unknown) => {
+            if (error) {
+                console.warn(`[Animation] load asset keyframe value failed: ${uuid}`, error);
+                resolve(null);
+                return;
+            }
+            resolve(loaded instanceof assetCtor ? loaded as Asset : null);
+        });
+    });
+    return asset || createAnimationAssetPlaceholder(assetCtor, uuid);
+}

--- a/src/core/scene/scene-process/service/animation/asset-value.ts
+++ b/src/core/scene/scene-process/service/animation/asset-value.ts
@@ -6,7 +6,7 @@ export interface IAnimationAssetMetadata {
 }
 
 export function isAnimationAssetValue(value: unknown): value is Asset {
-    return value instanceof Asset;
+    return typeof Asset === 'function' && value instanceof Asset;
 }
 
 export function serializeAnimationAssetValue(value: Asset): { uuid: string } | null {
@@ -25,7 +25,7 @@ export function queryAnimationAssetUuid(value: unknown): string {
 
 export function queryAnimationAssetCtor(metadata: IAnimationAssetMetadata | null | undefined): (new () => Asset) | null {
     const ctor = metadata?.valueCtor || (metadata?.type?.value ? js.getClassByName(metadata.type.value) : null);
-    if (typeof ctor !== 'function') {
+    if (typeof ctor !== 'function' || typeof Asset !== 'function') {
         return null;
     }
     return ctor === Asset || ctor.prototype instanceof Asset ? ctor as new () => Asset : null;

--- a/src/core/scene/scene-process/service/animation/auxiliary-curve.ts
+++ b/src/core/scene/scene-process/service/animation/auxiliary-curve.ts
@@ -134,6 +134,36 @@ export function serializeAuxiliaryCurvesForMeta(clip: AnimationClip): Record<str
     return result;
 }
 
+export function replaceAuxiliaryCurves(clip: AnimationClip, curves: Record<string, IAnimationAuxiliaryCurveDump>): boolean {
+    const names = Object.keys(curves);
+    const clipAny = clip as any;
+    if (typeof clipAny.getAuxiliaryCurveNames_experimental !== 'function') {
+        return names.length === 0;
+    }
+    if (typeof clipAny.removeAuxiliaryCurve_experimental !== 'function' || typeof clipAny.addAuxiliaryCurve_experimental !== 'function') {
+        return false;
+    }
+
+    for (const name of clipAny.getAuxiliaryCurveNames_experimental() as string[]) {
+        clipAny.removeAuxiliaryCurve_experimental(name);
+    }
+
+    for (const name of names) {
+        if (!addAuxiliaryCurve(clip, name)) {
+            return false;
+        }
+        const curve = getAuxiliaryCurve(clip, name);
+        if (!curve) {
+            return false;
+        }
+        const dump = curves[name];
+        (curve as any).preExtrapolation = dump.preExtrap;
+        (curve as any).postExtrapolation = dump.postExtrap;
+        curve.assignSorted(dump.keyframes.map((key) => [key.frame / getClipSample(clip), key.value] as [number, any]));
+    }
+    return true;
+}
+
 function dumpAuxiliaryCurve(clip: AnimationClip, curve: RealCurve): IAnimationAuxiliaryCurveDump {
     const sample = getClipSample(clip);
     return {

--- a/src/core/scene/scene-process/service/animation/auxiliary-curve.ts
+++ b/src/core/scene/scene-process/service/animation/auxiliary-curve.ts
@@ -1,0 +1,154 @@
+import { AnimationClip, RealCurve } from 'cc';
+import type { IAnimationAuxiliaryCurveDump } from '../../../common';
+import {
+    cloneValue,
+    getClipSample,
+    normalizeAuxiliaryCurveValue,
+    normalizeFrames,
+} from './utils';
+
+export function dumpAuxiliaryCurves(clip: AnimationClip): Record<string, IAnimationAuxiliaryCurveDump> {
+    if (typeof (clip as any).getAuxiliaryCurveNames_experimental !== 'function') {
+        return {};
+    }
+
+    const result: Record<string, IAnimationAuxiliaryCurveDump> = {};
+    for (const name of (clip as any).getAuxiliaryCurveNames_experimental() as string[]) {
+        const curve = (clip as any).getAuxiliaryCurve_experimental(name) as RealCurve | null;
+        if (!curve) {
+            continue;
+        }
+        result[name] = dumpAuxiliaryCurve(clip, curve);
+    }
+    return result;
+}
+
+export function addAuxiliaryCurve(clip: AnimationClip, name: string): boolean {
+    if (!name || typeof (clip as any).addAuxiliaryCurve_experimental !== 'function') {
+        return false;
+    }
+    if (typeof (clip as any).hasAuxiliaryCurve_experimental === 'function' && (clip as any).hasAuxiliaryCurve_experimental(name)) {
+        return false;
+    }
+    return Boolean((clip as any).addAuxiliaryCurve_experimental(name));
+}
+
+export function removeAuxiliaryCurve(clip: AnimationClip, name: string): boolean {
+    if (!name || typeof (clip as any).removeAuxiliaryCurve_experimental !== 'function') {
+        return false;
+    }
+    (clip as any).removeAuxiliaryCurve_experimental(name);
+    return true;
+}
+
+export function renameAuxiliaryCurve(clip: AnimationClip, name: string, newName: string): boolean {
+    if (!name || !newName || typeof (clip as any).renameAuxiliaryCurve_experimental !== 'function') {
+        return false;
+    }
+    (clip as any).renameAuxiliaryCurve_experimental(name, newName);
+    return true;
+}
+
+export function createAuxKey(clip: AnimationClip, name: string, frameValue: unknown, value: unknown): boolean {
+    const curve = getAuxiliaryCurve(clip, name);
+    const frame = Number(frameValue);
+    if (!curve || !Number.isFinite(frame) || frame < 0 || typeof value !== 'number') {
+        return false;
+    }
+    const time = frame / getClipSample(clip);
+    const index = curve.indexOfKeyframe(time);
+    if (index >= 0) {
+        curve.removeKeyframe(index);
+    }
+    curve.addKeyFrame(time, value);
+    return true;
+}
+
+export function removeAuxKey(clip: AnimationClip, name: string, frameValue: unknown): boolean {
+    const curve = getAuxiliaryCurve(clip, name);
+    const frame = Number(frameValue);
+    if (!curve || !Number.isFinite(frame) || frame < 0) {
+        return false;
+    }
+    const index = curve.indexOfKeyframe(frame / getClipSample(clip));
+    if (index < 0) {
+        return false;
+    }
+    curve.removeKeyframe(index);
+    return true;
+}
+
+export function moveAuxKeys(clip: AnimationClip, name: string, framesValue: unknown, offsetValue: unknown): boolean {
+    const curve = getAuxiliaryCurve(clip, name);
+    const frames = normalizeFrames(framesValue);
+    const offset = Number(offsetValue);
+    if (!curve || !Number.isFinite(offset)) {
+        return false;
+    }
+
+    const keyframes = Array.from(curve.keyframes()).map(([time, value]) => {
+        const frame = Math.round(time * getClipSample(clip));
+        return {
+            frame: frames.includes(frame) ? Math.max(0, frame + offset) : frame,
+            value,
+        };
+    });
+    keyframes.sort((a, b) => a.frame - b.frame);
+    curve.assignSorted(keyframes.map((item) => [item.frame / getClipSample(clip), item.value] as [number, any]));
+    return true;
+}
+
+export function copyAuxKey(clip: AnimationClip, name: string, frameValue: unknown, dstFrameValue: unknown): boolean {
+    const curve = getAuxiliaryCurve(clip, name);
+    const frame = Number(frameValue);
+    const dstFrame = Number(dstFrameValue);
+    if (!curve || !Number.isFinite(frame) || !Number.isFinite(dstFrame)) {
+        return false;
+    }
+    const index = curve.indexOfKeyframe(frame / getClipSample(clip));
+    if (index < 0) {
+        return false;
+    }
+    const dstIndex = curve.indexOfKeyframe(dstFrame / getClipSample(clip));
+    if (dstIndex >= 0) {
+        curve.removeKeyframe(dstIndex);
+    }
+    curve.addKeyFrame(dstFrame / getClipSample(clip), cloneValue(curve.getKeyframeValue(index)));
+    return true;
+}
+
+export function serializeAuxiliaryCurvesForMeta(clip: AnimationClip): Record<string, { curve: unknown }> {
+    if (typeof (clip as any).getAuxiliaryCurveNames_experimental !== 'function') {
+        return {};
+    }
+
+    const result: Record<string, { curve: unknown }> = {};
+    for (const name of (clip as any).getAuxiliaryCurveNames_experimental() as string[]) {
+        const curve = (clip as any).getAuxiliaryCurve_experimental(name) as RealCurve | null;
+        if (curve) {
+            result[name] = {
+                curve: EditorExtends.serialize(curve, { stringify: false }),
+            };
+        }
+    }
+    return result;
+}
+
+function dumpAuxiliaryCurve(clip: AnimationClip, curve: RealCurve): IAnimationAuxiliaryCurveDump {
+    const sample = getClipSample(clip);
+    return {
+        keyframes: Array.from(curve.keyframes()).map(([time, value]) => ({
+            frame: Math.round(time * sample),
+            value: normalizeAuxiliaryCurveValue((value as any).value),
+        })),
+        preExtrap: Number((curve as any).preExtrapolation) || 0,
+        postExtrap: Number((curve as any).postExtrapolation) || 0,
+    };
+}
+
+function getAuxiliaryCurve(clip: AnimationClip, name: string): RealCurve | null {
+    if (!name || typeof (clip as any).getAuxiliaryCurve_experimental !== 'function') {
+        return null;
+    }
+    return (clip as any).getAuxiliaryCurve_experimental(name) || null;
+}

--- a/src/core/scene/scene-process/service/animation/auxiliary-curve.ts
+++ b/src/core/scene/scene-process/service/animation/auxiliary-curve.ts
@@ -1,30 +1,43 @@
 import { AnimationClip, RealCurve } from 'cc';
-import type { IAnimationAuxiliaryCurveDump } from '../../../common';
+import type {
+    IAnimationAuxiliaryCurveDump,
+    IAnimationCurveKeyData,
+    IAnimationKeyValueDump,
+} from '../../../common';
 import {
     cloneValue,
     getClipSample,
-    normalizeAuxiliaryCurveValue,
     normalizeFrames,
 } from './utils';
+import {
+    copyRealKeyDataInternalMetadata,
+    createRealCurveValue,
+    type IDumpRealKeyDataOptions,
+    dumpRealKeyData,
+    queryRealCurveKeyframes,
+    queryRealCurveNumberValue,
+    setRealCurveKey,
+    updateRealCurveKeyData,
+} from './real-curve-key-data';
 
-export function dumpAuxiliaryCurves(clip: AnimationClip): Record<string, IAnimationAuxiliaryCurveDump> {
-    if (typeof (clip as any).getAuxiliaryCurveNames_experimental !== 'function') {
+export function dumpAuxiliaryCurves(clip: AnimationClip, options: IDumpRealKeyDataOptions = {}): Record<string, IAnimationAuxiliaryCurveDump> {
+    if (typeof (clip as any).getAuxiliaryCurveNames_experimental !== 'function' || !ensureAuxiliaryCurveEntries(clip)) {
         return {};
     }
 
     const result: Record<string, IAnimationAuxiliaryCurveDump> = {};
-    for (const name of (clip as any).getAuxiliaryCurveNames_experimental() as string[]) {
+    for (const name of Array.from((clip as any).getAuxiliaryCurveNames_experimental() || []) as string[]) {
         const curve = (clip as any).getAuxiliaryCurve_experimental(name) as RealCurve | null;
         if (!curve) {
             continue;
         }
-        result[name] = dumpAuxiliaryCurve(clip, curve);
+        result[name] = dumpAuxiliaryCurve(clip, curve, options);
     }
     return result;
 }
 
 export function addAuxiliaryCurve(clip: AnimationClip, name: string): boolean {
-    if (!name || typeof (clip as any).addAuxiliaryCurve_experimental !== 'function') {
+    if (!name || typeof (clip as any).addAuxiliaryCurve_experimental !== 'function' || !ensureAuxiliaryCurveEntries(clip)) {
         return false;
     }
     if (typeof (clip as any).hasAuxiliaryCurve_experimental === 'function' && (clip as any).hasAuxiliaryCurve_experimental(name)) {
@@ -34,7 +47,7 @@ export function addAuxiliaryCurve(clip: AnimationClip, name: string): boolean {
 }
 
 export function removeAuxiliaryCurve(clip: AnimationClip, name: string): boolean {
-    if (!name || typeof (clip as any).removeAuxiliaryCurve_experimental !== 'function') {
+    if (!name || typeof (clip as any).removeAuxiliaryCurve_experimental !== 'function' || !ensureAuxiliaryCurveEntries(clip)) {
         return false;
     }
     (clip as any).removeAuxiliaryCurve_experimental(name);
@@ -42,25 +55,20 @@ export function removeAuxiliaryCurve(clip: AnimationClip, name: string): boolean
 }
 
 export function renameAuxiliaryCurve(clip: AnimationClip, name: string, newName: string): boolean {
-    if (!name || !newName || typeof (clip as any).renameAuxiliaryCurve_experimental !== 'function') {
+    if (!name || !newName || typeof (clip as any).renameAuxiliaryCurve_experimental !== 'function' || !ensureAuxiliaryCurveEntries(clip)) {
         return false;
     }
     (clip as any).renameAuxiliaryCurve_experimental(name, newName);
     return true;
 }
 
-export function createAuxKey(clip: AnimationClip, name: string, frameValue: unknown, value: unknown): boolean {
+export function createAuxKey(clip: AnimationClip, name: string, frameValue: unknown, value: unknown, keyData?: IAnimationCurveKeyData): boolean {
     const curve = getAuxiliaryCurve(clip, name);
     const frame = Number(frameValue);
     if (!curve || !Number.isFinite(frame) || frame < 0 || typeof value !== 'number') {
         return false;
     }
-    const time = frame / getClipSample(clip);
-    const index = curve.indexOfKeyframe(time);
-    if (index >= 0) {
-        curve.removeKeyframe(index);
-    }
-    curve.addKeyFrame(time, value);
+    setRealCurveKey(curve as any, frame / getClipSample(clip), createRealCurveValue(value, keyData));
     return true;
 }
 
@@ -86,7 +94,7 @@ export function moveAuxKeys(clip: AnimationClip, name: string, framesValue: unkn
         return false;
     }
 
-    const keyframes = Array.from(curve.keyframes()).map(([time, value]) => {
+    const keyframes = queryRealCurveKeyframes(curve as any).map(([time, value]) => {
         const frame = Math.round(time * getClipSample(clip));
         return {
             frame: frames.includes(frame) ? Math.max(0, frame + offset) : frame,
@@ -113,17 +121,38 @@ export function copyAuxKey(clip: AnimationClip, name: string, frameValue: unknow
     if (dstIndex >= 0) {
         curve.removeKeyframe(dstIndex);
     }
-    curve.addKeyFrame(dstFrame / getClipSample(clip), cloneValue(curve.getKeyframeValue(index)));
+    setRealCurveKey(curve as any, dstFrame / getClipSample(clip), cloneValue(curve.getKeyframeValue(index)));
     return true;
 }
 
+export function updateAuxKeyData(clip: AnimationClip, name: string, frameValue: unknown, keyData?: IAnimationCurveKeyData): boolean {
+    const curve = getAuxiliaryCurve(clip, name);
+    const frame = Number(frameValue);
+    if (!curve || !Number.isFinite(frame) || frame < 0) {
+        return false;
+    }
+    return updateRealCurveKeyData(curve as any, frame / getClipSample(clip), keyData);
+}
+
+export function queryAuxiliaryCurveValueAtFrame(clip: AnimationClip, name: string, frameValue: unknown): IAnimationKeyValueDump | null {
+    const curve = getAuxiliaryCurve(clip, name);
+    const frame = Number(frameValue);
+    if (!curve || !Number.isFinite(frame) || frame < 0) {
+        return null;
+    }
+    return {
+        value: queryRealCurveNumberValue(curve.evaluate(frame / getClipSample(clip))),
+        type: 'cc.Number',
+    };
+}
+
 export function serializeAuxiliaryCurvesForMeta(clip: AnimationClip): Record<string, { curve: unknown }> {
-    if (typeof (clip as any).getAuxiliaryCurveNames_experimental !== 'function') {
+    if (typeof (clip as any).getAuxiliaryCurveNames_experimental !== 'function' || !ensureAuxiliaryCurveEntries(clip)) {
         return {};
     }
 
     const result: Record<string, { curve: unknown }> = {};
-    for (const name of (clip as any).getAuxiliaryCurveNames_experimental() as string[]) {
+    for (const name of Array.from((clip as any).getAuxiliaryCurveNames_experimental() || []) as string[]) {
         const curve = (clip as any).getAuxiliaryCurve_experimental(name) as RealCurve | null;
         if (curve) {
             result[name] = {
@@ -140,11 +169,11 @@ export function replaceAuxiliaryCurves(clip: AnimationClip, curves: Record<strin
     if (typeof clipAny.getAuxiliaryCurveNames_experimental !== 'function') {
         return names.length === 0;
     }
-    if (typeof clipAny.removeAuxiliaryCurve_experimental !== 'function' || typeof clipAny.addAuxiliaryCurve_experimental !== 'function') {
+    if (!ensureAuxiliaryCurveEntries(clip) || typeof clipAny.removeAuxiliaryCurve_experimental !== 'function' || typeof clipAny.addAuxiliaryCurve_experimental !== 'function') {
         return false;
     }
 
-    for (const name of clipAny.getAuxiliaryCurveNames_experimental() as string[]) {
+    for (const name of Array.from(clipAny.getAuxiliaryCurveNames_experimental() || []) as string[]) {
         clipAny.removeAuxiliaryCurve_experimental(name);
     }
 
@@ -159,26 +188,44 @@ export function replaceAuxiliaryCurves(clip: AnimationClip, curves: Record<strin
         const dump = curves[name];
         (curve as any).preExtrapolation = dump.preExtrap;
         (curve as any).postExtrapolation = dump.postExtrap;
-        curve.assignSorted(dump.keyframes.map((key) => [key.frame / getClipSample(clip), key.value] as [number, any]));
+        curve.assignSorted(dump.keyframes.map((key) => [key.frame / getClipSample(clip), createRealCurveValue(key.value, key)] as [number, any]));
     }
     return true;
 }
 
-function dumpAuxiliaryCurve(clip: AnimationClip, curve: RealCurve): IAnimationAuxiliaryCurveDump {
+function dumpAuxiliaryCurve(clip: AnimationClip, curve: RealCurve, options: IDumpRealKeyDataOptions): IAnimationAuxiliaryCurveDump {
     const sample = getClipSample(clip);
     return {
-        keyframes: Array.from(curve.keyframes()).map(([time, value]) => ({
-            frame: Math.round(time * sample),
-            value: normalizeAuxiliaryCurveValue((value as any).value),
-        })),
+        keyframes: queryRealCurveKeyframes(curve as any).map(([time, value]) => {
+            const keyData = dumpRealKeyData(value, options);
+            const keyframe = {
+                frame: Math.round(time * sample),
+                value: queryRealCurveNumberValue(value),
+                ...keyData,
+            };
+            copyRealKeyDataInternalMetadata(keyData, keyframe);
+            return keyframe;
+        }),
         preExtrap: Number((curve as any).preExtrapolation) || 0,
         postExtrap: Number((curve as any).postExtrapolation) || 0,
     };
 }
 
 function getAuxiliaryCurve(clip: AnimationClip, name: string): RealCurve | null {
-    if (!name || typeof (clip as any).getAuxiliaryCurve_experimental !== 'function') {
+    if (!name || typeof (clip as any).getAuxiliaryCurve_experimental !== 'function' || !ensureAuxiliaryCurveEntries(clip)) {
         return null;
     }
     return (clip as any).getAuxiliaryCurve_experimental(name) || null;
+}
+
+function ensureAuxiliaryCurveEntries(clip: AnimationClip): boolean {
+    const clipAny = clip as any;
+    if (Array.isArray(clipAny._auxiliaryCurveEntries)) {
+        return true;
+    }
+    if (clipAny._auxiliaryCurveEntries === null || clipAny._auxiliaryCurveEntries === undefined) {
+        clipAny._auxiliaryCurveEntries = [];
+        return true;
+    }
+    return false;
 }

--- a/src/core/scene/scene-process/service/animation/auxiliary-curve.ts
+++ b/src/core/scene/scene-process/service/animation/auxiliary-curve.ts
@@ -55,10 +55,16 @@ export function removeAuxiliaryCurve(clip: AnimationClip, name: string): boolean
 }
 
 export function renameAuxiliaryCurve(clip: AnimationClip, name: string, newName: string): boolean {
-    if (!name || !newName || typeof (clip as any).renameAuxiliaryCurve_experimental !== 'function' || !ensureAuxiliaryCurveEntries(clip)) {
+    const clipAny = clip as any;
+    if (!name || !newName || typeof clipAny.renameAuxiliaryCurve_experimental !== 'function' || !ensureAuxiliaryCurveEntries(clip)) {
         return false;
     }
-    (clip as any).renameAuxiliaryCurve_experimental(name, newName);
+    if (typeof clipAny.hasAuxiliaryCurve_experimental === 'function') {
+        if (!clipAny.hasAuxiliaryCurve_experimental(name) || (name !== newName && clipAny.hasAuxiliaryCurve_experimental(newName))) {
+            return false;
+        }
+    }
+    clipAny.renameAuxiliaryCurve_experimental(name, newName);
     return true;
 }
 
@@ -94,13 +100,25 @@ export function moveAuxKeys(clip: AnimationClip, name: string, framesValue: unkn
         return false;
     }
 
-    const keyframes = queryRealCurveKeyframes(curve as any).map(([time, value]) => {
+    let changed = false;
+    const retained: Array<{ frame: number; value: unknown }> = [];
+    const moved = new Map<number, unknown>();
+    for (const [time, value] of queryRealCurveKeyframes(curve as any)) {
         const frame = Math.round(time * getClipSample(clip));
-        return {
-            frame: frames.includes(frame) ? Math.max(0, frame + offset) : frame,
-            value,
-        };
-    });
+        if (frames.includes(frame)) {
+            changed = true;
+            moved.set(Math.max(0, frame + offset), value);
+        } else {
+            retained.push({ frame, value });
+        }
+    }
+    if (!changed) {
+        return false;
+    }
+    const movedFrames = new Set(moved.keys());
+    const keyframes = retained
+        .filter((item) => !movedFrames.has(item.frame))
+        .concat(Array.from(moved, ([frame, value]) => ({ frame, value })));
     keyframes.sort((a, b) => a.frame - b.frame);
     curve.assignSorted(keyframes.map((item) => [item.frame / getClipSample(clip), item.value] as [number, any]));
     return true;
@@ -117,11 +135,12 @@ export function copyAuxKey(clip: AnimationClip, name: string, frameValue: unknow
     if (index < 0) {
         return false;
     }
+    const value = cloneValue(curve.getKeyframeValue(index));
     const dstIndex = curve.indexOfKeyframe(dstFrame / getClipSample(clip));
     if (dstIndex >= 0) {
         curve.removeKeyframe(dstIndex);
     }
-    setRealCurveKey(curve as any, dstFrame / getClipSample(clip), cloneValue(curve.getKeyframeValue(index)));
+    setRealCurveKey(curve as any, dstFrame / getClipSample(clip), value);
     return true;
 }
 

--- a/src/core/scene/scene-process/service/animation/clip-dump.ts
+++ b/src/core/scene/scene-process/service/animation/clip-dump.ts
@@ -2,13 +2,13 @@ import type { AnimationClip, AnimationState } from 'cc';
 import type { IAnimationClipDump } from '../../../common';
 import { dumpAuxiliaryCurves } from './auxiliary-curve';
 import { dumpEmbeddedPlayers, queryEmbeddedPlayerGroups } from './embedded-player';
-import { dumpPropertyCurves } from './property-curve';
+import { dumpPropertyCurves, type IPropertyCurveMetadataContext } from './property-curve';
 import { cloneValue, getClipSample } from './utils';
 
 export function createClipDump(clip: AnimationClip, state: AnimationState | undefined, options: {
     isSkeleton: boolean;
     useBakedAnimation: boolean;
-}): IAnimationClipDump {
+} & IPropertyCurveMetadataContext): IAnimationClipDump {
     const sample = getClipSample(clip);
     const events = Array.isArray((clip as any).events) ? (clip as any).events : [];
     return {
@@ -17,7 +17,7 @@ export function createClipDump(clip: AnimationClip, state: AnimationState | unde
         sample,
         speed: Number((clip as any).speed) || 0,
         wrapMode: Number((clip as any).wrapMode) || 0,
-        curves: dumpPropertyCurves(clip),
+        curves: dumpPropertyCurves(clip, options),
         events: events.map((event: any) => ({
             frame: Math.round((Number(event.frame) || 0) * sample),
             func: event.func || '',

--- a/src/core/scene/scene-process/service/animation/clip-dump.ts
+++ b/src/core/scene/scene-process/service/animation/clip-dump.ts
@@ -2,6 +2,7 @@ import type { AnimationClip, AnimationState, Node } from 'cc';
 import type { IAnimationClipDump } from '../../../common';
 import { dumpAuxiliaryCurves } from './auxiliary-curve';
 import { dumpEmbeddedPlayers, queryEmbeddedPlayerGroups } from './embedded-player';
+import { dumpPropertyCurves } from './property-curve';
 import { cloneValue, getClipSample } from './utils';
 
 export function createClipDump(rootNode: Node, clip: AnimationClip, state: AnimationState | undefined, options: {
@@ -16,7 +17,7 @@ export function createClipDump(rootNode: Node, clip: AnimationClip, state: Anima
         sample,
         speed: Number((clip as any).speed) || 0,
         wrapMode: Number((clip as any).wrapMode) || 0,
-        curves: [],
+        curves: dumpPropertyCurves(clip),
         events: events.map((event: any) => ({
             frame: Math.round((Number(event.frame) || 0) * sample),
             func: event.func || '',

--- a/src/core/scene/scene-process/service/animation/clip-dump.ts
+++ b/src/core/scene/scene-process/service/animation/clip-dump.ts
@@ -1,11 +1,11 @@
-import type { AnimationClip, AnimationState, Node } from 'cc';
+import type { AnimationClip, AnimationState } from 'cc';
 import type { IAnimationClipDump } from '../../../common';
 import { dumpAuxiliaryCurves } from './auxiliary-curve';
 import { dumpEmbeddedPlayers, queryEmbeddedPlayerGroups } from './embedded-player';
 import { dumpPropertyCurves } from './property-curve';
 import { cloneValue, getClipSample } from './utils';
 
-export function createClipDump(rootNode: Node, clip: AnimationClip, state: AnimationState | undefined, options: {
+export function createClipDump(clip: AnimationClip, state: AnimationState | undefined, options: {
     isSkeleton: boolean;
     useBakedAnimation: boolean;
 }): IAnimationClipDump {

--- a/src/core/scene/scene-process/service/animation/clip-dump.ts
+++ b/src/core/scene/scene-process/service/animation/clip-dump.ts
@@ -1,0 +1,33 @@
+import type { AnimationClip, AnimationState, Node } from 'cc';
+import type { IAnimationClipDump } from '../../../common';
+import { dumpAuxiliaryCurves } from './auxiliary-curve';
+import { dumpEmbeddedPlayers, queryEmbeddedPlayerGroups } from './embedded-player';
+import { cloneValue, getClipSample } from './utils';
+
+export function createClipDump(rootNode: Node, clip: AnimationClip, state: AnimationState | undefined, options: {
+    isSkeleton: boolean;
+    useBakedAnimation: boolean;
+}): IAnimationClipDump {
+    const sample = getClipSample(clip);
+    const events = Array.isArray((clip as any).events) ? (clip as any).events : [];
+    return {
+        name: clip.name,
+        duration: Number((clip as any).duration) || 0,
+        sample,
+        speed: Number((clip as any).speed) || 0,
+        wrapMode: Number((clip as any).wrapMode) || 0,
+        curves: [],
+        events: events.map((event: any) => ({
+            frame: Math.round((Number(event.frame) || 0) * sample),
+            func: event.func || '',
+            params: Array.isArray(event.params) ? cloneValue(event.params) : [],
+        })),
+        embeddedPlayers: dumpEmbeddedPlayers(clip),
+        embeddedPlayerGroups: queryEmbeddedPlayerGroups(clip),
+        auxiliaryCurves: dumpAuxiliaryCurves(clip),
+        time: state?.current ?? 0,
+        isLock: false,
+        isSkeleton: options.isSkeleton,
+        useBakedAnimation: options.useBakedAnimation,
+    };
+}

--- a/src/core/scene/scene-process/service/animation/clip-duration.ts
+++ b/src/core/scene/scene-process/service/animation/clip-duration.ts
@@ -72,10 +72,10 @@ function queryAuxiliaryCurveDuration(clip: AnimationClip, sample: number): numbe
 function queryCurveTimes(curve: unknown): number[] {
     const curveAny = curve as any;
     if (typeof curveAny?.times === 'function') {
-        return Array.from(curveAny.times()).map((time) => queryFiniteDuration(time));
+        return Array.from(curveAny.times() || []).map((time) => queryFiniteDuration(time));
     }
     if (typeof curveAny?.keyframes === 'function') {
-        return Array.from(curveAny.keyframes()).map((keyframe: any) => queryFiniteDuration(keyframe?.[0]));
+        return Array.from(curveAny.keyframes() || []).map((keyframe: any) => queryFiniteDuration(keyframe?.[0]));
     }
     return [];
 }

--- a/src/core/scene/scene-process/service/animation/clip-duration.ts
+++ b/src/core/scene/scene-process/service/animation/clip-duration.ts
@@ -11,8 +11,6 @@ import {
     queryTrackChannels,
 } from './property-curve-track';
 
-const SPRITE_FRAME_PROP_KEY = 'cc.Sprite.spriteFrame';
-
 export function syncAnimationClipDuration(clip: AnimationClip): number {
     const duration = queryAnimationClipDuration(clip);
     (clip as any).duration = duration;
@@ -33,7 +31,7 @@ function queryTrackDuration(clip: AnimationClip, sample: number): number {
     let duration = queryFiniteDuration(typeof (clip as any).range === 'function' ? (clip as any).range()?.max : 0);
     for (const track of getClipTracks(clip)) {
         const parsed = parsePropertyTrack(track);
-        const frameDuration = parsed?.descriptor.propKey === SPRITE_FRAME_PROP_KEY ? 1 / sample : 0;
+        const frameDuration = parsed?.descriptor.kind === 'object' && parsed.descriptor.isCurveSupport === false ? 1 / sample : 0;
         for (const channel of queryTrackChannels(track)) {
             for (const time of queryCurveTimes(channel.curve)) {
                 duration = Math.max(duration, time + frameDuration);

--- a/src/core/scene/scene-process/service/animation/clip-duration.ts
+++ b/src/core/scene/scene-process/service/animation/clip-duration.ts
@@ -1,0 +1,86 @@
+import type { AnimationClip } from 'cc';
+import { dumpAuxiliaryCurves } from './auxiliary-curve';
+import { dumpEmbeddedPlayers } from './embedded-player';
+import {
+    getClipSample,
+    queryClipEvents,
+} from './utils';
+import {
+    getClipTracks,
+    parsePropertyTrack,
+    queryTrackChannels,
+} from './property-curve-track';
+
+const SPRITE_FRAME_PROP_KEY = 'cc.Sprite.spriteFrame';
+
+export function syncAnimationClipDuration(clip: AnimationClip): number {
+    const duration = queryAnimationClipDuration(clip);
+    (clip as any).duration = duration;
+    return duration;
+}
+
+function queryAnimationClipDuration(clip: AnimationClip): number {
+    const sample = getClipSample(clip);
+    return Math.max(
+        queryTrackDuration(clip, sample),
+        queryEventDuration(clip),
+        queryEmbeddedPlayerDuration(clip, sample),
+        queryAuxiliaryCurveDuration(clip, sample),
+    );
+}
+
+function queryTrackDuration(clip: AnimationClip, sample: number): number {
+    let duration = queryFiniteDuration(typeof (clip as any).range === 'function' ? (clip as any).range()?.max : 0);
+    for (const track of getClipTracks(clip)) {
+        const parsed = parsePropertyTrack(track);
+        const frameDuration = parsed?.descriptor.propKey === SPRITE_FRAME_PROP_KEY ? 1 / sample : 0;
+        for (const channel of queryTrackChannels(track)) {
+            for (const time of queryCurveTimes(channel.curve)) {
+                duration = Math.max(duration, time + frameDuration);
+            }
+        }
+    }
+    return duration;
+}
+
+function queryEventDuration(clip: AnimationClip): number {
+    let duration = 0;
+    for (const event of queryClipEvents(clip) || []) {
+        duration = Math.max(duration, queryFiniteDuration((event as any).frame));
+    }
+    return duration;
+}
+
+function queryEmbeddedPlayerDuration(clip: AnimationClip, sample: number): number {
+    let duration = 0;
+    for (const player of dumpEmbeddedPlayers(clip)) {
+        duration = Math.max(duration, queryFiniteDuration(player.end / sample));
+    }
+    return duration;
+}
+
+function queryAuxiliaryCurveDuration(clip: AnimationClip, sample: number): number {
+    let duration = 0;
+    for (const curve of Object.values(dumpAuxiliaryCurves(clip))) {
+        for (const keyframe of curve.keyframes) {
+            duration = Math.max(duration, queryFiniteDuration(keyframe.frame / sample));
+        }
+    }
+    return duration;
+}
+
+function queryCurveTimes(curve: unknown): number[] {
+    const curveAny = curve as any;
+    if (typeof curveAny?.times === 'function') {
+        return Array.from(curveAny.times()).map((time) => queryFiniteDuration(time));
+    }
+    if (typeof curveAny?.keyframes === 'function') {
+        return Array.from(curveAny.keyframes()).map((keyframe: any) => queryFiniteDuration(keyframe?.[0]));
+    }
+    return [];
+}
+
+function queryFiniteDuration(value: unknown): number {
+    const duration = Number(value);
+    return Number.isFinite(duration) && duration > 0 ? duration : 0;
+}

--- a/src/core/scene/scene-process/service/animation/clip-library.ts
+++ b/src/core/scene/scene-process/service/animation/clip-library.ts
@@ -1,0 +1,149 @@
+import {
+    Animation,
+    AnimationClip,
+    Node,
+    animation,
+    assetManager as ccAssetManager,
+} from 'cc';
+import type {
+    IAnimationClipMenuItem,
+    IAnimationClipsInfo,
+} from '../../../common';
+import type { IAnimationData } from './types';
+import { clipUuid } from './utils';
+import { getNodePath, queryAnimationComponent } from './scene-node';
+
+export async function queryNodeAnimationData(node: Node, preferredClipUuid?: string, options: { allowEmpty?: boolean; recoverClipBinding?: boolean } = {}): Promise<IAnimationData> {
+    const animComp = queryAnimationComponent(node);
+    if (!animComp) {
+        throw new Error(`Animation component not found on node: ${getNodePath(node)}`);
+    }
+
+    let clips: AnimationClip[] = [];
+    let defaultClip: AnimationClip | null = null;
+    if (animComp instanceof Animation) {
+        clips = (animComp.clips || []).filter((clip): clip is AnimationClip => Boolean(clip?.name));
+        defaultClip = animComp.defaultClip || clips[0] || null;
+        if (defaultClip?.name) {
+            clips.push(defaultClip);
+        }
+    } else {
+        clips = (await visitAnimationClipsInController(animComp))
+            .filter((clip): clip is AnimationClip => Boolean(clip?.name));
+        defaultClip = clips[0] || null;
+    }
+
+    clips = uniqAnimationClips(clips);
+    if (!defaultClip?.name) {
+        defaultClip = clips[0] || null;
+    }
+    if (options.recoverClipBinding && (clips.length === 0 || !defaultClip) && preferredClipUuid && animComp instanceof Animation) {
+        const recoveredClip = await loadAnimationClip(preferredClipUuid);
+        if (recoveredClip?.name) {
+            rebindAnimationComponentClip(animComp, recoveredClip);
+            clips = uniqAnimationClips((animComp.clips || []).filter((clip): clip is AnimationClip => Boolean(clip?.name)));
+            defaultClip = animComp.defaultClip?.name ? animComp.defaultClip : clips[0] || null;
+        }
+    }
+    if (clips.length === 0 || !defaultClip) {
+        if (options.allowEmpty) {
+            return { node, animComp, clips, defaultClip };
+        }
+        throw new Error(`Animation clips not found on node: ${getNodePath(node)}`);
+    }
+
+    return { node, animComp, clips, defaultClip };
+}
+
+export async function queryAnimationClipsInfo(rootNode: Node): Promise<IAnimationClipsInfo> {
+    const animData = await queryNodeAnimationData(rootNode, undefined, { allowEmpty: true });
+    return {
+        rootUuid: rootNode.uuid,
+        rootPath: getNodePath(rootNode),
+        clipsMenu: decodeClipsMenu(animData.clips),
+        defaultClip: clipUuid(animData.defaultClip),
+    };
+}
+
+export function resolveAnimationClip(animData: IAnimationData, uuid?: string): AnimationClip {
+    const targetUuid = uuid || clipUuid(animData.defaultClip);
+    const clip = animData.clips.find((item) => clipUuid(item) === targetUuid);
+    if (!clip) {
+        throw new Error(`Animation clip not found: ${targetUuid}`);
+    }
+    return clip;
+}
+
+export function decodeClipsMenu(clips: AnimationClip[]): IAnimationClipMenuItem[] {
+    return clips.map((clip) => ({
+        uuid: clipUuid(clip),
+        name: clip.name,
+    }));
+}
+
+export function uniqAnimationClips(clips: AnimationClip[]): AnimationClip[] {
+    const seen = new Set<string>();
+    const result: AnimationClip[] = [];
+    for (const clip of clips) {
+        const uuid = clipUuid(clip);
+        if (!uuid || seen.has(uuid)) {
+            continue;
+        }
+        seen.add(uuid);
+        result.push(clip);
+    }
+    return result;
+}
+
+export async function visitAnimationClipsInController(controller: animation.AnimationController): Promise<AnimationClip[]> {
+    const system = (globalThis as any).System;
+    if (system?.import) {
+        const mod = await system.import('cc/editor/new-gen-anim');
+        if (typeof mod?.visitAnimationClipsInController === 'function') {
+            return Array.from(mod.visitAnimationClipsInController(controller) as Iterable<AnimationClip>);
+        }
+    }
+
+    const mod = await import('cc/editor/new-gen-anim');
+    if (typeof mod.visitAnimationClipsInController !== 'function') {
+        throw new Error('visitAnimationClipsInController is not available.');
+    }
+    return Array.from(mod.visitAnimationClipsInController(controller) as Iterable<AnimationClip>);
+}
+
+export function rebindAnimationComponentClip(animComp: Animation, clip: AnimationClip): void {
+    const uuid = clipUuid(clip);
+    const currentDefaultUuid = animComp.defaultClip ? clipUuid(animComp.defaultClip) : '';
+    let found = false;
+    const clips = (animComp.clips || []).map((item) => {
+        if (item && clipUuid(item) === uuid) {
+            found = true;
+            return clip;
+        }
+        return item;
+    });
+    if (!found) {
+        clips.push(clip);
+    }
+    animComp.clips = clips;
+    if (!currentDefaultUuid || currentDefaultUuid === uuid) {
+        animComp.defaultClip = clip;
+    }
+}
+
+export async function loadAnimationClip(uuid: string): Promise<AnimationClip | null> {
+    const cached = ccAssetManager.assets.get(uuid);
+    if (cached instanceof AnimationClip) {
+        return cached;
+    }
+
+    return await new Promise((resolve, reject) => {
+        ccAssetManager.loadAny(uuid, (error, asset: AnimationClip) => {
+            if (error) {
+                reject(error);
+                return;
+            }
+            resolve(asset instanceof AnimationClip ? asset : null);
+        });
+    });
+}

--- a/src/core/scene/scene-process/service/animation/clip-library.ts
+++ b/src/core/scene/scene-process/service/animation/clip-library.ts
@@ -115,19 +115,48 @@ export function rebindAnimationComponentClip(animComp: Animation, clip: Animatio
     const uuid = clipUuid(clip);
     const currentDefaultUuid = animComp.defaultClip ? clipUuid(animComp.defaultClip) : '';
     let found = false;
-    const clips = (animComp.clips || []).map((item) => {
-        if (item && clipUuid(item) === uuid) {
-            found = true;
-            return clip;
+    const clips: AnimationClip[] = [];
+    ensureAnimationClipRuntimeArrays(clip);
+    for (const item of animComp.clips || []) {
+        if (!item) {
+            continue;
         }
-        return item;
-    });
+        if (clipUuid(item) === uuid) {
+            found = true;
+            clips.push(clip);
+            continue;
+        }
+        if (!item.name) {
+            continue;
+        }
+        ensureAnimationClipRuntimeArrays(item);
+        clips.push(item);
+    }
     if (!found) {
         clips.push(clip);
     }
-    animComp.clips = clips;
+    animComp.clips = uniqAnimationClips(clips);
     if (!currentDefaultUuid || currentDefaultUuid === uuid) {
         animComp.defaultClip = clip;
+    }
+}
+
+function ensureAnimationClipRuntimeArrays(clip: AnimationClip): void {
+    const clipAny = clip as any;
+    ensureArrayProperty(clipAny, '_tracks');
+    if (!Array.isArray(clipAny._events)) {
+        clipAny.events = [];
+        if (!Array.isArray(clipAny._events)) {
+            clipAny._events = [];
+        }
+    }
+    ensureArrayProperty(clipAny, '_embeddedPlayers');
+    ensureArrayProperty(clipAny, '_auxiliaryCurveEntries');
+}
+
+function ensureArrayProperty(target: Record<string, unknown>, key: string): void {
+    if (!Array.isArray(target[key])) {
+        target[key] = [];
     }
 }
 

--- a/src/core/scene/scene-process/service/animation/clip-operations.ts
+++ b/src/core/scene/scene-process/service/animation/clip-operations.ts
@@ -1,0 +1,291 @@
+import type { AnimationClip, AnimationState } from 'cc';
+import type {
+    IAnimationEventDump,
+    IAnimationOperation,
+    IAnimationOperationResult,
+} from '../../../common';
+import {
+    addAuxiliaryCurve,
+    copyAuxKey,
+    createAuxKey,
+    moveAuxKeys,
+    removeAuxKey,
+    removeAuxiliaryCurve,
+    renameAuxiliaryCurve,
+} from './auxiliary-curve';
+import {
+    addEmbeddedPlayer,
+    addEmbeddedPlayerGroup,
+    clearEmbeddedPlayers,
+    deleteEmbeddedPlayer,
+    removeEmbeddedPlayerGroup,
+    updateEmbeddedPlayer,
+} from './embedded-player';
+import {
+    cloneValue,
+    ensureClipEvents,
+    getClipSample,
+    normalizeFrames,
+    queryClipEvents,
+    updateClipEventData,
+} from './utils';
+
+const SUPPORTED_CLIP_OPERATIONS = [
+    'changeSample',
+    'changeSpeed',
+    'changeWrapMode',
+    'addEvent',
+    'deleteEvent',
+    'updateEvent',
+    'moveEvents',
+    'copyEventsTo',
+    'addEmbeddedPlayer',
+    'deleteEmbeddedPlayer',
+    'updateEmbeddedPlayer',
+    'clearEmbeddedPlayer',
+    'addEmbeddedPlayerGroup',
+    'removeEmbeddedPlayerGroup',
+    'clearEmbeddedPlayerGroup',
+    'addAuxiliaryCurve',
+    'removeAuxiliaryCurve',
+    'renameAuxiliaryCurve',
+    'createAuxKey',
+    'removeAuxKey',
+    'moveAuxKeys',
+    'copyAuxKey',
+];
+
+export function validateAnimationOperation(operation: IAnimationOperation, currentClipUuid: string): IAnimationOperationResult | null {
+    if (!operation || typeof (operation as any).type !== 'string' || typeof (operation as any).clipUuid !== 'string') {
+        return {
+            state: 'failure',
+            result: false,
+            reason: 'Animation operation is invalid.',
+        };
+    }
+
+    if (operation.clipUuid !== currentClipUuid) {
+        return {
+            state: 'failure',
+            result: false,
+            reason: `current edit clip: '${currentClipUuid}' but you want to operate: '${operation.clipUuid}'`,
+        };
+    }
+
+    if (!isSupportedClipOperation(operation.type)) {
+        return {
+            state: 'failure',
+            result: false,
+            reason: `Method '${operation.type}' does not exist to manipulate the animation.`,
+        };
+    }
+
+    return null;
+}
+
+export function isSupportedClipOperation(funcName: string): boolean {
+    return SUPPORTED_CLIP_OPERATIONS.includes(funcName);
+}
+
+export async function applyClipOperation(state: AnimationState, operation: IAnimationOperation): Promise<boolean> {
+    const clip = state.clip;
+    switch (operation.type) {
+        case 'changeSample':
+            return changeClipSample(clip, operation.sample);
+        case 'changeSpeed':
+            return changeClipSpeed(clip, operation.speed);
+        case 'changeWrapMode':
+            return changeClipWrapMode(clip, operation.wrapMode);
+        case 'addEvent':
+            return addClipEvent(clip, operation.frame, operation.func, operation.params, true);
+        case 'deleteEvent':
+            return deleteClipEvents(clip, operation.frames, true);
+        case 'updateEvent':
+            return updateClipEvents(clip, operation.frames, operation.events);
+        case 'moveEvents':
+            return moveClipEvents(clip, operation.frames, operation.offset);
+        case 'copyEventsTo':
+            return copyClipEventsTo(clip, operation.frames, operation.dstFrame);
+        case 'addEmbeddedPlayer':
+            return await addEmbeddedPlayer(clip, operation.embeddedPlayer);
+        case 'deleteEmbeddedPlayer':
+            return await deleteEmbeddedPlayer(clip, operation.embeddedPlayer);
+        case 'updateEmbeddedPlayer':
+            return await updateEmbeddedPlayer(clip, operation.embeddedPlayer, operation.newEmbeddedPlayer);
+        case 'clearEmbeddedPlayer':
+            return await clearEmbeddedPlayers(clip, operation.group);
+        case 'addEmbeddedPlayerGroup':
+            return addEmbeddedPlayerGroup(clip, operation.group);
+        case 'removeEmbeddedPlayerGroup':
+            return await removeEmbeddedPlayerGroup(clip, operation.key);
+        case 'clearEmbeddedPlayerGroup':
+            return await clearEmbeddedPlayers(clip, operation.key);
+        case 'addAuxiliaryCurve':
+            return addAuxiliaryCurve(clip, operation.name);
+        case 'removeAuxiliaryCurve':
+            return removeAuxiliaryCurve(clip, operation.name);
+        case 'renameAuxiliaryCurve':
+            return renameAuxiliaryCurve(clip, operation.name, operation.newName);
+        case 'createAuxKey':
+            return createAuxKey(clip, operation.name, operation.frame, operation.value);
+        case 'removeAuxKey':
+            return removeAuxKey(clip, operation.name, operation.frame);
+        case 'moveAuxKeys':
+            return moveAuxKeys(clip, operation.name, operation.frames, operation.offset);
+        case 'copyAuxKey':
+            return copyAuxKey(clip, operation.name, operation.frame, operation.dstFrame);
+        default:
+            return false;
+    }
+}
+
+function changeClipSample(clip: AnimationClip, value: unknown): boolean {
+    let sample = Math.round(Number(value));
+    if (!Number.isFinite(sample) || sample < 1) {
+        sample = 1;
+    }
+
+    const oldSample = getClipSample(clip);
+    const events = queryClipEvents(clip);
+    if (events) {
+        for (const event of events) {
+            const frame = Math.round((Number(event.frame) || 0) * oldSample);
+            event.frame = frame / sample;
+        }
+    }
+
+    (clip as any).sample = sample;
+    updateClipEventData(clip);
+    return true;
+}
+
+function changeClipSpeed(clip: AnimationClip, value: unknown): boolean {
+    const speed = Number(value);
+    if (!Number.isFinite(speed)) {
+        return false;
+    }
+    (clip as any).speed = speed;
+    return true;
+}
+
+function changeClipWrapMode(clip: AnimationClip, value: unknown): boolean {
+    const wrapMode = Number(value);
+    (clip as any).wrapMode = Number.isFinite(wrapMode) ? wrapMode : 0;
+    return true;
+}
+
+function addClipEvent(clip: AnimationClip, frameValue: unknown, funcName: unknown, paramsValue: unknown, updateEventData: boolean): boolean {
+    const frame = Number(frameValue);
+    if (!Number.isFinite(frame) || frame < 0) {
+        return false;
+    }
+
+    const events = ensureClipEvents(clip);
+    events.push({
+        frame: frame / getClipSample(clip),
+        func: typeof funcName === 'string' ? funcName : '',
+        params: Array.isArray(paramsValue) ? cloneValue(paramsValue) : [],
+    });
+    events.sort((a, b) => Number(a.frame) - Number(b.frame));
+
+    if (updateEventData) {
+        updateClipEventData(clip);
+    }
+    return true;
+}
+
+function deleteClipEvents(clip: AnimationClip, framesValue: unknown, updateEventData: boolean): boolean {
+    const events = queryClipEvents(clip);
+    if (!events) {
+        return false;
+    }
+
+    const frames = normalizeFrames(framesValue);
+    const sample = getClipSample(clip);
+    for (let i = events.length - 1; i >= 0; i--) {
+        const frame = Math.round((Number(events[i].frame) || 0) * sample);
+        if (frames.includes(frame)) {
+            events.splice(i, 1);
+        }
+    }
+
+    if (updateEventData) {
+        updateClipEventData(clip);
+    }
+    return true;
+}
+
+function updateClipEvents(clip: AnimationClip, framesValue: unknown, eventsValue: IAnimationEventDump[]): boolean {
+    const frames = normalizeFrames(framesValue);
+    if (frames.length === 0) {
+        return false;
+    }
+
+    const newEvents = Array.isArray(eventsValue) ? eventsValue : [];
+    for (const frame of frames) {
+        if (!deleteClipEvents(clip, [frame], false)) {
+            return false;
+        }
+        for (const event of newEvents) {
+            addClipEvent(clip, frame, event.func, event.params, false);
+        }
+    }
+
+    updateClipEventData(clip);
+    return true;
+}
+
+function moveClipEvents(clip: AnimationClip, framesValue: unknown, offsetValue: unknown): boolean {
+    const events = queryClipEvents(clip);
+    if (!events) {
+        return false;
+    }
+
+    const frames = normalizeFrames(framesValue);
+    const offset = Number(offsetValue);
+    if (!Number.isFinite(offset)) {
+        return false;
+    }
+
+    const sample = getClipSample(clip);
+    for (const event of events) {
+        const frame = Math.round((Number(event.frame) || 0) * sample);
+        if (frames.includes(frame)) {
+            event.frame = Math.max(0, frame + offset) / sample;
+        }
+    }
+
+    events.sort((a, b) => Number(a.frame) - Number(b.frame));
+    updateClipEventData(clip);
+    return true;
+}
+
+function copyClipEventsTo(clip: AnimationClip, framesValue: unknown, dstFrameValue: unknown): boolean {
+    const events = queryClipEvents(clip);
+    if (!events) {
+        return false;
+    }
+
+    const frames = normalizeFrames(framesValue).sort((a, b) => a - b);
+    const dstFrame = Number(dstFrameValue);
+    if (frames.length === 0 || !Number.isFinite(dstFrame)) {
+        return false;
+    }
+
+    const sample = getClipSample(clip);
+    const baseFrame = frames[0];
+    const matched = events
+        .filter((event) => frames.includes(Math.round((Number(event.frame) || 0) * sample)))
+        .map((event) => ({
+            frame: Math.max(0, Math.round((Number(event.frame) || 0) * sample) - baseFrame + dstFrame),
+            func: event.func,
+            params: cloneValue(event.params || []),
+        }));
+
+    for (const event of matched) {
+        addClipEvent(clip, event.frame, event.func, event.params, false);
+    }
+
+    updateClipEventData(clip);
+    return true;
+}

--- a/src/core/scene/scene-process/service/animation/clip-operations.ts
+++ b/src/core/scene/scene-process/service/animation/clip-operations.ts
@@ -22,6 +22,12 @@ import {
     updateEmbeddedPlayer,
 } from './embedded-player';
 import {
+    createPropertyKey,
+    movePropertyKeys,
+    removePropertyKey,
+    type IPropertyCurveOperationContext,
+} from './property-curve';
+import {
     cloneValue,
     ensureClipEvents,
     getClipSample,
@@ -53,6 +59,9 @@ const SUPPORTED_CLIP_OPERATIONS = [
     'removeAuxKey',
     'moveAuxKeys',
     'copyAuxKey',
+    'createPropertyKey',
+    'removePropertyKey',
+    'movePropertyKeys',
 ];
 
 export function validateAnimationOperation(operation: IAnimationOperation, currentClipUuid: string): IAnimationOperationResult | null {
@@ -87,7 +96,7 @@ export function isSupportedClipOperation(funcName: string): boolean {
     return SUPPORTED_CLIP_OPERATIONS.includes(funcName);
 }
 
-export async function applyClipOperation(state: AnimationState, operation: IAnimationOperation): Promise<boolean> {
+export async function applyClipOperation(state: AnimationState, operation: IAnimationOperation, context: IPropertyCurveOperationContext): Promise<boolean> {
     const clip = state.clip;
     switch (operation.type) {
         case 'changeSample':
@@ -134,6 +143,12 @@ export async function applyClipOperation(state: AnimationState, operation: IAnim
             return moveAuxKeys(clip, operation.name, operation.frames, operation.offset);
         case 'copyAuxKey':
             return copyAuxKey(clip, operation.name, operation.frame, operation.dstFrame);
+        case 'createPropertyKey':
+            return createPropertyKey(clip, context, operation);
+        case 'removePropertyKey':
+            return removePropertyKey(clip, context, operation);
+        case 'movePropertyKeys':
+            return movePropertyKeys(clip, context, operation);
         default:
             return false;
     }

--- a/src/core/scene/scene-process/service/animation/clip-operations.ts
+++ b/src/core/scene/scene-process/service/animation/clip-operations.ts
@@ -27,6 +27,7 @@ import {
     copyPropertyKeysTo,
     createPropertyKey,
     movePropertyKeys,
+    removePropertyCurve,
     removePropertyKey,
     removePropertyKeys,
     setPropertyCurveExtrapolation,
@@ -71,6 +72,7 @@ const SUPPORTED_CLIP_OPERATIONS = [
     'createPropertyKey',
     'updatePropertyKey',
     'updatePropertyKeyData',
+    'removePropertyCurve',
     'removePropertyKey',
     'removePropertyKeys',
     'movePropertyKeys',
@@ -167,6 +169,8 @@ export async function applyClipOperation(state: AnimationState, operation: IAnim
             return updatePropertyKey(clip, context, operation);
         case 'updatePropertyKeyData':
             return updatePropertyKeyData(clip, context, operation);
+        case 'removePropertyCurve':
+            return removePropertyCurve(clip, context, operation);
         case 'removePropertyKey':
             return removePropertyKey(clip, context, operation);
         case 'removePropertyKeys':

--- a/src/core/scene/scene-process/service/animation/clip-operations.ts
+++ b/src/core/scene/scene-process/service/animation/clip-operations.ts
@@ -12,6 +12,7 @@ import {
     removeAuxKey,
     removeAuxiliaryCurve,
     renameAuxiliaryCurve,
+    updateAuxKeyData,
 } from './auxiliary-curve';
 import {
     addEmbeddedPlayer,
@@ -30,6 +31,7 @@ import {
     removePropertyKeys,
     setPropertyCurveExtrapolation,
     updatePropertyKey,
+    updatePropertyKeyData,
     type IPropertyCurveOperationContext,
 } from './property-curve';
 import {
@@ -64,9 +66,11 @@ const SUPPORTED_CLIP_OPERATIONS = [
     'removeAuxKey',
     'moveAuxKeys',
     'copyAuxKey',
+    'updateAuxKeyData',
     'addPropertyCurve',
     'createPropertyKey',
     'updatePropertyKey',
+    'updatePropertyKeyData',
     'removePropertyKey',
     'removePropertyKeys',
     'movePropertyKeys',
@@ -146,19 +150,23 @@ export async function applyClipOperation(state: AnimationState, operation: IAnim
         case 'renameAuxiliaryCurve':
             return renameAuxiliaryCurve(clip, operation.name, operation.newName);
         case 'createAuxKey':
-            return createAuxKey(clip, operation.name, operation.frame, operation.value);
+            return createAuxKey(clip, operation.name, operation.frame, operation.value, operation.keyData ?? operation.curveData);
         case 'removeAuxKey':
             return removeAuxKey(clip, operation.name, operation.frame);
         case 'moveAuxKeys':
             return moveAuxKeys(clip, operation.name, operation.frames, operation.offset);
         case 'copyAuxKey':
             return copyAuxKey(clip, operation.name, operation.frame, operation.dstFrame);
+        case 'updateAuxKeyData':
+            return updateAuxKeyData(clip, operation.name, operation.frame, operation.keyData ?? operation.curveData);
         case 'addPropertyCurve':
             return addPropertyCurve(clip, context, operation);
         case 'createPropertyKey':
             return createPropertyKey(clip, context, operation);
         case 'updatePropertyKey':
             return updatePropertyKey(clip, context, operation);
+        case 'updatePropertyKeyData':
+            return updatePropertyKeyData(clip, context, operation);
         case 'removePropertyKey':
             return removePropertyKey(clip, context, operation);
         case 'removePropertyKeys':

--- a/src/core/scene/scene-process/service/animation/clip-operations.ts
+++ b/src/core/scene/scene-process/service/animation/clip-operations.ts
@@ -22,9 +22,14 @@ import {
     updateEmbeddedPlayer,
 } from './embedded-player';
 import {
+    addPropertyCurve,
+    copyPropertyKeysTo,
     createPropertyKey,
     movePropertyKeys,
     removePropertyKey,
+    removePropertyKeys,
+    setPropertyCurveExtrapolation,
+    updatePropertyKey,
     type IPropertyCurveOperationContext,
 } from './property-curve';
 import {
@@ -59,9 +64,14 @@ const SUPPORTED_CLIP_OPERATIONS = [
     'removeAuxKey',
     'moveAuxKeys',
     'copyAuxKey',
+    'addPropertyCurve',
     'createPropertyKey',
+    'updatePropertyKey',
     'removePropertyKey',
+    'removePropertyKeys',
     'movePropertyKeys',
+    'copyPropertyKeysTo',
+    'setPropertyCurveExtrapolation',
 ];
 
 export function validateAnimationOperation(operation: IAnimationOperation, currentClipUuid: string): IAnimationOperationResult | null {
@@ -143,12 +153,22 @@ export async function applyClipOperation(state: AnimationState, operation: IAnim
             return moveAuxKeys(clip, operation.name, operation.frames, operation.offset);
         case 'copyAuxKey':
             return copyAuxKey(clip, operation.name, operation.frame, operation.dstFrame);
+        case 'addPropertyCurve':
+            return addPropertyCurve(clip, context, operation);
         case 'createPropertyKey':
             return createPropertyKey(clip, context, operation);
+        case 'updatePropertyKey':
+            return updatePropertyKey(clip, context, operation);
         case 'removePropertyKey':
             return removePropertyKey(clip, context, operation);
+        case 'removePropertyKeys':
+            return removePropertyKeys(clip, context, operation);
         case 'movePropertyKeys':
             return movePropertyKeys(clip, context, operation);
+        case 'copyPropertyKeysTo':
+            return copyPropertyKeysTo(clip, context, operation);
+        case 'setPropertyCurveExtrapolation':
+            return setPropertyCurveExtrapolation(clip, context, operation);
         default:
             return false;
     }

--- a/src/core/scene/scene-process/service/animation/clip-operations.ts
+++ b/src/core/scene/scene-process/service/animation/clip-operations.ts
@@ -192,15 +192,6 @@ function changeClipSample(clip: AnimationClip, value: unknown): boolean {
         sample = 1;
     }
 
-    const oldSample = getClipSample(clip);
-    const events = queryClipEvents(clip);
-    if (events) {
-        for (const event of events) {
-            const frame = Math.round((Number(event.frame) || 0) * oldSample);
-            event.frame = frame / sample;
-        }
-    }
-
     (clip as any).sample = sample;
     updateClipEventData(clip);
     return true;

--- a/src/core/scene/scene-process/service/animation/clip-snapshot.ts
+++ b/src/core/scene/scene-process/service/animation/clip-snapshot.ts
@@ -41,7 +41,7 @@ export function captureAnimationClipSnapshot(clip: AnimationClip): IAnimationCli
         sample,
         speed: Number((clip as any).speed) || 0,
         wrapMode: Number((clip as any).wrapMode) || 0,
-        curves: dumpPropertyCurves(clip),
+        curves: dumpPropertyCurves(clip, { includeDefaults: true }),
         events: events.map((event: any) => ({
             frame: Math.round((Number(event.frame) || 0) * sample),
             func: event.func || '',
@@ -49,7 +49,7 @@ export function captureAnimationClipSnapshot(clip: AnimationClip): IAnimationCli
         })),
         embeddedPlayers: dumpEmbeddedPlayers(clip),
         embeddedPlayerGroups: queryEmbeddedPlayerGroups(clip),
-        auxiliaryCurves: dumpAuxiliaryCurves(clip),
+        auxiliaryCurves: dumpAuxiliaryCurves(clip, { includeDefaults: true }),
     };
 }
 

--- a/src/core/scene/scene-process/service/animation/clip-snapshot.ts
+++ b/src/core/scene/scene-process/service/animation/clip-snapshot.ts
@@ -1,0 +1,76 @@
+import type { AnimationClip } from 'cc';
+import type {
+    IAnimationAuxiliaryCurveDump,
+    IAnimationEmbeddedPlayerDump,
+    IAnimationEmbeddedPlayerGroup,
+    IAnimationEventDump,
+} from '../../../common';
+import { dumpAuxiliaryCurves, replaceAuxiliaryCurves } from './auxiliary-curve';
+import {
+    dumpEmbeddedPlayers,
+    queryEmbeddedPlayerGroups,
+    replaceEmbeddedPlayerGroups,
+    replaceEmbeddedPlayers,
+} from './embedded-player';
+import {
+    cloneValue,
+    getClipSample,
+    queryClipEvents,
+    updateClipEventData,
+} from './utils';
+
+export interface IAnimationClipSnapshot {
+    sample: number;
+    speed: number;
+    wrapMode: number;
+    events: IAnimationEventDump[];
+    embeddedPlayers: IAnimationEmbeddedPlayerDump[];
+    embeddedPlayerGroups: IAnimationEmbeddedPlayerGroup[];
+    auxiliaryCurves: Record<string, IAnimationAuxiliaryCurveDump>;
+}
+
+export function captureAnimationClipSnapshot(clip: AnimationClip): IAnimationClipSnapshot {
+    const sample = getClipSample(clip);
+    const events = queryClipEvents(clip) || [];
+    return {
+        sample,
+        speed: Number((clip as any).speed) || 0,
+        wrapMode: Number((clip as any).wrapMode) || 0,
+        events: events.map((event: any) => ({
+            frame: Math.round((Number(event.frame) || 0) * sample),
+            func: event.func || '',
+            params: Array.isArray(event.params) ? cloneValue(event.params) : [],
+        })),
+        embeddedPlayers: dumpEmbeddedPlayers(clip),
+        embeddedPlayerGroups: queryEmbeddedPlayerGroups(clip),
+        auxiliaryCurves: dumpAuxiliaryCurves(clip),
+    };
+}
+
+export async function restoreAnimationClipSnapshot(clip: AnimationClip, snapshot: IAnimationClipSnapshot): Promise<void> {
+    (clip as any).sample = snapshot.sample;
+    (clip as any).speed = snapshot.speed;
+    (clip as any).wrapMode = snapshot.wrapMode;
+    restoreEvents(clip, snapshot);
+    replaceEmbeddedPlayerGroups(clip, snapshot.embeddedPlayerGroups);
+    if (!await replaceEmbeddedPlayers(clip, snapshot.embeddedPlayers)) {
+        throw new Error('Failed to restore animation embedded players.');
+    }
+    if (!replaceAuxiliaryCurves(clip, snapshot.auxiliaryCurves)) {
+        throw new Error('Failed to restore animation auxiliary curves.');
+    }
+}
+
+export function animationClipSnapshotsEqual(left: IAnimationClipSnapshot, right: IAnimationClipSnapshot): boolean {
+    return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function restoreEvents(clip: AnimationClip, snapshot: IAnimationClipSnapshot): void {
+    const sample = snapshot.sample || 1;
+    (clip as any).events = snapshot.events.map((event) => ({
+        frame: event.frame / sample,
+        func: event.func,
+        params: cloneValue(event.params || []),
+    }));
+    updateClipEventData(clip);
+}

--- a/src/core/scene/scene-process/service/animation/clip-snapshot.ts
+++ b/src/core/scene/scene-process/service/animation/clip-snapshot.ts
@@ -14,6 +14,7 @@ import {
     replaceEmbeddedPlayers,
 } from './embedded-player';
 import { dumpPropertyCurves, replacePropertyCurves } from './property-curve';
+import type { IPropertyCurveMetadataContext } from './property-curve';
 import {
     cloneValue,
     getClipSample,
@@ -33,7 +34,7 @@ export interface IAnimationClipSnapshot {
     auxiliaryCurves: Record<string, IAnimationAuxiliaryCurveDump>;
 }
 
-export function captureAnimationClipSnapshot(clip: AnimationClip): IAnimationClipSnapshot {
+export function captureAnimationClipSnapshot(clip: AnimationClip, options: IPropertyCurveMetadataContext = {}): IAnimationClipSnapshot {
     const sample = getClipSample(clip);
     const events = queryClipEvents(clip) || [];
     return {
@@ -41,7 +42,7 @@ export function captureAnimationClipSnapshot(clip: AnimationClip): IAnimationCli
         sample,
         speed: Number((clip as any).speed) || 0,
         wrapMode: Number((clip as any).wrapMode) || 0,
-        curves: dumpPropertyCurves(clip, { includeDefaults: true }),
+        curves: dumpPropertyCurves(clip, { ...options, includeDefaults: true }),
         events: events.map((event: any) => ({
             frame: Math.round((Number(event.frame) || 0) * sample),
             func: event.func || '',

--- a/src/core/scene/scene-process/service/animation/clip-snapshot.ts
+++ b/src/core/scene/scene-process/service/animation/clip-snapshot.ts
@@ -1,6 +1,7 @@
 import type { AnimationClip } from 'cc';
 import type {
     IAnimationAuxiliaryCurveDump,
+    IAnimationCurveDump,
     IAnimationEmbeddedPlayerDump,
     IAnimationEmbeddedPlayerGroup,
     IAnimationEventDump,
@@ -12,6 +13,7 @@ import {
     replaceEmbeddedPlayerGroups,
     replaceEmbeddedPlayers,
 } from './embedded-player';
+import { dumpPropertyCurves, replacePropertyCurves } from './property-curve';
 import {
     cloneValue,
     getClipSample,
@@ -23,6 +25,7 @@ export interface IAnimationClipSnapshot {
     sample: number;
     speed: number;
     wrapMode: number;
+    curves: IAnimationCurveDump[];
     events: IAnimationEventDump[];
     embeddedPlayers: IAnimationEmbeddedPlayerDump[];
     embeddedPlayerGroups: IAnimationEmbeddedPlayerGroup[];
@@ -36,6 +39,7 @@ export function captureAnimationClipSnapshot(clip: AnimationClip): IAnimationCli
         sample,
         speed: Number((clip as any).speed) || 0,
         wrapMode: Number((clip as any).wrapMode) || 0,
+        curves: dumpPropertyCurves(clip),
         events: events.map((event: any) => ({
             frame: Math.round((Number(event.frame) || 0) * sample),
             func: event.func || '',
@@ -51,6 +55,9 @@ export async function restoreAnimationClipSnapshot(clip: AnimationClip, snapshot
     (clip as any).sample = snapshot.sample;
     (clip as any).speed = snapshot.speed;
     (clip as any).wrapMode = snapshot.wrapMode;
+    if (!replacePropertyCurves(clip, snapshot.curves)) {
+        throw new Error('Failed to restore animation property curves.');
+    }
     restoreEvents(clip, snapshot);
     replaceEmbeddedPlayerGroups(clip, snapshot.embeddedPlayerGroups);
     if (!await replaceEmbeddedPlayers(clip, snapshot.embeddedPlayers)) {

--- a/src/core/scene/scene-process/service/animation/clip-snapshot.ts
+++ b/src/core/scene/scene-process/service/animation/clip-snapshot.ts
@@ -22,6 +22,7 @@ import {
 } from './utils';
 
 export interface IAnimationClipSnapshot {
+    duration: number;
     sample: number;
     speed: number;
     wrapMode: number;
@@ -36,6 +37,7 @@ export function captureAnimationClipSnapshot(clip: AnimationClip): IAnimationCli
     const sample = getClipSample(clip);
     const events = queryClipEvents(clip) || [];
     return {
+        duration: Number((clip as any).duration) || 0,
         sample,
         speed: Number((clip as any).speed) || 0,
         wrapMode: Number((clip as any).wrapMode) || 0,
@@ -52,6 +54,7 @@ export function captureAnimationClipSnapshot(clip: AnimationClip): IAnimationCli
 }
 
 export async function restoreAnimationClipSnapshot(clip: AnimationClip, snapshot: IAnimationClipSnapshot): Promise<void> {
+    (clip as any).duration = snapshot.duration;
     (clip as any).sample = snapshot.sample;
     (clip as any).speed = snapshot.speed;
     (clip as any).wrapMode = snapshot.wrapMode;

--- a/src/core/scene/scene-process/service/animation/clip-snapshot.ts
+++ b/src/core/scene/scene-process/service/animation/clip-snapshot.ts
@@ -55,6 +55,20 @@ export function captureAnimationClipSnapshot(clip: AnimationClip, options: IProp
 }
 
 export async function restoreAnimationClipSnapshot(clip: AnimationClip, snapshot: IAnimationClipSnapshot): Promise<void> {
+    const previous = captureAnimationClipSnapshot(clip);
+    try {
+        await applyAnimationClipSnapshot(clip, snapshot);
+    } catch (error) {
+        try {
+            await applyAnimationClipSnapshot(clip, previous);
+        } catch (restoreError) {
+            console.error('[Animation] rollback failed animation clip snapshot restore:', restoreError);
+        }
+        throw error;
+    }
+}
+
+async function applyAnimationClipSnapshot(clip: AnimationClip, snapshot: IAnimationClipSnapshot): Promise<void> {
     (clip as any).duration = snapshot.duration;
     (clip as any).sample = snapshot.sample;
     (clip as any).speed = snapshot.speed;

--- a/src/core/scene/scene-process/service/animation/embedded-player.ts
+++ b/src/core/scene/scene-process/service/animation/embedded-player.ts
@@ -1,0 +1,223 @@
+import {
+    AnimationClip,
+    assetManager as ccAssetManager,
+    editorExtrasTag,
+} from 'cc';
+import {
+    EmbeddedAnimationClipPlayable,
+    EmbeddedParticleSystemPlayable,
+    EmbeddedPlayer,
+    addEmbeddedPlayerTag,
+    clearEmbeddedPlayersTag,
+    getEmbeddedPlayersTag,
+} from 'cc/editor/embedded-player';
+import type {
+    IAnimationEmbeddedPlayerDump,
+    IAnimationEmbeddedPlayerGroup,
+} from '../../../common';
+import { cloneValue, clipUuid, getClipSample } from './utils';
+
+export function queryEmbeddedPlayerGroups(clip: AnimationClip): IAnimationEmbeddedPlayerGroup[] {
+    const groups = (clip as any)[editorExtrasTag]?.embeddedPlayerGroups;
+    return Array.isArray(groups) ? cloneValue(groups) : [];
+}
+
+export function ensureEmbeddedPlayerGroups(clip: AnimationClip): IAnimationEmbeddedPlayerGroup[] {
+    const clipAny = clip as any;
+    if (!clipAny[editorExtrasTag]) {
+        clipAny[editorExtrasTag] = {};
+    }
+    if (!Array.isArray(clipAny[editorExtrasTag].embeddedPlayerGroups)) {
+        clipAny[editorExtrasTag].embeddedPlayerGroups = [];
+    }
+    return clipAny[editorExtrasTag].embeddedPlayerGroups;
+}
+
+export function dumpEmbeddedPlayers(clip: AnimationClip): IAnimationEmbeddedPlayerDump[] {
+    if (typeof (clip as any)[getEmbeddedPlayersTag] !== 'function') {
+        return [];
+    }
+    return Array.from((clip as any)[getEmbeddedPlayersTag]() as Iterable<EmbeddedPlayer>).map((embeddedPlayer) => {
+        const dump: IAnimationEmbeddedPlayerDump = {
+            begin: Math.round((Number(embeddedPlayer.begin) || 0) * getClipSample(clip)),
+            end: Math.round((Number(embeddedPlayer.end) || 0) * getClipSample(clip)),
+            reconciledSpeed: Boolean(embeddedPlayer.reconciledSpeed),
+            group: (embeddedPlayer as any)[editorExtrasTag]?.group || '',
+        };
+        const displayName = (embeddedPlayer as any)[editorExtrasTag]?.displayName;
+        const playable = dumpEmbeddedPlayable(embeddedPlayer.playable);
+        if (displayName) {
+            dump.displayName = displayName;
+        }
+        if (playable) {
+            dump.playable = playable;
+        }
+        return dump;
+    });
+}
+
+export function dumpEmbeddedPlayable(playable: unknown): IAnimationEmbeddedPlayerDump['playable'] {
+    if (!playable) {
+        return undefined;
+    }
+    if (playable instanceof EmbeddedAnimationClipPlayable) {
+        const clip = playable.clip as AnimationClip | null;
+        return {
+            type: 'animation-clip',
+            clip: clip ? clipUuid(clip) : undefined,
+            path: playable.path || undefined,
+        };
+    }
+    if (playable instanceof EmbeddedParticleSystemPlayable) {
+        return {
+            type: 'particle-system',
+            path: playable.path || undefined,
+        };
+    }
+    return undefined;
+}
+
+export async function addEmbeddedPlayer(clip: AnimationClip, dump: IAnimationEmbeddedPlayerDump): Promise<boolean> {
+    const players = dumpEmbeddedPlayers(clip);
+    players.push(cloneValue(dump));
+    return await replaceEmbeddedPlayers(clip, players);
+}
+
+export async function deleteEmbeddedPlayer(clip: AnimationClip, dump: IAnimationEmbeddedPlayerDump): Promise<boolean> {
+    const key = embeddedPlayerKey(dump);
+    const players = dumpEmbeddedPlayers(clip);
+    const filtered = players.filter((player) => embeddedPlayerKey(player) !== key);
+    if (filtered.length === players.length) {
+        return false;
+    }
+    return await replaceEmbeddedPlayers(clip, filtered);
+}
+
+export async function updateEmbeddedPlayer(clip: AnimationClip, oldDump: IAnimationEmbeddedPlayerDump, newDump: IAnimationEmbeddedPlayerDump): Promise<boolean> {
+    const key = embeddedPlayerKey(oldDump);
+    const players = dumpEmbeddedPlayers(clip);
+    const index = players.findIndex((player) => embeddedPlayerKey(player) === key);
+    if (index < 0) {
+        return false;
+    }
+    players[index] = cloneValue(newDump);
+    return await replaceEmbeddedPlayers(clip, players);
+}
+
+export async function clearEmbeddedPlayers(clip: AnimationClip, group?: string): Promise<boolean> {
+    if (!group) {
+        return await replaceEmbeddedPlayers(clip, []);
+    }
+    const players = dumpEmbeddedPlayers(clip).filter((player) => player.group !== group);
+    return await replaceEmbeddedPlayers(clip, players);
+}
+
+export function addEmbeddedPlayerGroup(clip: AnimationClip, group: IAnimationEmbeddedPlayerGroup): boolean {
+    if (!group?.key || !group.type) {
+        return false;
+    }
+    const groups = ensureEmbeddedPlayerGroups(clip);
+    if (groups.some((item) => item.key === group.key)) {
+        return false;
+    }
+    groups.push({
+        key: group.key,
+        name: group.name || group.key,
+        type: group.type,
+    });
+    return true;
+}
+
+export async function removeEmbeddedPlayerGroup(clip: AnimationClip, key: string): Promise<boolean> {
+    const groups = ensureEmbeddedPlayerGroups(clip);
+    const index = groups.findIndex((item) => item.key === key);
+    if (index >= 0) {
+        groups.splice(index, 1);
+    }
+    await clearEmbeddedPlayers(clip, key);
+    return true;
+}
+
+export function serializeEmbeddedPlayersForMeta(clip: AnimationClip) {
+    if (typeof (clip as any)[getEmbeddedPlayersTag] !== 'function') {
+        return [];
+    }
+    return Array.from((clip as any)[getEmbeddedPlayersTag]() as Iterable<EmbeddedPlayer>).map((embeddedPlayer) => ({
+        begin: Number(embeddedPlayer.begin) || 0,
+        end: Number(embeddedPlayer.end) || 0,
+        reconciledSpeed: Boolean(embeddedPlayer.reconciledSpeed),
+        editorExtras: {
+            group: (embeddedPlayer as any)[editorExtrasTag]?.group,
+            displayName: (embeddedPlayer as any)[editorExtrasTag]?.displayName,
+        },
+        playable: dumpEmbeddedPlayable(embeddedPlayer.playable),
+    }));
+}
+
+async function replaceEmbeddedPlayers(clip: AnimationClip, players: IAnimationEmbeddedPlayerDump[]): Promise<boolean> {
+    if (typeof (clip as any)[clearEmbeddedPlayersTag] !== 'function' || typeof (clip as any)[addEmbeddedPlayerTag] !== 'function') {
+        return false;
+    }
+
+    (clip as any)[clearEmbeddedPlayersTag]();
+    for (const player of players) {
+        (clip as any)[addEmbeddedPlayerTag](await createEmbeddedPlayer(clip, player));
+    }
+    return true;
+}
+
+async function createEmbeddedPlayer(clip: AnimationClip, dump: IAnimationEmbeddedPlayerDump): Promise<EmbeddedPlayer> {
+    if (dump.end < dump.begin || dump.begin < 0) {
+        throw new Error(`Invalid embedded player range: ${dump.begin}-${dump.end}`);
+    }
+
+    const embeddedPlayer = new EmbeddedPlayer();
+    embeddedPlayer.begin = dump.begin / getClipSample(clip);
+    embeddedPlayer.end = dump.end / getClipSample(clip);
+    embeddedPlayer.reconciledSpeed = Boolean(dump.reconciledSpeed);
+    (embeddedPlayer as any)[editorExtrasTag] = {
+        group: dump.group || '',
+        displayName: dump.displayName,
+    };
+
+    if (dump.playable?.type === 'animation-clip') {
+        const playable = new EmbeddedAnimationClipPlayable();
+        if (dump.playable.clip) {
+            playable.clip = await loadAnimationClip(dump.playable.clip);
+        }
+        if (dump.playable.path) {
+            playable.path = dump.playable.path;
+        }
+        embeddedPlayer.playable = playable;
+    } else if (dump.playable?.type === 'particle-system') {
+        const playable = new EmbeddedParticleSystemPlayable();
+        if (dump.playable.path) {
+            playable.path = dump.playable.path;
+        }
+        embeddedPlayer.playable = playable;
+    }
+
+    return embeddedPlayer;
+}
+
+async function loadAnimationClip(uuid: string): Promise<AnimationClip | null> {
+    return await new Promise((resolve, reject) => {
+        ccAssetManager.loadAny(uuid, (error, asset: AnimationClip) => {
+            if (error) {
+                reject(error);
+                return;
+            }
+            resolve(asset instanceof AnimationClip ? asset : null);
+        });
+    });
+}
+
+function embeddedPlayerKey(dump: IAnimationEmbeddedPlayerDump): string {
+    return [
+        `begin:${dump.begin}`,
+        `end:${dump.end}`,
+        `player:${dump.playable?.type || ''}`,
+        `group:${dump.group || ''}`,
+        `displayName:${dump.displayName || ''}`,
+    ].join(',');
+}

--- a/src/core/scene/scene-process/service/animation/embedded-player.ts
+++ b/src/core/scene/scene-process/service/animation/embedded-player.ts
@@ -33,6 +33,11 @@ export function ensureEmbeddedPlayerGroups(clip: AnimationClip): IAnimationEmbed
     return clipAny[editorExtrasTag].embeddedPlayerGroups;
 }
 
+export function replaceEmbeddedPlayerGroups(clip: AnimationClip, groups: IAnimationEmbeddedPlayerGroup[]): void {
+    const target = ensureEmbeddedPlayerGroups(clip);
+    target.splice(0, target.length, ...cloneValue(groups));
+}
+
 export function dumpEmbeddedPlayers(clip: AnimationClip): IAnimationEmbeddedPlayerDump[] {
     if (typeof (clip as any)[getEmbeddedPlayersTag] !== 'function') {
         return [];
@@ -154,7 +159,7 @@ export function serializeEmbeddedPlayersForMeta(clip: AnimationClip) {
     }));
 }
 
-async function replaceEmbeddedPlayers(clip: AnimationClip, players: IAnimationEmbeddedPlayerDump[]): Promise<boolean> {
+export async function replaceEmbeddedPlayers(clip: AnimationClip, players: IAnimationEmbeddedPlayerDump[]): Promise<boolean> {
     if (typeof (clip as any)[clearEmbeddedPlayersTag] !== 'function' || typeof (clip as any)[addEmbeddedPlayerTag] !== 'function') {
         return false;
     }

--- a/src/core/scene/scene-process/service/animation/embedded-player.ts
+++ b/src/core/scene/scene-process/service/animation/embedded-player.ts
@@ -42,7 +42,8 @@ export function dumpEmbeddedPlayers(clip: AnimationClip): IAnimationEmbeddedPlay
     if (typeof (clip as any)[getEmbeddedPlayersTag] !== 'function') {
         return [];
     }
-    return Array.from((clip as any)[getEmbeddedPlayersTag]() as Iterable<EmbeddedPlayer>).map((embeddedPlayer) => {
+    ensureEmbeddedPlayers(clip);
+    return queryEmbeddedPlayers(clip).map((embeddedPlayer) => {
         const dump: IAnimationEmbeddedPlayerDump = {
             begin: Math.round((Number(embeddedPlayer.begin) || 0) * getClipSample(clip)),
             end: Math.round((Number(embeddedPlayer.end) || 0) * getClipSample(clip)),
@@ -147,7 +148,8 @@ export function serializeEmbeddedPlayersForMeta(clip: AnimationClip) {
     if (typeof (clip as any)[getEmbeddedPlayersTag] !== 'function') {
         return [];
     }
-    return Array.from((clip as any)[getEmbeddedPlayersTag]() as Iterable<EmbeddedPlayer>).map((embeddedPlayer) => ({
+    ensureEmbeddedPlayers(clip);
+    return queryEmbeddedPlayers(clip).map((embeddedPlayer) => ({
         begin: Number(embeddedPlayer.begin) || 0,
         end: Number(embeddedPlayer.end) || 0,
         reconciledSpeed: Boolean(embeddedPlayer.reconciledSpeed),
@@ -164,6 +166,7 @@ export async function replaceEmbeddedPlayers(clip: AnimationClip, players: IAnim
         return false;
     }
 
+    ensureEmbeddedPlayers(clip);
     (clip as any)[clearEmbeddedPlayersTag]();
     for (const player of players) {
         (clip as any)[addEmbeddedPlayerTag](await createEmbeddedPlayer(clip, player));
@@ -203,6 +206,19 @@ async function createEmbeddedPlayer(clip: AnimationClip, dump: IAnimationEmbedde
     }
 
     return embeddedPlayer;
+}
+
+function queryEmbeddedPlayers(clip: AnimationClip): EmbeddedPlayer[] {
+    ensureEmbeddedPlayers(clip);
+    return Array.from(((clip as any)[getEmbeddedPlayersTag]?.() || []) as Iterable<EmbeddedPlayer>);
+}
+
+function ensureEmbeddedPlayers(clip: AnimationClip): EmbeddedPlayer[] {
+    const clipAny = clip as any;
+    if (!Array.isArray(clipAny._embeddedPlayers)) {
+        clipAny._embeddedPlayers = [];
+    }
+    return clipAny._embeddedPlayers as EmbeddedPlayer[];
 }
 
 async function loadAnimationClip(uuid: string): Promise<AnimationClip | null> {

--- a/src/core/scene/scene-process/service/animation/embedded-player.ts
+++ b/src/core/scene/scene-process/service/animation/embedded-player.ts
@@ -162,14 +162,23 @@ export function serializeEmbeddedPlayersForMeta(clip: AnimationClip) {
 }
 
 export async function replaceEmbeddedPlayers(clip: AnimationClip, players: IAnimationEmbeddedPlayerDump[]): Promise<boolean> {
-    if (typeof (clip as any)[clearEmbeddedPlayersTag] !== 'function' || typeof (clip as any)[addEmbeddedPlayerTag] !== 'function') {
-        return false;
+    const clipAny = clip as any;
+    const canClear = typeof clipAny[clearEmbeddedPlayersTag] === 'function';
+    const canAdd = typeof clipAny[addEmbeddedPlayerTag] === 'function';
+    if (!canClear || !canAdd) {
+        if (players.length > 0) {
+            return false;
+        }
+        if (typeof clipAny[getEmbeddedPlayersTag] === 'function') {
+            return queryEmbeddedPlayers(clip).length === 0;
+        }
+        return true;
     }
 
     ensureEmbeddedPlayers(clip);
-    (clip as any)[clearEmbeddedPlayersTag]();
+    clipAny[clearEmbeddedPlayersTag]();
     for (const player of players) {
-        (clip as any)[addEmbeddedPlayerTag](await createEmbeddedPlayer(clip, player));
+        clipAny[addEmbeddedPlayerTag](await createEmbeddedPlayer(clip, player));
     }
     return true;
 }

--- a/src/core/scene/scene-process/service/animation/embedded-player.ts
+++ b/src/core/scene/scene-process/service/animation/embedded-player.ts
@@ -243,10 +243,16 @@ async function loadAnimationClip(uuid: string): Promise<AnimationClip | null> {
 }
 
 function embeddedPlayerKey(dump: IAnimationEmbeddedPlayerDump): string {
+    const playable = dump.playable;
+    const playableClip = playable?.type === 'animation-clip' ? playable.clip || '' : '';
+    const playablePath = playable?.path || '';
     return [
         `begin:${dump.begin}`,
         `end:${dump.end}`,
-        `player:${dump.playable?.type || ''}`,
+        `speed:${dump.reconciledSpeed ? 1 : 0}`,
+        `player:${playable?.type || ''}`,
+        `clip:${playableClip}`,
+        `path:${playablePath}`,
         `group:${dump.group || ''}`,
         `displayName:${dump.displayName || ''}`,
     ].join(',');

--- a/src/core/scene/scene-process/service/animation/material-uniform.ts
+++ b/src/core/scene/scene-process/service/animation/material-uniform.ts
@@ -1,0 +1,175 @@
+import { Color, Mat4, Vec2, Vec3, Vec4, gfx, renderer } from 'cc';
+
+export interface IMaterialUniformProperty {
+    comp: string;
+    materialProperty: string;
+    materialIndex?: number;
+    passIndex: number;
+    uniformName: string;
+}
+
+export function parseMaterialUniformPropertyKey(propKey: string): IMaterialUniformProperty | null {
+    const arrayMatch = /^(.+)\.([^.]+)\.(\d+)\.pass\.(\d+)\.([^.]+)$/.exec(propKey);
+    if (arrayMatch) {
+        return {
+            comp: arrayMatch[1],
+            materialProperty: arrayMatch[2],
+            materialIndex: Number(arrayMatch[3]),
+            passIndex: Number(arrayMatch[4]),
+            uniformName: arrayMatch[5],
+        };
+    }
+
+    const singleMatch = /^(.+)\.([^.]+)\.pass\.(\d+)\.([^.]+)$/.exec(propKey);
+    if (!singleMatch) {
+        return null;
+    }
+    return {
+        comp: singleMatch[1],
+        materialProperty: singleMatch[2],
+        passIndex: Number(singleMatch[3]),
+        uniformName: singleMatch[4],
+    };
+}
+
+export function createMaterialUniformPropertyKey(data: IMaterialUniformProperty): string {
+    const materialPath = data.materialIndex === undefined
+        ? data.materialProperty
+        : `${data.materialProperty}.${data.materialIndex}`;
+    return `${data.comp}.${materialPath}.pass.${data.passIndex}.${data.uniformName}`;
+}
+
+export function queryMaterialUniformTarget(component: Record<string, unknown>, data: IMaterialUniformProperty): { material: any; pass: any } | null {
+    const value = component[data.materialProperty];
+    const material = data.materialIndex === undefined
+        ? value
+        : Array.isArray(value) ? value[data.materialIndex] : undefined;
+    const pass = material && Array.isArray((material as any).passes) ? (material as any).passes[data.passIndex] : undefined;
+    return material && pass ? { material, pass } : null;
+}
+
+export function queryMaterialUniformType(pass: any, uniformName: string): string {
+    const propInfo = pass?.properties?.[uniformName];
+    if (propInfo?.editor?.type === 'color') {
+        return 'cc.Color';
+    }
+
+    let gfxType: unknown;
+    if (typeof pass?.getHandle === 'function' && typeof renderer.Pass?.getTypeFromHandle === 'function') {
+        gfxType = renderer.Pass.getTypeFromHandle(pass.getHandle(uniformName));
+    }
+
+    return queryGfxValueType(gfxType) || queryGfxValueType(propInfo?.type);
+}
+
+export function readMaterialUniformValue(component: Record<string, unknown>, data: IMaterialUniformProperty): unknown {
+    const target = queryMaterialUniformTarget(component, data);
+    if (!target) {
+        return undefined;
+    }
+
+    const { material, pass } = target;
+    const handle = typeof pass.getHandle === 'function' ? pass.getHandle(data.uniformName) : 0;
+    if (!handle) {
+        return undefined;
+    }
+
+    const type = typeof renderer.Pass?.getTypeFromHandle === 'function'
+        ? renderer.Pass.getTypeFromHandle(handle)
+        : undefined;
+    const sampler1D = (gfx.Type as any).SAMPLER1D ?? (gfx.Type as any).SAMPLER2D;
+    if (
+        (typeof type === 'number' && sampler1D !== undefined && type >= sampler1D)
+        || (type === undefined && isSamplerUniformType(queryMaterialUniformType(pass, data.uniformName)))
+    ) {
+        return typeof material.getProperty === 'function' ? material.getProperty(data.uniformName, data.passIndex) : undefined;
+    }
+
+    const value = createDefaultUniformValue(queryMaterialUniformType(pass, data.uniformName));
+    if (typeof pass.getUniform !== 'function') {
+        return value;
+    }
+    return pass.getUniform(handle, value as any);
+}
+
+function isSamplerUniformType(type: string): boolean {
+    return type === 'cc.TextureBase' || type === 'cc.TextureCube';
+}
+
+function queryGfxValueType(type: unknown): string {
+    if (typeof type === 'string') {
+        return normalizePrimitiveTypeName(type);
+    }
+    if (typeof type !== 'number') {
+        return '';
+    }
+
+    const Type = gfx.Type as any;
+    switch (type) {
+        case Type.INT:
+            return 'Integer';
+        case Type.INT2:
+            return 'cc.Vec2';
+        case Type.INT3:
+            return 'cc.Vec3';
+        case Type.INT4:
+            return 'cc.Vec4';
+        case Type.FLOAT:
+            return 'Float';
+        case Type.FLOAT2:
+            return 'cc.Vec2';
+        case Type.FLOAT3:
+            return 'cc.Vec3';
+        case Type.FLOAT4:
+            return 'cc.Vec4';
+        case Type.MAT4:
+            return 'cc.Mat4';
+        case Type.SAMPLER2D:
+            return 'cc.TextureBase';
+        case Type.SAMPLER_CUBE:
+            return 'cc.TextureCube';
+        default:
+            return '';
+    }
+}
+
+function createDefaultUniformValue(type: string): unknown {
+    switch (normalizePrimitiveTypeName(type)) {
+        case 'cc.Boolean':
+            return false;
+        case 'cc.Number':
+            return 0;
+        case 'cc.String':
+            return '';
+        case 'cc.Vec2':
+            return new Vec2();
+        case 'cc.Vec3':
+            return new Vec3();
+        case 'cc.Vec4':
+            return new Vec4();
+        case 'cc.Color':
+            return new Color();
+        case 'cc.Mat4':
+            return new Mat4();
+        default:
+            return undefined;
+    }
+}
+
+function normalizePrimitiveTypeName(type: string): string {
+    switch (type) {
+        case 'number':
+        case 'Number':
+        case 'Float':
+        case 'Integer':
+            return 'cc.Number';
+        case 'boolean':
+        case 'Boolean':
+            return 'cc.Boolean';
+        case 'string':
+        case 'String':
+            return 'cc.String';
+        default:
+            return type;
+    }
+}

--- a/src/core/scene/scene-process/service/animation/operation-normalizer.ts
+++ b/src/core/scene/scene-process/service/animation/operation-normalizer.ts
@@ -1,0 +1,86 @@
+import type { Node } from 'cc';
+import type {
+    IAnimationOperation,
+    IAnimationOperationResult,
+    IAnimationQueryPropertyValueAtFrameOptions,
+    IAnimationValue,
+} from '../../../common';
+import { normalizeProvidedAnimationPropertyOperationValue } from './property-value';
+import {
+    extractSampledOperationValue,
+    getNodeByUuid,
+    getNodePath,
+} from './scene-node';
+
+type PropertyKeyOperation = Extract<IAnimationOperation, { type: 'createPropertyKey' | 'updatePropertyKey' }>;
+
+interface IAnimationOperationNormalizerContext {
+    currentClipUuid: string;
+    rootNode: Node;
+    rootPath: string;
+    queryPropertyValueAtFrame(options: IAnimationQueryPropertyValueAtFrameOptions): Promise<IAnimationValue>;
+}
+
+export async function normalizeAnimationOperation(
+    operation: IAnimationOperation,
+    context: IAnimationOperationNormalizerContext,
+): Promise<IAnimationOperation | IAnimationOperationResult> {
+    const type = (operation as any)?.type;
+    if (type === 'updatePropertyKeyData') {
+        const keyOperation = operation as Extract<IAnimationOperation, { type: 'updatePropertyKeyData' }>;
+        const keyData = keyOperation.keyData ?? keyOperation.curveData;
+        return keyData === keyOperation.keyData ? operation : { ...keyOperation, keyData };
+    }
+    if (type !== 'createPropertyKey' && type !== 'updatePropertyKey') {
+        return operation;
+    }
+
+    return normalizePropertyKeyOperation(operation as PropertyKeyOperation, context);
+}
+
+async function normalizePropertyKeyOperation(
+    operation: PropertyKeyOperation,
+    context: IAnimationOperationNormalizerContext,
+): Promise<IAnimationOperation | IAnimationOperationResult> {
+    const keyData = operation.keyData ?? operation.curveData;
+    if (operation.value !== undefined) {
+        const value = await normalizeProvidedAnimationPropertyOperationValue(context.rootNode, context.rootPath, operation, {
+            queryNodeByUuid: (uuid) => getNodeByUuid(uuid),
+            queryNodePath: (node) => getNodePath(node),
+        });
+        return { ...operation, keyData, value };
+    }
+    if (operation.type === 'updatePropertyKey' && keyData) {
+        return {
+            ...operation,
+            type: 'updatePropertyKeyData',
+            keyData,
+        };
+    }
+
+    try {
+        const sampled = await context.queryPropertyValueAtFrame({
+            clipUuid: operation.clipUuid || context.currentClipUuid,
+            nodePath: operation.nodePath,
+            nodeUuid: operation.nodeUuid,
+            propKey: operation.propKey,
+            frame: operation.frame,
+        });
+        const value = extractSampledOperationValue(sampled, operation.channel);
+        if (value === undefined) {
+            return {
+                state: 'failure',
+                result: false,
+                reason: `Failed to sample animation property value: ${operation.propKey}`,
+            };
+        }
+        return { ...operation, keyData, value };
+    } catch (error) {
+        const normalized = error instanceof Error ? error : new Error(String(error));
+        return {
+            state: 'failure',
+            result: false,
+            reason: normalized.message,
+        };
+    }
+}

--- a/src/core/scene/scene-process/service/animation/operation-policy.ts
+++ b/src/core/scene/scene-process/service/animation/operation-policy.ts
@@ -1,0 +1,71 @@
+import type {
+    IAnimationOperation,
+    IAnimationOperationResult,
+} from '../../../common';
+
+export function isAnimationOperationResult(value: IAnimationOperation | IAnimationOperationResult): value is IAnimationOperationResult {
+    return (value as IAnimationOperationResult).state === 'success' || (value as IAnimationOperationResult).state === 'failure';
+}
+
+export function shouldSyncClipDuration(operation: IAnimationOperation): boolean {
+    switch (operation.type) {
+        case 'changeSample':
+        case 'addEvent':
+        case 'deleteEvent':
+        case 'updateEvent':
+        case 'moveEvents':
+        case 'copyEventsTo':
+        case 'addEmbeddedPlayer':
+        case 'deleteEmbeddedPlayer':
+        case 'updateEmbeddedPlayer':
+        case 'clearEmbeddedPlayer':
+        case 'removeEmbeddedPlayerGroup':
+        case 'clearEmbeddedPlayerGroup':
+        case 'removeAuxiliaryCurve':
+        case 'createAuxKey':
+        case 'removeAuxKey':
+        case 'moveAuxKeys':
+        case 'copyAuxKey':
+        case 'createPropertyKey':
+        case 'updatePropertyKey':
+        case 'removePropertyCurve':
+        case 'removePropertyKey':
+        case 'removePropertyKeys':
+        case 'movePropertyKeys':
+        case 'copyPropertyKeysTo':
+            return true;
+        default:
+            return false;
+    }
+}
+
+export function isAllowedSkeletonAnimationOperation(operation: IAnimationOperation): boolean {
+    switch (operation.type) {
+        case 'changeSample':
+        case 'changeSpeed':
+        case 'changeWrapMode':
+        case 'addEvent':
+        case 'deleteEvent':
+        case 'updateEvent':
+        case 'moveEvents':
+        case 'copyEventsTo':
+        case 'addEmbeddedPlayer':
+        case 'deleteEmbeddedPlayer':
+        case 'updateEmbeddedPlayer':
+        case 'clearEmbeddedPlayer':
+        case 'addEmbeddedPlayerGroup':
+        case 'removeEmbeddedPlayerGroup':
+        case 'clearEmbeddedPlayerGroup':
+        case 'addAuxiliaryCurve':
+        case 'removeAuxiliaryCurve':
+        case 'renameAuxiliaryCurve':
+        case 'createAuxKey':
+        case 'removeAuxKey':
+        case 'moveAuxKeys':
+        case 'copyAuxKey':
+        case 'updateAuxKeyData':
+            return true;
+        default:
+            return false;
+    }
+}

--- a/src/core/scene/scene-process/service/animation/property-commit-event.ts
+++ b/src/core/scene/scene-process/service/animation/property-commit-event.ts
@@ -1,0 +1,16 @@
+import type { IAnimationPropertyCommittedEvent } from '../../../common';
+import { ServiceEvents } from '../core';
+
+export function normalizeAnimationPropertyCommitPath(propPath: string): string {
+    return propPath.replace(/^_components\b/, '__comps__');
+}
+
+export function broadcastAnimationPropertyCommitted(event: IAnimationPropertyCommittedEvent): void {
+    if (!event.nodePath || !event.propPath) {
+        return;
+    }
+    ServiceEvents.broadcast('animation:property-committed', {
+        ...event,
+        propPath: normalizeAnimationPropertyCommitPath(event.propPath),
+    });
+}

--- a/src/core/scene/scene-process/service/animation/property-curve-keyframe.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve-keyframe.ts
@@ -163,6 +163,63 @@ export function setTrackKey(
     }
 }
 
+export function updateTrackKey(
+    track: AnyTrack,
+    descriptor: IPropertyTrackDescriptor,
+    time: number,
+    value: IAnimationValue,
+    channel?: string,
+    keyData?: IAnimationCurveKeyData,
+): boolean {
+    const channels = queryTrackChannels(track);
+    switch (descriptor.kind) {
+        case 'vector':
+        case 'color':
+        case 'size': {
+            const partKeys = descriptor.partKeys || [];
+            if (channel) {
+                const channelIndex = partKeys.indexOf(channel);
+                if (channelIndex < 0) {
+                    return false;
+                }
+                const channelValue = value === undefined ? undefined : normalizeNumberValue(value);
+                if (value !== undefined && channelValue === null) {
+                    return false;
+                }
+                return updateRealCurveKey(channels[channelIndex].curve, time, channelValue, keyData);
+            }
+
+            const compositeValue = value === undefined ? null : normalizeCompositeValue(value, partKeys);
+            if (value !== undefined && !compositeValue) {
+                return false;
+            }
+            for (let index = 0; index < partKeys.length; index++) {
+                if (!updateRealCurveKey(channels[index].curve, time, compositeValue?.[partKeys[index]], keyData)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        case 'real': {
+            const numberValue = value === undefined ? undefined : normalizeNumberValue(value);
+            if (value !== undefined && numberValue === null) {
+                return false;
+            }
+            return updateRealCurveKey(channels[0].curve, time, numberValue, keyData);
+        }
+        case 'quat':
+            return updateQuatCurveKey(channels[0].curve, time, value, keyData);
+        case 'object':
+            if (value === undefined) {
+                return false;
+            }
+            setCurveKey(channels[0].curve, time, cloneValue(value));
+            return true;
+        default:
+            return false;
+    }
+}
+
 export function queryTargetCurves(track: AnyTrack, descriptor: IPropertyTrackDescriptor, channel?: string): AnyCurve[] {
     const channels = queryTrackChannels(track);
     if (!channel || !descriptor.partKeys) {
@@ -341,6 +398,44 @@ function setCurveKey(curve: AnyCurve, time: number, value: unknown): void {
     (curve as any).assignSorted(keyframes);
 }
 
+function updateRealCurveKey(curve: AnyCurve, time: number, value: number | undefined | null, keyData?: IAnimationCurveKeyData): boolean {
+    const existed = queryCurveKeyframes(curve).find(([keyTime]) => isSameTime(keyTime, time));
+    if (!existed) {
+        if (value === undefined || value === null) {
+            return false;
+        }
+        setCurveKey(curve, time, createRealCurveValue(value, keyData));
+        return true;
+    }
+
+    const currentValue = value ?? queryRealCurveNumberValue(existed[1]);
+    setCurveKey(curve, time, createMergedRealCurveValue(currentValue, existed[1], keyData));
+    return true;
+}
+
+function updateQuatCurveKey(curve: AnyCurve, time: number, value: IAnimationValue, keyData?: IAnimationCurveKeyData): boolean {
+    const existed = queryCurveKeyframes(curve).find(([keyTime]) => isSameTime(keyTime, time));
+    if (!existed) {
+        const quatValue = normalizeQuatValue(value);
+        if (!quatValue) {
+            return false;
+        }
+        setCurveKey(curve, time, createQuatCurveValue(quatValue, keyData));
+        return true;
+    }
+
+    const nextValue = value === undefined ? normalizeQuatValue(existed[1]?.value) : normalizeQuatValue(value);
+    if (!nextValue) {
+        return false;
+    }
+    setCurveKey(curve, time, {
+        value: nextValue,
+        interpolationMode: keyData?.interpMode ?? existed[1]?.interpolationMode,
+        easingMethod: keyData?.easingMethod ?? existed[1]?.easingMethod,
+    });
+    return true;
+}
+
 function createRealCurveValue(value: number, keyData?: IAnimationCurveKeyData): number | Record<string, unknown> {
     if (!keyData || !hasKeyData(keyData)) {
         return value;
@@ -360,6 +455,13 @@ function createRealCurveValue(value: number, keyData?: IAnimationCurveKeyData): 
         curveValue[EDITOR_EXTRAS_TAG] = editorExtras;
     }
     return curveValue;
+}
+
+function createMergedRealCurveValue(value: number, existed: unknown, keyData?: IAnimationCurveKeyData): number | Record<string, unknown> {
+    return createRealCurveValue(value, {
+        ...dumpRealKeyData(existed),
+        ...keyData,
+    });
 }
 
 function createQuatCurveValue(value: IAnimationValue, keyData?: IAnimationCurveKeyData): Record<string, unknown> {
@@ -467,6 +569,10 @@ function normalizeQuatValue(value: unknown): IAnimationValue {
         return null;
     }
     return { x, y, z, w };
+}
+
+function queryRealCurveNumberValue(value: any): number {
+    return normalizeNumber(value && typeof value === 'object' ? value.value : value);
 }
 
 function normalizeNumberValue(value: IAnimationValue): number | null {

--- a/src/core/scene/scene-process/service/animation/property-curve-keyframe.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve-keyframe.ts
@@ -1,4 +1,4 @@
-import { Asset, js, type AnimationClip } from 'cc';
+import type { AnimationClip, Asset } from 'cc';
 import type {
     IAnimationCurveChannelDump,
     IAnimationCurveDump,
@@ -28,6 +28,13 @@ import {
     findRealCurveKey,
     queryRealCurveNumberValue,
 } from './real-curve-key-data';
+import {
+    createAnimationAssetPlaceholder,
+    isAnimationAssetValue,
+    queryAnimationAssetCtor,
+    queryAnimationAssetUuid,
+    serializeAnimationAssetValue,
+} from './asset-value';
 
 export function dumpPropertyTrack(
     clip: AnimationClip,
@@ -447,23 +454,17 @@ function normalizeObjectCurveValue(descriptor: IPropertyTrackDescriptor, value: 
 }
 
 function dumpObjectCurveValue(value: unknown, descriptor: IPropertyTrackDescriptor): IAnimationValue {
-    if (isAssetDescriptor(descriptor) || value instanceof Asset) {
+    if (isAssetDescriptor(descriptor) || isAnimationAssetValue(value)) {
         if (value === null || value === undefined) {
             return null;
         }
-        const uuid = queryAssetUuid(value);
+        if (isAnimationAssetValue(value)) {
+            return serializeAnimationAssetValue(value);
+        }
+        const uuid = queryAnimationAssetUuid(value);
         return uuid ? { uuid } : null;
     }
     return cloneValue(value) as IAnimationValue;
-}
-
-function queryAssetUuid(value: unknown): string {
-    if (!value || typeof value !== 'object') {
-        return '';
-    }
-    const record = value as Record<string, unknown>;
-    const uuid = record.uuid || record._uuid || record.__uuid__;
-    return typeof uuid === 'string' ? uuid : '';
 }
 
 const NOT_ASSET_TYPE = Symbol('notAssetType');
@@ -480,11 +481,11 @@ function normalizeAssetCurveValue(descriptor: IPropertyTrackDescriptor, value: I
     if (value instanceof assetCtor) {
         return value;
     }
-    const uuid = queryAssetUuid(value);
+    const uuid = queryAnimationAssetUuid(value);
     if (!uuid) {
         return INVALID_ASSET_VALUE;
     }
-    return createAssetPlaceholder(assetCtor, uuid);
+    return createAnimationAssetPlaceholder(assetCtor, uuid);
 }
 
 function isAssetDescriptor(descriptor: IPropertyTrackDescriptor): boolean {
@@ -492,17 +493,7 @@ function isAssetDescriptor(descriptor: IPropertyTrackDescriptor): boolean {
 }
 
 function queryAssetCtor(descriptor: IPropertyTrackDescriptor): (new () => Asset) | null {
-    const ctor = descriptor.valueCtor || js.getClassByName(descriptor.type.value);
-    if (typeof ctor !== 'function') {
-        return null;
-    }
-    return ctor === Asset || ctor.prototype instanceof Asset ? ctor as new () => Asset : null;
-}
-
-function createAssetPlaceholder(assetCtor: new () => Asset, uuid: string): Asset {
-    const asset = new assetCtor();
-    asset.initDefault(uuid);
-    return asset;
+    return queryAnimationAssetCtor(descriptor);
 }
 
 function updateRealCurveKey(curve: AnyCurve, time: number, value: number | undefined | null, keyData?: IAnimationCurveKeyData): boolean {

--- a/src/core/scene/scene-process/service/animation/property-curve-keyframe.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve-keyframe.ts
@@ -1,4 +1,4 @@
-import type { AnimationClip } from 'cc';
+import { Asset, js, type AnimationClip } from 'cc';
 import type {
     IAnimationCurveChannelDump,
     IAnimationCurveDump,
@@ -70,7 +70,7 @@ export function dumpPropertyTrack(
         case 'object':
             return {
                 ...base,
-                keyframes: dumpObjectCurveKeyframes(clip, queryTrackChannels(track)[0].curve, descriptor.type.value),
+                keyframes: dumpObjectCurveKeyframes(clip, queryTrackChannels(track)[0].curve, descriptor),
             };
         default:
             return null;
@@ -110,7 +110,7 @@ export function restoreTrackKeyframes(
             assignQuatCurveKeyframes(queryTrackChannels(track)[0].curve, sample, keyframes);
             return true;
         case 'object':
-            assignObjectCurveKeyframes(queryTrackChannels(track)[0].curve, sample, keyframes);
+            assignObjectCurveKeyframes(queryTrackChannels(track)[0].curve, sample, keyframes, descriptor);
             return true;
         default:
             return false;
@@ -166,9 +166,14 @@ export function setTrackKey(
             setCurveKey(channels[0].curve, time, createQuatCurveValue(quatValue, keyData));
             return true;
         }
-        case 'object':
-            setCurveKey(channels[0].curve, time, cloneValue(value));
+        case 'object': {
+            const objectValue = normalizeObjectCurveValue(descriptor, value);
+            if (objectValue === undefined) {
+                return false;
+            }
+            setCurveKey(channels[0].curve, time, objectValue);
             return true;
+        }
         default:
             return false;
     }
@@ -229,7 +234,13 @@ export function updateTrackKey(
             if (value === undefined) {
                 return false;
             }
-            setCurveKey(channels[0].curve, time, cloneValue(value));
+            {
+                const objectValue = normalizeObjectCurveValue(descriptor, value);
+                if (objectValue === undefined) {
+                    return false;
+                }
+                setCurveKey(channels[0].curve, time, objectValue);
+            }
             return true;
         default:
             return false;
@@ -375,15 +386,15 @@ function dumpQuatCurveKeyframes(clip: AnimationClip, curve: AnyCurve): IAnimatio
         }));
 }
 
-function dumpObjectCurveKeyframes(clip: AnimationClip, curve: AnyCurve, type: string): IAnimationCurveKeyDump[] {
+function dumpObjectCurveKeyframes(clip: AnimationClip, curve: AnyCurve, descriptor: IPropertyTrackDescriptor): IAnimationCurveKeyDump[] {
     const sample = getClipSample(clip);
     return queryCurveKeyframes(curve)
         .sort(([leftTime], [rightTime]) => leftTime - rightTime)
         .map(([time, value]) => ({
             frame: timeToFrame(time, sample),
             dump: {
-                value: cloneValue(value) as IAnimationValue,
-                type,
+                value: dumpObjectCurveValue(value, descriptor),
+                type: descriptor.type.value,
             },
         }));
 }
@@ -408,10 +419,10 @@ function assignQuatCurveKeyframes(curve: AnyCurve, sample: number, keyframes: IA
     (curve as any).assignSorted(sorted);
 }
 
-function assignObjectCurveKeyframes(curve: AnyCurve, sample: number, keyframes: IAnimationCurveKeyDump[]): void {
+function assignObjectCurveKeyframes(curve: AnyCurve, sample: number, keyframes: IAnimationCurveKeyDump[], descriptor: IPropertyTrackDescriptor): void {
     const sorted = [...keyframes].sort((a, b) => a.frame - b.frame).map((keyframe) => [
         keyframe.frame / sample,
-        cloneValue(keyframe.dump.value),
+        normalizeObjectCurveValue({ ...descriptor, type: { value: keyframe.dump.type || descriptor.type.value } }, keyframe.dump.value),
     ]);
     (curve as any).assignSorted(sorted);
 }
@@ -422,6 +433,76 @@ function setCurveKey(curve: AnyCurve, time: number, value: unknown): void {
         .concat([[time, value] as [number, unknown]]);
     keyframes.sort((a, b) => a[0] - b[0]);
     (curve as any).assignSorted(keyframes);
+}
+
+function normalizeObjectCurveValue(descriptor: IPropertyTrackDescriptor, value: IAnimationValue): unknown {
+    const assetValue = normalizeAssetCurveValue(descriptor, value);
+    if (assetValue === INVALID_ASSET_VALUE) {
+        return undefined;
+    }
+    if (assetValue !== NOT_ASSET_TYPE) {
+        return assetValue;
+    }
+    return cloneValue(value);
+}
+
+function dumpObjectCurveValue(value: unknown, descriptor: IPropertyTrackDescriptor): IAnimationValue {
+    if (isAssetDescriptor(descriptor) || value instanceof Asset) {
+        if (value === null || value === undefined) {
+            return null;
+        }
+        const uuid = queryAssetUuid(value);
+        return uuid ? { uuid } : null;
+    }
+    return cloneValue(value) as IAnimationValue;
+}
+
+function queryAssetUuid(value: unknown): string {
+    if (!value || typeof value !== 'object') {
+        return '';
+    }
+    const record = value as Record<string, unknown>;
+    const uuid = record.uuid || record._uuid || record.__uuid__;
+    return typeof uuid === 'string' ? uuid : '';
+}
+
+const NOT_ASSET_TYPE = Symbol('notAssetType');
+const INVALID_ASSET_VALUE = Symbol('invalidAssetValue');
+
+function normalizeAssetCurveValue(descriptor: IPropertyTrackDescriptor, value: IAnimationValue): unknown | typeof NOT_ASSET_TYPE | typeof INVALID_ASSET_VALUE {
+    const assetCtor = queryAssetCtor(descriptor);
+    if (!assetCtor) {
+        return NOT_ASSET_TYPE;
+    }
+    if (value === null) {
+        return null;
+    }
+    if (value instanceof assetCtor) {
+        return value;
+    }
+    const uuid = queryAssetUuid(value);
+    if (!uuid) {
+        return INVALID_ASSET_VALUE;
+    }
+    return createAssetPlaceholder(assetCtor, uuid);
+}
+
+function isAssetDescriptor(descriptor: IPropertyTrackDescriptor): boolean {
+    return Boolean(queryAssetCtor(descriptor));
+}
+
+function queryAssetCtor(descriptor: IPropertyTrackDescriptor): (new () => Asset) | null {
+    const ctor = descriptor.valueCtor || js.getClassByName(descriptor.type.value);
+    if (typeof ctor !== 'function') {
+        return null;
+    }
+    return ctor === Asset || ctor.prototype instanceof Asset ? ctor as new () => Asset : null;
+}
+
+function createAssetPlaceholder(assetCtor: new () => Asset, uuid: string): Asset {
+    const asset = new assetCtor();
+    asset.initDefault(uuid);
+    return asset;
 }
 
 function updateRealCurveKey(curve: AnyCurve, time: number, value: number | undefined | null, keyData?: IAnimationCurveKeyData): boolean {

--- a/src/core/scene/scene-process/service/animation/property-curve-keyframe.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve-keyframe.ts
@@ -1,4 +1,3 @@
-import { editorExtrasTag } from 'cc';
 import type { AnimationClip } from 'cc';
 import type {
     IAnimationCurveChannelDump,
@@ -20,10 +19,22 @@ import {
     queryFirstRealCurve,
     queryTrackChannels,
 } from './property-curve-track';
+import {
+    copyRealKeyDataInternalMetadata,
+    createMergedRealCurveValue,
+    createRealCurveValue,
+    type IDumpRealKeyDataOptions,
+    dumpRealKeyData,
+    findRealCurveKey,
+    queryRealCurveNumberValue,
+} from './real-curve-key-data';
 
-const EDITOR_EXTRAS_TAG = editorExtrasTag || '__editorExtras__';
-
-export function dumpPropertyTrack(clip: AnimationClip, track: AnyTrack, descriptor: IPropertyTrackDescriptor): Omit<IAnimationCurveDump, 'nodePath' | 'key'> | null {
+export function dumpPropertyTrack(
+    clip: AnimationClip,
+    track: AnyTrack,
+    descriptor: IPropertyTrackDescriptor,
+    options: IDumpRealKeyDataOptions = {},
+): Omit<IAnimationCurveDump, 'nodePath' | 'key'> | null {
     const base = {
         displayName: descriptor.displayName,
         name: descriptor.displayName,
@@ -39,7 +50,7 @@ export function dumpPropertyTrack(clip: AnimationClip, track: AnyTrack, descript
             return {
                 ...base,
                 keyframes: dumpCompositeRealTrackKeyframes(clip, track, descriptor),
-                channels: dumpCompositeRealTrackChannels(clip, track, descriptor),
+                channels: dumpCompositeRealTrackChannels(clip, track, descriptor, options),
                 partKeys: descriptor.partKeys ? [...descriptor.partKeys] : undefined,
                 preExtrap: queryFirstRealCurve(track)?.preExtrapolation ?? 0,
                 postExtrap: queryFirstRealCurve(track)?.postExtrapolation ?? 0,
@@ -47,7 +58,7 @@ export function dumpPropertyTrack(clip: AnimationClip, track: AnyTrack, descript
         case 'real':
             return {
                 ...base,
-                keyframes: dumpRealCurveKeyframes(clip, queryTrackChannels(track)[0].curve),
+                keyframes: dumpRealCurveKeyframes(clip, queryTrackChannels(track)[0].curve, options),
                 preExtrap: queryFirstRealCurve(track)?.preExtrapolation ?? 0,
                 postExtrap: queryFirstRealCurve(track)?.postExtrapolation ?? 0,
             };
@@ -194,6 +205,11 @@ export function updateTrackKey(
                 return false;
             }
             for (let index = 0; index < partKeys.length; index++) {
+                if (!canUpdateRealCurveKey(channels[index].curve, time, compositeValue?.[partKeys[index]])) {
+                    return false;
+                }
+            }
+            for (let index = 0; index < partKeys.length; index++) {
                 if (!updateRealCurveKey(channels[index].curve, time, compositeValue?.[partKeys[index]], keyData)) {
                     return false;
                 }
@@ -288,14 +304,19 @@ export function copyCurveKeysTo(clip: AnimationClip, curve: AnyCurve, frames: nu
     return true;
 }
 
-function dumpCompositeRealTrackChannels(clip: AnimationClip, track: AnyTrack, descriptor: IPropertyTrackDescriptor): IAnimationCurveChannelDump[] {
+function dumpCompositeRealTrackChannels(
+    clip: AnimationClip,
+    track: AnyTrack,
+    descriptor: IPropertyTrackDescriptor,
+    options: IDumpRealKeyDataOptions,
+): IAnimationCurveChannelDump[] {
     const partKeys = descriptor.partKeys || [];
     const channels = queryTrackChannels(track);
     return partKeys.map((key, index) => ({
         key,
         displayName: key,
         type: { value: 'cc.Number' },
-        keyframes: dumpRealCurveKeyframes(clip, channels[index].curve),
+        keyframes: dumpRealCurveKeyframes(clip, channels[index].curve, options),
     }));
 }
 
@@ -305,7 +326,7 @@ function dumpCompositeRealTrackKeyframes(clip: AnimationClip, track: AnyTrack, d
     const partKeys = descriptor.partKeys || [];
     const times = new Set<number>();
     for (let index = 0; index < partKeys.length; index++) {
-        for (const time of channels[index].curve.times()) {
+        for (const time of queryCurveTimes(channels[index].curve)) {
             times.add(time);
         }
     }
@@ -321,18 +342,23 @@ function dumpCompositeRealTrackKeyframes(clip: AnimationClip, track: AnyTrack, d
         }));
 }
 
-function dumpRealCurveKeyframes(clip: AnimationClip, curve: AnyCurve): IAnimationCurveKeyDump[] {
+function dumpRealCurveKeyframes(clip: AnimationClip, curve: AnyCurve, options: IDumpRealKeyDataOptions): IAnimationCurveKeyDump[] {
     const sample = getClipSample(clip);
     return queryCurveKeyframes(curve)
         .sort(([leftTime], [rightTime]) => leftTime - rightTime)
-        .map(([time, value]) => ({
-            frame: timeToFrame(time, sample),
-            dump: {
-                value: normalizeNumber(value.value),
-                type: 'cc.Number',
-            },
-            ...dumpRealKeyData(value),
-        }));
+        .map(([time, value]) => {
+            const keyData = dumpRealKeyData(value, options);
+            const keyframe = {
+                frame: timeToFrame(time, sample),
+                dump: {
+                    value: queryRealCurveNumberValue(value),
+                    type: 'cc.Number',
+                },
+                ...keyData,
+            };
+            copyRealKeyDataInternalMetadata(keyData, keyframe);
+            return keyframe;
+        });
 }
 
 function dumpQuatCurveKeyframes(clip: AnimationClip, curve: AnyCurve): IAnimationCurveKeyDump[] {
@@ -399,7 +425,7 @@ function setCurveKey(curve: AnyCurve, time: number, value: unknown): void {
 }
 
 function updateRealCurveKey(curve: AnyCurve, time: number, value: number | undefined | null, keyData?: IAnimationCurveKeyData): boolean {
-    const existed = queryCurveKeyframes(curve).find(([keyTime]) => isSameTime(keyTime, time));
+    const existed = findRealCurveKey(curve as any, time);
     if (!existed) {
         if (value === undefined || value === null) {
             return false;
@@ -411,6 +437,10 @@ function updateRealCurveKey(curve: AnyCurve, time: number, value: number | undef
     const currentValue = value ?? queryRealCurveNumberValue(existed[1]);
     setCurveKey(curve, time, createMergedRealCurveValue(currentValue, existed[1], keyData));
     return true;
+}
+
+function canUpdateRealCurveKey(curve: AnyCurve, time: number, value: number | undefined | null): boolean {
+    return Boolean(findRealCurveKey(curve as any, time)) || (value !== undefined && value !== null);
 }
 
 function updateQuatCurveKey(curve: AnyCurve, time: number, value: IAnimationValue, keyData?: IAnimationCurveKeyData): boolean {
@@ -436,57 +466,12 @@ function updateQuatCurveKey(curve: AnyCurve, time: number, value: IAnimationValu
     return true;
 }
 
-function createRealCurveValue(value: number, keyData?: IAnimationCurveKeyData): number | Record<string, unknown> {
-    if (!keyData || !hasKeyData(keyData)) {
-        return value;
-    }
-    const curveValue: Record<string, unknown> = {
-        value,
-        leftTangent: keyData.inTangent,
-        rightTangent: keyData.outTangent,
-        leftTangentWeight: keyData.inTangentWeight,
-        rightTangentWeight: keyData.outTangentWeight,
-        interpolationMode: keyData.interpMode,
-        tangentWeightMode: keyData.tangentWeightMode,
-        easingMethod: keyData.easingMethod,
-    };
-    const editorExtras = createRealCurveEditorExtras(keyData);
-    if (editorExtras) {
-        curveValue[EDITOR_EXTRAS_TAG] = editorExtras;
-    }
-    return curveValue;
-}
-
-function createMergedRealCurveValue(value: number, existed: unknown, keyData?: IAnimationCurveKeyData): number | Record<string, unknown> {
-    return createRealCurveValue(value, {
-        ...dumpRealKeyData(existed),
-        ...keyData,
-    });
-}
-
 function createQuatCurveValue(value: IAnimationValue, keyData?: IAnimationCurveKeyData): Record<string, unknown> {
     return {
         value,
         interpolationMode: keyData?.interpMode,
         easingMethod: keyData?.easingMethod,
     };
-}
-
-function dumpRealKeyData(value: any): IAnimationCurveKeyData {
-    const data: IAnimationCurveKeyData = {};
-    setNonDefaultNumber(data, 'inTangent', value.leftTangent);
-    setNonDefaultNumber(data, 'outTangent', value.rightTangent);
-    setNonDefaultNumber(data, 'inTangentWeight', value.leftTangentWeight);
-    setNonDefaultNumber(data, 'outTangentWeight', value.rightTangentWeight);
-    setNonDefaultNumber(data, 'interpMode', value.interpolationMode);
-    setNonDefaultNumber(data, 'tangentWeightMode', value.tangentWeightMode);
-    setNonDefaultNumber(data, 'easingMethod', value.easingMethod);
-    const editorExtras = queryRealCurveEditorExtras(value);
-    setNonDefaultNumber(data, 'tangentMode', editorExtras?.tangentMode);
-    if (typeof editorExtras?.broken === 'boolean') {
-        data.broken = editorExtras.broken;
-    }
-    return data;
 }
 
 function dumpQuatKeyData(value: any): IAnimationCurveKeyData {
@@ -501,36 +486,6 @@ function setNonDefaultNumber(data: IAnimationCurveKeyData, key: keyof IAnimation
     if (Number.isFinite(numberValue) && numberValue !== 0) {
         (data as any)[key] = numberValue;
     }
-}
-
-function createRealCurveEditorExtras(keyData: IAnimationCurveKeyData): Record<string, unknown> | null {
-    const editorExtras: Record<string, unknown> = {};
-    if (keyData.tangentMode !== undefined) {
-        editorExtras.tangentMode = keyData.tangentMode;
-    }
-    if (keyData.broken !== undefined) {
-        editorExtras.broken = keyData.broken;
-    }
-    return Object.keys(editorExtras).length > 0 ? editorExtras : null;
-}
-
-function queryRealCurveEditorExtras(value: unknown): any {
-    if (!value || typeof value !== 'object') {
-        return undefined;
-    }
-    return (value as any)[EDITOR_EXTRAS_TAG];
-}
-
-function hasKeyData(keyData: IAnimationCurveKeyData): boolean {
-    return keyData.inTangent !== undefined
-        || keyData.inTangentWeight !== undefined
-        || keyData.outTangent !== undefined
-        || keyData.outTangentWeight !== undefined
-        || keyData.interpMode !== undefined
-        || keyData.tangentWeightMode !== undefined
-        || keyData.tangentMode !== undefined
-        || keyData.easingMethod !== undefined
-        || keyData.broken !== undefined;
 }
 
 function buildCompositeValue(channels: Array<{ curve: any }>, partKeys: readonly string[], time: number): IAnimationValue {
@@ -571,10 +526,6 @@ function normalizeQuatValue(value: unknown): IAnimationValue {
     return { x, y, z, w };
 }
 
-function queryRealCurveNumberValue(value: any): number {
-    return normalizeNumber(value && typeof value === 'object' ? value.value : value);
-}
-
 function normalizeNumberValue(value: IAnimationValue): number | null {
     const numberValue = Number(value);
     return Number.isFinite(numberValue) ? numberValue : null;
@@ -586,7 +537,11 @@ function normalizeNumber(value: unknown): number {
 }
 
 function queryCurveKeyframes(curve: AnyCurve): Array<[number, any]> {
-    return Array.from((curve as any).keyframes()) as Array<[number, any]>;
+    return Array.from((curve as any).keyframes?.() || []) as Array<[number, any]>;
+}
+
+function queryCurveTimes(curve: AnyCurve): number[] {
+    return Array.from((curve as any).times?.() || []) as number[];
 }
 
 function timeToFrame(time: number, sample: number): number {

--- a/src/core/scene/scene-process/service/animation/property-curve-keyframe.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve-keyframe.ts
@@ -1,0 +1,434 @@
+import type { AnimationClip } from 'cc';
+import type {
+    IAnimationCurveChannelDump,
+    IAnimationCurveDump,
+    IAnimationCurveKeyData,
+    IAnimationCurveKeyDump,
+    IAnimationValue,
+} from '../../../common';
+import {
+    cloneValue,
+    getClipSample,
+} from './utils';
+import type {
+    AnyCurve,
+    AnyTrack,
+    IPropertyTrackDescriptor,
+} from './property-curve-types';
+import {
+    queryFirstRealCurve,
+    queryTrackChannels,
+} from './property-curve-track';
+
+export function dumpPropertyTrack(clip: AnimationClip, track: AnyTrack, descriptor: IPropertyTrackDescriptor): Omit<IAnimationCurveDump, 'nodePath' | 'key'> | null {
+    const base = {
+        displayName: descriptor.displayName,
+        name: descriptor.displayName,
+        menuName: descriptor.menuName,
+        type: descriptor.type,
+        comp: descriptor.comp,
+        isCurveSupport: descriptor.isCurveSupport,
+    };
+    switch (descriptor.kind) {
+        case 'vector':
+        case 'color':
+        case 'size':
+            return {
+                ...base,
+                keyframes: dumpCompositeRealTrackKeyframes(clip, track, descriptor),
+                channels: dumpCompositeRealTrackChannels(clip, track, descriptor),
+                partKeys: descriptor.partKeys ? [...descriptor.partKeys] : undefined,
+                preExtrap: queryFirstRealCurve(track)?.preExtrapolation ?? 0,
+                postExtrap: queryFirstRealCurve(track)?.postExtrapolation ?? 0,
+            };
+        case 'real':
+            return {
+                ...base,
+                keyframes: dumpRealCurveKeyframes(clip, queryTrackChannels(track)[0].curve),
+                preExtrap: queryFirstRealCurve(track)?.preExtrapolation ?? 0,
+                postExtrap: queryFirstRealCurve(track)?.postExtrapolation ?? 0,
+            };
+        case 'quat':
+            return {
+                ...base,
+                keyframes: dumpQuatCurveKeyframes(clip, queryTrackChannels(track)[0].curve),
+            };
+        case 'object':
+            return {
+                ...base,
+                keyframes: dumpObjectCurveKeyframes(clip, queryTrackChannels(track)[0].curve, descriptor.type.value),
+            };
+        default:
+            return null;
+    }
+}
+
+export function restoreTrackKeyframes(
+    clip: AnimationClip,
+    track: AnyTrack,
+    descriptor: IPropertyTrackDescriptor,
+    keyframes: IAnimationCurveKeyDump[],
+    channelDumps: IAnimationCurveChannelDump[],
+): boolean {
+    const sample = getClipSample(clip);
+    switch (descriptor.kind) {
+        case 'vector':
+        case 'color':
+        case 'size':
+            if (channelDumps.length > 0) {
+                const channelMap = new Map(channelDumps.map((channel) => [channel.key, channel]));
+                const channels = queryTrackChannels(track);
+                for (const [index, key] of (descriptor.partKeys || []).entries()) {
+                    assignRealCurveKeyframes(channels[index].curve, sample, channelMap.get(key)?.keyframes || []);
+                }
+                return true;
+            }
+            for (const keyframe of keyframes) {
+                if (!setTrackKey(track, descriptor, keyframe.frame / sample, keyframe.dump.value, undefined, keyframe)) {
+                    return false;
+                }
+            }
+            return true;
+        case 'real':
+            assignRealCurveKeyframes(queryTrackChannels(track)[0].curve, sample, keyframes);
+            return true;
+        case 'quat':
+            assignQuatCurveKeyframes(queryTrackChannels(track)[0].curve, sample, keyframes);
+            return true;
+        case 'object':
+            assignObjectCurveKeyframes(queryTrackChannels(track)[0].curve, sample, keyframes);
+            return true;
+        default:
+            return false;
+    }
+}
+
+export function setTrackKey(
+    track: AnyTrack,
+    descriptor: IPropertyTrackDescriptor,
+    time: number,
+    value: IAnimationValue,
+    channel?: string,
+    keyData?: IAnimationCurveKeyData,
+): boolean {
+    const channels = queryTrackChannels(track);
+    switch (descriptor.kind) {
+        case 'vector':
+        case 'color':
+        case 'size': {
+            const partKeys = descriptor.partKeys || [];
+            if (channel) {
+                const channelIndex = partKeys.indexOf(channel);
+                const channelValue = normalizeNumberValue(value);
+                if (channelIndex < 0 || channelValue === null) {
+                    return false;
+                }
+                setCurveKey(channels[channelIndex].curve, time, createRealCurveValue(channelValue, keyData));
+                return true;
+            }
+
+            const compositeValue = normalizeCompositeValue(value, partKeys);
+            if (!compositeValue) {
+                return false;
+            }
+            for (let index = 0; index < partKeys.length; index++) {
+                setCurveKey(channels[index].curve, time, createRealCurveValue(compositeValue[partKeys[index]], keyData));
+            }
+            return true;
+        }
+        case 'real': {
+            const numberValue = normalizeNumberValue(value);
+            if (numberValue === null) {
+                return false;
+            }
+            setCurveKey(channels[0].curve, time, createRealCurveValue(numberValue, keyData));
+            return true;
+        }
+        case 'quat': {
+            const quatValue = normalizeQuatValue(value);
+            if (!quatValue) {
+                return false;
+            }
+            setCurveKey(channels[0].curve, time, createQuatCurveValue(quatValue, keyData));
+            return true;
+        }
+        case 'object':
+            setCurveKey(channels[0].curve, time, cloneValue(value));
+            return true;
+        default:
+            return false;
+    }
+}
+
+export function queryTargetCurves(track: AnyTrack, descriptor: IPropertyTrackDescriptor, channel?: string): AnyCurve[] {
+    const channels = queryTrackChannels(track);
+    if (!channel || !descriptor.partKeys) {
+        return channels.map((item) => item.curve);
+    }
+
+    const channelIndex = descriptor.partKeys.indexOf(channel);
+    return channelIndex >= 0 ? [channels[channelIndex].curve] : [];
+}
+
+export function removeCurveKeys(clip: AnimationClip, curve: AnyCurve, frames: number[]): boolean {
+    const sample = getClipSample(clip);
+    const before = queryCurveKeyframes(curve);
+    const after = before.filter(([time]) => !frames.includes(timeToFrame(time, sample)));
+    if (after.length === before.length) {
+        return false;
+    }
+    (curve as any).assignSorted(after);
+    return true;
+}
+
+export function moveCurveKeys(clip: AnimationClip, curve: AnyCurve, frames: number[], offset: number): boolean {
+    const sample = getClipSample(clip);
+    let changed = false;
+    const keyframes = queryCurveKeyframes(curve).map(([time, value]) => {
+        const frame = timeToFrame(time, sample);
+        if (!frames.includes(frame)) {
+            return { frame, value };
+        }
+        changed = true;
+        return { frame: Math.max(0, frame + offset), value };
+    });
+
+    if (!changed) {
+        return false;
+    }
+    keyframes.sort((a, b) => a.frame - b.frame);
+    (curve as any).assignSorted(keyframes.map((keyframe) => [keyframe.frame / sample, keyframe.value] as [number, any]));
+    return true;
+}
+
+function dumpCompositeRealTrackChannels(clip: AnimationClip, track: AnyTrack, descriptor: IPropertyTrackDescriptor): IAnimationCurveChannelDump[] {
+    const partKeys = descriptor.partKeys || [];
+    const channels = queryTrackChannels(track);
+    return partKeys.map((key, index) => ({
+        key,
+        displayName: key,
+        type: { value: 'cc.Number' },
+        keyframes: dumpRealCurveKeyframes(clip, channels[index].curve),
+    }));
+}
+
+function dumpCompositeRealTrackKeyframes(clip: AnimationClip, track: AnyTrack, descriptor: IPropertyTrackDescriptor): IAnimationCurveKeyDump[] {
+    const sample = getClipSample(clip);
+    const channels = queryTrackChannels(track);
+    const partKeys = descriptor.partKeys || [];
+    const times = new Set<number>();
+    for (let index = 0; index < partKeys.length; index++) {
+        for (const time of channels[index].curve.times()) {
+            times.add(time);
+        }
+    }
+
+    return Array.from(times)
+        .sort((a, b) => a - b)
+        .map((time) => ({
+            frame: timeToFrame(time, sample),
+            dump: {
+                value: buildCompositeValue(channels, partKeys, time),
+                type: descriptor.type.value,
+            },
+        }));
+}
+
+function dumpRealCurveKeyframes(clip: AnimationClip, curve: AnyCurve): IAnimationCurveKeyDump[] {
+    const sample = getClipSample(clip);
+    return queryCurveKeyframes(curve)
+        .sort(([leftTime], [rightTime]) => leftTime - rightTime)
+        .map(([time, value]) => ({
+            frame: timeToFrame(time, sample),
+            dump: {
+                value: normalizeNumber(value.value),
+                type: 'cc.Number',
+            },
+            ...dumpRealKeyData(value),
+        }));
+}
+
+function dumpQuatCurveKeyframes(clip: AnimationClip, curve: AnyCurve): IAnimationCurveKeyDump[] {
+    const sample = getClipSample(clip);
+    return queryCurveKeyframes(curve)
+        .sort(([leftTime], [rightTime]) => leftTime - rightTime)
+        .map(([time, value]) => ({
+            frame: timeToFrame(time, sample),
+            dump: {
+                value: cloneValue(normalizeQuatValue(value.value)),
+                type: 'cc.Quat',
+            },
+            ...dumpQuatKeyData(value),
+        }));
+}
+
+function dumpObjectCurveKeyframes(clip: AnimationClip, curve: AnyCurve, type: string): IAnimationCurveKeyDump[] {
+    const sample = getClipSample(clip);
+    return queryCurveKeyframes(curve)
+        .sort(([leftTime], [rightTime]) => leftTime - rightTime)
+        .map(([time, value]) => ({
+            frame: timeToFrame(time, sample),
+            dump: {
+                value: cloneValue(value) as IAnimationValue,
+                type,
+            },
+        }));
+}
+
+function assignRealCurveKeyframes(curve: AnyCurve, sample: number, keyframes: IAnimationCurveKeyDump[]): void {
+    const sorted = [...keyframes].sort((a, b) => a.frame - b.frame).map((keyframe) => [
+        keyframe.frame / sample,
+        createRealCurveValue(normalizeNumber(keyframe.dump.value), keyframe),
+    ]);
+    (curve as any).assignSorted(sorted);
+}
+
+function assignQuatCurveKeyframes(curve: AnyCurve, sample: number, keyframes: IAnimationCurveKeyDump[]): void {
+    const sorted = [...keyframes].sort((a, b) => a.frame - b.frame).map((keyframe) => [
+        keyframe.frame / sample,
+        {
+            value: normalizeQuatValue(keyframe.dump.value),
+            interpolationMode: keyframe.interpMode,
+            easingMethod: keyframe.easingMethod,
+        },
+    ]);
+    (curve as any).assignSorted(sorted);
+}
+
+function assignObjectCurveKeyframes(curve: AnyCurve, sample: number, keyframes: IAnimationCurveKeyDump[]): void {
+    const sorted = [...keyframes].sort((a, b) => a.frame - b.frame).map((keyframe) => [
+        keyframe.frame / sample,
+        cloneValue(keyframe.dump.value),
+    ]);
+    (curve as any).assignSorted(sorted);
+}
+
+function setCurveKey(curve: AnyCurve, time: number, value: unknown): void {
+    const keyframes = queryCurveKeyframes(curve)
+        .filter(([keyTime]) => !isSameTime(keyTime, time))
+        .concat([[time, value] as [number, unknown]]);
+    keyframes.sort((a, b) => a[0] - b[0]);
+    (curve as any).assignSorted(keyframes);
+}
+
+function createRealCurveValue(value: number, keyData?: IAnimationCurveKeyData): number | Record<string, unknown> {
+    if (!keyData || !hasKeyData(keyData)) {
+        return value;
+    }
+    return {
+        value,
+        leftTangent: keyData.inTangent,
+        rightTangent: keyData.outTangent,
+        leftTangentWeight: keyData.inTangentWeight,
+        rightTangentWeight: keyData.outTangentWeight,
+        interpolationMode: keyData.interpMode,
+        tangentWeightMode: keyData.tangentWeightMode,
+        easingMethod: keyData.easingMethod,
+    };
+}
+
+function createQuatCurveValue(value: IAnimationValue, keyData?: IAnimationCurveKeyData): Record<string, unknown> {
+    return {
+        value,
+        interpolationMode: keyData?.interpMode,
+        easingMethod: keyData?.easingMethod,
+    };
+}
+
+function dumpRealKeyData(value: any): IAnimationCurveKeyData {
+    const data: IAnimationCurveKeyData = {};
+    setNonDefaultNumber(data, 'inTangent', value.leftTangent);
+    setNonDefaultNumber(data, 'outTangent', value.rightTangent);
+    setNonDefaultNumber(data, 'inTangentWeight', value.leftTangentWeight);
+    setNonDefaultNumber(data, 'outTangentWeight', value.rightTangentWeight);
+    setNonDefaultNumber(data, 'interpMode', value.interpolationMode);
+    setNonDefaultNumber(data, 'tangentWeightMode', value.tangentWeightMode);
+    setNonDefaultNumber(data, 'easingMethod', value.easingMethod);
+    return data;
+}
+
+function dumpQuatKeyData(value: any): IAnimationCurveKeyData {
+    const data: IAnimationCurveKeyData = {};
+    setNonDefaultNumber(data, 'interpMode', value.interpolationMode);
+    setNonDefaultNumber(data, 'easingMethod', value.easingMethod);
+    return data;
+}
+
+function setNonDefaultNumber(data: IAnimationCurveKeyData, key: keyof IAnimationCurveKeyData, value: unknown): void {
+    const numberValue = Number(value);
+    if (Number.isFinite(numberValue) && numberValue !== 0) {
+        (data as any)[key] = numberValue;
+    }
+}
+
+function hasKeyData(keyData: IAnimationCurveKeyData): boolean {
+    return keyData.inTangent !== undefined
+        || keyData.inTangentWeight !== undefined
+        || keyData.outTangent !== undefined
+        || keyData.outTangentWeight !== undefined
+        || keyData.interpMode !== undefined
+        || keyData.tangentWeightMode !== undefined
+        || keyData.tangentMode !== undefined
+        || keyData.easingMethod !== undefined
+        || keyData.broken !== undefined;
+}
+
+function buildCompositeValue(channels: Array<{ curve: any }>, partKeys: readonly string[], time: number): IAnimationValue {
+    const value: Record<string, IAnimationValue> = {};
+    for (let index = 0; index < partKeys.length; index++) {
+        value[partKeys[index]] = normalizeNumber(channels[index].curve.evaluate(time));
+    }
+    return value;
+}
+
+function normalizeCompositeValue(value: IAnimationValue, partKeys: readonly string[]): Record<string, number> | null {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return null;
+    }
+
+    const result: Record<string, number> = {};
+    for (const key of partKeys) {
+        const numberValue = Number((value as any)[key]);
+        if (!Number.isFinite(numberValue)) {
+            return null;
+        }
+        result[key] = numberValue;
+    }
+    return result;
+}
+
+function normalizeQuatValue(value: unknown): IAnimationValue {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return null;
+    }
+    const x = Number((value as any).x);
+    const y = Number((value as any).y);
+    const z = Number((value as any).z);
+    const w = Number((value as any).w);
+    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z) || !Number.isFinite(w)) {
+        return null;
+    }
+    return { x, y, z, w };
+}
+
+function normalizeNumberValue(value: IAnimationValue): number | null {
+    const numberValue = Number(value);
+    return Number.isFinite(numberValue) ? numberValue : null;
+}
+
+function normalizeNumber(value: unknown): number {
+    const numberValue = Number(value);
+    return Number.isFinite(numberValue) ? numberValue : 0;
+}
+
+function queryCurveKeyframes(curve: AnyCurve): Array<[number, any]> {
+    return Array.from((curve as any).keyframes()) as Array<[number, any]>;
+}
+
+function timeToFrame(time: number, sample: number): number {
+    return Math.round(time * sample);
+}
+
+function isSameTime(left: number, right: number): boolean {
+    return Math.abs(left - right) <= 1e-6;
+}

--- a/src/core/scene/scene-process/service/animation/property-curve-keyframe.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve-keyframe.ts
@@ -1,3 +1,4 @@
+import { editorExtrasTag } from 'cc';
 import type { AnimationClip } from 'cc';
 import type {
     IAnimationCurveChannelDump,
@@ -19,6 +20,8 @@ import {
     queryFirstRealCurve,
     queryTrackChannels,
 } from './property-curve-track';
+
+const EDITOR_EXTRAS_TAG = editorExtrasTag || '__editorExtras__';
 
 export function dumpPropertyTrack(clip: AnimationClip, track: AnyTrack, descriptor: IPropertyTrackDescriptor): Omit<IAnimationCurveDump, 'nodePath' | 'key'> | null {
     const base = {
@@ -342,7 +345,7 @@ function createRealCurveValue(value: number, keyData?: IAnimationCurveKeyData): 
     if (!keyData || !hasKeyData(keyData)) {
         return value;
     }
-    return {
+    const curveValue: Record<string, unknown> = {
         value,
         leftTangent: keyData.inTangent,
         rightTangent: keyData.outTangent,
@@ -352,6 +355,11 @@ function createRealCurveValue(value: number, keyData?: IAnimationCurveKeyData): 
         tangentWeightMode: keyData.tangentWeightMode,
         easingMethod: keyData.easingMethod,
     };
+    const editorExtras = createRealCurveEditorExtras(keyData);
+    if (editorExtras) {
+        curveValue[EDITOR_EXTRAS_TAG] = editorExtras;
+    }
+    return curveValue;
 }
 
 function createQuatCurveValue(value: IAnimationValue, keyData?: IAnimationCurveKeyData): Record<string, unknown> {
@@ -371,6 +379,11 @@ function dumpRealKeyData(value: any): IAnimationCurveKeyData {
     setNonDefaultNumber(data, 'interpMode', value.interpolationMode);
     setNonDefaultNumber(data, 'tangentWeightMode', value.tangentWeightMode);
     setNonDefaultNumber(data, 'easingMethod', value.easingMethod);
+    const editorExtras = queryRealCurveEditorExtras(value);
+    setNonDefaultNumber(data, 'tangentMode', editorExtras?.tangentMode);
+    if (typeof editorExtras?.broken === 'boolean') {
+        data.broken = editorExtras.broken;
+    }
     return data;
 }
 
@@ -386,6 +399,24 @@ function setNonDefaultNumber(data: IAnimationCurveKeyData, key: keyof IAnimation
     if (Number.isFinite(numberValue) && numberValue !== 0) {
         (data as any)[key] = numberValue;
     }
+}
+
+function createRealCurveEditorExtras(keyData: IAnimationCurveKeyData): Record<string, unknown> | null {
+    const editorExtras: Record<string, unknown> = {};
+    if (keyData.tangentMode !== undefined) {
+        editorExtras.tangentMode = keyData.tangentMode;
+    }
+    if (keyData.broken !== undefined) {
+        editorExtras.broken = keyData.broken;
+    }
+    return Object.keys(editorExtras).length > 0 ? editorExtras : null;
+}
+
+function queryRealCurveEditorExtras(value: unknown): any {
+    if (!value || typeof value !== 'object') {
+        return undefined;
+    }
+    return (value as any)[EDITOR_EXTRAS_TAG];
 }
 
 function hasKeyData(keyData: IAnimationCurveKeyData): boolean {

--- a/src/core/scene/scene-process/service/animation/property-curve-keyframe.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve-keyframe.ts
@@ -201,6 +201,33 @@ export function moveCurveKeys(clip: AnimationClip, curve: AnyCurve, frames: numb
     return true;
 }
 
+export function copyCurveKeysTo(clip: AnimationClip, curve: AnyCurve, frames: number[], dstFrame: number): boolean {
+    const sample = getClipSample(clip);
+    const sortedFrames = [...frames].sort((a, b) => a - b);
+    if (sortedFrames.length === 0 || !Number.isFinite(dstFrame)) {
+        return false;
+    }
+
+    const keyframes = queryCurveKeyframes(curve);
+    const baseFrame = sortedFrames[0];
+    const copied = keyframes
+        .filter(([time]) => sortedFrames.includes(timeToFrame(time, sample)))
+        .map(([time, value]) => ({
+            frame: Math.max(0, timeToFrame(time, sample) - baseFrame + dstFrame),
+            value: cloneValue(value),
+        }));
+    if (copied.length === 0) {
+        return false;
+    }
+
+    const copiedFrames = copied.map(keyframe => keyframe.frame);
+    const retained = keyframes.filter(([time]) => !copiedFrames.includes(timeToFrame(time, sample)));
+    const next = retained.concat(copied.map(keyframe => [keyframe.frame / sample, keyframe.value] as [number, any]));
+    next.sort(([leftTime], [rightTime]) => leftTime - rightTime);
+    (curve as any).assignSorted(next);
+    return true;
+}
+
 function dumpCompositeRealTrackChannels(clip: AnimationClip, track: AnyTrack, descriptor: IPropertyTrackDescriptor): IAnimationCurveChannelDump[] {
     const partKeys = descriptor.partKeys || [];
     const channels = queryTrackChannels(track);

--- a/src/core/scene/scene-process/service/animation/property-curve-keyframe.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve-keyframe.ts
@@ -280,18 +280,25 @@ export function removeCurveKeys(clip: AnimationClip, curve: AnyCurve, frames: nu
 export function moveCurveKeys(clip: AnimationClip, curve: AnyCurve, frames: number[], offset: number): boolean {
     const sample = getClipSample(clip);
     let changed = false;
-    const keyframes = queryCurveKeyframes(curve).map(([time, value]) => {
+    const retained: Array<{ frame: number; value: unknown }> = [];
+    const moved = new Map<number, unknown>();
+    for (const [time, value] of queryCurveKeyframes(curve)) {
         const frame = timeToFrame(time, sample);
-        if (!frames.includes(frame)) {
-            return { frame, value };
+        if (frames.includes(frame)) {
+            changed = true;
+            moved.set(Math.max(0, frame + offset), value);
+        } else {
+            retained.push({ frame, value });
         }
-        changed = true;
-        return { frame: Math.max(0, frame + offset), value };
-    });
+    }
 
     if (!changed) {
         return false;
     }
+    const movedFrames = new Set(moved.keys());
+    const keyframes = retained
+        .filter((keyframe) => !movedFrames.has(keyframe.frame))
+        .concat(Array.from(moved, ([frame, value]) => ({ frame, value })));
     keyframes.sort((a, b) => a.frame - b.frame);
     (curve as any).assignSorted(keyframes.map((keyframe) => [keyframe.frame / sample, keyframe.value] as [number, any]));
     return true;

--- a/src/core/scene/scene-process/service/animation/property-curve-keyframe.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve-keyframe.ts
@@ -1,3 +1,4 @@
+import { deserialize, js } from 'cc';
 import type { AnimationClip, Asset } from 'cc';
 import type {
     IAnimationCurveChannelDump,
@@ -7,6 +8,7 @@ import type {
     IAnimationValue,
 } from '../../../common';
 import {
+    cloneSerializableValue,
     cloneValue,
     getClipSample,
 } from './utils';
@@ -450,6 +452,10 @@ function normalizeObjectCurveValue(descriptor: IPropertyTrackDescriptor, value: 
     if (assetValue !== NOT_ASSET_TYPE) {
         return assetValue;
     }
+    const typedValue = normalizeTypedObjectCurveValue(descriptor, value);
+    if (typedValue !== NOT_TYPED_OBJECT) {
+        return typedValue;
+    }
     return cloneValue(value);
 }
 
@@ -464,11 +470,12 @@ function dumpObjectCurveValue(value: unknown, descriptor: IPropertyTrackDescript
         const uuid = queryAnimationAssetUuid(value);
         return uuid ? { uuid } : null;
     }
-    return cloneValue(value) as IAnimationValue;
+    return cloneSerializableValue(value) as IAnimationValue;
 }
 
 const NOT_ASSET_TYPE = Symbol('notAssetType');
 const INVALID_ASSET_VALUE = Symbol('invalidAssetValue');
+const NOT_TYPED_OBJECT = Symbol('notTypedObject');
 
 function normalizeAssetCurveValue(descriptor: IPropertyTrackDescriptor, value: IAnimationValue): unknown | typeof NOT_ASSET_TYPE | typeof INVALID_ASSET_VALUE {
     const assetCtor = queryAssetCtor(descriptor);
@@ -494,6 +501,45 @@ function isAssetDescriptor(descriptor: IPropertyTrackDescriptor): boolean {
 
 function queryAssetCtor(descriptor: IPropertyTrackDescriptor): (new () => Asset) | null {
     return queryAnimationAssetCtor(descriptor);
+}
+
+function normalizeTypedObjectCurveValue(descriptor: IPropertyTrackDescriptor, value: IAnimationValue): unknown | typeof NOT_TYPED_OBJECT {
+    const ctor = queryTypedObjectCtor(descriptor);
+    if (!ctor) {
+        return NOT_TYPED_OBJECT;
+    }
+    if (value === null || value === undefined) {
+        return value;
+    }
+    if (value instanceof ctor) {
+        return cloneValue(value);
+    }
+    if (typeof value !== 'object' || Array.isArray(value)) {
+        return undefined;
+    }
+
+    const typeName = descriptor.type?.value || '';
+    if (!typeName) {
+        const result = new ctor();
+        Object.assign(result as object, value);
+        return result;
+    }
+    return deserialize({
+        __type__: typeName,
+        ...(value as Record<string, unknown>),
+    });
+}
+
+function queryTypedObjectCtor(descriptor: IPropertyTrackDescriptor): (new () => unknown) | null {
+    if (queryAnimationAssetCtor(descriptor)) {
+        return null;
+    }
+    const typeName = descriptor.type?.value || '';
+    if (!descriptor.valueCtor && (!typeName || typeName === 'cc.Object' || typeName === 'Object' || typeName === 'Unknown')) {
+        return null;
+    }
+    const ctor = descriptor.valueCtor || js.getClassByName(typeName);
+    return typeof ctor === 'function' ? ctor as new () => unknown : null;
 }
 
 function updateRealCurveKey(curve: AnyCurve, time: number, value: number | undefined | null, keyData?: IAnimationCurveKeyData): boolean {

--- a/src/core/scene/scene-process/service/animation/property-curve-track.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve-track.ts
@@ -78,6 +78,7 @@ export function createPropertyTrack(clip: AnimationClip, nodePath: string, descr
     }
     path.toProperty(descriptor.propName);
     track.path = path;
+    ensureClipTrackArray(clip);
     clip.addTrack(track);
     return track;
 }
@@ -170,7 +171,8 @@ export function createPropertyDescriptorFromDump(curve: IAnimationCurveDump): IP
 }
 
 export function removeSupportedPropertyTracks(clip: AnimationClip): void {
-    for (let index = clip.tracksCount - 1; index >= 0; index--) {
+    const tracks = getClipTracks(clip);
+    for (let index = tracks.length - 1; index >= 0; index--) {
         if (parsePropertyTrack(clip.getTrack(index))) {
             clip.removeTrack(index);
         }
@@ -182,7 +184,8 @@ export function removeTrackIfEmpty(clip: AnimationClip, track: AnyTrack): void {
         return;
     }
 
-    for (let index = clip.tracksCount - 1; index >= 0; index--) {
+    const tracks = getClipTracks(clip);
+    for (let index = tracks.length - 1; index >= 0; index--) {
         if (clip.getTrack(index) === track) {
             clip.removeTrack(index);
             return;
@@ -208,11 +211,11 @@ export function queryFirstRealCurve(track: AnyTrack): any | null {
 }
 
 export function queryTrackChannels(track: AnyTrack): Array<{ curve: AnyCurve }> {
-    return Array.from(track.channels()) as Array<{ curve: AnyCurve }>;
+    return Array.from(track.channels() || []) as Array<{ curve: AnyCurve }>;
 }
 
 export function getClipTracks(clip: AnimationClip): AnyTrack[] {
-    return Array.from((clip as any).tracks || []) as AnyTrack[];
+    return ensureClipTrackArray(clip);
 }
 
 export function normalizePath(path: string): string {
@@ -239,6 +242,14 @@ function createTrackByKind(descriptor: IPropertyTrackDescriptor): AnyTrack {
         default:
             throw new Error(`Unsupported animation property track kind: ${String(descriptor.kind)}`);
     }
+}
+
+function ensureClipTrackArray(clip: AnimationClip): AnyTrack[] {
+    const clipAny = clip as any;
+    if (!Array.isArray(clipAny._tracks)) {
+        clipAny._tracks = [];
+    }
+    return clipAny._tracks as AnyTrack[];
 }
 
 function queryTrackKind(track: unknown): PropertyKind | null {

--- a/src/core/scene/scene-process/service/animation/property-curve-track.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve-track.ts
@@ -1,0 +1,384 @@
+import { AnimationClip, animation } from 'cc';
+import type {
+    IAnimationCurveDump,
+    IAnimationPropertyType,
+    IAnimationValue,
+} from '../../../common';
+import type {
+    AnyCurve,
+    AnyTrack,
+    IPropertyTrackDescriptor,
+    PropertyKind,
+} from './property-curve-types';
+
+const VECTOR_COMPONENTS = ['x', 'y', 'z'] as const;
+const VECTOR4_COMPONENTS = ['x', 'y', 'z', 'w'] as const;
+const COLOR_COMPONENTS = ['r', 'g', 'b', 'a'] as const;
+const SIZE_COMPONENTS = ['width', 'height'] as const;
+
+const NODE_PROPERTY_DESCRIPTORS: Record<string, Omit<IPropertyTrackDescriptor, 'propKey' | 'propName'>> = {
+    position: {
+        kind: 'vector',
+        displayName: 'position',
+        menuName: 'position',
+        type: { value: 'cc.Vec3' },
+        isCurveSupport: true,
+        partKeys: VECTOR_COMPONENTS,
+    },
+    scale: {
+        kind: 'vector',
+        displayName: 'scale',
+        menuName: 'scale',
+        type: { value: 'cc.Vec3' },
+        isCurveSupport: true,
+        partKeys: VECTOR_COMPONENTS,
+    },
+    eulerAngles: {
+        kind: 'vector',
+        displayName: 'rotation(eulerAngles)',
+        menuName: 'rotation(eulerAngles)',
+        type: { value: 'cc.Vec3' },
+        isCurveSupport: true,
+        partKeys: VECTOR_COMPONENTS,
+    },
+    rotation: {
+        kind: 'quat',
+        displayName: 'rotation(quaternion)',
+        menuName: 'rotation(quaternion)',
+        type: { value: 'cc.Quat' },
+        isCurveSupport: false,
+    },
+    active: {
+        kind: 'object',
+        displayName: 'active',
+        menuName: 'active',
+        type: { value: 'cc.Boolean' },
+        isCurveSupport: false,
+    },
+};
+
+export function findPropertyTrack(clip: AnimationClip, nodePath: string, propKey: string): AnyTrack | null {
+    for (const track of getClipTracks(clip)) {
+        const target = parsePropertyTrack(track);
+        if (target?.nodePath === nodePath && target.descriptor.propKey === propKey) {
+            return track;
+        }
+    }
+    return null;
+}
+
+export function createPropertyTrack(clip: AnimationClip, nodePath: string, descriptor: IPropertyTrackDescriptor): AnyTrack {
+    const track = createTrackByKind(descriptor);
+    const path = new animation.TrackPath();
+    if (nodePath) {
+        path.toHierarchy(nodePath);
+    }
+    if (descriptor.comp) {
+        path.toComponent(descriptor.comp);
+    }
+    path.toProperty(descriptor.propName);
+    track.path = path;
+    clip.addTrack(track);
+    return track;
+}
+
+export function parsePropertyTrack(track: unknown): { nodePath: string; descriptor: IPropertyTrackDescriptor } | null {
+    const kind = queryTrackKind(track);
+    if (!kind) {
+        return null;
+    }
+
+    const path = (track as AnyTrack).path;
+    let index = 0;
+    let nodePath = '';
+    while (index < path.length && path.isHierarchyAt(index)) {
+        const segment = normalizePath(path.parseHierarchyAt(index));
+        if (segment) {
+            nodePath = nodePath ? `${nodePath}/${segment}` : segment;
+        }
+        index++;
+    }
+
+    let comp: string | undefined;
+    if (index < path.length && path.isComponentAt(index)) {
+        comp = path.parseComponentAt(index);
+        index++;
+    }
+
+    if (index !== path.length - 1 || !path.isPropertyAt(index)) {
+        return null;
+    }
+
+    const propName = path.parsePropertyAt(index);
+    const propKey = comp ? `${comp}.${propName}` : propName;
+    const descriptor = createPropertyDescriptor(propKey, undefined, kind, track as AnyTrack);
+    return descriptor ? { nodePath, descriptor } : null;
+}
+
+export function createPropertyDescriptor(propKey: string, value?: IAnimationValue, trackKind?: PropertyKind, track?: AnyTrack): IPropertyTrackDescriptor | null {
+    const propertyKey = String(propKey || '');
+    const known = NODE_PROPERTY_DESCRIPTORS[propertyKey];
+    if (known) {
+        return {
+            ...known,
+            propKey: propertyKey,
+            propName: propertyKey,
+        };
+    }
+
+    const componentProperty = splitComponentPropertyKey(propertyKey);
+    const propName = componentProperty?.propName || propertyKey;
+    const comp = componentProperty?.comp;
+    const kind = trackKind || inferPropertyKind(value);
+    if (!kind) {
+        return null;
+    }
+
+    const partKeys = queryPartKeys(kind, value, track);
+    return {
+        propKey: propertyKey,
+        propName,
+        comp,
+        kind,
+        type: queryPropertyType(kind, value, partKeys),
+        displayName: propertyKey,
+        menuName: propertyKey,
+        isCurveSupport: kind !== 'object' && kind !== 'quat',
+        partKeys,
+    };
+}
+
+export function createPropertyDescriptorFromDump(curve: IAnimationCurveDump): IPropertyTrackDescriptor | null {
+    const keyframes = Array.isArray(curve.keyframes) ? curve.keyframes : [];
+    const firstValue = keyframes[0]?.dump.value;
+    const type = curve.type?.value;
+    const kind = type ? inferPropertyKindFromType(type) : undefined;
+    const descriptor = createPropertyDescriptor(curve.key, firstValue, kind);
+    if (!descriptor) {
+        return null;
+    }
+    if (curve.type) {
+        descriptor.type = curve.type;
+    }
+    if (Array.isArray(curve.partKeys) && curve.partKeys.length > 0) {
+        descriptor.partKeys = curve.partKeys;
+    }
+    if (curve.comp) {
+        descriptor.comp = curve.comp;
+    }
+    return descriptor;
+}
+
+export function removeSupportedPropertyTracks(clip: AnimationClip): void {
+    for (let index = clip.tracksCount - 1; index >= 0; index--) {
+        if (parsePropertyTrack(clip.getTrack(index))) {
+            clip.removeTrack(index);
+        }
+    }
+}
+
+export function removeTrackIfEmpty(clip: AnimationClip, track: AnyTrack): void {
+    if (queryTrackChannels(track).some((channel) => (channel.curve as any).keyFramesCount > 0)) {
+        return;
+    }
+
+    for (let index = clip.tracksCount - 1; index >= 0; index--) {
+        if (clip.getTrack(index) === track) {
+            clip.removeTrack(index);
+            return;
+        }
+    }
+}
+
+export function applyTrackExtrapolation(track: AnyTrack, preExtrap?: number, postExtrap?: number): void {
+    for (const channel of queryTrackChannels(track)) {
+        const curve = channel.curve as any;
+        if ('preExtrapolation' in curve) {
+            curve.preExtrapolation = Number(preExtrap) || 0;
+        }
+        if ('postExtrapolation' in curve) {
+            curve.postExtrapolation = Number(postExtrap) || 0;
+        }
+    }
+}
+
+export function queryFirstRealCurve(track: AnyTrack): any | null {
+    const curve = queryTrackChannels(track)[0]?.curve as any;
+    return curve && 'preExtrapolation' in curve ? curve : null;
+}
+
+export function queryTrackChannels(track: AnyTrack): Array<{ curve: AnyCurve }> {
+    return Array.from(track.channels()) as Array<{ curve: AnyCurve }>;
+}
+
+export function getClipTracks(clip: AnimationClip): AnyTrack[] {
+    return Array.from((clip as any).tracks || []) as AnyTrack[];
+}
+
+export function normalizePath(path: string): string {
+    return path.replace(/^\/+|\/+$/g, '');
+}
+
+function createTrackByKind(descriptor: IPropertyTrackDescriptor): AnyTrack {
+    switch (descriptor.kind) {
+        case 'vector': {
+            const track = new animation.VectorTrack();
+            track.componentsCount = descriptor.partKeys?.length || 3;
+            return track as AnyTrack;
+        }
+        case 'real':
+            return new animation.RealTrack() as AnyTrack;
+        case 'quat':
+            return new animation.QuatTrack() as AnyTrack;
+        case 'color':
+            return new animation.ColorTrack() as AnyTrack;
+        case 'size':
+            return new animation.SizeTrack() as AnyTrack;
+        case 'object':
+            return new animation.ObjectTrack<IAnimationValue>() as AnyTrack;
+        default:
+            throw new Error(`Unsupported animation property track kind: ${String(descriptor.kind)}`);
+    }
+}
+
+function queryTrackKind(track: unknown): PropertyKind | null {
+    if (track instanceof animation.VectorTrack) {
+        return 'vector';
+    }
+    if (track instanceof animation.RealTrack) {
+        return 'real';
+    }
+    if (track instanceof animation.QuatTrack) {
+        return 'quat';
+    }
+    if (track instanceof animation.ColorTrack) {
+        return 'color';
+    }
+    if (track instanceof animation.SizeTrack) {
+        return 'size';
+    }
+    if (track instanceof animation.ObjectTrack) {
+        return 'object';
+    }
+    return null;
+}
+
+function splitComponentPropertyKey(propKey: string): { comp: string; propName: string } | null {
+    const index = propKey.lastIndexOf('.');
+    if (index <= 0 || index === propKey.length - 1) {
+        return null;
+    }
+    return {
+        comp: propKey.slice(0, index),
+        propName: propKey.slice(index + 1),
+    };
+}
+
+function inferPropertyKind(value: IAnimationValue | undefined): PropertyKind | null {
+    if (typeof value === 'number') {
+        return 'real';
+    }
+    if (typeof value === 'boolean' || typeof value === 'string' || value === null) {
+        return 'object';
+    }
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return null;
+    }
+    if (hasNumericFields(value, COLOR_COMPONENTS)) {
+        return 'color';
+    }
+    if (hasNumericFields(value, SIZE_COMPONENTS)) {
+        return 'size';
+    }
+    if (hasNumericFields(value, VECTOR4_COMPONENTS)) {
+        return 'vector';
+    }
+    if (hasNumericFields(value, VECTOR_COMPONENTS) || hasNumericFields(value, ['x', 'y'])) {
+        return 'vector';
+    }
+    return 'object';
+}
+
+function inferPropertyKindFromType(type: string): PropertyKind | undefined {
+    switch (type) {
+        case 'cc.Number':
+        case 'number':
+        case 'Number':
+            return 'real';
+        case 'cc.Quat':
+            return 'quat';
+        case 'cc.Color':
+            return 'color';
+        case 'cc.Size':
+            return 'size';
+        case 'cc.Vec2':
+        case 'cc.Vec3':
+        case 'cc.Vec4':
+            return 'vector';
+        case 'cc.Boolean':
+        case 'Boolean':
+        case 'cc.String':
+        case 'String':
+            return 'object';
+        default:
+            return undefined;
+    }
+}
+
+function queryPartKeys(kind: PropertyKind, value?: IAnimationValue, track?: AnyTrack): readonly string[] | undefined {
+    if (kind === 'color') {
+        return COLOR_COMPONENTS;
+    }
+    if (kind === 'size') {
+        return SIZE_COMPONENTS;
+    }
+    if (kind !== 'vector') {
+        return undefined;
+    }
+    if (track instanceof animation.VectorTrack) {
+        return VECTOR4_COMPONENTS.slice(0, track.componentsCount);
+    }
+    if (value && typeof value === 'object' && !Array.isArray(value) && hasNumericFields(value, VECTOR4_COMPONENTS)) {
+        return VECTOR4_COMPONENTS;
+    }
+    if (value && typeof value === 'object' && !Array.isArray(value) && hasNumericFields(value, ['x', 'y']) && !hasNumericFields(value, VECTOR_COMPONENTS)) {
+        return ['x', 'y'];
+    }
+    return VECTOR_COMPONENTS;
+}
+
+function queryPropertyType(kind: PropertyKind, value?: IAnimationValue, partKeys?: readonly string[]): IAnimationPropertyType {
+    switch (kind) {
+        case 'real':
+            return { value: 'cc.Number' };
+        case 'quat':
+            return { value: 'cc.Quat' };
+        case 'color':
+            return { value: 'cc.Color' };
+        case 'size':
+            return { value: 'cc.Size' };
+        case 'vector':
+            return { value: `cc.Vec${partKeys?.length || 3}` };
+        case 'object':
+            return { value: queryObjectValueType(value) };
+        default:
+            return { value: 'cc.Object' };
+    }
+}
+
+function queryObjectValueType(value: IAnimationValue | undefined): string {
+    if (typeof value === 'boolean') {
+        return 'cc.Boolean';
+    }
+    if (typeof value === 'string') {
+        return 'cc.String';
+    }
+    if (typeof value === 'number') {
+        return 'cc.Number';
+    }
+    return 'cc.Object';
+}
+
+function hasNumericFields(value: object, fields: readonly string[]): boolean {
+    return fields.every((field) => Number.isFinite(Number((value as any)[field])));
+}

--- a/src/core/scene/scene-process/service/animation/property-curve-track.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve-track.ts
@@ -116,7 +116,14 @@ export function parsePropertyTrack(track: unknown): { nodePath: string; descript
     return descriptor ? { nodePath, descriptor } : null;
 }
 
-export function createPropertyDescriptor(propKey: string, value?: IAnimationValue, trackKind?: PropertyKind, track?: AnyTrack): IPropertyTrackDescriptor | null {
+export function createPropertyDescriptor(
+    propKey: string,
+    value?: IAnimationValue,
+    trackKind?: PropertyKind,
+    track?: AnyTrack,
+    propertyType?: IAnimationPropertyType,
+    valueCtor?: new () => unknown,
+): IPropertyTrackDescriptor | null {
     const propertyKey = String(propKey || '');
     const known = NODE_PROPERTY_DESCRIPTORS[propertyKey];
     if (known) {
@@ -126,11 +133,10 @@ export function createPropertyDescriptor(propKey: string, value?: IAnimationValu
             propName: propertyKey,
         };
     }
-
     const componentProperty = splitComponentPropertyKey(propertyKey);
     const propName = componentProperty?.propName || propertyKey;
     const comp = componentProperty?.comp;
-    const kind = trackKind || inferPropertyKind(value);
+    const kind = trackKind || (propertyType ? inferPropertyKindFromType(propertyType.value) : undefined) || inferPropertyKind(value);
     if (!kind) {
         return null;
     }
@@ -141,11 +147,12 @@ export function createPropertyDescriptor(propKey: string, value?: IAnimationValu
         propName,
         comp,
         kind,
-        type: queryPropertyType(kind, value, partKeys),
+        type: propertyType || queryPropertyType(kind, value, partKeys),
         displayName: propertyKey,
         menuName: propertyKey,
         isCurveSupport: kind !== 'object' && kind !== 'quat',
         partKeys,
+        valueCtor,
     };
 }
 
@@ -315,6 +322,8 @@ function inferPropertyKindFromType(type: string): PropertyKind | undefined {
         case 'cc.Number':
         case 'number':
         case 'Number':
+        case 'Float':
+        case 'Integer':
             return 'real';
         case 'cc.Quat':
             return 'quat';
@@ -332,6 +341,9 @@ function inferPropertyKindFromType(type: string): PropertyKind | undefined {
         case 'String':
             return 'object';
         default:
+            if (type && type !== 'Object' && type !== 'Unknown') {
+                return 'object';
+            }
             return undefined;
     }
 }

--- a/src/core/scene/scene-process/service/animation/property-curve-track.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve-track.ts
@@ -105,6 +105,9 @@ export function parsePropertyTrack(track: unknown): { nodePath: string; descript
     }
 
     const path = (track as AnyTrack).path;
+    if (!path || typeof path.length !== 'number') {
+        return null;
+    }
     let index = 0;
     let nodePath = '';
     while (index < path.length && path.isHierarchyAt(index)) {

--- a/src/core/scene/scene-process/service/animation/property-curve-track.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve-track.ts
@@ -10,6 +10,10 @@ import type {
     IPropertyTrackDescriptor,
     PropertyKind,
 } from './property-curve-types';
+import {
+    createMaterialUniformPropertyKey,
+    parseMaterialUniformPropertyKey,
+} from './material-uniform';
 
 const VECTOR_COMPONENTS = ['x', 'y', 'z'] as const;
 const VECTOR4_COMPONENTS = ['x', 'y', 'z', 'w'] as const;
@@ -76,7 +80,18 @@ export function createPropertyTrack(clip: AnimationClip, nodePath: string, descr
     if (descriptor.comp) {
         path.toComponent(descriptor.comp);
     }
-    path.toProperty(descriptor.propName);
+    if (descriptor.materialUniform) {
+        path.toProperty(descriptor.materialUniform.materialProperty);
+        if (descriptor.materialUniform.materialIndex !== undefined) {
+            path.toElement(descriptor.materialUniform.materialIndex);
+        }
+        track.proxy = new animation.UniformProxyFactory(
+            descriptor.materialUniform.uniformName,
+            descriptor.materialUniform.passIndex,
+        );
+    } else {
+        path.toProperty(descriptor.propName);
+    }
     track.path = path;
     ensureClipTrackArray(clip);
     clip.addTrack(track);
@@ -106,6 +121,32 @@ export function parsePropertyTrack(track: unknown): { nodePath: string; descript
         index++;
     }
 
+    const uniformProxy = queryUniformProxy(track);
+    if (uniformProxy) {
+        if (!comp || index >= path.length || !path.isPropertyAt(index)) {
+            return null;
+        }
+        const materialProperty = path.parsePropertyAt(index);
+        index++;
+        let materialIndex: number | undefined;
+        if (index < path.length && path.isElementAt(index)) {
+            materialIndex = path.parseElementAt(index);
+            index++;
+        }
+        if (index !== path.length) {
+            return null;
+        }
+        const propKey = createMaterialUniformPropertyKey({
+            comp,
+            materialProperty,
+            materialIndex,
+            passIndex: uniformProxy.passIndex,
+            uniformName: uniformProxy.uniformName,
+        });
+        const descriptor = createPropertyDescriptor(propKey, undefined, kind, track as AnyTrack);
+        return descriptor ? { nodePath, descriptor } : null;
+    }
+
     if (index !== path.length - 1 || !path.isPropertyAt(index)) {
         return null;
     }
@@ -133,7 +174,10 @@ export function createPropertyDescriptor(
             propName: propertyKey,
         };
     }
-    const componentProperty = splitComponentPropertyKey(propertyKey);
+    const materialUniform = parseMaterialUniformPropertyKey(propertyKey) || undefined;
+    const componentProperty = materialUniform
+        ? { comp: materialUniform.comp, propName: materialUniform.materialProperty }
+        : splitComponentPropertyKey(propertyKey);
     const propName = componentProperty?.propName || propertyKey;
     const comp = componentProperty?.comp;
     const kind = trackKind || (propertyType ? inferPropertyKindFromType(propertyType.value) : undefined) || inferPropertyKind(value);
@@ -153,6 +197,7 @@ export function createPropertyDescriptor(
         isCurveSupport: kind !== 'object' && kind !== 'quat',
         partKeys,
         valueCtor,
+        materialUniform,
     };
 }
 
@@ -279,6 +324,19 @@ function queryTrackKind(track: unknown): PropertyKind | null {
         return 'object';
     }
     return null;
+}
+
+function queryUniformProxy(track: unknown): { passIndex: number; uniformName: string } | null {
+    const proxy = (track as AnyTrack).proxy as any;
+    if (!proxy) {
+        return null;
+    }
+    if (!(proxy instanceof animation.UniformProxyFactory)) {
+        return null;
+    }
+    return typeof proxy.uniformName === 'string' && Number.isInteger(proxy.passIndex)
+        ? { passIndex: proxy.passIndex, uniformName: proxy.uniformName }
+        : null;
 }
 
 function splitComponentPropertyKey(propKey: string): { comp: string; propName: string } | null {

--- a/src/core/scene/scene-process/service/animation/property-curve-types.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve-types.ts
@@ -35,6 +35,13 @@ export interface ICreatePropertyKeyOperation extends IPropertyTarget {
     curveData?: IAnimationCurveKeyData;
 }
 
+export interface IUpdatePropertyKeyDataOperation extends IPropertyTarget {
+    frame: number;
+    channel?: string;
+    keyData?: IAnimationCurveKeyData;
+    curveData?: IAnimationCurveKeyData;
+}
+
 export interface IPropertyKeyFramesOperation extends IPropertyTarget {
     frames: number[];
     channel?: string;

--- a/src/core/scene/scene-process/service/animation/property-curve-types.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve-types.ts
@@ -29,7 +29,26 @@ export interface IPropertyTrackDescriptor {
 
 export interface ICreatePropertyKeyOperation extends IPropertyTarget {
     frame: number;
-    value: IAnimationValue;
+    value?: IAnimationValue;
     channel?: string;
     keyData?: IAnimationCurveKeyData;
+    curveData?: IAnimationCurveKeyData;
+}
+
+export interface IPropertyKeyFramesOperation extends IPropertyTarget {
+    frames: number[];
+    channel?: string;
+}
+
+export interface IMovePropertyKeysOperation extends IPropertyKeyFramesOperation {
+    offset: number;
+}
+
+export interface ICopyPropertyKeysOperation extends IPropertyKeyFramesOperation {
+    dstFrame: number;
+}
+
+export interface ISetPropertyCurveExtrapolationOperation extends IPropertyTarget {
+    preExtrap?: number;
+    postExtrap?: number;
 }

--- a/src/core/scene/scene-process/service/animation/property-curve-types.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve-types.ts
@@ -25,6 +25,7 @@ export interface IPropertyTrackDescriptor {
     menuName: string;
     isCurveSupport: boolean;
     partKeys?: readonly string[];
+    valueCtor?: new () => unknown;
 }
 
 export interface ICreatePropertyKeyOperation extends IPropertyTarget {

--- a/src/core/scene/scene-process/service/animation/property-curve-types.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve-types.ts
@@ -1,0 +1,35 @@
+import type { animation } from 'cc';
+import type {
+    IAnimationCurveKeyData,
+    IAnimationPropertyType,
+    IAnimationValue,
+} from '../../../common';
+
+export type PropertyKind = 'real' | 'vector' | 'quat' | 'color' | 'size' | 'object';
+export type AnyTrack = InstanceType<typeof animation.Track>;
+export type AnyCurve = ReturnType<AnyTrack['channels']> extends Iterable<infer T> ? T extends { curve: infer C } ? C : never : never;
+
+export interface IPropertyTarget {
+    nodePath?: string;
+    nodeUuid?: string;
+    propKey: string;
+}
+
+export interface IPropertyTrackDescriptor {
+    propKey: string;
+    propName: string;
+    comp?: string;
+    kind: PropertyKind;
+    type: IAnimationPropertyType;
+    displayName: string;
+    menuName: string;
+    isCurveSupport: boolean;
+    partKeys?: readonly string[];
+}
+
+export interface ICreatePropertyKeyOperation extends IPropertyTarget {
+    frame: number;
+    value: IAnimationValue;
+    channel?: string;
+    keyData?: IAnimationCurveKeyData;
+}

--- a/src/core/scene/scene-process/service/animation/property-curve-types.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve-types.ts
@@ -4,6 +4,7 @@ import type {
     IAnimationPropertyType,
     IAnimationValue,
 } from '../../../common';
+import type { IMaterialUniformProperty } from './material-uniform';
 
 export type PropertyKind = 'real' | 'vector' | 'quat' | 'color' | 'size' | 'object';
 export type AnyTrack = InstanceType<typeof animation.Track>;
@@ -26,6 +27,7 @@ export interface IPropertyTrackDescriptor {
     isCurveSupport: boolean;
     partKeys?: readonly string[];
     valueCtor?: new () => unknown;
+    materialUniform?: IMaterialUniformProperty;
 }
 
 export interface ICreatePropertyKeyOperation extends IPropertyTarget {

--- a/src/core/scene/scene-process/service/animation/property-curve.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve.ts
@@ -1,6 +1,7 @@
 import { AnimationClip, Node } from 'cc';
 import type {
     IAnimationCurveDump,
+    IAnimationPropertyType,
     IAnimationValue,
 } from '../../../common';
 import {
@@ -31,10 +32,13 @@ import {
     removeSupportedPropertyTracks,
 } from './property-curve-track';
 import type {
+    AnyTrack,
     ICopyPropertyKeysOperation,
     ICreatePropertyKeyOperation,
     IMovePropertyKeysOperation,
     IPropertyKeyFramesOperation,
+    IPropertyTrackDescriptor,
+    PropertyKind,
     IPropertyTarget,
     ISetPropertyCurveExtrapolationOperation,
     IUpdatePropertyKeyDataOperation,
@@ -45,12 +49,21 @@ interface IResolvedPropertyTarget {
     propKey: string;
 }
 
-export interface IPropertyCurveOperationContext {
+export interface IAnimationPropertyMetadata {
+    type: IAnimationPropertyType;
+    valueCtor?: new () => unknown;
+}
+
+export interface IPropertyCurveMetadataContext {
+    queryPropertyMetadata?: (nodePath: string, propKey: string) => IAnimationPropertyMetadata | null;
+}
+
+export interface IPropertyCurveOperationContext extends IPropertyCurveMetadataContext {
     rootNode: Node;
     rootPath: string;
 }
 
-export function dumpPropertyCurves(clip: AnimationClip, options: IDumpRealKeyDataOptions = {}): IAnimationCurveDump[] {
+export function dumpPropertyCurves(clip: AnimationClip, options: IDumpRealKeyDataOptions & IPropertyCurveMetadataContext = {}): IAnimationCurveDump[] {
     const curves: IAnimationCurveDump[] = [];
     for (const track of getClipTracks(clip)) {
         const parsed = parsePropertyTrack(track);
@@ -58,11 +71,12 @@ export function dumpPropertyCurves(clip: AnimationClip, options: IDumpRealKeyDat
             continue;
         }
 
-        const curveDump = dumpPropertyTrack(clip, track, parsed.descriptor, options);
+        const descriptor = applyPropertyMetadata(options, parsed.nodePath, parsed.descriptor, track);
+        const curveDump = dumpPropertyTrack(clip, track, descriptor, options);
         if (curveDump) {
             curves.push({
                 nodePath: parsed.nodePath,
-                key: parsed.descriptor.propKey,
+                key: descriptor.propKey,
                 ...curveDump,
             });
         }
@@ -83,8 +97,8 @@ export function createPropertyKey(
 
     const existedTrack = findPropertyTrack(clip, target.nodePath, target.propKey);
     const descriptor = existedTrack
-        ? parsePropertyTrack(existedTrack)?.descriptor
-        : createPropertyDescriptor(target.propKey, operation.value);
+        ? queryTrackDescriptor(context, existedTrack)
+        : createDescriptor(context, target, operation.value);
     if (!descriptor) {
         return false;
     }
@@ -108,7 +122,7 @@ export function addPropertyCurve(
         return true;
     }
 
-    const descriptor = createPropertyDescriptor(target.propKey, operation.value);
+    const descriptor = createDescriptor(context, target, operation.value);
     if (!descriptor) {
         return false;
     }
@@ -129,7 +143,7 @@ export function updatePropertyKey(
     }
 
     const track = findPropertyTrack(clip, target.nodePath, target.propKey);
-    const descriptor = track ? parsePropertyTrack(track)?.descriptor : null;
+    const descriptor = track ? queryTrackDescriptor(context, track) : null;
     if (track && descriptor) {
         return updateTrackKey(track, descriptor, frame / getClipSample(clip), operation.value, operation.channel, operation.keyData ?? operation.curveData);
     }
@@ -149,7 +163,7 @@ export function updatePropertyKeyData(
     }
 
     const track = findPropertyTrack(clip, target.nodePath, target.propKey);
-    const descriptor = track ? parsePropertyTrack(track)?.descriptor : null;
+    const descriptor = track ? queryTrackDescriptor(context, track) : null;
     if (!track || !descriptor) {
         return false;
     }
@@ -169,7 +183,7 @@ export function removePropertyKey(
     }
 
     const track = findPropertyTrack(clip, target.nodePath, target.propKey);
-    const descriptor = track ? parsePropertyTrack(track)?.descriptor : null;
+    const descriptor = track ? queryTrackDescriptor(context, track) : null;
     if (!track || !descriptor) {
         return false;
     }
@@ -227,7 +241,7 @@ export function movePropertyKeys(
     }
 
     const track = findPropertyTrack(clip, target.nodePath, target.propKey);
-    const descriptor = track ? parsePropertyTrack(track)?.descriptor : null;
+    const descriptor = track ? queryTrackDescriptor(context, track) : null;
     if (!track || !descriptor) {
         return false;
     }
@@ -252,7 +266,7 @@ export function copyPropertyKeysTo(
     }
 
     const track = findPropertyTrack(clip, target.nodePath, target.propKey);
-    const descriptor = track ? parsePropertyTrack(track)?.descriptor : null;
+    const descriptor = track ? queryTrackDescriptor(context, track) : null;
     if (!track || !descriptor) {
         return false;
     }
@@ -317,6 +331,39 @@ function resolvePropertyTarget(context: IPropertyCurveOperationContext, operatio
     return {
         nodePath,
         propKey: operation.propKey,
+    };
+}
+
+function createDescriptor(
+    context: IPropertyCurveOperationContext,
+    target: IResolvedPropertyTarget,
+    value?: IAnimationValue,
+    trackKind?: PropertyKind,
+    track?: AnyTrack,
+): IPropertyTrackDescriptor | null {
+    const metadata = context.queryPropertyMetadata?.(target.nodePath, target.propKey) || undefined;
+    return createPropertyDescriptor(target.propKey, value, trackKind, track, metadata?.type, metadata?.valueCtor);
+}
+
+function queryTrackDescriptor(context: IPropertyCurveMetadataContext, track: AnyTrack): IPropertyTrackDescriptor | null {
+    const parsed = parsePropertyTrack(track);
+    return parsed ? applyPropertyMetadata(context, parsed.nodePath, parsed.descriptor, track) : null;
+}
+
+function applyPropertyMetadata(
+    context: IPropertyCurveMetadataContext,
+    nodePath: string,
+    descriptor: IPropertyTrackDescriptor,
+    track?: AnyTrack,
+): IPropertyTrackDescriptor {
+    const metadata = context.queryPropertyMetadata?.(nodePath, descriptor.propKey) || undefined;
+    if (!metadata) {
+        return descriptor;
+    }
+    return createPropertyDescriptor(descriptor.propKey, undefined, descriptor.kind, track, metadata.type, metadata.valueCtor) || {
+        ...descriptor,
+        type: metadata.type,
+        valueCtor: metadata.valueCtor,
     };
 }
 

--- a/src/core/scene/scene-process/service/animation/property-curve.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve.ts
@@ -1,36 +1,40 @@
-import { AnimationClip, Node, animation } from 'cc';
+import { AnimationClip, Node } from 'cc';
 import type {
     IAnimationCurveDump,
-    IAnimationCurveKeyDump,
-    IAnimationValue,
 } from '../../../common';
 import {
     getClipSample,
     normalizeFrames,
 } from './utils';
+import {
+    dumpPropertyTrack,
+    moveCurveKeys,
+    queryTargetCurves,
+    removeCurveKeys,
+    restoreTrackKeyframes,
+    setTrackKey,
+} from './property-curve-keyframe';
+import {
+    applyTrackExtrapolation,
+    createPropertyDescriptor,
+    createPropertyDescriptorFromDump,
+    createPropertyTrack,
+    findPropertyTrack,
+    getClipTracks,
+    normalizePath,
+    parsePropertyTrack,
+    removeSupportedPropertyTracks,
+    removeTrackIfEmpty,
+} from './property-curve-track';
+import type {
+    ICreatePropertyKeyOperation,
+    IPropertyTarget,
+} from './property-curve-types';
 
-type PropertyKey = 'position' | 'scale' | 'eulerAngles';
-type VectorTrack = InstanceType<typeof animation.VectorTrack>;
-
-interface IPropertyTarget {
-    nodePath?: string;
-    nodeUuid?: string;
+interface IResolvedPropertyTarget {
+    nodePath: string;
     propKey: string;
 }
-
-interface IVector3Value {
-    x: number;
-    y: number;
-    z: number;
-}
-
-const VECTOR_PROPERTY_TYPES: Record<PropertyKey, { displayName: string; type: { value: string } }> = {
-    position: { displayName: 'position', type: { value: 'cc.Vec3' } },
-    scale: { displayName: 'scale', type: { value: 'cc.Vec3' } },
-    eulerAngles: { displayName: 'rotation(eulerAngles)', type: { value: 'cc.Vec3' } },
-};
-
-const VECTOR_COMPONENTS = ['x', 'y', 'z'] as const;
 
 export interface IPropertyCurveOperationContext {
     rootNode: Node;
@@ -40,23 +44,19 @@ export interface IPropertyCurveOperationContext {
 export function dumpPropertyCurves(clip: AnimationClip): IAnimationCurveDump[] {
     const curves: IAnimationCurveDump[] = [];
     for (const track of getClipTracks(clip)) {
-        const target = parsePropertyTrack(track);
-        if (!target) {
+        const parsed = parsePropertyTrack(track);
+        if (!parsed) {
             continue;
         }
-        const info = VECTOR_PROPERTY_TYPES[target.propKey];
-        curves.push({
-            nodePath: target.nodePath,
-            key: target.propKey,
-            keyframes: dumpVectorTrackKeyframes(clip, track),
-            displayName: info.displayName,
-            name: info.displayName,
-            menuName: info.displayName,
-            type: info.type,
-            isCurveSupport: true,
-            preExtrap: Number((track.channels()[0].curve as any).preExtrapolation) || 0,
-            postExtrap: Number((track.channels()[0].curve as any).postExtrapolation) || 0,
-        });
+
+        const curveDump = dumpPropertyTrack(clip, track, parsed.descriptor);
+        if (curveDump) {
+            curves.push({
+                nodePath: parsed.nodePath,
+                key: parsed.descriptor.propKey,
+                ...curveDump,
+            });
+        }
     }
     return curves.sort((a, b) => `${a.nodePath}:${a.key}`.localeCompare(`${b.nodePath}:${b.key}`));
 }
@@ -64,28 +64,31 @@ export function dumpPropertyCurves(clip: AnimationClip): IAnimationCurveDump[] {
 export function createPropertyKey(
     clip: AnimationClip,
     context: IPropertyCurveOperationContext,
-    operation: IPropertyTarget & { frame: number; value: IAnimationValue },
+    operation: ICreatePropertyKeyOperation,
 ): boolean {
     const target = resolvePropertyTarget(context, operation);
-    const value = normalizeVector3Value(operation.value);
     const frame = Number(operation.frame);
-    if (!target || !value || !Number.isFinite(frame) || frame < 0) {
+    if (!target || !Number.isFinite(frame) || frame < 0) {
         return false;
     }
 
-    const track = findPropertyTrack(clip, target.nodePath, target.propKey) || createPropertyTrack(clip, target.nodePath, target.propKey);
-    const time = frame / getClipSample(clip);
-    const channels = track.channels();
-    for (let index = 0; index < VECTOR_COMPONENTS.length; index++) {
-        setCurveKey(channels[index].curve, time, value[VECTOR_COMPONENTS[index]]);
+    const existedTrack = findPropertyTrack(clip, target.nodePath, target.propKey);
+    const descriptor = existedTrack
+        ? parsePropertyTrack(existedTrack)?.descriptor
+        : createPropertyDescriptor(target.propKey, operation.value);
+    if (!descriptor) {
+        return false;
     }
-    return true;
+
+    const track = existedTrack || createPropertyTrack(clip, target.nodePath, descriptor);
+    const time = frame / getClipSample(clip);
+    return setTrackKey(track, descriptor, time, operation.value, operation.channel, operation.keyData);
 }
 
 export function removePropertyKey(
     clip: AnimationClip,
     context: IPropertyCurveOperationContext,
-    operation: IPropertyTarget & { frames: number[] },
+    operation: IPropertyTarget & { frames: number[]; channel?: string },
 ): boolean {
     const target = resolvePropertyTarget(context, operation);
     const frames = normalizeFrames(operation.frames);
@@ -94,13 +97,14 @@ export function removePropertyKey(
     }
 
     const track = findPropertyTrack(clip, target.nodePath, target.propKey);
-    if (!track) {
+    const descriptor = track ? parsePropertyTrack(track)?.descriptor : null;
+    if (!track || !descriptor) {
         return false;
     }
 
     let changed = false;
-    for (const channel of track.channels().slice(0, VECTOR_COMPONENTS.length)) {
-        changed = removeCurveKeys(clip, channel.curve, frames) || changed;
+    for (const curve of queryTargetCurves(track, descriptor, operation.channel)) {
+        changed = removeCurveKeys(clip, curve, frames) || changed;
     }
     removeTrackIfEmpty(clip, track);
     return changed;
@@ -109,7 +113,7 @@ export function removePropertyKey(
 export function movePropertyKeys(
     clip: AnimationClip,
     context: IPropertyCurveOperationContext,
-    operation: IPropertyTarget & { frames: number[]; offset: number },
+    operation: IPropertyTarget & { frames: number[]; offset: number; channel?: string },
 ): boolean {
     const target = resolvePropertyTarget(context, operation);
     const frames = normalizeFrames(operation.frames);
@@ -119,13 +123,14 @@ export function movePropertyKeys(
     }
 
     const track = findPropertyTrack(clip, target.nodePath, target.propKey);
-    if (!track) {
+    const descriptor = track ? parsePropertyTrack(track)?.descriptor : null;
+    if (!track || !descriptor) {
         return false;
     }
 
     let changed = false;
-    for (const channel of track.channels().slice(0, VECTOR_COMPONENTS.length)) {
-        changed = moveCurveKeys(clip, channel.curve, frames, offset) || changed;
+    for (const curve of queryTargetCurves(track, descriptor, operation.channel)) {
+        changed = moveCurveKeys(clip, curve, frames, offset) || changed;
     }
     return changed;
 }
@@ -134,66 +139,28 @@ export function replacePropertyCurves(clip: AnimationClip, curves: IAnimationCur
     removeSupportedPropertyTracks(clip);
 
     for (const curve of curves) {
-        if (!isPropertyKey(curve.key)) {
-            continue;
-        }
-        if (!Array.isArray(curve.keyframes) || curve.keyframes.length === 0) {
+        const descriptor = createPropertyDescriptorFromDump(curve);
+        if (!descriptor) {
             continue;
         }
 
-        const track = createPropertyTrack(clip, curve.nodePath, curve.key);
-        for (const channel of track.channels().slice(0, VECTOR_COMPONENTS.length)) {
-            (channel.curve as any).preExtrapolation = Number(curve.preExtrap) || 0;
-            (channel.curve as any).postExtrapolation = Number(curve.postExtrap) || 0;
+        const keyframes = Array.isArray(curve.keyframes) ? [...curve.keyframes].sort((a, b) => a.frame - b.frame) : [];
+        const channelDumps = Array.isArray(curve.channels) ? curve.channels : [];
+        if (keyframes.length === 0 && channelDumps.length === 0) {
+            continue;
         }
 
-        const keyframes = [...curve.keyframes].sort((a, b) => a.frame - b.frame);
-        for (const keyframe of keyframes) {
-            const value = normalizeVector3Value(keyframe.dump.value);
-            if (!value) {
-                return false;
-            }
-            const time = keyframe.frame / getClipSample(clip);
-            const channels = track.channels();
-            for (let index = 0; index < VECTOR_COMPONENTS.length; index++) {
-                setCurveKey(channels[index].curve, time, value[VECTOR_COMPONENTS[index]]);
-            }
+        const track = createPropertyTrack(clip, curve.nodePath, descriptor);
+        applyTrackExtrapolation(track, curve.preExtrap, curve.postExtrap);
+        if (!restoreTrackKeyframes(clip, track, descriptor, keyframes, channelDumps)) {
+            return false;
         }
     }
 
     return true;
 }
 
-function dumpVectorTrackKeyframes(clip: AnimationClip, track: VectorTrack): IAnimationCurveKeyDump[] {
-    const sample = getClipSample(clip);
-    const channels = track.channels();
-    const times = new Set<number>();
-    for (const channel of channels.slice(0, VECTOR_COMPONENTS.length)) {
-        for (const time of channel.curve.times()) {
-            times.add(time);
-        }
-    }
-
-    return Array.from(times)
-        .sort((a, b) => a - b)
-        .map((time) => ({
-            frame: Math.round(time * sample),
-            dump: {
-                value: {
-                    x: normalizeNumber(channels[0].curve.evaluate(time)),
-                    y: normalizeNumber(channels[1].curve.evaluate(time)),
-                    z: normalizeNumber(channels[2].curve.evaluate(time)),
-                },
-                type: 'cc.Vec3',
-            },
-        }));
-}
-
-function resolvePropertyTarget(context: IPropertyCurveOperationContext, operation: IPropertyTarget): { nodePath: string; propKey: PropertyKey } | null {
-    if (!isPropertyKey(operation.propKey)) {
-        return null;
-    }
-
+function resolvePropertyTarget(context: IPropertyCurveOperationContext, operation: IPropertyTarget): IResolvedPropertyTarget | null {
     const nodePath = resolveRelativeNodePath(context, operation);
     if (nodePath === null) {
         return null;
@@ -237,146 +204,4 @@ function findRelativeNodePathByUuid(node: Node, uuid: string, prefix = ''): stri
         }
     }
     return null;
-}
-
-function findPropertyTrack(clip: AnimationClip, nodePath: string, propKey: PropertyKey): VectorTrack | null {
-    for (const track of getClipTracks(clip)) {
-        const target = parsePropertyTrack(track);
-        if (target?.nodePath === nodePath && target.propKey === propKey) {
-            return track;
-        }
-    }
-    return null;
-}
-
-function createPropertyTrack(clip: AnimationClip, nodePath: string, propKey: PropertyKey): VectorTrack {
-    const track = new animation.VectorTrack();
-    const path = new animation.TrackPath();
-    if (nodePath) {
-        path.toHierarchy(nodePath);
-    }
-    path.toProperty(propKey);
-    track.path = path;
-    track.componentsCount = 3;
-    clip.addTrack(track);
-    return track;
-}
-
-function parsePropertyTrack(track: unknown): { nodePath: string; propKey: PropertyKey } | null {
-    if (!(track instanceof animation.VectorTrack) || track.componentsCount !== 3) {
-        return null;
-    }
-
-    const path = track.path;
-    let index = 0;
-    let nodePath = '';
-    while (index < path.length && path.isHierarchyAt(index)) {
-        const segment = normalizePath(path.parseHierarchyAt(index));
-        if (segment) {
-            nodePath = nodePath ? `${nodePath}/${segment}` : segment;
-        }
-        index++;
-    }
-
-    if (index !== path.length - 1 || !path.isPropertyAt(index)) {
-        return null;
-    }
-
-    const propKey = path.parsePropertyAt(index);
-    return isPropertyKey(propKey) ? { nodePath, propKey } : null;
-}
-
-function removeSupportedPropertyTracks(clip: AnimationClip): void {
-    for (let index = clip.tracksCount - 1; index >= 0; index--) {
-        if (parsePropertyTrack(clip.getTrack(index))) {
-            clip.removeTrack(index);
-        }
-    }
-}
-
-function removeTrackIfEmpty(clip: AnimationClip, track: VectorTrack): void {
-    if (track.channels().slice(0, VECTOR_COMPONENTS.length).some((channel) => channel.curve.keyFramesCount > 0)) {
-        return;
-    }
-
-    for (let index = clip.tracksCount - 1; index >= 0; index--) {
-        if (clip.getTrack(index) === track) {
-            clip.removeTrack(index);
-            return;
-        }
-    }
-}
-
-function setCurveKey(curve: ReturnType<VectorTrack['channels']>[number]['curve'], time: number, value: number): void {
-    const keyframes = Array.from(curve.keyframes())
-        .filter(([keyTime]) => !isSameTime(keyTime, time))
-        .concat([[time, { value } as any]]);
-    keyframes.sort((a, b) => a[0] - b[0]);
-    curve.assignSorted(keyframes as any);
-}
-
-function removeCurveKeys(clip: AnimationClip, curve: ReturnType<VectorTrack['channels']>[number]['curve'], frames: number[]): boolean {
-    const sample = getClipSample(clip);
-    const before = Array.from(curve.keyframes());
-    const after = before.filter(([time]) => !frames.includes(Math.round(time * sample)));
-    if (after.length === before.length) {
-        return false;
-    }
-    curve.assignSorted(after);
-    return true;
-}
-
-function moveCurveKeys(clip: AnimationClip, curve: ReturnType<VectorTrack['channels']>[number]['curve'], frames: number[], offset: number): boolean {
-    const sample = getClipSample(clip);
-    let changed = false;
-    const keyframes = Array.from(curve.keyframes()).map(([time, value]) => {
-        const frame = Math.round(time * sample);
-        if (!frames.includes(frame)) {
-            return { frame, value };
-        }
-        changed = true;
-        return { frame: Math.max(0, frame + offset), value };
-    });
-
-    if (!changed) {
-        return false;
-    }
-    keyframes.sort((a, b) => a.frame - b.frame);
-    curve.assignSorted(keyframes.map((keyframe) => [keyframe.frame / sample, keyframe.value] as [number, any]));
-    return true;
-}
-
-function getClipTracks(clip: AnimationClip): any[] {
-    return Array.from((clip as any).tracks || []);
-}
-
-function isPropertyKey(value: unknown): value is PropertyKey {
-    return value === 'position' || value === 'scale' || value === 'eulerAngles';
-}
-
-function normalizeVector3Value(value: IAnimationValue): IVector3Value | null {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
-        return null;
-    }
-
-    const x = Number((value as any).x);
-    const y = Number((value as any).y);
-    const z = Number((value as any).z);
-    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
-        return null;
-    }
-    return { x, y, z };
-}
-
-function normalizeNumber(value: unknown): number {
-    const numberValue = Number(value);
-    return Number.isFinite(numberValue) ? numberValue : 0;
-}
-
-function normalizePath(path: string): string {
-    return path.replace(/^\/+|\/+$/g, '');
-}
-
-function isSameTime(left: number, right: number): boolean {
-    return Math.abs(left - right) <= 1e-6;
 }

--- a/src/core/scene/scene-process/service/animation/property-curve.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve.ts
@@ -1,6 +1,7 @@
 import { AnimationClip, Node } from 'cc';
 import type {
     IAnimationCurveDump,
+    IAnimationValue,
 } from '../../../common';
 import {
     getClipSample,
@@ -8,6 +9,7 @@ import {
 } from './utils';
 import {
     dumpPropertyTrack,
+    copyCurveKeysTo,
     moveCurveKeys,
     queryTargetCurves,
     removeCurveKeys,
@@ -23,12 +25,17 @@ import {
     getClipTracks,
     normalizePath,
     parsePropertyTrack,
+    queryFirstRealCurve,
     removeSupportedPropertyTracks,
     removeTrackIfEmpty,
 } from './property-curve-track';
 import type {
+    ICopyPropertyKeysOperation,
     ICreatePropertyKeyOperation,
+    IMovePropertyKeysOperation,
+    IPropertyKeyFramesOperation,
     IPropertyTarget,
+    ISetPropertyCurveExtrapolationOperation,
 } from './property-curve-types';
 
 interface IResolvedPropertyTarget {
@@ -82,13 +89,44 @@ export function createPropertyKey(
 
     const track = existedTrack || createPropertyTrack(clip, target.nodePath, descriptor);
     const time = frame / getClipSample(clip);
-    return setTrackKey(track, descriptor, time, operation.value, operation.channel, operation.keyData);
+    return setTrackKey(track, descriptor, time, operation.value, operation.channel, operation.keyData ?? operation.curveData);
+}
+
+export function addPropertyCurve(
+    clip: AnimationClip,
+    context: IPropertyCurveOperationContext,
+    operation: IPropertyTarget & { value?: IAnimationValue },
+): boolean {
+    const target = resolvePropertyTarget(context, operation);
+    if (!target) {
+        return false;
+    }
+
+    if (findPropertyTrack(clip, target.nodePath, target.propKey)) {
+        return true;
+    }
+
+    const descriptor = createPropertyDescriptor(target.propKey, operation.value);
+    if (!descriptor) {
+        return false;
+    }
+
+    createPropertyTrack(clip, target.nodePath, descriptor);
+    return true;
+}
+
+export function updatePropertyKey(
+    clip: AnimationClip,
+    context: IPropertyCurveOperationContext,
+    operation: ICreatePropertyKeyOperation,
+): boolean {
+    return createPropertyKey(clip, context, operation);
 }
 
 export function removePropertyKey(
     clip: AnimationClip,
     context: IPropertyCurveOperationContext,
-    operation: IPropertyTarget & { frames: number[]; channel?: string },
+    operation: IPropertyKeyFramesOperation,
 ): boolean {
     const target = resolvePropertyTarget(context, operation);
     const frames = normalizeFrames(operation.frames);
@@ -110,10 +148,18 @@ export function removePropertyKey(
     return changed;
 }
 
+export function removePropertyKeys(
+    clip: AnimationClip,
+    context: IPropertyCurveOperationContext,
+    operation: IPropertyKeyFramesOperation,
+): boolean {
+    return removePropertyKey(clip, context, operation);
+}
+
 export function movePropertyKeys(
     clip: AnimationClip,
     context: IPropertyCurveOperationContext,
-    operation: IPropertyTarget & { frames: number[]; offset: number; channel?: string },
+    operation: IMovePropertyKeysOperation,
 ): boolean {
     const target = resolvePropertyTarget(context, operation);
     const frames = normalizeFrames(operation.frames);
@@ -133,6 +179,50 @@ export function movePropertyKeys(
         changed = moveCurveKeys(clip, curve, frames, offset) || changed;
     }
     return changed;
+}
+
+export function copyPropertyKeysTo(
+    clip: AnimationClip,
+    context: IPropertyCurveOperationContext,
+    operation: ICopyPropertyKeysOperation,
+): boolean {
+    const target = resolvePropertyTarget(context, operation);
+    const frames = normalizeFrames(operation.frames);
+    const dstFrame = Number(operation.dstFrame);
+    if (!target || frames.length === 0 || !Number.isFinite(dstFrame)) {
+        return false;
+    }
+
+    const track = findPropertyTrack(clip, target.nodePath, target.propKey);
+    const descriptor = track ? parsePropertyTrack(track)?.descriptor : null;
+    if (!track || !descriptor) {
+        return false;
+    }
+
+    let changed = false;
+    for (const curve of queryTargetCurves(track, descriptor, operation.channel)) {
+        changed = copyCurveKeysTo(clip, curve, frames, dstFrame) || changed;
+    }
+    return changed;
+}
+
+export function setPropertyCurveExtrapolation(
+    clip: AnimationClip,
+    context: IPropertyCurveOperationContext,
+    operation: ISetPropertyCurveExtrapolationOperation,
+): boolean {
+    const target = resolvePropertyTarget(context, operation);
+    if (!target) {
+        return false;
+    }
+
+    const track = findPropertyTrack(clip, target.nodePath, target.propKey);
+    if (!track || !queryFirstRealCurve(track)) {
+        return false;
+    }
+
+    applyTrackExtrapolation(track, operation.preExtrap, operation.postExtrap);
+    return true;
 }
 
 export function replacePropertyCurves(clip: AnimationClip, curves: IAnimationCurveDump[]): boolean {

--- a/src/core/scene/scene-process/service/animation/property-curve.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve.ts
@@ -17,6 +17,7 @@ import {
     setTrackKey,
     updateTrackKey,
 } from './property-curve-keyframe';
+import type { IDumpRealKeyDataOptions } from './real-curve-key-data';
 import {
     applyTrackExtrapolation,
     createPropertyDescriptor,
@@ -37,6 +38,7 @@ import type {
     IPropertyKeyFramesOperation,
     IPropertyTarget,
     ISetPropertyCurveExtrapolationOperation,
+    IUpdatePropertyKeyDataOperation,
 } from './property-curve-types';
 
 interface IResolvedPropertyTarget {
@@ -49,7 +51,7 @@ export interface IPropertyCurveOperationContext {
     rootPath: string;
 }
 
-export function dumpPropertyCurves(clip: AnimationClip): IAnimationCurveDump[] {
+export function dumpPropertyCurves(clip: AnimationClip, options: IDumpRealKeyDataOptions = {}): IAnimationCurveDump[] {
     const curves: IAnimationCurveDump[] = [];
     for (const track of getClipTracks(clip)) {
         const parsed = parsePropertyTrack(track);
@@ -57,7 +59,7 @@ export function dumpPropertyCurves(clip: AnimationClip): IAnimationCurveDump[] {
             continue;
         }
 
-        const curveDump = dumpPropertyTrack(clip, track, parsed.descriptor);
+        const curveDump = dumpPropertyTrack(clip, track, parsed.descriptor, options);
         if (curveDump) {
             curves.push({
                 nodePath: parsed.nodePath,
@@ -134,6 +136,26 @@ export function updatePropertyKey(
     }
 
     return createPropertyKey(clip, context, operation);
+}
+
+export function updatePropertyKeyData(
+    clip: AnimationClip,
+    context: IPropertyCurveOperationContext,
+    operation: IUpdatePropertyKeyDataOperation,
+): boolean {
+    const target = resolvePropertyTarget(context, operation);
+    const frame = Number(operation.frame);
+    if (!target || !Number.isFinite(frame) || frame < 0) {
+        return false;
+    }
+
+    const track = findPropertyTrack(clip, target.nodePath, target.propKey);
+    const descriptor = track ? parsePropertyTrack(track)?.descriptor : null;
+    if (!track || !descriptor) {
+        return false;
+    }
+
+    return updateTrackKey(track, descriptor, frame / getClipSample(clip), undefined, operation.channel, operation.keyData ?? operation.curveData);
 }
 
 export function removePropertyKey(

--- a/src/core/scene/scene-process/service/animation/property-curve.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve.ts
@@ -1,0 +1,382 @@
+import { AnimationClip, Node, animation } from 'cc';
+import type {
+    IAnimationCurveDump,
+    IAnimationCurveKeyDump,
+    IAnimationValue,
+} from '../../../common';
+import {
+    getClipSample,
+    normalizeFrames,
+} from './utils';
+
+type PropertyKey = 'position' | 'scale' | 'eulerAngles';
+type VectorTrack = InstanceType<typeof animation.VectorTrack>;
+
+interface IPropertyTarget {
+    nodePath?: string;
+    nodeUuid?: string;
+    propKey: string;
+}
+
+interface IVector3Value {
+    x: number;
+    y: number;
+    z: number;
+}
+
+const VECTOR_PROPERTY_TYPES: Record<PropertyKey, { displayName: string; type: { value: string } }> = {
+    position: { displayName: 'position', type: { value: 'cc.Vec3' } },
+    scale: { displayName: 'scale', type: { value: 'cc.Vec3' } },
+    eulerAngles: { displayName: 'rotation(eulerAngles)', type: { value: 'cc.Vec3' } },
+};
+
+const VECTOR_COMPONENTS = ['x', 'y', 'z'] as const;
+
+export interface IPropertyCurveOperationContext {
+    rootNode: Node;
+    rootPath: string;
+}
+
+export function dumpPropertyCurves(clip: AnimationClip): IAnimationCurveDump[] {
+    const curves: IAnimationCurveDump[] = [];
+    for (const track of getClipTracks(clip)) {
+        const target = parsePropertyTrack(track);
+        if (!target) {
+            continue;
+        }
+        const info = VECTOR_PROPERTY_TYPES[target.propKey];
+        curves.push({
+            nodePath: target.nodePath,
+            key: target.propKey,
+            keyframes: dumpVectorTrackKeyframes(clip, track),
+            displayName: info.displayName,
+            name: info.displayName,
+            menuName: info.displayName,
+            type: info.type,
+            isCurveSupport: true,
+            preExtrap: Number((track.channels()[0].curve as any).preExtrapolation) || 0,
+            postExtrap: Number((track.channels()[0].curve as any).postExtrapolation) || 0,
+        });
+    }
+    return curves.sort((a, b) => `${a.nodePath}:${a.key}`.localeCompare(`${b.nodePath}:${b.key}`));
+}
+
+export function createPropertyKey(
+    clip: AnimationClip,
+    context: IPropertyCurveOperationContext,
+    operation: IPropertyTarget & { frame: number; value: IAnimationValue },
+): boolean {
+    const target = resolvePropertyTarget(context, operation);
+    const value = normalizeVector3Value(operation.value);
+    const frame = Number(operation.frame);
+    if (!target || !value || !Number.isFinite(frame) || frame < 0) {
+        return false;
+    }
+
+    const track = findPropertyTrack(clip, target.nodePath, target.propKey) || createPropertyTrack(clip, target.nodePath, target.propKey);
+    const time = frame / getClipSample(clip);
+    const channels = track.channels();
+    for (let index = 0; index < VECTOR_COMPONENTS.length; index++) {
+        setCurveKey(channels[index].curve, time, value[VECTOR_COMPONENTS[index]]);
+    }
+    return true;
+}
+
+export function removePropertyKey(
+    clip: AnimationClip,
+    context: IPropertyCurveOperationContext,
+    operation: IPropertyTarget & { frames: number[] },
+): boolean {
+    const target = resolvePropertyTarget(context, operation);
+    const frames = normalizeFrames(operation.frames);
+    if (!target || frames.length === 0) {
+        return false;
+    }
+
+    const track = findPropertyTrack(clip, target.nodePath, target.propKey);
+    if (!track) {
+        return false;
+    }
+
+    let changed = false;
+    for (const channel of track.channels().slice(0, VECTOR_COMPONENTS.length)) {
+        changed = removeCurveKeys(clip, channel.curve, frames) || changed;
+    }
+    removeTrackIfEmpty(clip, track);
+    return changed;
+}
+
+export function movePropertyKeys(
+    clip: AnimationClip,
+    context: IPropertyCurveOperationContext,
+    operation: IPropertyTarget & { frames: number[]; offset: number },
+): boolean {
+    const target = resolvePropertyTarget(context, operation);
+    const frames = normalizeFrames(operation.frames);
+    const offset = Number(operation.offset);
+    if (!target || frames.length === 0 || !Number.isFinite(offset)) {
+        return false;
+    }
+
+    const track = findPropertyTrack(clip, target.nodePath, target.propKey);
+    if (!track) {
+        return false;
+    }
+
+    let changed = false;
+    for (const channel of track.channels().slice(0, VECTOR_COMPONENTS.length)) {
+        changed = moveCurveKeys(clip, channel.curve, frames, offset) || changed;
+    }
+    return changed;
+}
+
+export function replacePropertyCurves(clip: AnimationClip, curves: IAnimationCurveDump[]): boolean {
+    removeSupportedPropertyTracks(clip);
+
+    for (const curve of curves) {
+        if (!isPropertyKey(curve.key)) {
+            continue;
+        }
+        if (!Array.isArray(curve.keyframes) || curve.keyframes.length === 0) {
+            continue;
+        }
+
+        const track = createPropertyTrack(clip, curve.nodePath, curve.key);
+        for (const channel of track.channels().slice(0, VECTOR_COMPONENTS.length)) {
+            (channel.curve as any).preExtrapolation = Number(curve.preExtrap) || 0;
+            (channel.curve as any).postExtrapolation = Number(curve.postExtrap) || 0;
+        }
+
+        const keyframes = [...curve.keyframes].sort((a, b) => a.frame - b.frame);
+        for (const keyframe of keyframes) {
+            const value = normalizeVector3Value(keyframe.dump.value);
+            if (!value) {
+                return false;
+            }
+            const time = keyframe.frame / getClipSample(clip);
+            const channels = track.channels();
+            for (let index = 0; index < VECTOR_COMPONENTS.length; index++) {
+                setCurveKey(channels[index].curve, time, value[VECTOR_COMPONENTS[index]]);
+            }
+        }
+    }
+
+    return true;
+}
+
+function dumpVectorTrackKeyframes(clip: AnimationClip, track: VectorTrack): IAnimationCurveKeyDump[] {
+    const sample = getClipSample(clip);
+    const channels = track.channels();
+    const times = new Set<number>();
+    for (const channel of channels.slice(0, VECTOR_COMPONENTS.length)) {
+        for (const time of channel.curve.times()) {
+            times.add(time);
+        }
+    }
+
+    return Array.from(times)
+        .sort((a, b) => a - b)
+        .map((time) => ({
+            frame: Math.round(time * sample),
+            dump: {
+                value: {
+                    x: normalizeNumber(channels[0].curve.evaluate(time)),
+                    y: normalizeNumber(channels[1].curve.evaluate(time)),
+                    z: normalizeNumber(channels[2].curve.evaluate(time)),
+                },
+                type: 'cc.Vec3',
+            },
+        }));
+}
+
+function resolvePropertyTarget(context: IPropertyCurveOperationContext, operation: IPropertyTarget): { nodePath: string; propKey: PropertyKey } | null {
+    if (!isPropertyKey(operation.propKey)) {
+        return null;
+    }
+
+    const nodePath = resolveRelativeNodePath(context, operation);
+    if (nodePath === null) {
+        return null;
+    }
+
+    return {
+        nodePath,
+        propKey: operation.propKey,
+    };
+}
+
+function resolveRelativeNodePath(context: IPropertyCurveOperationContext, operation: IPropertyTarget): string | null {
+    if (operation.nodeUuid) {
+        return findRelativeNodePathByUuid(context.rootNode, operation.nodeUuid);
+    }
+
+    const nodePath = normalizePath(operation.nodePath || '');
+    if (!nodePath) {
+        return '';
+    }
+
+    const rootPath = normalizePath(context.rootPath);
+    if (nodePath === rootPath) {
+        return '';
+    }
+    if (rootPath && nodePath.startsWith(`${rootPath}/`)) {
+        return nodePath.slice(rootPath.length + 1);
+    }
+    return context.rootNode.getChildByPath(nodePath) ? nodePath : null;
+}
+
+function findRelativeNodePathByUuid(node: Node, uuid: string, prefix = ''): string | null {
+    if (node.uuid === uuid) {
+        return prefix;
+    }
+    for (const child of node.children) {
+        const path = prefix ? `${prefix}/${child.name}` : child.name;
+        const result = findRelativeNodePathByUuid(child, uuid, path);
+        if (result !== null) {
+            return result;
+        }
+    }
+    return null;
+}
+
+function findPropertyTrack(clip: AnimationClip, nodePath: string, propKey: PropertyKey): VectorTrack | null {
+    for (const track of getClipTracks(clip)) {
+        const target = parsePropertyTrack(track);
+        if (target?.nodePath === nodePath && target.propKey === propKey) {
+            return track;
+        }
+    }
+    return null;
+}
+
+function createPropertyTrack(clip: AnimationClip, nodePath: string, propKey: PropertyKey): VectorTrack {
+    const track = new animation.VectorTrack();
+    const path = new animation.TrackPath();
+    if (nodePath) {
+        path.toHierarchy(nodePath);
+    }
+    path.toProperty(propKey);
+    track.path = path;
+    track.componentsCount = 3;
+    clip.addTrack(track);
+    return track;
+}
+
+function parsePropertyTrack(track: unknown): { nodePath: string; propKey: PropertyKey } | null {
+    if (!(track instanceof animation.VectorTrack) || track.componentsCount !== 3) {
+        return null;
+    }
+
+    const path = track.path;
+    let index = 0;
+    let nodePath = '';
+    while (index < path.length && path.isHierarchyAt(index)) {
+        const segment = normalizePath(path.parseHierarchyAt(index));
+        if (segment) {
+            nodePath = nodePath ? `${nodePath}/${segment}` : segment;
+        }
+        index++;
+    }
+
+    if (index !== path.length - 1 || !path.isPropertyAt(index)) {
+        return null;
+    }
+
+    const propKey = path.parsePropertyAt(index);
+    return isPropertyKey(propKey) ? { nodePath, propKey } : null;
+}
+
+function removeSupportedPropertyTracks(clip: AnimationClip): void {
+    for (let index = clip.tracksCount - 1; index >= 0; index--) {
+        if (parsePropertyTrack(clip.getTrack(index))) {
+            clip.removeTrack(index);
+        }
+    }
+}
+
+function removeTrackIfEmpty(clip: AnimationClip, track: VectorTrack): void {
+    if (track.channels().slice(0, VECTOR_COMPONENTS.length).some((channel) => channel.curve.keyFramesCount > 0)) {
+        return;
+    }
+
+    for (let index = clip.tracksCount - 1; index >= 0; index--) {
+        if (clip.getTrack(index) === track) {
+            clip.removeTrack(index);
+            return;
+        }
+    }
+}
+
+function setCurveKey(curve: ReturnType<VectorTrack['channels']>[number]['curve'], time: number, value: number): void {
+    const keyframes = Array.from(curve.keyframes())
+        .filter(([keyTime]) => !isSameTime(keyTime, time))
+        .concat([[time, { value } as any]]);
+    keyframes.sort((a, b) => a[0] - b[0]);
+    curve.assignSorted(keyframes as any);
+}
+
+function removeCurveKeys(clip: AnimationClip, curve: ReturnType<VectorTrack['channels']>[number]['curve'], frames: number[]): boolean {
+    const sample = getClipSample(clip);
+    const before = Array.from(curve.keyframes());
+    const after = before.filter(([time]) => !frames.includes(Math.round(time * sample)));
+    if (after.length === before.length) {
+        return false;
+    }
+    curve.assignSorted(after);
+    return true;
+}
+
+function moveCurveKeys(clip: AnimationClip, curve: ReturnType<VectorTrack['channels']>[number]['curve'], frames: number[], offset: number): boolean {
+    const sample = getClipSample(clip);
+    let changed = false;
+    const keyframes = Array.from(curve.keyframes()).map(([time, value]) => {
+        const frame = Math.round(time * sample);
+        if (!frames.includes(frame)) {
+            return { frame, value };
+        }
+        changed = true;
+        return { frame: Math.max(0, frame + offset), value };
+    });
+
+    if (!changed) {
+        return false;
+    }
+    keyframes.sort((a, b) => a.frame - b.frame);
+    curve.assignSorted(keyframes.map((keyframe) => [keyframe.frame / sample, keyframe.value] as [number, any]));
+    return true;
+}
+
+function getClipTracks(clip: AnimationClip): any[] {
+    return Array.from((clip as any).tracks || []);
+}
+
+function isPropertyKey(value: unknown): value is PropertyKey {
+    return value === 'position' || value === 'scale' || value === 'eulerAngles';
+}
+
+function normalizeVector3Value(value: IAnimationValue): IVector3Value | null {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return null;
+    }
+
+    const x = Number((value as any).x);
+    const y = Number((value as any).y);
+    const z = Number((value as any).z);
+    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
+        return null;
+    }
+    return { x, y, z };
+}
+
+function normalizeNumber(value: unknown): number {
+    const numberValue = Number(value);
+    return Number.isFinite(numberValue) ? numberValue : 0;
+}
+
+function normalizePath(path: string): string {
+    return path.replace(/^\/+|\/+$/g, '');
+}
+
+function isSameTime(left: number, right: number): boolean {
+    return Math.abs(left - right) <= 1e-6;
+}

--- a/src/core/scene/scene-process/service/animation/property-curve.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve.ts
@@ -15,6 +15,7 @@ import {
     removeCurveKeys,
     restoreTrackKeyframes,
     setTrackKey,
+    updateTrackKey,
 } from './property-curve-keyframe';
 import {
     applyTrackExtrapolation,
@@ -120,6 +121,18 @@ export function updatePropertyKey(
     context: IPropertyCurveOperationContext,
     operation: ICreatePropertyKeyOperation,
 ): boolean {
+    const target = resolvePropertyTarget(context, operation);
+    const frame = Number(operation.frame);
+    if (!target || !Number.isFinite(frame) || frame < 0) {
+        return false;
+    }
+
+    const track = findPropertyTrack(clip, target.nodePath, target.propKey);
+    const descriptor = track ? parsePropertyTrack(track)?.descriptor : null;
+    if (track && descriptor) {
+        return updateTrackKey(track, descriptor, frame / getClipSample(clip), operation.value, operation.channel, operation.keyData ?? operation.curveData);
+    }
+
     return createPropertyKey(clip, context, operation);
 }
 

--- a/src/core/scene/scene-process/service/animation/property-curve.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve.ts
@@ -29,7 +29,6 @@ import {
     parsePropertyTrack,
     queryFirstRealCurve,
     removeSupportedPropertyTracks,
-    removeTrackIfEmpty,
 } from './property-curve-track';
 import type {
     ICopyPropertyKeysOperation,
@@ -179,7 +178,6 @@ export function removePropertyKey(
     for (const curve of queryTargetCurves(track, descriptor, operation.channel)) {
         changed = removeCurveKeys(clip, curve, frames) || changed;
     }
-    removeTrackIfEmpty(clip, track);
     return changed;
 }
 
@@ -189,6 +187,31 @@ export function removePropertyKeys(
     operation: IPropertyKeyFramesOperation,
 ): boolean {
     return removePropertyKey(clip, context, operation);
+}
+
+export function removePropertyCurve(
+    clip: AnimationClip,
+    context: IPropertyCurveOperationContext,
+    operation: IPropertyTarget,
+): boolean {
+    const target = resolvePropertyTarget(context, operation);
+    if (!target) {
+        return false;
+    }
+
+    const track = findPropertyTrack(clip, target.nodePath, target.propKey);
+    if (!track) {
+        return false;
+    }
+
+    const tracks = getClipTracks(clip);
+    for (let index = tracks.length - 1; index >= 0; index--) {
+        if (clip.getTrack(index) === track) {
+            clip.removeTrack(index);
+            return true;
+        }
+    }
+    return false;
 }
 
 export function movePropertyKeys(

--- a/src/core/scene/scene-process/service/animation/property-curve.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve.ts
@@ -81,7 +81,7 @@ export function dumpPropertyCurves(clip: AnimationClip, options: IDumpRealKeyDat
             });
         }
     }
-    return curves.sort((a, b) => `${a.nodePath}:${a.key}`.localeCompare(`${b.nodePath}:${b.key}`));
+    return curves;
 }
 
 export function createPropertyKey(

--- a/src/core/scene/scene-process/service/animation/property-menu.ts
+++ b/src/core/scene/scene-process/service/animation/property-menu.ts
@@ -1,0 +1,21 @@
+import type { IAnimationPropertyInfo } from '../../../common';
+
+export const DEFAULT_PROPERTIES: IAnimationPropertyInfo[] = [
+    createPropertyInfo('position', 'cc.Vec3'),
+    createPropertyInfo('eulerAngles', 'cc.Vec3', 'rotation(eulerAngles)'),
+    createPropertyInfo('rotation', 'cc.Quat', 'rotation(quaternion)'),
+    createPropertyInfo('scale', 'cc.Vec3'),
+];
+
+export const ACTIVE_PROPERTY = createPropertyInfo('active', 'cc.Boolean');
+
+function createPropertyInfo(name: string, type: string, displayName = name, comp?: string): IAnimationPropertyInfo {
+    return {
+        name,
+        key: comp ? `${comp}.${name}` : name,
+        displayName,
+        type: { value: type },
+        menuName: displayName,
+        comp,
+    };
+}

--- a/src/core/scene/scene-process/service/animation/property-metadata.ts
+++ b/src/core/scene/scene-process/service/animation/property-metadata.ts
@@ -2,6 +2,7 @@ import { CCClass, Component, Node, js } from 'cc';
 import type {
     IAnimationPropertyInfo,
 } from '../../../common';
+import { getConstructor, getTypeName } from '../dump/utils';
 import type { IAnimationPropertyMetadata } from './property-curve';
 
 export function queryComponentAnimableProperties(component: Component): IAnimationPropertyInfo[] {
@@ -64,46 +65,20 @@ function queryAnimablePropertyType(component: Record<string, unknown>, prop: str
 }
 
 function queryAnimablePropertyTypeFromAttr(component: Record<string, unknown>, prop: string, attr: any): string {
-    const ctorType = queryAttrCtorType(attr);
-    if (ctorType) {
-        return ctorType;
-    }
-    const type = attr.type;
-    if (typeof type === 'string') {
-        return type;
-    }
-    if (type instanceof (CCClass.Attr as any).PrimitiveType) {
-        return type.name;
-    }
-    if (typeof type === 'function') {
-        return js.getClassName(type);
-    }
     const value = component[prop];
-    if (typeof value === 'number') {
-        return 'cc.Number';
+    if (!attr.ctor && attr.type) {
+        return normalizeAttrType(attr.type);
     }
-    if (typeof value === 'boolean') {
-        return 'cc.Boolean';
-    }
-    if (typeof value === 'string') {
-        return 'cc.String';
-    }
-    if (value && typeof value === 'object') {
-        return queryAnimableObjectPropertyType(value);
-    }
-    return '';
-}
 
-function queryAnimableObjectPropertyType(value: object): string {
-    if (value instanceof Node || value instanceof Component || Array.isArray(value)) {
+    const ctor = getConstructor(value, attr);
+    if (isNodeOrComponentCtor(ctor)) {
         return '';
     }
-    const ctor = (value as { constructor?: Function }).constructor;
-    if (!ctor || ctor === Object) {
+    const type = getTypeName(ctor);
+    if (!type || type === 'Object' || type === 'Unknown') {
         return '';
     }
-    const type = js.getClassName(ctor);
-    return type && type !== 'Object' ? type : '';
+    return normalizePrimitiveTypeName(type);
 }
 
 function isAnimablePropertyAttr(attr: any): boolean {
@@ -123,13 +98,29 @@ function queryPropertyAttr(component: Record<string, unknown>, prop: string): an
     return CCClass.attr(component as any, prop) || CCClass.attr((component as any).constructor, prop);
 }
 
-function queryAttrCtorType(attr: any): string {
-    const ctor = attr?.ctor;
-    if (typeof ctor !== 'function') {
-        return '';
+function normalizeAttrType(type: unknown): string {
+    if (type instanceof (CCClass.Attr as any).PrimitiveType) {
+        return normalizePrimitiveTypeName((type as { name: string }).name);
     }
-    const type = js.getClassName(ctor);
-    return type && type !== 'Object' ? type : '';
+    if (typeof type === 'function') {
+        return getTypeName(type);
+    }
+    return normalizePrimitiveTypeName(String(type || ''));
+}
+
+function normalizePrimitiveTypeName(type: string): string {
+    switch (type) {
+        case 'Number':
+        case 'Float':
+        case 'Integer':
+            return 'cc.Number';
+        case 'Boolean':
+            return 'cc.Boolean';
+        case 'String':
+            return 'cc.String';
+        default:
+            return type;
+    }
 }
 
 function isNodeOrComponentCtor(ctor: unknown): boolean {

--- a/src/core/scene/scene-process/service/animation/property-metadata.ts
+++ b/src/core/scene/scene-process/service/animation/property-metadata.ts
@@ -82,10 +82,7 @@ function queryAnimablePropertyTypeFromAttr(component: Record<string, unknown>, p
 }
 
 function isAnimablePropertyAttr(attr: any): boolean {
-    if (attr.type === js.getClassName(Node)) {
-        return false;
-    }
-    if (isNodeOrComponentCtor(attr.ctor)) {
+    if (isNodeOrComponentType(attr.type) || isNodeOrComponentCtor(attr.ctor)) {
         return false;
     }
     if (attr.animatable !== undefined) {
@@ -128,6 +125,13 @@ function isNodeOrComponentCtor(ctor: unknown): boolean {
         return false;
     }
     return ctor === Node || ctor === Component || ctor.prototype instanceof Node || ctor.prototype instanceof Component;
+}
+
+function isNodeOrComponentType(type: unknown): boolean {
+    if (isNodeOrComponentCtor(type)) {
+        return true;
+    }
+    return typeof type === 'string' && (type === js.getClassName(Node) || type === js.getClassName(Component));
 }
 
 function splitComponentPropertyKey(propKey: string): { comp: string; propName: string } | null {

--- a/src/core/scene/scene-process/service/animation/property-metadata.ts
+++ b/src/core/scene/scene-process/service/animation/property-metadata.ts
@@ -1,0 +1,151 @@
+import { CCClass, Component, Node, js } from 'cc';
+import type {
+    IAnimationPropertyInfo,
+} from '../../../common';
+import type { IAnimationPropertyMetadata } from './property-curve';
+
+export function queryComponentAnimableProperties(component: Component): IAnimationPropertyInfo[] {
+    const ctor = component.constructor as any;
+    const props = Array.isArray(ctor.__props__) ? ctor.__props__ as string[] : [];
+    const compName = js.getClassName(component);
+    const result: IAnimationPropertyInfo[] = [];
+    for (const prop of props) {
+        const type = queryAnimablePropertyType(component as any, prop);
+        if (!type) {
+            continue;
+        }
+        result.push({
+            name: prop,
+            key: `${compName}.${prop}`,
+            displayName: `${compName}.${prop}`,
+            type: { value: type },
+            menuName: `${compName}.${prop}`,
+            comp: compName,
+        });
+    }
+    return result;
+}
+
+export function queryAnimationPropertyMetadata(rootNode: Node, nodePath: string, propKey: string): IAnimationPropertyMetadata | null {
+    const componentProperty = splitComponentPropertyKey(propKey);
+    if (!componentProperty) {
+        return null;
+    }
+
+    const node = nodePath ? rootNode.getChildByPath(nodePath) : rootNode;
+    const component = node?.components.find((item) => js.getClassName(item) === componentProperty.comp);
+    if (!component) {
+        return null;
+    }
+
+    const attr = queryPropertyAttr(component as any, componentProperty.propName);
+    if (!attr || attr.readonly || !isAnimablePropertyAttr(attr)) {
+        return null;
+    }
+    const type = queryAnimablePropertyTypeFromAttr(component as any, componentProperty.propName, attr);
+    if (!type) {
+        return null;
+    }
+    return {
+        type: { value: type },
+        valueCtor: typeof attr.ctor === 'function' ? attr.ctor as new () => unknown : undefined,
+    };
+}
+
+function queryAnimablePropertyType(component: Record<string, unknown>, prop: string): string {
+    if (prop === 'type' || prop === '__scriptAsset') {
+        return '';
+    }
+    const attr = queryPropertyAttr(component, prop);
+    if (!attr || attr.readonly || !isAnimablePropertyAttr(attr)) {
+        return '';
+    }
+    return queryAnimablePropertyTypeFromAttr(component, prop, attr);
+}
+
+function queryAnimablePropertyTypeFromAttr(component: Record<string, unknown>, prop: string, attr: any): string {
+    const ctorType = queryAttrCtorType(attr);
+    if (ctorType) {
+        return ctorType;
+    }
+    const type = attr.type;
+    if (typeof type === 'string') {
+        return type;
+    }
+    if (type instanceof (CCClass.Attr as any).PrimitiveType) {
+        return type.name;
+    }
+    if (typeof type === 'function') {
+        return js.getClassName(type);
+    }
+    const value = component[prop];
+    if (typeof value === 'number') {
+        return 'cc.Number';
+    }
+    if (typeof value === 'boolean') {
+        return 'cc.Boolean';
+    }
+    if (typeof value === 'string') {
+        return 'cc.String';
+    }
+    if (value && typeof value === 'object') {
+        return queryAnimableObjectPropertyType(value);
+    }
+    return '';
+}
+
+function queryAnimableObjectPropertyType(value: object): string {
+    if (value instanceof Node || value instanceof Component || Array.isArray(value)) {
+        return '';
+    }
+    const ctor = (value as { constructor?: Function }).constructor;
+    if (!ctor || ctor === Object) {
+        return '';
+    }
+    const type = js.getClassName(ctor);
+    return type && type !== 'Object' ? type : '';
+}
+
+function isAnimablePropertyAttr(attr: any): boolean {
+    if (attr.type === js.getClassName(Node)) {
+        return false;
+    }
+    if (isNodeOrComponentCtor(attr.ctor)) {
+        return false;
+    }
+    if (attr.animatable !== undefined) {
+        return Boolean(attr.animatable);
+    }
+    return attr.visible === undefined ? true : Boolean(attr.visible);
+}
+
+function queryPropertyAttr(component: Record<string, unknown>, prop: string): any {
+    return CCClass.attr(component as any, prop) || CCClass.attr((component as any).constructor, prop);
+}
+
+function queryAttrCtorType(attr: any): string {
+    const ctor = attr?.ctor;
+    if (typeof ctor !== 'function') {
+        return '';
+    }
+    const type = js.getClassName(ctor);
+    return type && type !== 'Object' ? type : '';
+}
+
+function isNodeOrComponentCtor(ctor: unknown): boolean {
+    if (typeof ctor !== 'function') {
+        return false;
+    }
+    return ctor === Node || ctor === Component || ctor.prototype instanceof Node || ctor.prototype instanceof Component;
+}
+
+function splitComponentPropertyKey(propKey: string): { comp: string; propName: string } | null {
+    const index = propKey.lastIndexOf('.');
+    if (index <= 0 || index === propKey.length - 1) {
+        return null;
+    }
+    return {
+        comp: propKey.slice(0, index),
+        propName: propKey.slice(index + 1),
+    };
+}

--- a/src/core/scene/scene-process/service/animation/property-metadata.ts
+++ b/src/core/scene/scene-process/service/animation/property-metadata.ts
@@ -9,6 +9,7 @@ import {
     queryMaterialUniformTarget,
     queryMaterialUniformType,
 } from './material-uniform';
+import { isWritableProperty } from './property-writability';
 
 export function queryComponentAnimableProperties(component: Component): IAnimationPropertyInfo[] {
     const ctor = component.constructor as any;
@@ -34,6 +35,9 @@ export function queryComponentAnimableProperties(component: Component): IAnimati
         const materialProperties = queryMaterialAnimableProperties(component as any, prop, compName);
         if (materialProperties.length > 0) {
             result.push(...materialProperties);
+            continue;
+        }
+        if (!isWritableProperty(component, prop)) {
             continue;
         }
         const type = queryAnimablePropertyTypeFromAttr(component as any, prop, attr);
@@ -77,7 +81,7 @@ export function queryAnimationPropertyMetadata(rootNode: Node, nodePath: string,
     }
 
     const attr = queryPropertyAttr(component as any, componentProperty.propName);
-    if (!attr || attr.readonly || !isAnimablePropertyAttr(attr)) {
+    if (!attr || attr.readonly || !isWritableProperty(component, componentProperty.propName) || !isAnimablePropertyAttr(attr)) {
         return null;
     }
     const type = queryAnimablePropertyTypeFromAttr(component as any, componentProperty.propName, attr);

--- a/src/core/scene/scene-process/service/animation/property-metadata.ts
+++ b/src/core/scene/scene-process/service/animation/property-metadata.ts
@@ -1,4 +1,4 @@
-import { CCClass, Component, Node, js } from 'cc';
+import { CCClass, Component, Node, gfx, js, renderer } from 'cc';
 import type {
     IAnimationPropertyInfo,
 } from '../../../common';
@@ -11,11 +11,16 @@ export function queryComponentAnimableProperties(component: Component): IAnimati
     const compName = js.getClassName(component);
     const result: IAnimationPropertyInfo[] = [];
     for (const prop of props) {
-        if (prop === 'type' || prop === '__scriptAsset') {
+        if (prop === '__scriptAsset') {
             continue;
         }
         const attr = queryPropertyAttr(component as any, prop);
         if (!attr || attr.readonly || !isAnimablePropertyAttr(attr)) {
+            continue;
+        }
+        const materialProperties = queryMaterialAnimableProperties(component as any, prop, compName);
+        if (materialProperties.length > 0) {
+            result.push(...materialProperties);
             continue;
         }
         const type = queryAnimablePropertyTypeFromAttr(component as any, prop, attr);
@@ -75,6 +80,111 @@ function queryAnimablePropertyTypeFromAttr(component: Record<string, unknown>, p
         return '';
     }
     return normalizePrimitiveTypeName(type);
+}
+
+function queryMaterialAnimableProperties(component: Record<string, unknown>, prop: string, compName: string): IAnimationPropertyInfo[] {
+    const targets = queryMaterialTargets(component[prop], prop);
+    const result: IAnimationPropertyInfo[] = [];
+    for (const target of targets) {
+        const passes = Array.isArray(target.material?.passes) ? target.material.passes : [];
+        passes.forEach((pass: any, passIndex: number) => {
+            const properties = pass?.properties;
+            if (!properties || typeof properties !== 'object') {
+                return;
+            }
+            for (const uniformName of Object.keys(properties)) {
+                const type = queryUniformPropertyType(pass, uniformName);
+                if (!type) {
+                    continue;
+                }
+                const uniform = queryUniformNameData(passIndex, uniformName);
+                result.push({
+                    name: uniformName,
+                    key: `${compName}.${target.path}.${uniform.key}`,
+                    displayName: `${compName}.${target.path}.${uniform.displayName}`,
+                    type,
+                    menuName: uniform.displayName,
+                    comp: compName,
+                    category: `${compName}/${target.category}/${uniformName}`,
+                });
+            }
+        });
+    }
+    return result;
+}
+
+function queryMaterialTargets(value: unknown, prop: string): Array<{ material: any; path: string; category: string }> {
+    if (Array.isArray(value)) {
+        return value.map((material, index) => ({
+            material,
+            path: `${prop}.${index}`,
+            category: `${prop}/${index}`,
+        }));
+    }
+    return [{
+        material: value,
+        path: prop,
+        category: prop,
+    }];
+}
+
+function queryUniformNameData(passIndex: number, uniformName: string): { key: string; displayName: string } {
+    return {
+        key: `pass.${passIndex}.${uniformName}`,
+        displayName: `pass[${passIndex}].${uniformName}`,
+    };
+}
+
+function queryUniformPropertyType(pass: any, uniformName: string): IAnimationPropertyInfo['type'] | null {
+    const propInfo = pass?.properties?.[uniformName];
+    if (propInfo?.editor?.type === 'color') {
+        return { value: 'cc.Color' };
+    }
+
+    let gfxType: unknown;
+    if (typeof pass?.getHandle === 'function' && typeof renderer.Pass?.getTypeFromHandle === 'function') {
+        gfxType = renderer.Pass.getTypeFromHandle(pass.getHandle(uniformName));
+    }
+
+    const type = queryGfxValueType(gfxType) || queryGfxValueType(propInfo?.type);
+    return type ? { value: type } : null;
+}
+
+function queryGfxValueType(type: unknown): string {
+    if (typeof type === 'string') {
+        return normalizePrimitiveTypeName(type);
+    }
+    if (typeof type !== 'number') {
+        return '';
+    }
+
+    const Type = gfx.Type as any;
+    switch (type) {
+        case Type.INT:
+            return 'Integer';
+        case Type.INT2:
+            return 'cc.Vec2';
+        case Type.INT3:
+            return 'cc.Vec3';
+        case Type.INT4:
+            return 'cc.Vec4';
+        case Type.FLOAT:
+            return 'Float';
+        case Type.FLOAT2:
+            return 'cc.Vec2';
+        case Type.FLOAT3:
+            return 'cc.Vec3';
+        case Type.FLOAT4:
+            return 'cc.Vec4';
+        case Type.MAT4:
+            return 'cc.Mat4';
+        case Type.SAMPLER2D:
+            return 'cc.TextureBase';
+        case Type.SAMPLER_CUBE:
+            return 'cc.TextureCube';
+        default:
+            return '';
+    }
 }
 
 function isAnimablePropertyAttr(attr: any): boolean {

--- a/src/core/scene/scene-process/service/animation/property-metadata.ts
+++ b/src/core/scene/scene-process/service/animation/property-metadata.ts
@@ -11,7 +11,14 @@ export function queryComponentAnimableProperties(component: Component): IAnimati
     const compName = js.getClassName(component);
     const result: IAnimationPropertyInfo[] = [];
     for (const prop of props) {
-        const type = queryAnimablePropertyType(component as any, prop);
+        if (prop === 'type' || prop === '__scriptAsset') {
+            continue;
+        }
+        const attr = queryPropertyAttr(component as any, prop);
+        if (!attr || attr.readonly || !isAnimablePropertyAttr(attr)) {
+            continue;
+        }
+        const type = queryAnimablePropertyTypeFromAttr(component as any, prop, attr);
         if (!type) {
             continue;
         }
@@ -19,7 +26,7 @@ export function queryComponentAnimableProperties(component: Component): IAnimati
             name: prop,
             key: `${compName}.${prop}`,
             displayName: `${compName}.${prop}`,
-            type: { value: type },
+            type: createAnimationPropertyType(type, attr),
             menuName: `${compName}.${prop}`,
             comp: compName,
         });
@@ -48,20 +55,9 @@ export function queryAnimationPropertyMetadata(rootNode: Node, nodePath: string,
         return null;
     }
     return {
-        type: { value: type },
+        type: createAnimationPropertyType(type, attr),
         valueCtor: typeof attr.ctor === 'function' ? attr.ctor as new () => unknown : undefined,
     };
-}
-
-function queryAnimablePropertyType(component: Record<string, unknown>, prop: string): string {
-    if (prop === 'type' || prop === '__scriptAsset') {
-        return '';
-    }
-    const attr = queryPropertyAttr(component, prop);
-    if (!attr || attr.readonly || !isAnimablePropertyAttr(attr)) {
-        return '';
-    }
-    return queryAnimablePropertyTypeFromAttr(component, prop, attr);
 }
 
 function queryAnimablePropertyTypeFromAttr(component: Record<string, unknown>, prop: string, attr: any): string {
@@ -118,6 +114,17 @@ function normalizePrimitiveTypeName(type: string): string {
         default:
             return type;
     }
+}
+
+function createAnimationPropertyType(type: string, attr: any): IAnimationPropertyInfo['type'] {
+    const result: IAnimationPropertyInfo['type'] = { value: type };
+    if (type === 'Enum' && Array.isArray(attr.enumList)) {
+        result.enumList = attr.enumList.map((item: any) => ({
+            name: String(item.name ?? ''),
+            value: Number(item.value),
+        }));
+    }
+    return result;
 }
 
 function isNodeOrComponentCtor(ctor: unknown): boolean {

--- a/src/core/scene/scene-process/service/animation/property-metadata.ts
+++ b/src/core/scene/scene-process/service/animation/property-metadata.ts
@@ -1,9 +1,14 @@
-import { CCClass, Component, Node, gfx, js, renderer } from 'cc';
+import { CCClass, Component, Node, Renderer, js } from 'cc';
 import type {
     IAnimationPropertyInfo,
 } from '../../../common';
 import { getConstructor, getTypeName } from '../dump/utils';
 import type { IAnimationPropertyMetadata } from './property-curve';
+import {
+    parseMaterialUniformPropertyKey,
+    queryMaterialUniformTarget,
+    queryMaterialUniformType,
+} from './material-uniform';
 
 export function queryComponentAnimableProperties(component: Component): IAnimationPropertyInfo[] {
     const ctor = component.constructor as any;
@@ -13,6 +18,14 @@ export function queryComponentAnimableProperties(component: Component): IAnimati
     for (const prop of props) {
         if (prop === '__scriptAsset') {
             continue;
+        }
+        const rendererMaterialProp = queryRendererMaterialProperty(component, prop);
+        if (rendererMaterialProp) {
+            const materialProperties = queryMaterialAnimableProperties(component as any, rendererMaterialProp, compName);
+            if (materialProperties.length > 0) {
+                result.push(...materialProperties);
+                continue;
+            }
         }
         const attr = queryPropertyAttr(component as any, prop);
         if (!attr || attr.readonly || !isAnimablePropertyAttr(attr)) {
@@ -40,6 +53,18 @@ export function queryComponentAnimableProperties(component: Component): IAnimati
 }
 
 export function queryAnimationPropertyMetadata(rootNode: Node, nodePath: string, propKey: string): IAnimationPropertyMetadata | null {
+    const materialUniform = parseMaterialUniformPropertyKey(propKey);
+    if (materialUniform) {
+        const node = nodePath ? rootNode.getChildByPath(nodePath) : rootNode;
+        const component = node?.components.find((item) => js.getClassName(item) === materialUniform.comp);
+        const target = component ? queryMaterialUniformTarget(component as any, materialUniform) : null;
+        const type = target ? queryMaterialUniformType(target.pass, materialUniform.uniformName) : '';
+        return type ? {
+            type: { value: type },
+            valueCtor: undefined,
+        } : null;
+    }
+
     const componentProperty = splitComponentPropertyKey(propKey);
     if (!componentProperty) {
         return null;
@@ -101,7 +126,7 @@ function queryMaterialAnimableProperties(component: Record<string, unknown>, pro
                 result.push({
                     name: uniformName,
                     key: `${compName}.${target.path}.${uniform.key}`,
-                    displayName: `${compName}.${target.path}.${uniform.displayName}`,
+                    displayName: `${compName}.${target.displayPath}.${uniform.displayName}`,
                     type,
                     menuName: uniform.displayName,
                     comp: compName,
@@ -113,17 +138,23 @@ function queryMaterialAnimableProperties(component: Record<string, unknown>, pro
     return result;
 }
 
-function queryMaterialTargets(value: unknown, prop: string): Array<{ material: any; path: string; category: string }> {
+function queryRendererMaterialProperty(component: Component, prop: string): string {
+    return prop === 'sharedMaterials' && component instanceof Renderer ? 'materials' : '';
+}
+
+function queryMaterialTargets(value: unknown, prop: string): Array<{ material: any; path: string; displayPath: string; category: string }> {
     if (Array.isArray(value)) {
         return value.map((material, index) => ({
             material,
             path: `${prop}.${index}`,
+            displayPath: `${prop}[${index}]`,
             category: `${prop}/${index}`,
         }));
     }
     return [{
         material: value,
         path: prop,
+        displayPath: prop,
         category: prop,
     }];
 }
@@ -136,55 +167,8 @@ function queryUniformNameData(passIndex: number, uniformName: string): { key: st
 }
 
 function queryUniformPropertyType(pass: any, uniformName: string): IAnimationPropertyInfo['type'] | null {
-    const propInfo = pass?.properties?.[uniformName];
-    if (propInfo?.editor?.type === 'color') {
-        return { value: 'cc.Color' };
-    }
-
-    let gfxType: unknown;
-    if (typeof pass?.getHandle === 'function' && typeof renderer.Pass?.getTypeFromHandle === 'function') {
-        gfxType = renderer.Pass.getTypeFromHandle(pass.getHandle(uniformName));
-    }
-
-    const type = queryGfxValueType(gfxType) || queryGfxValueType(propInfo?.type);
+    const type = queryMaterialUniformType(pass, uniformName);
     return type ? { value: type } : null;
-}
-
-function queryGfxValueType(type: unknown): string {
-    if (typeof type === 'string') {
-        return normalizePrimitiveTypeName(type);
-    }
-    if (typeof type !== 'number') {
-        return '';
-    }
-
-    const Type = gfx.Type as any;
-    switch (type) {
-        case Type.INT:
-            return 'Integer';
-        case Type.INT2:
-            return 'cc.Vec2';
-        case Type.INT3:
-            return 'cc.Vec3';
-        case Type.INT4:
-            return 'cc.Vec4';
-        case Type.FLOAT:
-            return 'Float';
-        case Type.FLOAT2:
-            return 'cc.Vec2';
-        case Type.FLOAT3:
-            return 'cc.Vec3';
-        case Type.FLOAT4:
-            return 'cc.Vec4';
-        case Type.MAT4:
-            return 'cc.Mat4';
-        case Type.SAMPLER2D:
-            return 'cc.TextureBase';
-        case Type.SAMPLER_CUBE:
-            return 'cc.TextureCube';
-        default:
-            return '';
-    }
 }
 
 function isAnimablePropertyAttr(attr: any): boolean {

--- a/src/core/scene/scene-process/service/animation/property-value.ts
+++ b/src/core/scene/scene-process/service/animation/property-value.ts
@@ -1,15 +1,21 @@
-import { Asset, Node, assetManager as ccAssetManager, js } from 'cc';
+import { Node } from 'cc';
 import type { IAnimationOperation, IAnimationValue } from '../../../common';
 import type { IAnimationPropertyMetadata } from './property-curve';
 import { queryAnimationPropertyMetadata } from './property-metadata';
+import {
+    isAnimationAssetValue,
+    loadAnimationAssetValue,
+    queryAnimationAssetCtor,
+    queryAnimationAssetUuid,
+    serializeAnimationAssetValue,
+} from './asset-value';
 import { cloneValue } from './utils';
 
 type PropertyKeyOperation = Extract<IAnimationOperation, { type: 'createPropertyKey' | 'updatePropertyKey' }>;
 
 export function serializeAnimationPropertyValue(value: unknown): IAnimationValue {
-    if (value instanceof Asset) {
-        const uuid = queryAssetUuid(value);
-        return uuid ? { uuid } : null;
+    if (isAnimationAssetValue(value)) {
+        return serializeAnimationAssetValue(value);
     }
     return cloneValue(value) as IAnimationValue;
 }
@@ -45,7 +51,7 @@ async function normalizeProvidedAnimationPropertyValue(
         return value;
     }
 
-    const assetCtor = metadata ? queryAssetValueCtor(metadata) : null;
+    const assetCtor = queryAnimationAssetCtor(metadata);
     if (!assetCtor) {
         return value;
     }
@@ -53,12 +59,12 @@ async function normalizeProvidedAnimationPropertyValue(
         return value as unknown as IAnimationValue;
     }
 
-    const uuid = queryAssetUuid(value);
+    const uuid = queryAnimationAssetUuid(value);
     if (!uuid) {
         return value;
     }
 
-    return await loadAssetValue(assetCtor, uuid) as unknown as IAnimationValue;
+    return await loadAnimationAssetValue(assetCtor, uuid) as unknown as IAnimationValue;
 }
 
 function resolveOperationRelativeNodePath(
@@ -88,40 +94,4 @@ function toRelativeNodePath(rootNode: Node, rootPath: string, nodePath: string):
 
 function normalizeNodePath(path: string): string {
     return String(path || '').replace(/^\/+|\/+$/g, '');
-}
-
-function queryAssetUuid(value: unknown): string {
-    if (!value || typeof value !== 'object') {
-        return '';
-    }
-    const record = value as Record<string, unknown>;
-    const uuid = record.uuid || record._uuid || record.__uuid__;
-    return typeof uuid === 'string' ? uuid : '';
-}
-
-function queryAssetValueCtor(metadata: IAnimationPropertyMetadata): (new () => Asset) | null {
-    const ctor = metadata.valueCtor || js.getClassByName(metadata.type.value);
-    if (typeof ctor !== 'function') {
-        return null;
-    }
-    return ctor === Asset || ctor.prototype instanceof Asset ? ctor as new () => Asset : null;
-}
-
-async function loadAssetValue(assetCtor: new () => Asset, uuid: string): Promise<Asset> {
-    const asset = await new Promise<Asset | null>((resolve) => {
-        ccAssetManager.loadAny(uuid, (error: Error | null, loaded: unknown) => {
-            if (error) {
-                console.warn(`[Animation] load asset keyframe value failed: ${uuid}`, error);
-                resolve(null);
-                return;
-            }
-            resolve(loaded instanceof assetCtor ? loaded as Asset : null);
-        });
-    });
-    if (asset) {
-        return asset;
-    }
-    const placeholder = new assetCtor();
-    placeholder.initDefault(uuid);
-    return placeholder;
 }

--- a/src/core/scene/scene-process/service/animation/property-value.ts
+++ b/src/core/scene/scene-process/service/animation/property-value.ts
@@ -1,0 +1,127 @@
+import { Asset, Node, assetManager as ccAssetManager, js } from 'cc';
+import type { IAnimationOperation, IAnimationValue } from '../../../common';
+import type { IAnimationPropertyMetadata } from './property-curve';
+import { queryAnimationPropertyMetadata } from './property-metadata';
+import { cloneValue } from './utils';
+
+type PropertyKeyOperation = Extract<IAnimationOperation, { type: 'createPropertyKey' | 'updatePropertyKey' }>;
+
+export function serializeAnimationPropertyValue(value: unknown): IAnimationValue {
+    if (value instanceof Asset) {
+        const uuid = queryAssetUuid(value);
+        return uuid ? { uuid } : null;
+    }
+    return cloneValue(value) as IAnimationValue;
+}
+
+export async function normalizeProvidedAnimationPropertyOperationValue(
+    rootNode: Node,
+    rootPath: string,
+    operation: PropertyKeyOperation,
+    options: {
+        queryNodeByUuid: (uuid: string) => Node | null;
+        queryNodePath: (node: Node) => string;
+    },
+): Promise<IAnimationValue> {
+    const value = operation.value;
+    if (value === null || value === undefined) {
+        return value as IAnimationValue;
+    }
+
+    const nodePath = resolveOperationRelativeNodePath(rootNode, rootPath, operation, options);
+    if (nodePath === null) {
+        return value;
+    }
+
+    const metadata = queryAnimationPropertyMetadata(rootNode, nodePath, operation.propKey);
+    return await normalizeProvidedAnimationPropertyValue(metadata, value);
+}
+
+async function normalizeProvidedAnimationPropertyValue(
+    metadata: IAnimationPropertyMetadata | null,
+    value: IAnimationValue,
+): Promise<IAnimationValue> {
+    if (value === null || value === undefined) {
+        return value;
+    }
+
+    const assetCtor = metadata ? queryAssetValueCtor(metadata) : null;
+    if (!assetCtor) {
+        return value;
+    }
+    if (value instanceof assetCtor) {
+        return value as unknown as IAnimationValue;
+    }
+
+    const uuid = queryAssetUuid(value);
+    if (!uuid) {
+        return value;
+    }
+
+    return await loadAssetValue(assetCtor, uuid) as unknown as IAnimationValue;
+}
+
+function resolveOperationRelativeNodePath(
+    rootNode: Node,
+    rootPath: string,
+    operation: { nodeUuid?: string; nodePath?: string },
+    options: { queryNodeByUuid: (uuid: string) => Node | null; queryNodePath: (node: Node) => string },
+): string | null {
+    const node = options.queryNodeByUuid(operation.nodeUuid || '');
+    if (node) {
+        return toRelativeNodePath(rootNode, rootPath, options.queryNodePath(node));
+    }
+    return toRelativeNodePath(rootNode, rootPath, operation.nodePath || '');
+}
+
+function toRelativeNodePath(rootNode: Node, rootPath: string, nodePath: string): string | null {
+    const normalizedRootPath = normalizeNodePath(rootPath);
+    const normalizedNodePath = normalizeNodePath(nodePath);
+    if (!normalizedNodePath || normalizedNodePath === normalizedRootPath) {
+        return '';
+    }
+    if (normalizedRootPath && normalizedNodePath.startsWith(`${normalizedRootPath}/`)) {
+        return normalizedNodePath.slice(normalizedRootPath.length + 1);
+    }
+    return rootNode.getChildByPath(normalizedNodePath) ? normalizedNodePath : null;
+}
+
+function normalizeNodePath(path: string): string {
+    return String(path || '').replace(/^\/+|\/+$/g, '');
+}
+
+function queryAssetUuid(value: unknown): string {
+    if (!value || typeof value !== 'object') {
+        return '';
+    }
+    const record = value as Record<string, unknown>;
+    const uuid = record.uuid || record._uuid || record.__uuid__;
+    return typeof uuid === 'string' ? uuid : '';
+}
+
+function queryAssetValueCtor(metadata: IAnimationPropertyMetadata): (new () => Asset) | null {
+    const ctor = metadata.valueCtor || js.getClassByName(metadata.type.value);
+    if (typeof ctor !== 'function') {
+        return null;
+    }
+    return ctor === Asset || ctor.prototype instanceof Asset ? ctor as new () => Asset : null;
+}
+
+async function loadAssetValue(assetCtor: new () => Asset, uuid: string): Promise<Asset> {
+    const asset = await new Promise<Asset | null>((resolve) => {
+        ccAssetManager.loadAny(uuid, (error: Error | null, loaded: unknown) => {
+            if (error) {
+                console.warn(`[Animation] load asset keyframe value failed: ${uuid}`, error);
+                resolve(null);
+                return;
+            }
+            resolve(loaded instanceof assetCtor ? loaded as Asset : null);
+        });
+    });
+    if (asset) {
+        return asset;
+    }
+    const placeholder = new assetCtor();
+    placeholder.initDefault(uuid);
+    return placeholder;
+}

--- a/src/core/scene/scene-process/service/animation/property-value.ts
+++ b/src/core/scene/scene-process/service/animation/property-value.ts
@@ -17,7 +17,25 @@ export function serializeAnimationPropertyValue(value: unknown): IAnimationValue
     if (isAnimationAssetValue(value)) {
         return serializeAnimationAssetValue(value);
     }
+    const colorValue = serializeColorValue(value);
+    if (colorValue) {
+        return colorValue;
+    }
     return cloneValue(value) as IAnimationValue;
+}
+
+function serializeColorValue(value: unknown): IAnimationValue | undefined {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return undefined;
+    }
+    const r = Number((value as any).r);
+    const g = Number((value as any).g);
+    const b = Number((value as any).b);
+    const a = Number((value as any).a);
+    if (!Number.isFinite(r) || !Number.isFinite(g) || !Number.isFinite(b) || !Number.isFinite(a)) {
+        return undefined;
+    }
+    return { r, g, b, a };
 }
 
 export async function normalizeProvidedAnimationPropertyOperationValue(

--- a/src/core/scene/scene-process/service/animation/property-value.ts
+++ b/src/core/scene/scene-process/service/animation/property-value.ts
@@ -9,7 +9,7 @@ import {
     queryAnimationAssetUuid,
     serializeAnimationAssetValue,
 } from './asset-value';
-import { cloneValue } from './utils';
+import { cloneSerializableValue } from './utils';
 
 type PropertyKeyOperation = Extract<IAnimationOperation, { type: 'createPropertyKey' | 'updatePropertyKey' }>;
 
@@ -21,7 +21,7 @@ export function serializeAnimationPropertyValue(value: unknown): IAnimationValue
     if (colorValue) {
         return colorValue;
     }
-    return cloneValue(value) as IAnimationValue;
+    return cloneSerializableValue(value) as IAnimationValue;
 }
 
 function serializeColorValue(value: unknown): IAnimationValue | undefined {

--- a/src/core/scene/scene-process/service/animation/property-writability.ts
+++ b/src/core/scene/scene-process/service/animation/property-writability.ts
@@ -1,0 +1,27 @@
+export function isWritableProperty(target: object, key: string): boolean {
+    const descriptor = findPropertyDescriptor(target, key);
+    if (!descriptor) {
+        return true;
+    }
+    if (isAccessorDescriptor(descriptor)) {
+        return typeof descriptor.set === 'function';
+    }
+    return descriptor.writable !== false;
+}
+
+function findPropertyDescriptor(target: object, key: string): PropertyDescriptor | undefined {
+    let current: object | null = target;
+    while (current) {
+        const descriptor = Object.getOwnPropertyDescriptor(current, key);
+        if (descriptor) {
+            return descriptor;
+        }
+        current = Object.getPrototypeOf(current);
+    }
+    return undefined;
+}
+
+function isAccessorDescriptor(descriptor: PropertyDescriptor): boolean {
+    return Object.prototype.hasOwnProperty.call(descriptor, 'get')
+        || Object.prototype.hasOwnProperty.call(descriptor, 'set');
+}

--- a/src/core/scene/scene-process/service/animation/real-curve-key-data.ts
+++ b/src/core/scene/scene-process/service/animation/real-curve-key-data.ts
@@ -1,0 +1,200 @@
+import { editorExtrasTag } from 'cc';
+import type { IAnimationCurveKeyData } from '../../../common';
+
+const EDITOR_EXTRAS_TAG = editorExtrasTag || '__editorExtras__';
+const KEY_DATA_KEYS_TAG = 'keyDataKeys';
+const EXPLICIT_KEY_DATA_KEYS = Symbol('AnimationRealCurveExplicitKeyDataKeys');
+const NUMERIC_KEY_DATA_KEYS: Array<keyof IAnimationCurveKeyData> = [
+    'inTangent',
+    'outTangent',
+    'inTangentWeight',
+    'outTangentWeight',
+    'interpMode',
+    'tangentWeightMode',
+    'tangentMode',
+    'easingMethod',
+];
+
+export interface IDumpRealKeyDataOptions {
+    includeDefaults?: boolean;
+}
+
+type IInternalAnimationCurveKeyData = IAnimationCurveKeyData & {
+    [EXPLICIT_KEY_DATA_KEYS]?: Array<keyof IAnimationCurveKeyData>;
+};
+
+export function createRealCurveValue(value: number, keyData?: IAnimationCurveKeyData): number | Record<string, unknown> {
+    if (!keyData || !hasRealCurveKeyData(keyData)) {
+        return value;
+    }
+    const curveValue: Record<string, unknown> = {
+        value,
+        leftTangent: keyData.inTangent,
+        rightTangent: keyData.outTangent,
+        leftTangentWeight: keyData.inTangentWeight,
+        rightTangentWeight: keyData.outTangentWeight,
+        interpolationMode: keyData.interpMode,
+        tangentWeightMode: keyData.tangentWeightMode,
+        easingMethod: keyData.easingMethod,
+    };
+    const editorExtras = createRealCurveEditorExtras(keyData);
+    if (editorExtras) {
+        curveValue[EDITOR_EXTRAS_TAG] = editorExtras;
+    }
+    return curveValue;
+}
+
+export function createMergedRealCurveValue(value: number, existed: unknown, keyData?: IAnimationCurveKeyData): number | Record<string, unknown> {
+    const existedKeyData = dumpRealKeyData(existed, { includeDefaults: true }) as IInternalAnimationCurveKeyData;
+    const explicitKeys = new Set(readMarkedExplicitKeyDataKeys(existedKeyData) || []);
+    for (const key of NUMERIC_KEY_DATA_KEYS) {
+        const item = keyData?.[key];
+        if (item !== undefined && Number.isFinite(Number(item))) {
+            explicitKeys.add(key);
+        }
+    }
+    const merged = {
+        ...existedKeyData,
+        ...keyData,
+    } as IInternalAnimationCurveKeyData;
+    markExplicitKeyDataKeys(merged, explicitKeys);
+    return createRealCurveValue(value, merged);
+}
+
+export function dumpRealKeyData(value: any, options: IDumpRealKeyDataOptions = {}): IAnimationCurveKeyData {
+    const data: IAnimationCurveKeyData = {};
+    const editorExtras = queryRealCurveEditorExtras(value);
+    const explicitKeys = queryExplicitKeyDataKeys(editorExtras);
+    setKeyDataNumber(data, 'inTangent', value?.leftTangent, explicitKeys, options);
+    setKeyDataNumber(data, 'outTangent', value?.rightTangent, explicitKeys, options);
+    setKeyDataNumber(data, 'inTangentWeight', value?.leftTangentWeight, explicitKeys, options);
+    setKeyDataNumber(data, 'outTangentWeight', value?.rightTangentWeight, explicitKeys, options);
+    setKeyDataNumber(data, 'interpMode', value?.interpolationMode, explicitKeys, options);
+    setKeyDataNumber(data, 'tangentWeightMode', value?.tangentWeightMode, explicitKeys, options);
+    setKeyDataNumber(data, 'easingMethod', value?.easingMethod, explicitKeys, options);
+    setKeyDataNumber(data, 'tangentMode', editorExtras?.tangentMode, explicitKeys, options);
+    if (typeof editorExtras?.broken === 'boolean') {
+        data.broken = editorExtras.broken;
+    }
+    if (options.includeDefaults) {
+        markExplicitKeyDataKeys(data, explicitKeys);
+    }
+    return data;
+}
+
+export function copyRealKeyDataInternalMetadata(source: IAnimationCurveKeyData, target: IAnimationCurveKeyData): void {
+    const explicitKeys = readMarkedExplicitKeyDataKeys(source);
+    if (explicitKeys) {
+        markExplicitKeyDataKeys(target, new Set(explicitKeys));
+    }
+}
+
+export function queryRealCurveNumberValue(value: any): number {
+    return normalizeNumber(value && typeof value === 'object' ? value.value : value);
+}
+
+export function queryRealCurveKeyframes(curve: { keyframes(): Iterable<[number, any]> | null | undefined }): Array<[number, any]> {
+    return Array.from(curve.keyframes() || []) as Array<[number, any]>;
+}
+
+export function findRealCurveKey(curve: { keyframes(): Iterable<[number, any]> }, time: number): [number, any] | undefined {
+    return queryRealCurveKeyframes(curve).find(([keyTime]) => isSameTime(keyTime, time));
+}
+
+export function setRealCurveKey(curve: { keyframes(): Iterable<[number, any]>; assignSorted(keyframes: Array<[number, unknown]>): void }, time: number, value: unknown): void {
+    const keyframes = queryRealCurveKeyframes(curve)
+        .filter(([keyTime]) => !isSameTime(keyTime, time))
+        .concat([[time, value] as [number, unknown]]);
+    keyframes.sort((a, b) => a[0] - b[0]);
+    curve.assignSorted(keyframes);
+}
+
+export function updateRealCurveKeyData(curve: { keyframes(): Iterable<[number, any]>; assignSorted(keyframes: Array<[number, unknown]>): void }, time: number, keyData?: IAnimationCurveKeyData): boolean {
+    const existed = findRealCurveKey(curve, time);
+    if (!existed) {
+        return false;
+    }
+    setRealCurveKey(curve, time, createMergedRealCurveValue(queryRealCurveNumberValue(existed[1]), existed[1], keyData));
+    return true;
+}
+
+export function hasRealCurveKeyData(keyData: IAnimationCurveKeyData): boolean {
+    return keyData.inTangent !== undefined
+        || keyData.inTangentWeight !== undefined
+        || keyData.outTangent !== undefined
+        || keyData.outTangentWeight !== undefined
+        || keyData.interpMode !== undefined
+        || keyData.tangentWeightMode !== undefined
+        || keyData.tangentMode !== undefined
+        || keyData.easingMethod !== undefined
+        || keyData.broken !== undefined;
+}
+
+function setKeyDataNumber(
+    data: IAnimationCurveKeyData,
+    key: keyof IAnimationCurveKeyData,
+    value: unknown,
+    explicitKeys: Set<keyof IAnimationCurveKeyData>,
+    options: IDumpRealKeyDataOptions,
+): void {
+    const numberValue = Number(value);
+    if (Number.isFinite(numberValue) && (options.includeDefaults || numberValue !== 0 || explicitKeys.has(key))) {
+        (data as any)[key] = numberValue;
+    }
+}
+
+function createRealCurveEditorExtras(keyData: IAnimationCurveKeyData): Record<string, unknown> | null {
+    const editorExtras: Record<string, unknown> = {};
+    const keyDataKeys = readMarkedExplicitKeyDataKeys(keyData) || queryKeyDataKeys(keyData);
+    if (keyDataKeys.length > 0) {
+        editorExtras[KEY_DATA_KEYS_TAG] = keyDataKeys;
+    }
+    if (keyData.tangentMode !== undefined) {
+        editorExtras.tangentMode = keyData.tangentMode;
+    }
+    if (keyData.broken !== undefined) {
+        editorExtras.broken = keyData.broken;
+    }
+    return Object.keys(editorExtras).length > 0 ? editorExtras : null;
+}
+
+function queryKeyDataKeys(keyData: IAnimationCurveKeyData): Array<keyof IAnimationCurveKeyData> {
+    return NUMERIC_KEY_DATA_KEYS.filter((key) => {
+        const value = keyData[key];
+        return value !== undefined && Number.isFinite(Number(value));
+    });
+}
+
+function markExplicitKeyDataKeys(data: IAnimationCurveKeyData, keys: Set<keyof IAnimationCurveKeyData>): void {
+    Object.defineProperty(data, EXPLICIT_KEY_DATA_KEYS, {
+        value: [...keys],
+        enumerable: false,
+        configurable: true,
+    });
+}
+
+function readMarkedExplicitKeyDataKeys(keyData: IAnimationCurveKeyData): Array<keyof IAnimationCurveKeyData> | undefined {
+    const keys = (keyData as IInternalAnimationCurveKeyData)[EXPLICIT_KEY_DATA_KEYS];
+    return Array.isArray(keys) ? keys : undefined;
+}
+
+function queryExplicitKeyDataKeys(editorExtras: any): Set<keyof IAnimationCurveKeyData> {
+    const keys = Array.isArray(editorExtras?.[KEY_DATA_KEYS_TAG]) ? editorExtras[KEY_DATA_KEYS_TAG] : [];
+    return new Set(keys.filter((key: string): key is keyof IAnimationCurveKeyData => NUMERIC_KEY_DATA_KEYS.includes(key as keyof IAnimationCurveKeyData)));
+}
+
+function queryRealCurveEditorExtras(value: unknown): any {
+    if (!value || typeof value !== 'object') {
+        return undefined;
+    }
+    return (value as any)[EDITOR_EXTRAS_TAG];
+}
+
+function normalizeNumber(value: unknown): number {
+    const numberValue = Number(value);
+    return Number.isFinite(numberValue) ? numberValue : 0;
+}
+
+function isSameTime(left: number, right: number): boolean {
+    return Math.abs(left - right) <= 1e-6;
+}

--- a/src/core/scene/scene-process/service/animation/sampled-state.ts
+++ b/src/core/scene/scene-process/service/animation/sampled-state.ts
@@ -1,0 +1,136 @@
+import {
+    Animation,
+    CCClass,
+    Component,
+    Node,
+    animation,
+} from 'cc';
+
+const NODE_SAMPLED_PROPERTIES = ['active', 'position', 'rotation', 'scale'] as const;
+
+export interface IAnimationSampledNodeState {
+    uuid: string;
+    properties: Record<string, unknown>;
+    components: IAnimationSampledComponentState[];
+    children: IAnimationSampledNodeState[];
+}
+
+interface IAnimationSampledComponentState {
+    uuid: string;
+    properties: Record<string, unknown>;
+}
+
+export function captureAnimationSampledState(rootNode: Node): IAnimationSampledNodeState {
+    return {
+        uuid: rootNode.uuid,
+        properties: captureNodeProperties(rootNode),
+        components: rootNode.components
+            .map(captureComponentState)
+            .filter((state): state is IAnimationSampledComponentState => Boolean(state)),
+        children: rootNode.children.map(captureAnimationSampledState),
+    };
+}
+
+export async function restoreAnimationSampledState(rootNode: Node, state: IAnimationSampledNodeState): Promise<void> {
+    restoreProperties(rootNode as any, state.properties);
+
+    for (const componentState of state.components) {
+        const component = rootNode.components.find((item) => item.uuid === componentState.uuid);
+        if (component) {
+            restoreProperties(component as any, componentState.properties);
+            (component as any).onRestore?.();
+        }
+    }
+
+    for (const childState of state.children) {
+        const child = rootNode.children.find((item) => item.uuid === childState.uuid);
+        if (child) {
+            await restoreAnimationSampledState(child, childState);
+        }
+    }
+}
+
+function captureNodeProperties(node: Node): Record<string, unknown> {
+    const properties: Record<string, unknown> = {};
+    for (const key of NODE_SAMPLED_PROPERTIES) {
+        properties[key] = cloneSampledValue((node as any)[key]);
+    }
+    return properties;
+}
+
+function captureComponentState(component: Component): IAnimationSampledComponentState | null {
+    if (isAnimationComponent(component)) {
+        return null;
+    }
+
+    const properties: Record<string, unknown> = {};
+    const ctor = component.constructor as any;
+    const props = Array.isArray(ctor.__props__) ? ctor.__props__ as string[] : [];
+    for (const prop of props) {
+        if (!isAnimatableComponentProperty(ctor, prop) || !(prop in component)) {
+            continue;
+        }
+        properties[prop] = cloneSampledValue((component as any)[prop]);
+    }
+
+    return {
+        uuid: component.uuid,
+        properties,
+    };
+}
+
+function isAnimatableComponentProperty(ctor: Function, prop: string): boolean {
+    if (prop === 'type' || prop === '__scriptAsset') {
+        return false;
+    }
+    const attr = CCClass.attr(ctor, prop);
+    return Boolean(attr && attr.animatable !== false && !attr.readonly);
+}
+
+function isAnimationComponent(component: Component): boolean {
+    const controllerCtor = (animation as any).AnimationController;
+    return component instanceof Animation || Boolean(controllerCtor && component instanceof controllerCtor);
+}
+
+function restoreProperties(target: Record<string, any>, properties: Record<string, unknown>): void {
+    for (const [key, value] of Object.entries(properties)) {
+        assignSampledValue(target, key, value);
+    }
+}
+
+function assignSampledValue(target: Record<string, any>, key: string, value: unknown): void {
+    const current = target[key];
+    if (current && typeof current === 'object' && typeof current.set === 'function' && value && typeof value === 'object') {
+        current.set(value);
+        return;
+    }
+    target[key] = cloneSampledValue(value);
+}
+
+function cloneSampledValue<T>(value: T): T {
+    if (value === null || value === undefined || typeof value !== 'object') {
+        return value;
+    }
+    if (typeof (value as any).clone === 'function') {
+        return (value as any).clone();
+    }
+    if (Array.isArray(value)) {
+        return value.map((item) => cloneSampledValue(item)) as T;
+    }
+    if (isPlainObject(value)) {
+        const result: Record<string, unknown> = {};
+        for (const [key, item] of Object.entries(value)) {
+            result[key] = cloneSampledValue(item);
+        }
+        return result as T;
+    }
+    return value;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    if (!value || typeof value !== 'object') {
+        return false;
+    }
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+}

--- a/src/core/scene/scene-process/service/animation/sampled-state.ts
+++ b/src/core/scene/scene-process/service/animation/sampled-state.ts
@@ -100,12 +100,35 @@ function restoreProperties(target: Record<string, any>, properties: Record<strin
 }
 
 function assignSampledValue(target: Record<string, any>, key: string, value: unknown): void {
+    const cloned = cloneSampledValue(value);
+    const descriptor = findPropertyDescriptor(target, key);
+    if (descriptor?.set || descriptor?.writable !== false) {
+        try {
+            target[key] = cloned;
+            return;
+        } catch {
+            // Fall back to in-place ValueType restore below.
+        }
+    }
+
     const current = target[key];
-    if (current && typeof current === 'object' && typeof current.set === 'function' && value && typeof value === 'object') {
-        current.set(value);
+    if (current && typeof current === 'object' && typeof current.set === 'function' && cloned && typeof cloned === 'object') {
+        current.set(cloned);
         return;
     }
-    target[key] = cloneSampledValue(value);
+    target[key] = cloned;
+}
+
+function findPropertyDescriptor(target: Record<string, any>, key: string): PropertyDescriptor | undefined {
+    let current: unknown = target;
+    while (current) {
+        const descriptor = Object.getOwnPropertyDescriptor(current, key);
+        if (descriptor) {
+            return descriptor;
+        }
+        current = Object.getPrototypeOf(current);
+    }
+    return undefined;
 }
 
 function cloneSampledValue<T>(value: T): T {

--- a/src/core/scene/scene-process/service/animation/sampled-state.ts
+++ b/src/core/scene/scene-process/service/animation/sampled-state.ts
@@ -6,6 +6,7 @@ import {
     animation,
 } from 'cc';
 import { isAnimationAssetValue } from './asset-value';
+import { isWritableProperty } from './property-writability';
 
 const NODE_SAMPLED_PROPERTIES = ['active', 'position', 'rotation', 'scale'] as const;
 
@@ -68,7 +69,7 @@ function captureComponentState(component: Component): IAnimationSampledComponent
     const ctor = component.constructor as any;
     const props = Array.isArray(ctor.__props__) ? ctor.__props__ as string[] : [];
     for (const prop of props) {
-        if (!isAnimatableComponentProperty(ctor, prop) || !(prop in component)) {
+        if (!(prop in component) || !isAnimatableComponentProperty(ctor, prop) || !canRestoreComponentProperty(component, prop)) {
             continue;
         }
         properties[prop] = cloneSampledValue((component as any)[prop]);
@@ -88,6 +89,14 @@ function isAnimatableComponentProperty(ctor: Function, prop: string): boolean {
     return Boolean(attr && attr.animatable !== false && !attr.readonly);
 }
 
+function canRestoreComponentProperty(component: Component, prop: string): boolean {
+    if (isWritableProperty(component, prop)) {
+        return true;
+    }
+    const value = (component as any)[prop];
+    return Boolean(value && typeof value === 'object' && typeof value.set === 'function');
+}
+
 function isAnimationComponent(component: Component): boolean {
     const controllerCtor = (animation as any).AnimationController;
     return component instanceof Animation || Boolean(controllerCtor && component instanceof controllerCtor);
@@ -101,12 +110,14 @@ function restoreProperties(target: Record<string, any>, properties: Record<strin
 
 function assignSampledValue(target: Record<string, any>, key: string, value: unknown): void {
     const cloned = cloneSampledValue(value);
-    const descriptor = findPropertyDescriptor(target, key);
-    if (descriptor?.set || descriptor?.writable !== false) {
+    const writable = isWritableProperty(target, key);
+    let assignError: unknown;
+    if (writable) {
         try {
             target[key] = cloned;
             return;
-        } catch {
+        } catch (error) {
+            assignError = error;
             // Fall back to in-place ValueType restore below.
         }
     }
@@ -116,19 +127,9 @@ function assignSampledValue(target: Record<string, any>, key: string, value: unk
         current.set(cloned);
         return;
     }
-    target[key] = cloned;
-}
-
-function findPropertyDescriptor(target: Record<string, any>, key: string): PropertyDescriptor | undefined {
-    let current: unknown = target;
-    while (current) {
-        const descriptor = Object.getOwnPropertyDescriptor(current, key);
-        if (descriptor) {
-            return descriptor;
-        }
-        current = Object.getPrototypeOf(current);
+    if (assignError) {
+        throw assignError;
     }
-    return undefined;
 }
 
 function cloneSampledValue<T>(value: T): T {

--- a/src/core/scene/scene-process/service/animation/sampled-state.ts
+++ b/src/core/scene/scene-process/service/animation/sampled-state.ts
@@ -5,6 +5,7 @@ import {
     Node,
     animation,
 } from 'cc';
+import { isAnimationAssetValue } from './asset-value';
 
 const NODE_SAMPLED_PROPERTIES = ['active', 'position', 'rotation', 'scale'] as const;
 
@@ -109,6 +110,9 @@ function assignSampledValue(target: Record<string, any>, key: string, value: unk
 
 function cloneSampledValue<T>(value: T): T {
     if (value === null || value === undefined || typeof value !== 'object') {
+        return value;
+    }
+    if (isAnimationAssetValue(value)) {
         return value;
     }
     if (typeof (value as any).clone === 'function') {

--- a/src/core/scene/scene-process/service/animation/scene-node.ts
+++ b/src/core/scene/scene-process/service/animation/scene-node.ts
@@ -1,0 +1,125 @@
+import {
+    Animation,
+    Component,
+    Node,
+    Scene,
+    SkeletalAnimation,
+    animation,
+    js,
+} from 'cc';
+import type { IAnimationValue } from '../../../common';
+import { cloneValue } from './utils';
+
+const NodeMgr = EditorExtends.Node;
+
+export function getAnimationMode(editorType: 'scene' | 'prefab' | 'unknown') {
+    if (editorType === 'scene') {
+        return 'general';
+    }
+    if (editorType === 'prefab') {
+        return 'prefab';
+    }
+    return 'unknown';
+}
+
+export function getNodeByUuid(uuid: string): Node | null {
+    if (!uuid) {
+        return null;
+    }
+    return NodeMgr.getNode(uuid) || null;
+}
+
+export function getNodeByPath(path: string): Node | null {
+    if (!path) {
+        return null;
+    }
+    return NodeMgr.getNodeByPath(path) || null;
+}
+
+export function getNodePath(node: Node): string {
+    return NodeMgr.getNodePath(node) || '';
+}
+
+export function queryAnimationRootNode(node: Node, editorRoot: Node | null): Node {
+    let current: Node | null = node;
+    while (current) {
+        if (queryAnimationComponent(current)) {
+            return current;
+        }
+        if (current === editorRoot || current.parent instanceof Scene) {
+            break;
+        }
+        current = current.parent;
+    }
+    return node;
+}
+
+export function queryAnimationComponent(node: Node): Animation | animation.AnimationController | null {
+    const controllerCtor = (animation as any).AnimationController;
+    const controller = controllerCtor ? node.getComponent(controllerCtor) : null;
+    if (controller) {
+        return controller as animation.AnimationController;
+    }
+    return node.getComponent(Animation);
+}
+
+export function isUsingBakedAnimation(rootNode: Node): boolean {
+    const animComp = queryAnimationComponent(rootNode);
+    return animComp instanceof SkeletalAnimation && Boolean(animComp.useBakedAnimation);
+}
+
+export function isSkeletonClip(uuid: string, rootNode?: Node | null): boolean {
+    if (uuid.includes('@')) {
+        return true;
+    }
+    return Boolean(rootNode && queryAnimationComponent(rootNode) instanceof SkeletalAnimation);
+}
+
+export function readPropertyValue(node: Node, propKey: string): unknown {
+    for (const component of node.components) {
+        const names = getComponentNames(component);
+        for (const name of names) {
+            const prefix = `${name}.`;
+            if (name && propKey.startsWith(prefix)) {
+                return readPathValue(component, propKey.slice(prefix.length));
+            }
+        }
+    }
+
+    return readPathValue(node, propKey);
+}
+
+export function extractSampledOperationValue(value: IAnimationValue, channel?: string): IAnimationValue {
+    if (!channel) {
+        return cloneValue(value);
+    }
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return undefined;
+    }
+    return cloneValue((value as Record<string, IAnimationValue>)[channel]);
+}
+
+function getComponentNames(component: Component): string[] {
+    const names = [
+        js.getClassName(component),
+        (component as any).__className,
+        (component as any).constructor?.__className,
+        (component as any).constructor?.name,
+    ];
+    return names.filter((name, index): name is string => typeof name === 'string' && name.length > 0 && names.indexOf(name) === index);
+}
+
+function readPathValue(target: unknown, path: string): unknown {
+    if (!path) {
+        return target;
+    }
+
+    let value = target as any;
+    for (const key of path.split('.')) {
+        if (value === null || value === undefined) {
+            return undefined;
+        }
+        value = value[key];
+    }
+    return value;
+}

--- a/src/core/scene/scene-process/service/animation/scene-node.ts
+++ b/src/core/scene/scene-process/service/animation/scene-node.ts
@@ -9,6 +9,10 @@ import {
 } from 'cc';
 import type { IAnimationValue } from '../../../common';
 import { cloneValue } from './utils';
+import {
+    parseMaterialUniformPropertyKey,
+    readMaterialUniformValue,
+} from './material-uniform';
 
 const NodeMgr = EditorExtends.Node;
 
@@ -76,9 +80,13 @@ export function isSkeletonClip(uuid: string, rootNode?: Node | null): boolean {
 }
 
 export function readPropertyValue(node: Node, propKey: string): unknown {
+    const materialUniform = parseMaterialUniformPropertyKey(propKey);
     for (const component of node.components) {
         const names = getComponentNames(component);
         for (const name of names) {
+            if (materialUniform && name === materialUniform.comp) {
+                return readMaterialUniformValue(component as any, materialUniform);
+            }
             const prefix = `${name}.`;
             if (name && propKey.startsWith(prefix)) {
                 return readPathValue(component, propKey.slice(prefix.length));

--- a/src/core/scene/scene-process/service/animation/service-playback.ts
+++ b/src/core/scene/scene-process/service/animation/service-playback.ts
@@ -1,0 +1,127 @@
+import type { AnimationState } from 'cc';
+import type { AnimationEventReason, AnimationPlayState } from '../../../common';
+
+export interface IAnimationServicePlaybackContext {
+    getCurrentState(): AnimationState | undefined;
+    getEditTime(): number;
+    getPlayState(): AnimationPlayState;
+    setEditTime(time: number): void;
+    setPlayState(playState: AnimationPlayState): void;
+    enterAnimationMode(): void;
+    exitAnimationMode(): void;
+    repaintInEditMode(): Promise<void>;
+    broadcastTimeChanged(reason: AnimationEventReason): void;
+    broadcastStateChanged(reason: AnimationEventReason): Promise<void>;
+}
+
+export class AnimationServicePlayback {
+    private _playbackTimeBroadcastTimer: ReturnType<typeof setInterval> | null = null;
+    private _lastPlaybackBroadcastTime = Number.NaN;
+
+    constructor(private readonly _context: IAnimationServicePlaybackContext) {}
+
+    play(state: AnimationState): void {
+        state.weight = 1;
+        if (state.isPlaying && state.isPaused) {
+            state.resume();
+        } else {
+            state.play();
+        }
+        this._context.setPlayState('playing');
+        this._context.enterAnimationMode();
+        this._startPlaybackTimeBroadcast();
+    }
+
+    pause(state: AnimationState): void {
+        this._stopPlaybackTimeBroadcast();
+        state.pause();
+        this._context.setEditTime(state.current);
+        this._context.setPlayState('pause');
+        this._context.exitAnimationMode();
+    }
+
+    resume(state: AnimationState): void {
+        if (!state.isPlaying) {
+            state.weight = 1;
+            state.play();
+        }
+        state.resume();
+        this._context.setPlayState('playing');
+        this._context.enterAnimationMode();
+        this._startPlaybackTimeBroadcast();
+    }
+
+    async stopCurrent(): Promise<void> {
+        this._stopPlaybackTimeBroadcast();
+        const state = this._context.getCurrentState();
+        if (state) {
+            state.setTime(0);
+            if (!state.isPaused) {
+                state.pause();
+            }
+            state.sample();
+            state.stop();
+        }
+        this._context.setEditTime(0);
+        this._context.setPlayState('stop');
+        this._context.exitAnimationMode();
+    }
+
+    dispose(): void {
+        this._stopPlaybackTimeBroadcast();
+        this._context.exitAnimationMode();
+        this._context.setPlayState('stop');
+    }
+
+    private _startPlaybackTimeBroadcast(): void {
+        this._stopPlaybackTimeBroadcast();
+        this._lastPlaybackBroadcastTime = Number.NaN;
+        this._playbackTimeBroadcastTimer = setInterval(() => {
+            this._broadcastPlaybackTimeTick();
+        }, 100);
+    }
+
+    private _stopPlaybackTimeBroadcast(): void {
+        if (this._playbackTimeBroadcastTimer) {
+            clearInterval(this._playbackTimeBroadcastTimer);
+            this._playbackTimeBroadcastTimer = null;
+        }
+    }
+
+    private _broadcastPlaybackTimeTick(): void {
+        if (this._context.getPlayState() !== 'playing') {
+            this._stopPlaybackTimeBroadcast();
+            return;
+        }
+        const state = this._context.getCurrentState();
+        const time = state?.current;
+        if (!state || state.isPaused) {
+            this._stopPlaybackTimeBroadcast();
+            return;
+        }
+        if (!state.isPlaying) {
+            this._stopPlaybackTimeBroadcast();
+            const duration = Number.isFinite(state.duration) ? state.duration : this._context.getEditTime();
+            this._context.setEditTime(Math.max(0, duration));
+            state.weight = 1;
+            state.setTime(this._context.getEditTime());
+            state.sample();
+            this._context.setPlayState('stop');
+            this._context.exitAnimationMode();
+            void this._context.repaintInEditMode();
+            this._context.broadcastTimeChanged('play-state');
+            void this._context.broadcastStateChanged('play-state')
+                .catch((error) => console.error('[Animation] broadcast playback stop state failed:', error));
+            return;
+        }
+        if (typeof time !== 'number' || !Number.isFinite(time)) {
+            return;
+        }
+        if (Math.abs(time - this._lastPlaybackBroadcastTime) < 0.001) {
+            return;
+        }
+        this._context.setEditTime(time);
+        this._lastPlaybackBroadcastTime = time;
+        this._context.broadcastTimeChanged('play-state');
+    }
+}

--- a/src/core/scene/scene-process/service/animation/service-playback.ts
+++ b/src/core/scene/scene-process/service/animation/service-playback.ts
@@ -95,8 +95,11 @@ export class AnimationServicePlayback {
         }
         const state = this._context.getCurrentState();
         const time = state?.current;
-        if (!state || state.isPaused) {
+        if (!state) {
             this._stopPlaybackTimeBroadcast();
+            return;
+        }
+        if (state.isPaused) {
             return;
         }
         if (!state.isPlaying) {

--- a/src/core/scene/scene-process/service/animation/service-save.ts
+++ b/src/core/scene/scene-process/service/animation/service-save.ts
@@ -1,0 +1,32 @@
+import {
+    AnimationClip,
+    Node,
+} from 'cc';
+import { Rpc } from '../../rpc';
+import { isSkeletonClip } from './scene-node';
+import { saveSkeletonAnimationMeta } from './skeleton-meta';
+import type { IAnimationSession } from './types';
+
+export async function saveAnimationServiceClip(options: {
+    session: IAnimationSession;
+    rootNode: Node;
+    clip: AnimationClip;
+}): Promise<boolean> {
+    const { session, rootNode, clip } = options;
+    if (isSkeletonClip(session.clipUuid, rootNode)) {
+        await saveSkeletonAnimationMeta(session.clipUuid, clip);
+        return true;
+    }
+
+    const content = EditorExtends.serialize(clip);
+    const assetInfo = await Rpc.getInstance().request('assetManager', 'queryAssetInfo', [session.clipUuid]);
+    if (assetInfo) {
+        await Rpc.getInstance().request('assetManager', 'saveAsset', [assetInfo.uuid, content]);
+    } else {
+        await Rpc.getInstance().request('assetManager', 'createAsset', [{
+            target: `db://assets/${clip.name}.anim`,
+            content,
+        }]);
+    }
+    return true;
+}

--- a/src/core/scene/scene-process/service/animation/service-save.ts
+++ b/src/core/scene/scene-process/service/animation/service-save.ts
@@ -20,13 +20,9 @@ export async function saveAnimationServiceClip(options: {
 
     const content = EditorExtends.serialize(clip);
     const assetInfo = await Rpc.getInstance().request('assetManager', 'queryAssetInfo', [session.clipUuid]);
-    if (assetInfo) {
-        await Rpc.getInstance().request('assetManager', 'saveAsset', [assetInfo.uuid, content]);
-    } else {
-        await Rpc.getInstance().request('assetManager', 'createAsset', [{
-            target: `db://assets/${clip.name}.anim`,
-            content,
-        }]);
+    if (!assetInfo) {
+        throw new Error(`Animation clip asset not found: ${session.clipUuid}`);
     }
+    await Rpc.getInstance().request('assetManager', 'saveAsset', [assetInfo.uuid, content]);
     return true;
 }

--- a/src/core/scene/scene-process/service/animation/service-target.ts
+++ b/src/core/scene/scene-process/service/animation/service-target.ts
@@ -1,0 +1,160 @@
+import {
+    Animation,
+    AnimationClip,
+    AnimationState,
+    Node,
+} from 'cc';
+import type {
+    AnimationEventReason,
+    IAnimationClipDump,
+    IAnimationClipEvent,
+    IAnimationEnterOptions,
+    IAnimationPropertyInfo,
+    IAnimationQueryClipOptions,
+    IAnimationQueryPropertyValueAtFrameOptions,
+    IAnimationTargetOptions,
+} from '../../../common';
+import { createClipDump } from './clip-dump';
+import type { IPropertyCurveMetadataContext } from './property-curve';
+import { ACTIVE_PROPERTY, DEFAULT_PROPERTIES } from './property-menu';
+import { queryAnimationPropertyMetadata, queryComponentAnimableProperties } from './property-metadata';
+import {
+    getNodeByPath,
+    getNodeByUuid,
+    isSkeletonClip,
+    isUsingBakedAnimation,
+    queryAnimationRootNode,
+} from './scene-node';
+import { IAnimationSession } from './types';
+import { clipUuid } from './utils';
+
+export function assertAnimationEditorOpened(editorRoot: Node | null): asserts editorRoot is Node {
+    if (!editorRoot) {
+        throw new Error('Animation editor requires an opened scene or prefab.');
+    }
+}
+
+export function requireAnimationSession(session: IAnimationSession | null): IAnimationSession {
+    if (!session) {
+        throw new Error('Animation editing session is not active.');
+    }
+    return session;
+}
+
+export function resolveAnimationRootTarget(options: IAnimationTargetOptions, editorRoot: Node | null, selection: string[]): Node {
+    const node = resolveAnimationTargetNode(options, editorRoot, selection);
+    return options.rootPath || options.rootUuid ? node : queryAnimationRootNode(node, editorRoot);
+}
+
+export function resolveAnimationTargetNode(
+    options: IAnimationTargetOptions | IAnimationEnterOptions,
+    editorRoot: Node | null,
+    selection: string[],
+): Node {
+    assertAnimationEditorOpened(editorRoot);
+    const uuid = 'rootUuid' in options ? options.rootUuid : undefined;
+    const path = 'rootPath' in options ? options.rootPath : undefined;
+    const nodeUuid = 'nodeUuid' in options ? options.nodeUuid : undefined;
+    const nodePath = 'nodePath' in options ? options.nodePath : undefined;
+    const target = getNodeByUuid(uuid || nodeUuid || '') || getNodeByPath(path || nodePath || '');
+    if (target) {
+        return target;
+    }
+
+    if (selection.length > 0) {
+        const selected = getNodeByPath(selection[0]);
+        if (selected) {
+            return selected;
+        }
+    }
+
+    throw new Error('Animation target node is required.');
+}
+
+export function resolveAnimationFrameQueryNode(options: IAnimationQueryPropertyValueAtFrameOptions, session: IAnimationSession): Node {
+    const nodeByUuid = getNodeByUuid(options.nodeUuid || '');
+    if (nodeByUuid) {
+        return nodeByUuid;
+    }
+
+    const path = options.nodePath || session.rootPath;
+    const nodeByPath = getNodeByPath(path);
+    if (nodeByPath) {
+        return nodeByPath;
+    }
+
+    if (options.nodePath && !options.nodePath.startsWith(session.rootPath)) {
+        const relativeNode = getNodeByPath(`${session.rootPath}/${options.nodePath}`);
+        if (relativeNode) {
+            return relativeNode;
+        }
+    }
+
+    throw new Error(`Animation target node is required: ${path}`);
+}
+
+export function isCurrentAnimationSessionClipQuery(
+    session: IAnimationSession | null,
+    options: IAnimationQueryClipOptions,
+    uuid: string,
+    hasTarget: boolean,
+): boolean {
+    if (!session || uuid !== session.clipUuid) {
+        return false;
+    }
+    if (!hasTarget) {
+        return true;
+    }
+    return options.rootUuid === session.rootUuid
+        || options.rootPath === session.rootPath
+        || options.nodeUuid === session.rootUuid
+        || options.nodePath === session.rootPath;
+}
+
+export function queryAnimationServiceProperties(node: Node, root: Node | null): IAnimationPropertyInfo[] {
+    const isChild = Boolean(root && root !== node);
+    const properties = isChild ? [ACTIVE_PROPERTY, ...DEFAULT_PROPERTIES] : [...DEFAULT_PROPERTIES];
+
+    for (const comp of node.components) {
+        if (!comp || comp instanceof Animation) {
+            continue;
+        }
+        properties.push(...queryComponentAnimableProperties(comp));
+    }
+
+    return properties;
+}
+
+export function createAnimationServiceClipDump(rootNode: Node, clip: AnimationClip, state?: AnimationState): IAnimationClipDump {
+    return createClipDump(clip, state, {
+        isSkeleton: isSkeletonClip(clipUuid(clip), rootNode),
+        useBakedAnimation: isUsingBakedAnimation(rootNode),
+        queryPropertyMetadata: (nodePath, propKey) => queryAnimationPropertyMetadata(rootNode, nodePath, propKey),
+    });
+}
+
+export function createAnimationPropertyCurveMetadataContext(rootNode: Node): IPropertyCurveMetadataContext {
+    return {
+        queryPropertyMetadata: (nodePath, propKey) => queryAnimationPropertyMetadata(rootNode, nodePath, propKey),
+    };
+}
+
+export function createAnimationServiceClipEvent(session: IAnimationSession | null, reason: AnimationEventReason): IAnimationClipEvent | null {
+    if (!session) {
+        return null;
+    }
+    return {
+        reason,
+        rootUuid: session.rootUuid,
+        rootPath: session.rootPath,
+        clipUuid: session.clipUuid,
+    };
+}
+
+export function getAnimationSessionRootNode(session: IAnimationSession): Node {
+    const rootNode = getNodeByUuid(session.rootUuid);
+    if (!rootNode) {
+        throw new Error(`Animation root node not found: ${session.rootUuid}`);
+    }
+    return rootNode;
+}

--- a/src/core/scene/scene-process/service/animation/service-target.ts
+++ b/src/core/scene/scene-process/service/animation/service-target.ts
@@ -77,20 +77,32 @@ export function resolveAnimationFrameQueryNode(options: IAnimationQueryPropertyV
         return nodeByUuid;
     }
 
-    const path = options.nodePath || session.rootPath;
-    const nodeByPath = getNodeByPath(path);
-    if (nodeByPath) {
-        return nodeByPath;
-    }
+    if (options.nodePath) {
+        const path = options.nodePath;
+        if (path === session.rootPath || path.startsWith(`${session.rootPath}/`)) {
+            const nodeByPath = getNodeByPath(path);
+            if (nodeByPath) {
+                return nodeByPath;
+            }
+        }
 
-    if (options.nodePath && !options.nodePath.startsWith(session.rootPath)) {
-        const relativeNode = getNodeByPath(`${session.rootPath}/${options.nodePath}`);
+        const relativeNode = getNodeByPath(`${session.rootPath}/${path}`);
         if (relativeNode) {
             return relativeNode;
         }
+
+        const nodeByPath = getNodeByPath(path);
+        if (nodeByPath) {
+            return nodeByPath;
+        }
+    } else {
+        const rootNode = getNodeByPath(session.rootPath);
+        if (rootNode) {
+            return rootNode;
+        }
     }
 
-    throw new Error(`Animation target node is required: ${path}`);
+    throw new Error(`Animation target node is required: ${options.nodePath || session.rootPath}`);
 }
 
 export function isCurrentAnimationSessionClipQuery(

--- a/src/core/scene/scene-process/service/animation/service-target.ts
+++ b/src/core/scene/scene-process/service/animation/service-target.ts
@@ -117,10 +117,17 @@ export function isCurrentAnimationSessionClipQuery(
     if (!hasTarget) {
         return true;
     }
+    const sessionRootPath = normalizeTargetPath(session.rootPath);
+    const optionRootPath = normalizeTargetPath(options.rootPath || '');
+    const optionNodePath = normalizeTargetPath(options.nodePath || '');
     return options.rootUuid === session.rootUuid
-        || options.rootPath === session.rootPath
+        || (options.rootPath !== undefined && optionRootPath === sessionRootPath)
         || options.nodeUuid === session.rootUuid
-        || options.nodePath === session.rootPath;
+        || (options.nodePath !== undefined && optionNodePath === sessionRootPath);
+}
+
+function normalizeTargetPath(path: string): string {
+    return String(path || '').replace(/^\/+|\/+$/g, '');
 }
 
 export function queryAnimationServiceProperties(node: Node, root: Node | null): IAnimationPropertyInfo[] {

--- a/src/core/scene/scene-process/service/animation/skeleton-meta.ts
+++ b/src/core/scene/scene-process/service/animation/skeleton-meta.ts
@@ -1,0 +1,46 @@
+import type { AnimationClip } from 'cc';
+import type { IAssetMeta } from '../../../../assets/@types/public';
+import { Rpc } from '../../rpc';
+import { serializeAuxiliaryCurvesForMeta } from './auxiliary-curve';
+import {
+    queryEmbeddedPlayerGroups,
+    serializeEmbeddedPlayersForMeta,
+} from './embedded-player';
+import { cloneValue, queryClipEvents } from './utils';
+
+export async function saveSkeletonAnimationMeta(clipUuid: string, clip: AnimationClip): Promise<void> {
+    const meta = await Rpc.getInstance().request('assetManager', 'queryAssetMeta', [clipUuid]) as IAssetMeta | null;
+    if (!meta) {
+        throw new Error(`Animation clip meta not found: ${clipUuid}`);
+    }
+    if (!meta.userData || typeof meta.userData !== 'object') {
+        meta.userData = {};
+    }
+    const userData = meta.userData as Record<string, any>;
+
+    const events = queryClipEvents(clip);
+    if (!events) {
+        throw new Error('Animation clip events are invalid.');
+    }
+
+    userData.events = events.map((event) => ({
+        frame: Number(event.frame) || 0,
+        func: typeof event.func === 'string' ? event.func : '',
+        params: Array.isArray(event.params) ? cloneValue(event.params) : [],
+    }));
+    userData.embeddedPlayers = serializeEmbeddedPlayersForMeta(clip);
+    userData.editorExtras = {
+        ...(isRecord(userData.editorExtras) ? userData.editorExtras : {}),
+        embeddedPlayerGroups: queryEmbeddedPlayerGroups(clip),
+    };
+    userData.wrapMode = Number((clip as any).wrapMode) || 0;
+    userData.speed = Number((clip as any).speed) || 0;
+    userData.sample = Number((clip as any).sample) || 0;
+    userData.auxiliaryCurves = serializeAuxiliaryCurvesForMeta(clip);
+
+    await Rpc.getInstance().request('assetManager', 'saveAssetMeta', [clipUuid, meta]);
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/core/scene/scene-process/service/animation/state-registry.ts
+++ b/src/core/scene/scene-process/service/animation/state-registry.ts
@@ -1,0 +1,59 @@
+import {
+    AnimationClip,
+    AnimationState,
+    Node,
+} from 'cc';
+
+export class AnimationStateRegistry {
+    private readonly _states = new Map<string, AnimationState>();
+
+    constructor(
+        private readonly _getRootNode: () => Node,
+        private readonly _loadClip: (uuid: string) => Promise<AnimationClip>,
+    ) {}
+
+    get(uuid: string): AnimationState | undefined {
+        return this._states.get(uuid);
+    }
+
+    async getOrCreate(uuid: string): Promise<AnimationState> {
+        const existed = this._states.get(uuid);
+        if (existed) {
+            return existed;
+        }
+
+        return this.create(uuid, await this._loadClip(uuid));
+    }
+
+    create(uuid: string, clip: AnimationClip): AnimationState {
+        const state = new AnimationState(clip);
+        (state as any)._curveLoaded = false;
+        state.initialize(this._getRootNode());
+        this._states.set(uuid, state);
+        return state;
+    }
+
+    reset(uuid: string): void {
+        const state = this._states.get(uuid);
+        if (!state) {
+            return;
+        }
+        destroyAnimationState(state);
+        this._states.delete(uuid);
+    }
+
+    clear(): void {
+        for (const state of this._states.values()) {
+            destroyAnimationState(state);
+        }
+        this._states.clear();
+    }
+}
+
+function destroyAnimationState(state: AnimationState): void {
+    try {
+        state.destroy();
+    } catch (e) {
+        console.warn('[Animation] destroy animation state failed:', e);
+    }
+}

--- a/src/core/scene/scene-process/service/animation/state-registry.ts
+++ b/src/core/scene/scene-process/service/animation/state-registry.ts
@@ -3,6 +3,7 @@ import {
     AnimationState,
     Node,
 } from 'cc';
+import { ensureClipEvents } from './utils';
 
 export class AnimationStateRegistry {
     private readonly _states = new Map<string, AnimationState>();
@@ -26,6 +27,7 @@ export class AnimationStateRegistry {
     }
 
     create(uuid: string, clip: AnimationClip): AnimationState {
+        ensureClipEvents(clip);
         const state = new AnimationState(clip);
         state.initialize(this._getRootNode());
         this._states.set(uuid, state);

--- a/src/core/scene/scene-process/service/animation/state-registry.ts
+++ b/src/core/scene/scene-process/service/animation/state-registry.ts
@@ -27,7 +27,6 @@ export class AnimationStateRegistry {
 
     create(uuid: string, clip: AnimationClip): AnimationState {
         const state = new AnimationState(clip);
-        (state as any)._curveLoaded = false;
         state.initialize(this._getRootNode());
         this._states.set(uuid, state);
         return state;

--- a/src/core/scene/scene-process/service/animation/types.ts
+++ b/src/core/scene/scene-process/service/animation/types.ts
@@ -1,4 +1,5 @@
 import type { Animation, AnimationClip, Node, animation } from 'cc';
+import type { IAnimationSampledNodeState } from './sampled-state';
 
 export interface IAnimationData {
     node: Node;
@@ -14,5 +15,5 @@ export interface IAnimationSession {
     rootUuid: string;
     rootPath: string;
     clipUuid: string;
-    sampledRootDump: unknown;
+    sampledRootState: IAnimationSampledNodeState | null;
 }

--- a/src/core/scene/scene-process/service/animation/types.ts
+++ b/src/core/scene/scene-process/service/animation/types.ts
@@ -1,0 +1,18 @@
+import type { Animation, AnimationClip, Node, animation } from 'cc';
+
+export interface IAnimationData {
+    node: Node;
+    animComp: Animation | animation.AnimationController;
+    clips: AnimationClip[];
+    defaultClip: AnimationClip | null;
+}
+
+export interface IAnimationSession {
+    previousEditorType: 'scene' | 'prefab' | 'unknown';
+    previousSelection: string[];
+    restoreSelectionOnExit: boolean;
+    rootUuid: string;
+    rootPath: string;
+    clipUuid: string;
+    sampledRootDump: unknown;
+}

--- a/src/core/scene/scene-process/service/animation/types.ts
+++ b/src/core/scene/scene-process/service/animation/types.ts
@@ -1,4 +1,5 @@
 import type { Animation, AnimationClip, Node, animation } from 'cc';
+import type { IUndoCheckpoint } from '../../../common';
 import type { IAnimationSampledNodeState } from './sampled-state';
 
 export interface IAnimationData {
@@ -16,4 +17,6 @@ export interface IAnimationSession {
     rootPath: string;
     clipUuid: string;
     sampledRootState: IAnimationSampledNodeState | null;
+    undoBaseline: IUndoCheckpoint;
+    globalDirtyAtEnter: boolean;
 }

--- a/src/core/scene/scene-process/service/animation/undo.ts
+++ b/src/core/scene/scene-process/service/animation/undo.ts
@@ -1,0 +1,54 @@
+import type { IUndoCommand, IUndoCommandMeta, IUndoRedoResult } from '../../../common';
+import { createUndoId } from '../undo/commands/command-utils-shared';
+import type { IAnimationClipSnapshot } from './clip-snapshot';
+
+interface IAnimationClipSnapshotCommandOptions {
+    clipUuid: string;
+    before: IAnimationClipSnapshot;
+    after: IAnimationClipSnapshot;
+    applySnapshot: (snapshot: IAnimationClipSnapshot) => Promise<void>;
+}
+
+export class AnimationClipSnapshotCommand implements IUndoCommand {
+    readonly meta: IUndoCommandMeta;
+
+    constructor(private readonly options: IAnimationClipSnapshotCommandOptions) {
+        this.meta = {
+            id: createUndoId('animation-operation'),
+            label: 'Animation Operation',
+            type: 'animation:clip-snapshot',
+            scope: {
+                assetUuid: options.clipUuid,
+                editorType: 'animation',
+                mode: 'animation',
+            },
+            timestamp: Date.now(),
+        };
+    }
+
+    async undo(): Promise<IUndoRedoResult> {
+        return await this._apply(this.options.before);
+    }
+
+    async redo(): Promise<IUndoRedoResult> {
+        return await this._apply(this.options.after);
+    }
+
+    private async _apply(snapshot: IAnimationClipSnapshot): Promise<IUndoRedoResult> {
+        try {
+            await this.options.applySnapshot(snapshot);
+            return {
+                success: true,
+                commandId: this.meta.id,
+                label: this.meta.label,
+            };
+        } catch (error) {
+            return {
+                success: false,
+                commandId: this.meta.id,
+                label: this.meta.label,
+                reason: error instanceof Error ? error.message : String(error),
+            };
+        }
+    }
+}

--- a/src/core/scene/scene-process/service/animation/utils.ts
+++ b/src/core/scene/scene-process/service/animation/utils.ts
@@ -1,0 +1,55 @@
+import type { AnimationClip } from 'cc';
+
+export function cloneDump<T>(dump: T): T {
+    return JSON.parse(JSON.stringify(dump)) as T;
+}
+
+export function cloneValue<T>(value: T): T {
+    if (value === null || value === undefined) {
+        return value;
+    }
+    if (typeof value !== 'object') {
+        return value;
+    }
+    return cloneDump(value);
+}
+
+export function clipUuid(clip: AnimationClip | null | undefined): string {
+    return ((clip as any)?._uuid || (clip as any)?.uuid || '') as string;
+}
+
+export function getClipSample(clip: AnimationClip): number {
+    const sample = Number((clip as any).sample);
+    return Number.isFinite(sample) && sample > 0 ? sample : 1;
+}
+
+export function queryClipEvents(clip: AnimationClip): any[] | null {
+    const events = (clip as any).events;
+    return Array.isArray(events) ? events : null;
+}
+
+export function ensureClipEvents(clip: AnimationClip): any[] {
+    if (!Array.isArray((clip as any).events)) {
+        (clip as any).events = [];
+    }
+    return (clip as any).events;
+}
+
+export function normalizeFrames(value: unknown): number[] {
+    const values = Array.isArray(value) ? value : [value];
+    return values
+        .map((item) => Number(item))
+        .filter((item) => Number.isFinite(item))
+        .map((item) => Math.round(item));
+}
+
+export function updateClipEventData(clip: AnimationClip): void {
+    if (typeof (clip as any).updateEventDatas === 'function') {
+        (clip as any).updateEventDatas();
+    }
+}
+
+export function normalizeAuxiliaryCurveValue(value: unknown): number {
+    const numberValue = Number(value);
+    return Number.isFinite(numberValue) ? numberValue : 0;
+}

--- a/src/core/scene/scene-process/service/animation/utils.ts
+++ b/src/core/scene/scene-process/service/animation/utils.ts
@@ -1,7 +1,8 @@
 import type { AnimationClip } from 'cc';
+import { isAnimationAssetValue } from './asset-value';
 
 export function cloneDump<T>(dump: T): T {
-    return JSON.parse(JSON.stringify(dump)) as T;
+    return cloneValue(dump);
 }
 
 export function cloneValue<T>(value: T): T {
@@ -11,7 +12,33 @@ export function cloneValue<T>(value: T): T {
     if (typeof value !== 'object') {
         return value;
     }
-    return cloneDump(value);
+    if (Array.isArray(value)) {
+        return value.map((item) => cloneValue(item)) as T;
+    }
+    if (isAnimationAssetValue(value)) {
+        return value;
+    }
+    if (isPlainObject(value)) {
+        const result: Record<string, unknown> = {};
+        for (const [key, item] of Object.entries(value)) {
+            result[key] = cloneValue(item);
+        }
+        return result as T;
+    }
+    if (isCloneableObject(value)) {
+        const cloned = value.clone();
+        return cloned === value ? value : cloned as T;
+    }
+    return value;
+}
+
+function isPlainObject(value: object): value is Record<string, unknown> {
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+}
+
+function isCloneableObject(value: object): value is { clone(): unknown } {
+    return typeof (value as { clone?: unknown }).clone === 'function';
 }
 
 export function clipUuid(clip: AnimationClip | null | undefined): string {

--- a/src/core/scene/scene-process/service/animation/utils.ts
+++ b/src/core/scene/scene-process/service/animation/utils.ts
@@ -32,6 +32,27 @@ export function cloneValue<T>(value: T): T {
     return value;
 }
 
+export function cloneSerializableValue<T>(value: T): T {
+    if (value === null || value === undefined) {
+        return value;
+    }
+    if (typeof value !== 'object') {
+        return value;
+    }
+    if (Array.isArray(value)) {
+        return value.map((item) => cloneSerializableValue(item)) as T;
+    }
+    if (isAnimationAssetValue(value)) {
+        return value;
+    }
+
+    const result: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value)) {
+        result[key] = cloneSerializableValue(item);
+    }
+    return result as T;
+}
+
 function isPlainObject(value: object): value is Record<string, unknown> {
     const prototype = Object.getPrototypeOf(value);
     return prototype === Object.prototype || prototype === null;

--- a/src/core/scene/scene-process/service/component.ts
+++ b/src/core/scene/scene-process/service/component.ts
@@ -26,6 +26,7 @@ import { SnapshotCommand, type ISnapshotAdapter } from './undo/commands/snapshot
 import { AddComponentCommand } from './undo/commands/add-component-command';
 import { RemoveComponentCommand } from './undo/commands/remove-component-command';
 import { createUndoId, restoreComponentSnapshotDump, snapshotMapsEqual } from './undo/commands/command-utils-shared';
+import { broadcastAnimationPropertyCommitted } from './animation/property-commit-event';
 
 const NodeMgr = EditorExtends.Node;
 
@@ -401,7 +402,7 @@ export class ComponentService extends BaseService<IComponentEvents> implements I
             return false;
         }
 
-        return this._recordComponentPropertySnapshot(node, {
+        const result = await this._recordComponentPropertySnapshot(node, {
             label: `Set ${options.path}`,
             type: 'component:set-property',
             path: options.path,
@@ -437,6 +438,14 @@ export class ComponentService extends BaseService<IComponentEvents> implements I
             }
             return true;
         });
+        if (result) {
+            broadcastAnimationPropertyCommitted({
+                nodePath: options.nodePath,
+                propPath: options.path,
+                source: 'editor',
+            });
+        }
+        return result;
     }
 
     private _shouldRecordComponentCommand(): boolean {

--- a/src/core/scene/scene-process/service/component.ts
+++ b/src/core/scene/scene-process/service/component.ts
@@ -538,7 +538,7 @@ export class ComponentService extends BaseService<IComponentEvents> implements I
             scope: {
                 editorType: 'scene',
                 nodePath: options.nodePath,
-                propPath: options.path,
+                propPath: this._createComponentAnimationPropPath(node, options.path),
             },
             timestamp: Date.now(),
         }, before, after, this._createComponentPropertySnapshotAdapter()));
@@ -635,6 +635,16 @@ export class ComponentService extends BaseService<IComponentEvents> implements I
         }
 
         return { component, index };
+    }
+
+    private _createComponentAnimationPropPath(node: Node, path: string): string {
+        const target = this._resolveComponentPropertyTarget(node, path);
+        const propName = path.replace(/^__comps__\.\d+\.?/, '');
+        const componentType = target ? this._getComponentType(target.component) : '';
+        if (!target || !propName || !componentType) {
+            return path;
+        }
+        return `${componentType}.${propName}`;
     }
 
     private _findSnapshotComponent(snapshot: IComponentPropertySnapshot): Component | null {

--- a/src/core/scene/scene-process/service/component.ts
+++ b/src/core/scene/scene-process/service/component.ts
@@ -26,6 +26,7 @@ import { SnapshotCommand, type ISnapshotAdapter } from './undo/commands/snapshot
 import { AddComponentCommand } from './undo/commands/add-component-command';
 import { RemoveComponentCommand } from './undo/commands/remove-component-command';
 import { createUndoId, restoreComponentSnapshotDump, snapshotMapsEqual } from './undo/commands/command-utils-shared';
+import { isUndoApplying } from './undo/applying-state';
 import { broadcastAnimationPropertyCommitted } from './animation/property-commit-event';
 
 const NodeMgr = EditorExtends.Node;
@@ -405,6 +406,7 @@ export class ComponentService extends BaseService<IComponentEvents> implements I
         const result = await this._recordComponentPropertySnapshot(node, {
             label: `Set ${options.path}`,
             type: 'component:set-property',
+            nodePath: options.nodePath,
             path: options.path,
             record: options.record,
         }, async () => {
@@ -438,7 +440,7 @@ export class ComponentService extends BaseService<IComponentEvents> implements I
             }
             return true;
         });
-        if (result) {
+        if (result && options.record !== false && !isUndoApplying()) {
             broadcastAnimationPropertyCommitted({
                 nodePath: options.nodePath,
                 propPath: options.path,
@@ -498,7 +500,7 @@ export class ComponentService extends BaseService<IComponentEvents> implements I
 
     private async _recordComponentPropertySnapshot(
         node: Node,
-        options: { label: string; type: string; path: string; record?: boolean },
+        options: { label: string; type: string; nodePath: string; path: string; record?: boolean },
         mutate: () => Promise<boolean>,
     ): Promise<boolean> {
         if (options.record === false || Service.Undo?.isApplying?.()) {
@@ -533,7 +535,11 @@ export class ComponentService extends BaseService<IComponentEvents> implements I
             id: this._createUndoSnapshotId(options.type),
             label: options.label,
             type: options.type,
-            scope: { editorType: 'scene' },
+            scope: {
+                editorType: 'scene',
+                nodePath: options.nodePath,
+                propPath: options.path,
+            },
             timestamp: Date.now(),
         }, before, after, this._createComponentPropertySnapshotAdapter()));
         return result;

--- a/src/core/scene/scene-process/service/core/decorator.ts
+++ b/src/core/scene/scene-process/service/core/decorator.ts
@@ -58,3 +58,7 @@ export const Service = new Proxy({} as IServiceManager, {
 export function getServiceAll() {
     return Object.values(_serviceRegistry);
 }
+
+export function queryRegisteredService<T = any>(name: string): T | null {
+    return _serviceRegistry[name] ?? null;
+}

--- a/src/core/scene/scene-process/service/dump/decode.ts
+++ b/src/core/scene/scene-process/service/dump/decode.ts
@@ -13,6 +13,7 @@ import { IComponent, INode, IScene, ITargetOverrideInfo } from '../../../common'
 import compMgr from './../component/index';
 import nodeMgr from './../node/index';
 import { IProperty } from '../../../@types/public';
+import { COMPONENT_SNAPSHOT_RESTORE_SKIP_KEYS } from './restore-policy';
 
 type TargetOverrideInfo = Prefab._utils.TargetOverrideInfo;
 const TargetOverrideInfo = Prefab._utils.TargetOverrideInfo;
@@ -226,6 +227,9 @@ async function decodeComponents(dumpComps: any, node: Node, excludeComps?: any) 
         // }
         // 对于原先还在的组件，还原内部的值
         for (const key in dumpComp.value) {
+            if (COMPONENT_SNAPSHOT_RESTORE_SKIP_KEYS.includes(key as typeof COMPONENT_SNAPSHOT_RESTORE_SKIP_KEYS[number])) {
+                continue;
+            }
             await decodePatch(key, dumpComp.value[key], component);
         }
 

--- a/src/core/scene/scene-process/service/dump/decode.ts
+++ b/src/core/scene/scene-process/service/dump/decode.ts
@@ -13,7 +13,6 @@ import { IComponent, INode, IScene, ITargetOverrideInfo } from '../../../common'
 import compMgr from './../component/index';
 import nodeMgr from './../node/index';
 import { IProperty } from '../../../@types/public';
-import { COMPONENT_SNAPSHOT_RESTORE_SKIP_KEYS } from './restore-policy';
 
 type TargetOverrideInfo = Prefab._utils.TargetOverrideInfo;
 const TargetOverrideInfo = Prefab._utils.TargetOverrideInfo;
@@ -227,9 +226,6 @@ async function decodeComponents(dumpComps: any, node: Node, excludeComps?: any) 
         // }
         // 对于原先还在的组件，还原内部的值
         for (const key in dumpComp.value) {
-            if (COMPONENT_SNAPSHOT_RESTORE_SKIP_KEYS.includes(key as typeof COMPONENT_SNAPSHOT_RESTORE_SKIP_KEYS[number])) {
-                continue;
-            }
             await decodePatch(key, dumpComp.value[key], component);
         }
 

--- a/src/core/scene/scene-process/service/dump/types/real-curve-dump.ts
+++ b/src/core/scene/scene-process/service/dump/types/real-curve-dump.ts
@@ -5,6 +5,8 @@ import {
 import { DumpInterface } from './dump-interface';
 import * as cc from 'cc';
 
+const EDITOR_EXTRAS_TAG = cc.editorExtrasTag || '__editorExtras__';
+
 // valueType 直接使用引擎序列化
 class RealCurveDump implements DumpInterface {
 
@@ -32,6 +34,7 @@ class RealCurveDump implements DumpInterface {
                 postExtrap: curve.postExtrapolation,
                 preExtrap: curve.preExtrapolation,
                 keyFrames: [...curve.keyframes()].map(([time, value]) => {
+                    const editorExtras = value[EDITOR_EXTRAS_TAG] || {};
                     return {
                         time,
                         value: value.value,
@@ -44,6 +47,8 @@ class RealCurveDump implements DumpInterface {
 
                         interpMode: value.interpolationMode,
                         tangentWeightMode: value.tangentWeightMode,
+                        tangentMode: editorExtras.tangentMode,
+                        broken: editorExtras.broken,
                     };
                 }),
             };
@@ -61,7 +66,7 @@ class RealCurveDump implements DumpInterface {
     public decodeByDump(dump: any, curve: cc.RealCurve, opts?: any): cc.RealCurve {
         if (dump.value.keyFrames) {
             const keyData = dump.value.keyFrames.map((item: any) => {
-                return [item.time, {
+                const value: any = {
                     value: item.value,
 
                     leftTangent: item.inTangent,
@@ -72,7 +77,14 @@ class RealCurveDump implements DumpInterface {
 
                     leftTangentWeight: item.inTangentWeight,
                     rightTangentWeight: item.outTangentWeight,
-                }];
+                };
+                if (item.tangentMode !== undefined || item.broken !== undefined) {
+                    value[EDITOR_EXTRAS_TAG] = {
+                        tangentMode: item.tangentMode,
+                        broken: item.broken,
+                    };
+                }
+                return [item.time, value];
             });
             curve.assignSorted(keyData);
             curve.postExtrapolation = dump.value.postExtrap;

--- a/src/core/scene/scene-process/service/engine.ts
+++ b/src/core/scene/scene-process/service/engine.ts
@@ -237,6 +237,14 @@ export class EngineService extends BaseService<IEngineEvents> implements IEngine
         this._updateTickState();
     }
 
+    public enterAnimationMode() {
+        this.enterState(NeedAnimState.ANIMATION_MODE);
+    }
+
+    public exitAnimationMode() {
+        this.exitState(NeedAnimState.ANIMATION_MODE);
+    }
+
     public resume() {
         this._paused = false;
         this.startTick();

--- a/src/core/scene/scene-process/service/gizmo/base/gizmo-base.ts
+++ b/src/core/scene/scene-process/service/gizmo/base/gizmo-base.ts
@@ -1,5 +1,9 @@
 import { Node, Component } from 'cc';
-import { broadcastAnimationPropertyCommitted } from '../../animation/property-commit-event';
+import type { IUndoScope } from '../../../../common';
+import {
+    broadcastAnimationPropertyCommitted,
+    normalizeAnimationPropertyCommitPath,
+} from '../../animation/property-commit-event';
 
 type BroadcastService = {
     broadcast?(event: string, ...args: unknown[]): void;
@@ -112,9 +116,9 @@ class GizmoBase<T extends Component = Component> {
         }
     }
 
-    onControlEnd(propPath: string | null) {
+    async onControlEnd(propPath: string | null) {
         this._isControlBegin = false;
-        this.commitChanges();
+        await this.commitChanges();
         try {
             const svcEvents = getServiceEvents();
             svcEvents?.broadcast?.('gizmo:control-end', propPath);
@@ -132,6 +136,7 @@ class GizmoBase<T extends Component = Component> {
                 const svc = getService();
                 this.undoID = svc?.Undo?.beginRecording?.(uuids, {
                     label: propPath ? `Gizmo ${propPath}` : 'Gizmo Change',
+                    scope: this.createRecordingScope(propPath),
                 }) ?? '';
             } catch (e) {
                 this.undoID = '';
@@ -140,18 +145,35 @@ class GizmoBase<T extends Component = Component> {
         }
     }
 
-    commitChanges() {
+    async commitChanges() {
         this._recorded = false;
         if (this.undoID !== '') {
             const undoID = this.undoID;
             try {
                 const svc = getService();
-                void svc?.Undo?.endRecording?.(undoID)?.catch?.((_error: unknown) => {});
+                await svc?.Undo?.endRecording?.(undoID);
             } catch (e) {
-                // 服务还没初始化完成。
+                console.warn('[Gizmo] Failed to end undo recording:', e);
             }
         }
         this.undoID = '';
+    }
+
+    private createRecordingScope(propPath?: string | null): IUndoScope | undefined {
+        const nodes = this.nodes;
+        if (!propPath || nodes.length !== 1) {
+            return undefined;
+        }
+        const EditorExtends = (cc as any).EditorExtends || (globalThis as any).EditorExtends;
+        const nodePath = EditorExtends?.Node?.getNodePath?.(nodes[0]);
+        if (!nodePath) {
+            return undefined;
+        }
+        return {
+            editorType: 'scene',
+            nodePath,
+            propPath: normalizeAnimationPropertyCommitPath(propPath),
+        };
     }
 
     public checkVisible(): boolean {
@@ -177,7 +199,7 @@ class GizmoBase<T extends Component = Component> {
         // 这种情况下 onControlEnd 不会触发，所以这里主动结束录制，
         // 避免该节点一直被认为正在录制，导致后续修改不再记录 undo。
         // 没有开始录制时，commitChanges 不会产生额外影响。
-        this.commitChanges();
+        void this.commitChanges();
         if (this.onDestroy) {
             this.onDestroy();
         }

--- a/src/core/scene/scene-process/service/gizmo/base/gizmo-base.ts
+++ b/src/core/scene/scene-process/service/gizmo/base/gizmo-base.ts
@@ -1,4 +1,5 @@
 import { Node, Component } from 'cc';
+import { broadcastAnimationPropertyCommitted } from '../../animation/property-commit-event';
 
 type BroadcastService = {
     broadcast?(event: string, ...args: unknown[]): void;
@@ -216,20 +217,19 @@ class GizmoBase<T extends Component = Component> {
         return null;
     }
 
-    private broadcastAnimationPropertyCommitted(svc: BroadcastService | null, propPath: string | null): void {
+    private broadcastAnimationPropertyCommitted(propPath: string | null): void {
         if (!propPath) {
             return;
         }
         const EditorExtends = (cc as any).EditorExtends || (globalThis as any).EditorExtends;
-        const normalizedPropPath = propPath.replace(/^_components\b/, '__comps__');
         for (const node of this.nodes) {
             const nodePath = EditorExtends?.Node?.getNodePath?.(node);
             if (!nodePath) {
                 continue;
             }
-            svc?.broadcast?.('animation:property-committed', {
+            broadcastAnimationPropertyCommitted({
                 nodePath,
-                propPath: normalizedPropPath,
+                propPath,
                 source: 'engine',
             });
         }

--- a/src/core/scene/scene-process/service/gizmo/base/gizmo-base.ts
+++ b/src/core/scene/scene-process/service/gizmo/base/gizmo-base.ts
@@ -122,7 +122,7 @@ class GizmoBase<T extends Component = Component> {
         try {
             const svcEvents = getServiceEvents();
             svcEvents?.broadcast?.('gizmo:control-end', propPath);
-			this.broadcastAnimationPropertyCommitted(svc, propPath);
+			this.broadcastAnimationPropertyCommitted(propPath);
         } catch (e) {
             console.warn('[Gizmo] Failed to broadcast legacy control-end event:', e);
         }

--- a/src/core/scene/scene-process/service/gizmo/base/gizmo-base.ts
+++ b/src/core/scene/scene-process/service/gizmo/base/gizmo-base.ts
@@ -122,7 +122,6 @@ class GizmoBase<T extends Component = Component> {
         try {
             const svcEvents = getServiceEvents();
             svcEvents?.broadcast?.('gizmo:control-end', propPath);
-			this.broadcastAnimationPropertyCommitted(propPath);
         } catch (e) {
             console.warn('[Gizmo] Failed to broadcast legacy control-end event:', e);
         }

--- a/src/core/scene/scene-process/service/gizmo/base/gizmo-base.ts
+++ b/src/core/scene/scene-process/service/gizmo/base/gizmo-base.ts
@@ -1,5 +1,9 @@
 import { Node, Component } from 'cc';
 
+type BroadcastService = {
+    broadcast?(event: string, ...args: unknown[]): void;
+};
+
 /**
  * 获取 Service（惰性访问，避免循环依赖）
  */
@@ -113,6 +117,7 @@ class GizmoBase<T extends Component = Component> {
         try {
             const svcEvents = getServiceEvents();
             svcEvents?.broadcast?.('gizmo:control-end', propPath);
+			this.broadcastAnimationPropertyCommitted(svc, propPath);
         } catch (e) {
             // not ready
         }
@@ -209,6 +214,25 @@ class GizmoBase<T extends Component = Component> {
             return '_components.' + compIdx + '.' + propName;
         }
         return null;
+    }
+
+    private broadcastAnimationPropertyCommitted(svc: BroadcastService | null, propPath: string | null): void {
+        if (!propPath) {
+            return;
+        }
+        const EditorExtends = (cc as any).EditorExtends || (globalThis as any).EditorExtends;
+        const normalizedPropPath = propPath.replace(/^_components\b/, '__comps__');
+        for (const node of this.nodes) {
+            const nodePath = EditorExtends?.Node?.getNodePath?.(node);
+            if (!nodePath) {
+                continue;
+            }
+            svc?.broadcast?.('animation:property-committed', {
+                nodePath,
+                propPath: normalizedPropPath,
+                source: 'engine',
+            });
+        }
     }
 
     protected onComponentChanged(_node: Node) {

--- a/src/core/scene/scene-process/service/gizmo/base/gizmo-base.ts
+++ b/src/core/scene/scene-process/service/gizmo/base/gizmo-base.ts
@@ -120,8 +120,9 @@ class GizmoBase<T extends Component = Component> {
             svcEvents?.broadcast?.('gizmo:control-end', propPath);
 			this.broadcastAnimationPropertyCommitted(svc, propPath);
         } catch (e) {
-            // not ready
+            console.warn('[Gizmo] Failed to broadcast legacy control-end event:', e);
         }
+        this.broadcastAnimationPropertyCommitted(propPath);
     }
 
     recordChanges(propPath?: string | null) {

--- a/src/core/scene/scene-process/service/index.ts
+++ b/src/core/scene/scene-process/service/index.ts
@@ -5,6 +5,7 @@ export * from './script';
 export * from './asset';
 export * from './component';
 export * from './engine';
+export * from './animation';
 export * from './prefab';
 export * from './selection';
 export * from './operation';

--- a/src/core/scene/scene-process/service/interfaces.ts
+++ b/src/core/scene/scene-process/service/interfaces.ts
@@ -29,6 +29,7 @@ import {
     ISceneViewService,
     IPublicUIService,
     IUIService,
+    IAnimationService,
 } from '../../common';
 
 /**
@@ -59,6 +60,7 @@ export interface IServiceManager {
     Script: IScriptService,
     Asset: IAssetService,
     Engine: IEngineService,
+    Animation: IAnimationService,
     Prefab: IPrefabService,
     Selection: ISelectionService,
     Operation: IOperationService,

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -30,6 +30,7 @@ import { CCClass, CCObject, Component, Node, Prefab, Quat, Vec3 } from 'cc';
 import { createNodeByAsset, loadAny } from './node/node-create';
 import { getUICanvasNode, setLayer } from './node/node-utils';
 import { NodeUndoHelper } from './node/node-undo';
+import { isUndoApplying } from './undo/applying-state';
 import { prefabUtils } from './prefab/utils';
 import { sceneUtils } from './scene/utils';
 import nodeMgr from './node/index';
@@ -485,6 +486,11 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             label: `Set ${options.path}`,
             type: 'node:set-property',
             record: options.record,
+            scope: {
+                editorType: 'scene',
+                nodePath: options.nodePath,
+                propPath: options.path,
+            },
         }, async () => {
             if (options.path === 'name' && options.dump.value !== node.name) {
                 // 这里相当于是做个hack的补充功能，因为setProperty并没有改变path。
@@ -496,7 +502,7 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             }
             return await nodeMgr.setProperty(node.uuid, options.path, options.dump, options.record);
         });
-        if (result) {
+        if (result && options.record !== false && !isUndoApplying()) {
             broadcastAnimationPropertyCommitted({
                 nodePath: options.nodePath,
                 propPath: options.path,

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -36,6 +36,7 @@ import nodeMgr from './node/index';
 import NodeConfig from './node/node-type-config';
 import { RemoveNodeCommand } from './undo/commands/remove-node-command';
 import { RemoveComponentCommand } from './undo/commands/remove-component-command';
+import { broadcastAnimationPropertyCommitted } from './animation/property-commit-event';
 
 const NodeMgr = EditorExtends.Node;
 
@@ -480,7 +481,7 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         if (!node) {
             return false;
         }
-        return this._undo.recordNodeSnapshot(node, {
+        const result = await this._undo.recordNodeSnapshot(node, {
             label: `Set ${options.path}`,
             type: 'node:set-property',
             record: options.record,
@@ -495,6 +496,14 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             }
             return await nodeMgr.setProperty(node.uuid, options.path, options.dump, options.record);
         });
+        if (result) {
+            broadcastAnimationPropertyCommitted({
+                nodePath: options.nodePath,
+                propPath: options.path,
+                source: 'editor',
+            });
+        }
+        return result;
     }
 
     public async reset(path: string): Promise<boolean> {

--- a/src/core/scene/scene-process/service/node/node-undo.ts
+++ b/src/core/scene/scene-process/service/node/node-undo.ts
@@ -1,5 +1,5 @@
 import { Component, Node } from 'cc';
-import { NodeEventType, type IUndoRedoResult } from '../../../common';
+import { NodeEventType, type IUndoRedoResult, type IUndoScope } from '../../../common';
 import { Service } from '../core';
 import dumpUtil from '../dump';
 import nodeMgr from './index';
@@ -79,7 +79,7 @@ export class NodeUndoHelper {
 
     async recordNodeSnapshot(
         node: Node,
-        options: { label: string; type: string; record?: boolean },
+        options: { label: string; type: string; record?: boolean; scope?: IUndoScope },
         mutate: () => Promise<boolean>,
     ): Promise<boolean> {
         if (
@@ -102,7 +102,7 @@ export class NodeUndoHelper {
         }
 
         const after = this.captureNodeSnapshots([latestNode]);
-        this.pushNodeSnapshotCommand(options.type, options.label, before, after);
+        this.pushNodeSnapshotCommand(options.type, options.label, before, after, options.scope);
         return result;
     }
 
@@ -200,6 +200,7 @@ export class NodeUndoHelper {
         label: string,
         before: Map<string, INodeSnapshot>,
         after: Map<string, INodeSnapshot>,
+        scope: IUndoScope = { editorType: 'scene' },
     ): void {
         if (this.snapshotMapsEqual(before, after)) {
             return;
@@ -209,7 +210,7 @@ export class NodeUndoHelper {
             id: this._createUndoSnapshotId(type),
             label,
             type,
-            scope: { editorType: 'scene' },
+            scope,
             timestamp: Date.now(),
         }, before, after, this._createNodeSnapshotAdapter()));
     }

--- a/src/core/scene/scene-process/service/redo.ts
+++ b/src/core/scene/scene-process/service/redo.ts
@@ -1,14 +1,14 @@
 import { BaseService } from './core';
 import { register, Service } from './core/decorator';
-import type { IRedoService, IUndoRedoResult } from '../../common';
+import type { IRedoService, IUndoOperationOptions, IUndoRedoResult } from '../../common';
 
 @register('Redo')
 export class RedoService extends BaseService<Record<string, never[]>> implements IRedoService {
-    redo(): Promise<IUndoRedoResult> {
-        return Service.Undo.redo();
+    redo(options?: IUndoOperationOptions): Promise<IUndoRedoResult> {
+        return Service.Undo.redo(options);
     }
 
-    canRedo(): boolean {
-        return Service.Undo.canRedo();
+    canRedo(options?: IUndoOperationOptions): boolean {
+        return Service.Undo.canRedo(options);
     }
 }

--- a/src/core/scene/scene-process/service/service-manager.ts
+++ b/src/core/scene/scene-process/service/service-manager.ts
@@ -15,6 +15,9 @@ type EventMap = {
 // 仅需 messageManager 转发、无服务方法扇出的事件
 const MESSAGE_ONLY_EVENTS = [
     'dirty:changed',
+    'animation:state-changed',
+    'animation:time-changed',
+    'animation:clip-changed',
     'gizmo:coordinate-changed',
     'gizmo:pivot-changed',
     'gizmo:view-mode-changed',

--- a/src/core/scene/scene-process/service/service-manager.ts
+++ b/src/core/scene/scene-process/service/service-manager.ts
@@ -18,6 +18,7 @@ const MESSAGE_ONLY_EVENTS = [
     'animation:state-changed',
     'animation:time-changed',
     'animation:clip-changed',
+    'animation:property-committed',
     'gizmo:coordinate-changed',
     'gizmo:pivot-changed',
     'gizmo:view-mode-changed',

--- a/src/core/scene/scene-process/service/undo.ts
+++ b/src/core/scene/scene-process/service/undo.ts
@@ -1,7 +1,7 @@
 import { BaseService } from './core';
 import { register } from './core/decorator';
 import { SceneUndoManager } from './undo/scene-undo-manager';
-import { EventSourceType, NodeEventType, type IUndoService, type IUndoEvents, type IUndoBeginOptions, type IUndoCommand, type IUndoGroupOptions, type IUndoOperationOptions, type IUndoRedoResult } from '../../common';
+import { EventSourceType, NodeEventType, type IUndoService, type IUndoEvents, type IUndoBeginOptions, type IUndoCommand, type IUndoGroupOptions, type IUndoOperationOptions, type IUndoPushWithPreviousOptions, type IUndoRedoResult } from '../../common';
 import type { Component, Node } from 'cc';
 import { ServiceEvents } from './core/global-events';
 import type { ISnapshotAdapter } from './undo/commands/snapshot-command';
@@ -149,6 +149,13 @@ export class UndoService extends BaseService<IUndoEvents> implements IUndoServic
     push(command: IUndoCommand): void {
         const wasDirty = this._undoMgr.isDirty();
         this._undoMgr.push(command);
+        this._emitDirtyIfChanged(wasDirty);
+        this.broadcast('undo:changed');
+    }
+
+    pushWithPrevious(command: IUndoCommand, options: IUndoPushWithPreviousOptions): void {
+        const wasDirty = this._undoMgr.isDirty();
+        this._undoMgr.pushWithPrevious(command, options);
         this._emitDirtyIfChanged(wasDirty);
         this.broadcast('undo:changed');
     }

--- a/src/core/scene/scene-process/service/undo.ts
+++ b/src/core/scene/scene-process/service/undo.ts
@@ -1,7 +1,7 @@
 import { BaseService } from './core';
 import { register } from './core/decorator';
 import { SceneUndoManager } from './undo/scene-undo-manager';
-import { EventSourceType, NodeEventType, type IUndoService, type IUndoEvents, type IUndoBeginOptions, type IUndoCommand, type IUndoGroupOptions, type IUndoRedoResult } from '../../common';
+import { EventSourceType, NodeEventType, type IUndoService, type IUndoEvents, type IUndoBeginOptions, type IUndoCommand, type IUndoGroupOptions, type IUndoOperationOptions, type IUndoRedoResult } from '../../common';
 import type { Component, Node } from 'cc';
 import { ServiceEvents } from './core/global-events';
 import type { ISnapshotAdapter } from './undo/commands/snapshot-command';
@@ -62,9 +62,9 @@ export class UndoService extends BaseService<IUndoEvents> implements IUndoServic
         this._emitDirtyIfChanged(wasDirty);
     }
 
-    async undo(): Promise<IUndoRedoResult> {
+    async undo(options?: IUndoOperationOptions): Promise<IUndoRedoResult> {
         const wasDirty = this._undoMgr.isDirty();
-        const result = await this._undoMgr.undo();
+        const result = await this._undoMgr.undo(options);
         if (result.success) {
             try {
                 const { Service } = require('./core/decorator');
@@ -78,9 +78,9 @@ export class UndoService extends BaseService<IUndoEvents> implements IUndoServic
         return result;
     }
 
-    async redo(): Promise<IUndoRedoResult> {
+    async redo(options?: IUndoOperationOptions): Promise<IUndoRedoResult> {
         const wasDirty = this._undoMgr.isDirty();
-        const result = await this._undoMgr.redo();
+        const result = await this._undoMgr.redo(options);
         if (result.success) {
             try {
                 const { Service } = require('./core/decorator');
@@ -116,12 +116,12 @@ export class UndoService extends BaseService<IUndoEvents> implements IUndoServic
         return this._undoMgr.isDirty();
     }
 
-    canUndo(): boolean {
-        return this._undoMgr.canUndo();
+    canUndo(options?: IUndoOperationOptions): boolean {
+        return this._undoMgr.canUndo(options);
     }
 
-    canRedo(): boolean {
-        return this._undoMgr.canRedo();
+    canRedo(options?: IUndoOperationOptions): boolean {
+        return this._undoMgr.canRedo(options);
     }
 
     beginGroup(options?: IUndoGroupOptions): string {

--- a/src/core/scene/scene-process/service/undo.ts
+++ b/src/core/scene/scene-process/service/undo.ts
@@ -1,7 +1,7 @@
 import { BaseService } from './core';
 import { register } from './core/decorator';
 import { SceneUndoManager } from './undo/scene-undo-manager';
-import { EventSourceType, NodeEventType, type IUndoService, type IUndoEvents, type IUndoBeginOptions, type IUndoCommand, type IUndoGroupOptions, type IUndoOperationOptions, type IUndoPushWithPreviousOptions, type IUndoRedoResult } from '../../common';
+import { EventSourceType, NodeEventType, type IUndoService, type IUndoEvents, type IUndoBeginOptions, type IUndoCheckpoint, type IUndoCommand, type IUndoGroupOptions, type IUndoOperationOptions, type IUndoPushWithPreviousOptions, type IUndoRedoResult, type IUndoScope } from '../../common';
 import type { Component, Node } from 'cc';
 import { ServiceEvents } from './core/global-events';
 import type { ISnapshotAdapter } from './undo/commands/snapshot-command';
@@ -114,6 +114,18 @@ export class UndoService extends BaseService<IUndoEvents> implements IUndoServic
 
     isDirty(): boolean {
         return this._undoMgr.isDirty();
+    }
+
+    createCheckpoint(): IUndoCheckpoint {
+        return this._undoMgr.createCheckpoint();
+    }
+
+    hasScopedDifference(checkpoint: IUndoCheckpoint, scope: Partial<IUndoScope>): boolean {
+        return this._undoMgr.hasScopedDifference(checkpoint, scope);
+    }
+
+    hasDifferenceOutsideScope(checkpoint: IUndoCheckpoint, scope: Partial<IUndoScope>): boolean {
+        return this._undoMgr.hasDifferenceOutsideScope(checkpoint, scope);
     }
 
     canUndo(options?: IUndoOperationOptions): boolean {

--- a/src/core/scene/scene-process/service/undo/applying-state.ts
+++ b/src/core/scene/scene-process/service/undo/applying-state.ts
@@ -1,0 +1,6 @@
+import { queryRegisteredService } from '../core';
+
+export function isUndoApplying(): boolean {
+    const undo = queryRegisteredService<{ isApplying?: () => boolean }>('Undo');
+    return Boolean(undo?.isApplying?.());
+}

--- a/src/core/scene/scene-process/service/undo/scene-undo-manager.ts
+++ b/src/core/scene/scene-process/service/undo/scene-undo-manager.ts
@@ -9,6 +9,7 @@ interface ISceneUndoOption {
     label?: string;
     tag?: string;
     auto?: boolean;
+    scope?: IUndoScope;
     customCommand?: IUndoCommand;
 }
 
@@ -26,6 +27,7 @@ interface IActiveGroup {
 interface IActiveSnapshotRecording {
     id: string;
     label: string;
+    scope: IUndoScope;
     uuids: string[];
     before: Map<string, any> | Promise<Map<string, any>>;
 }
@@ -253,6 +255,7 @@ class SceneUndoManager {
             this._snapshotRecordings.set(id, {
                 id,
                 label: option.label ?? option.tag ?? id,
+                scope: option.scope ?? {},
                 uuids: [...uuidSet],
                 before: this._snapshotAdapter.capture([...uuidSet]),
             });
@@ -274,22 +277,25 @@ class SceneUndoManager {
     async endRecording(id: SceneUndoCommandID): Promise<boolean> {
         if (this._snapshotAdapter && this._snapshotRecordings.has(id)) {
             const recording = this._snapshotRecordings.get(id)!;
-            const before = isPromiseLike(recording.before) ? await recording.before : recording.before;
-            const capturedAfter = this._snapshotAdapter.capture(recording.uuids);
-            const after = isPromiseLike(capturedAfter) ? await capturedAfter : capturedAfter;
-            this._snapshotRecordings.delete(id);
-            this._removeActiveRecordingUuids(recording.uuids);
-            if (this._snapshotAdapter.equals(before, after)) {
-                return false;
+            try {
+                const before = isPromiseLike(recording.before) ? await recording.before : recording.before;
+                const capturedAfter = this._snapshotAdapter.capture(recording.uuids);
+                const after = isPromiseLike(capturedAfter) ? await capturedAfter : capturedAfter;
+                if (this._snapshotAdapter.equals(before, after)) {
+                    return false;
+                }
+                this.push(new SnapshotCommand({
+                    id,
+                    label: recording.label,
+                    type: 'recording:snapshot',
+                    scope: recording.scope,
+                    timestamp: Date.now(),
+                }, before, after, this._snapshotAdapter));
+                return true;
+            } finally {
+                this._snapshotRecordings.delete(id);
+                this._removeActiveRecordingUuids(recording.uuids);
             }
-            this.push(new SnapshotCommand({
-                id,
-                label: recording.label,
-                type: 'recording:snapshot',
-                scope: {},
-                timestamp: Date.now(),
-            }, before, after, this._snapshotAdapter));
-            return true;
         }
 
         const command = this._autoCommands.find(t => t.id === id) ??
@@ -449,7 +455,7 @@ class SceneUndoManager {
             id,
             label: command.tag || id,
             type: command.custom ? 'custom' : 'recording:snapshot',
-            scope: {},
+            scope: option.scope ?? {},
             timestamp: Date.now(),
         };
         return command;

--- a/src/core/scene/scene-process/service/undo/scene-undo-manager.ts
+++ b/src/core/scene/scene-process/service/undo/scene-undo-manager.ts
@@ -1,4 +1,4 @@
-import type { IUndoCommand, IUndoGroupOptions, IUndoRedoResult } from '../../../common';
+import type { IUndoCommand, IUndoGroupOptions, IUndoOperationOptions, IUndoRedoResult, IUndoScope } from '../../../common';
 import { SceneUndoCommand, SceneUndoCommandID } from './undo-command';
 import { CompositeCommand } from './commands/composite-command';
 import { ISnapshotAdapter, SnapshotCommand } from './commands/snapshot-command';
@@ -57,13 +57,16 @@ class SceneUndoManager {
         this._pushToStack(command);
     }
 
-    async undo(): Promise<IUndoRedoResult> {
+    async undo(options?: IUndoOperationOptions): Promise<IUndoRedoResult> {
         return this._enqueue(async () => {
             if (this._index === -1) {
                 return { success: false, reason: 'Cannot undo' };
             }
             const command = this._commandArray[this._index];
             if (!command) {
+                return { success: false, reason: 'Cannot undo' };
+            }
+            if (!matchesUndoScope(command.meta.scope, options?.scope)) {
                 return { success: false, reason: 'Cannot undo' };
             }
             const result = await this._applyCommand(command, 'undo');
@@ -74,13 +77,16 @@ class SceneUndoManager {
         });
     }
 
-    async redo(): Promise<IUndoRedoResult> {
+    async redo(options?: IUndoOperationOptions): Promise<IUndoRedoResult> {
         return this._enqueue(async () => {
             if (this._index >= this._commandArray.length - 1) {
                 return { success: false, reason: 'Cannot redo' };
             }
             const command = this._commandArray[this._index + 1];
             if (!command) {
+                return { success: false, reason: 'Cannot redo' };
+            }
+            if (!matchesUndoScope(command.meta.scope, options?.scope)) {
                 return { success: false, reason: 'Cannot redo' };
             }
             const result = await this._applyCommand(command, 'redo');
@@ -115,12 +121,12 @@ class SceneUndoManager {
         return this._lastSavedCommandId !== this._currentCommandId();
     }
 
-    canUndo(): boolean {
-        return this._index >= 0;
+    canUndo(options?: IUndoOperationOptions): boolean {
+        return this._index >= 0 && this._commandMatchesAt(this._index, options?.scope);
     }
 
-    canRedo(): boolean {
-        return this._index < this._commandArray.length - 1;
+    canRedo(options?: IUndoOperationOptions): boolean {
+        return this._index < this._commandArray.length - 1 && this._commandMatchesAt(this._index + 1, options?.scope);
     }
 
     isApplying(): boolean {
@@ -177,6 +183,11 @@ class SceneUndoManager {
 
     getHistoryForTesting(): IUndoCommand[] {
         return [...this._commandArray];
+    }
+
+    private _commandMatchesAt(index: number, scope?: Partial<IUndoScope>): boolean {
+        const command = this._commandArray[index];
+        return Boolean(command && matchesUndoScope(command.meta.scope, scope));
     }
 
     hasActiveRecording(uuid?: string): boolean {
@@ -449,6 +460,18 @@ class SceneUndoManager {
 
 function isPromiseLike<T>(value: T | Promise<T>): value is Promise<T> {
     return !!value && typeof (value as Promise<T>).then === 'function';
+}
+
+function matchesUndoScope(commandScope: IUndoScope, expectedScope?: Partial<IUndoScope>): boolean {
+    if (!expectedScope) {
+        return true;
+    }
+    for (const [key, value] of Object.entries(expectedScope) as [keyof IUndoScope, unknown][]) {
+        if (value !== undefined && commandScope[key] !== value) {
+            return false;
+        }
+    }
+    return true;
 }
 
 export { SceneUndoManager, ISceneUndoOption };

--- a/src/core/scene/scene-process/service/undo/scene-undo-manager.ts
+++ b/src/core/scene/scene-process/service/undo/scene-undo-manager.ts
@@ -66,21 +66,36 @@ class SceneUndoManager {
             return;
         }
 
-        const previous = this._index === this._commandArray.length - 1 ? this._commandArray[this._index] : undefined;
-        if (!previous || !matchesUndoScope(previous.meta.scope, options.previousScope) || !matchesUndoType(previous.meta.type, options.previousTypes)) {
+        if (this._index !== this._commandArray.length - 1) {
             this._pushToStack(command);
             return;
         }
 
-        this._commandArray.splice(this._index, 1);
-        this._index--;
+        const previousCommands: IUndoCommand[] = [];
+        let previousIndex = this._index;
+        while (previousIndex >= 0) {
+            const previous = this._commandArray[previousIndex];
+            if (!previous || !matchesUndoScope(previous.meta.scope, options.previousScope) || !matchesUndoType(previous.meta.type, options.previousTypes)) {
+                break;
+            }
+            previousCommands.unshift(previous);
+            previousIndex--;
+        }
+
+        if (previousCommands.length === 0) {
+            this._pushToStack(command);
+            return;
+        }
+
+        this._commandArray.splice(previousIndex + 1, previousCommands.length);
+        this._index = previousIndex;
         this._pushToStack(new CompositeCommand({
             id: this._createId(options.type),
             label: options.label ?? command.meta.label,
             type: options.type,
             scope: options.scope,
             timestamp: Date.now(),
-        }, [previous, command]));
+        }, [...previousCommands, command]));
     }
 
     async undo(options?: IUndoOperationOptions): Promise<IUndoRedoResult> {

--- a/src/core/scene/scene-process/service/undo/scene-undo-manager.ts
+++ b/src/core/scene/scene-process/service/undo/scene-undo-manager.ts
@@ -1,4 +1,4 @@
-import type { IUndoCommand, IUndoGroupOptions, IUndoOperationOptions, IUndoRedoResult, IUndoScope } from '../../../common';
+import type { IUndoCommand, IUndoGroupOptions, IUndoOperationOptions, IUndoPushWithPreviousOptions, IUndoRedoResult, IUndoScope } from '../../../common';
 import { SceneUndoCommand, SceneUndoCommandID } from './undo-command';
 import { CompositeCommand } from './commands/composite-command';
 import { ISnapshotAdapter, SnapshotCommand } from './commands/snapshot-command';
@@ -55,6 +55,29 @@ class SceneUndoManager {
             return;
         }
         this._pushToStack(command);
+    }
+
+    pushWithPrevious(command: IUndoCommand, options: IUndoPushWithPreviousOptions): void {
+        if (this._activeGroup) {
+            this._activeGroup.children.push(command);
+            return;
+        }
+
+        const previous = this._index === this._commandArray.length - 1 ? this._commandArray[this._index] : undefined;
+        if (!previous || !matchesUndoScope(previous.meta.scope, options.previousScope) || !matchesUndoType(previous.meta.type, options.previousTypes)) {
+            this._pushToStack(command);
+            return;
+        }
+
+        this._commandArray.splice(this._index, 1);
+        this._index--;
+        this._pushToStack(new CompositeCommand({
+            id: this._createId(options.type),
+            label: options.label ?? command.meta.label,
+            type: options.type,
+            scope: options.scope,
+            timestamp: Date.now(),
+        }, [previous, command]));
     }
 
     async undo(options?: IUndoOperationOptions): Promise<IUndoRedoResult> {
@@ -472,6 +495,10 @@ function matchesUndoScope(commandScope: IUndoScope, expectedScope?: Partial<IUnd
         }
     }
     return true;
+}
+
+function matchesUndoType(commandType: string, expectedTypes?: string[]): boolean {
+    return !expectedTypes || expectedTypes.includes(commandType);
 }
 
 export { SceneUndoManager, ISceneUndoOption };

--- a/src/core/scene/scene-process/service/undo/scene-undo-manager.ts
+++ b/src/core/scene/scene-process/service/undo/scene-undo-manager.ts
@@ -1,4 +1,4 @@
-import type { IUndoCommand, IUndoGroupOptions, IUndoOperationOptions, IUndoPushWithPreviousOptions, IUndoRedoResult, IUndoScope } from '../../../common';
+import type { IUndoCheckpoint, IUndoCommand, IUndoGroupOptions, IUndoOperationOptions, IUndoPushWithPreviousOptions, IUndoRedoResult, IUndoScope } from '../../../common';
 import { SceneUndoCommand, SceneUndoCommandID } from './undo-command';
 import { CompositeCommand } from './commands/composite-command';
 import { ISnapshotAdapter, SnapshotCommand } from './commands/snapshot-command';
@@ -34,6 +34,7 @@ class SceneUndoManager {
     private _commandArray: IUndoCommand[] = [];
     private _index = -1;
     private _lastSavedCommandId: string | null = null;
+    private _checkpointGeneration = 0;
     private _autoCommands: SceneUndoCommand[] = [];
     private _manualCommands: SceneUndoCommand[] = [];
     private _snapshotRecordings: Map<string, IActiveSnapshotRecording> = new Map();
@@ -124,6 +125,7 @@ class SceneUndoManager {
         this._commandArray.length = 0;
         this._index = -1;
         this._lastSavedCommandId = null;
+        this._checkpointGeneration++;
         this._autoCommands.length = 0;
         this._manualCommands.length = 0;
         this._snapshotRecordings.clear();
@@ -142,6 +144,18 @@ class SceneUndoManager {
 
     isDirty(): boolean {
         return this._lastSavedCommandId !== this._currentCommandId();
+    }
+
+    createCheckpoint(): IUndoCheckpoint {
+        return { commandId: this._currentCommandId(), generation: this._checkpointGeneration };
+    }
+
+    hasScopedDifference(checkpoint: IUndoCheckpoint, scope: Partial<IUndoScope>): boolean {
+        return this._hasDifferenceSince(checkpoint, command => matchesUndoScope(command.meta.scope, scope));
+    }
+
+    hasDifferenceOutsideScope(checkpoint: IUndoCheckpoint, scope: Partial<IUndoScope>): boolean {
+        return this._hasDifferenceSince(checkpoint, command => !matchesUndoScope(command.meta.scope, scope));
     }
 
     canUndo(options?: IUndoOperationOptions): boolean {
@@ -372,6 +386,36 @@ class SceneUndoManager {
 
     private _currentCommandId(): string | null {
         return this._index === -1 ? null : this._commandArray[this._index]?.meta.id ?? null;
+    }
+
+    private _hasDifferenceSince(checkpoint: IUndoCheckpoint, matches: (command: IUndoCommand) => boolean): boolean {
+        if (checkpoint.generation !== this._checkpointGeneration) {
+            return false;
+        }
+        const checkpointIndex = this._resolveCheckpointIndex(checkpoint);
+        if (checkpointIndex === undefined) {
+            return this._currentCommandId() !== checkpoint.commandId;
+        }
+        if (checkpointIndex === this._index) {
+            return false;
+        }
+        const start = Math.min(checkpointIndex, this._index) + 1;
+        const end = Math.max(checkpointIndex, this._index);
+        for (let i = start; i <= end; i++) {
+            const command = this._commandArray[i];
+            if (command && matches(command)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private _resolveCheckpointIndex(checkpoint: IUndoCheckpoint): number | undefined {
+        if (checkpoint.commandId === null) {
+            return -1;
+        }
+        const index = this._commandArray.findIndex(command => command.meta.id === checkpoint.commandId);
+        return index === -1 ? undefined : index;
     }
 
     // 降级路径：仅在未注入 snapshotAdapter 时使用（主要是单测）。

--- a/src/core/scene/scene.scripting.middleware.ts
+++ b/src/core/scene/scene.scripting.middleware.ts
@@ -5,18 +5,6 @@ import ejs from 'ejs';
 import { GlobalPaths } from '../../global';
 import { scriptingRoutes } from '../preview/scripting-routes';
 
-function sendFileFromRoot(res: Response, root: string, filePath: string) {
-    const relativePath = path.relative(root, filePath);
-    if (!relativePath || relativePath === '..' || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)) {
-        res.sendStatus(403);
-        return;
-    }
-
-    // Keep hidden parent dirs such as `.temp` outside Express' dotfile check,
-    // while preserving the default protection for dotfiles inside the served root.
-    res.sendFile(relativePath, { root });
-}
-
 export default {
     get: [
         {

--- a/src/core/scene/scene.scripting.middleware.ts
+++ b/src/core/scene/scene.scripting.middleware.ts
@@ -5,6 +5,18 @@ import ejs from 'ejs';
 import { GlobalPaths } from '../../global';
 import { scriptingRoutes } from '../preview/scripting-routes';
 
+function sendFileFromRoot(res: Response, root: string, filePath: string) {
+    const relativePath = path.relative(root, filePath);
+    if (!relativePath || relativePath === '..' || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)) {
+        res.sendStatus(403);
+        return;
+    }
+
+    // Keep hidden parent dirs such as `.temp` outside Express' dotfile check,
+    // while preserving the default protection for dotfiles inside the served root.
+    res.sendFile(relativePath, { root });
+}
+
 export default {
     get: [
         {

--- a/src/core/scene/test/animation-asset-value.test.ts
+++ b/src/core/scene/test/animation-asset-value.test.ts
@@ -1,0 +1,67 @@
+const loadAny = jest.fn();
+
+jest.mock('cc', () => {
+    class Asset {
+        _uuid = '';
+
+        initDefault(uuid?: string) {
+            this._uuid = uuid || this._uuid;
+        }
+    }
+
+    class TextureAsset extends Asset { }
+
+    return {
+        Asset,
+        assetManager: { loadAny },
+        js: {
+            getClassByName(name: string) {
+                return name === 'cc.TextureAsset' ? TextureAsset : null;
+            },
+        },
+    };
+});
+
+describe('Animation asset value helpers', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        loadAny.mockReset();
+    });
+
+    it('uses metadata valueCtor for generic asset values without concrete asset type branches', () => {
+        const { Asset } = require('cc');
+        const {
+            createAnimationAssetPlaceholder,
+            queryAnimationAssetCtor,
+            queryAnimationAssetUuid,
+            serializeAnimationAssetValue,
+        } = require('../scene-process/service/animation/asset-value');
+
+        class IconAsset extends Asset { }
+        const ctor = queryAnimationAssetCtor({
+            type: { value: 'cc.DoesNotNeedClassLookup' },
+            valueCtor: IconAsset,
+        });
+
+        expect(ctor).toBe(IconAsset);
+
+        const placeholder = createAnimationAssetPlaceholder(ctor, 'icon-uuid');
+
+        expect(placeholder).toBeInstanceOf(IconAsset);
+        expect(queryAnimationAssetUuid(placeholder)).toBe('icon-uuid');
+        expect(serializeAnimationAssetValue(placeholder)).toEqual({ uuid: 'icon-uuid' });
+    });
+
+    it('falls back to metadata type class lookup for generic asset values', () => {
+        const {
+            createAnimationAssetPlaceholder,
+            queryAnimationAssetCtor,
+            serializeAnimationAssetValue,
+        } = require('../scene-process/service/animation/asset-value');
+
+        const ctor = queryAnimationAssetCtor({ type: { value: 'cc.TextureAsset' } });
+        const placeholder = createAnimationAssetPlaceholder(ctor, 'texture-uuid');
+
+        expect(serializeAnimationAssetValue(placeholder)).toEqual({ uuid: 'texture-uuid' });
+    });
+});

--- a/src/core/scene/test/animation-clip-library.test.ts
+++ b/src/core/scene/test/animation-clip-library.test.ts
@@ -1,0 +1,113 @@
+class FakeAnimationClip {
+    constructor(
+        public _uuid: string,
+        public name: string,
+        public _tracks: unknown,
+        public _events: unknown = [],
+        public _embeddedPlayers: unknown = [],
+        public _auxiliaryCurveEntries: unknown = [],
+    ) {}
+}
+
+class FakeAnimation {
+    private _clips: FakeAnimationClip[] = [];
+    defaultClip: FakeAnimationClip | null = null;
+
+    get clips() {
+        return this._clips;
+    }
+
+    set clips(value: FakeAnimationClip[]) {
+        for (const clip of value) {
+            if (clip && !Array.isArray(clip._tracks)) {
+                throw new TypeError('invalid clip tracks');
+            }
+            if (clip && !Array.isArray(clip._events)) {
+                throw new TypeError('invalid clip events');
+            }
+            if (clip && !Array.isArray(clip._embeddedPlayers)) {
+                throw new TypeError('invalid clip embedded players');
+            }
+            if (clip && !Array.isArray(clip._auxiliaryCurveEntries)) {
+                throw new TypeError('invalid clip auxiliary curves');
+            }
+        }
+        this._clips = value;
+    }
+
+    setRawClips(value: FakeAnimationClip[]) {
+        this._clips = value;
+    }
+}
+
+jest.mock('cc', () => ({
+    Animation: FakeAnimation,
+    AnimationClip: FakeAnimationClip,
+    Node: class Node {},
+    Scene: class Scene {},
+    SkeletalAnimation: class SkeletalAnimation extends FakeAnimation {},
+    animation: {
+        AnimationController: class AnimationController {},
+    },
+    assetManager: {
+        assets: {
+            get: jest.fn(),
+        },
+        loadAny: jest.fn(),
+    },
+    js: {
+        getClassName: jest.fn(),
+    },
+}));
+
+(globalThis as any).EditorExtends = {
+    Node: {
+        getNode: jest.fn(),
+        getNodeByPath: jest.fn(),
+        getNodePath: jest.fn(),
+    },
+};
+
+const { rebindAnimationComponentClip } = require('../scene-process/service/animation/clip-library');
+
+describe('animation clip library', () => {
+    it('rebindAnimationComponentClip drops stale unnamed clips before assigning Animation.clips', () => {
+        const anim = new FakeAnimation();
+        const stale = new FakeAnimationClip('stale-clip', '', null, null);
+        const current = new FakeAnimationClip('current-clip', 'CurrentClip', []);
+        anim.setRawClips([stale]);
+        anim.defaultClip = current;
+
+        expect(() => rebindAnimationComponentClip(anim as any, current as any)).not.toThrow();
+        expect(anim.clips).toEqual([current]);
+        expect(anim.defaultClip).toBe(current);
+    });
+
+    it('rebindAnimationComponentClip normalizes null runtime arrays on the bound clip', () => {
+        const anim = new FakeAnimation();
+        const current = new FakeAnimationClip('current-clip', 'CurrentClip', null, null, null, null);
+        anim.defaultClip = current;
+
+        expect(() => rebindAnimationComponentClip(anim as any, current as any)).not.toThrow();
+        expect(current._tracks).toEqual([]);
+        expect(current._events).toEqual([]);
+        expect(current._embeddedPlayers).toEqual([]);
+        expect(current._auxiliaryCurveEntries).toEqual([]);
+        expect(anim.clips).toEqual([current]);
+    });
+
+    it('rebindAnimationComponentClip normalizes retained named clips before assigning Animation.clips', () => {
+        const anim = new FakeAnimation();
+        const retained = new FakeAnimationClip('retained-clip', 'RetainedClip', null, null, null, null);
+        const current = new FakeAnimationClip('current-clip', 'CurrentClip', [], []);
+        anim.setRawClips([retained]);
+        anim.defaultClip = current;
+
+        expect(() => rebindAnimationComponentClip(anim as any, current as any)).not.toThrow();
+        expect(retained._tracks).toEqual([]);
+        expect(retained._events).toEqual([]);
+        expect(retained._embeddedPlayers).toEqual([]);
+        expect(retained._auxiliaryCurveEntries).toEqual([]);
+        expect(anim.clips).toEqual([retained, current]);
+    });
+});

--- a/src/core/scene/test/animation-clip-operations.test.ts
+++ b/src/core/scene/test/animation-clip-operations.test.ts
@@ -1,0 +1,56 @@
+jest.mock('../scene-process/service/animation/auxiliary-curve', () => ({
+    addAuxiliaryCurve: jest.fn(),
+    copyAuxKey: jest.fn(),
+    createAuxKey: jest.fn(),
+    moveAuxKeys: jest.fn(),
+    removeAuxKey: jest.fn(),
+    removeAuxiliaryCurve: jest.fn(),
+    renameAuxiliaryCurve: jest.fn(),
+    updateAuxKeyData: jest.fn(),
+}));
+
+jest.mock('../scene-process/service/animation/embedded-player', () => ({
+    addEmbeddedPlayer: jest.fn(),
+    addEmbeddedPlayerGroup: jest.fn(),
+    clearEmbeddedPlayers: jest.fn(),
+    deleteEmbeddedPlayer: jest.fn(),
+    removeEmbeddedPlayerGroup: jest.fn(),
+    updateEmbeddedPlayer: jest.fn(),
+}));
+
+jest.mock('../scene-process/service/animation/property-curve', () => ({
+    addPropertyCurve: jest.fn(),
+    copyPropertyKeysTo: jest.fn(),
+    createPropertyKey: jest.fn(),
+    movePropertyKeys: jest.fn(),
+    removePropertyCurve: jest.fn(),
+    removePropertyKey: jest.fn(),
+    removePropertyKeys: jest.fn(),
+    setPropertyCurveExtrapolation: jest.fn(),
+    updatePropertyKey: jest.fn(),
+    updatePropertyKeyData: jest.fn(),
+}));
+
+const { applyClipOperation } = require('../scene-process/service/animation/clip-operations');
+
+describe('animation clip operations', () => {
+    it('keeps event time stable when changing sample rate', async () => {
+        const clip = {
+            sample: 30,
+            events: [{ frame: 1, func: 'onOneSecond', params: [] }],
+            updateEventDatas: jest.fn(),
+        };
+
+        const result = await applyClipOperation({ clip }, {
+            type: 'changeSample',
+            clipUuid: 'clip-uuid',
+            sample: 60,
+        }, {});
+
+        expect(result).toBe(true);
+        expect(clip.sample).toBe(60);
+        expect(clip.events[0].frame).toBe(1);
+        expect(Math.round(clip.events[0].frame * clip.sample)).toBe(60);
+        expect(clip.updateEventDatas).toHaveBeenCalled();
+    });
+});

--- a/src/core/scene/test/animation-keyframe-conflicts.test.ts
+++ b/src/core/scene/test/animation-keyframe-conflicts.test.ts
@@ -1,0 +1,101 @@
+jest.mock('cc', () => ({
+    Asset: class Asset {},
+    deserialize: (value: unknown) => value,
+    editorExtrasTag: '__editorExtras__',
+    js: {
+        getClassByName: jest.fn(),
+    },
+}));
+
+import {
+    copyAuxKey,
+    moveAuxKeys,
+    renameAuxiliaryCurve,
+} from '../scene-process/service/animation/auxiliary-curve';
+import { moveCurveKeys } from '../scene-process/service/animation/property-curve-keyframe';
+
+class FakeCurve {
+    constructor(private _keyframes: Array<[number, unknown]>) {}
+
+    keyframes() {
+        return this._keyframes;
+    }
+
+    assignSorted(keyframes: Array<[number, unknown]>) {
+        this._keyframes = keyframes;
+    }
+
+    indexOfKeyframe(time: number) {
+        return this._keyframes.findIndex(([keyTime]) => Math.abs(keyTime - time) <= 1e-6);
+    }
+
+    removeKeyframe(index: number) {
+        this._keyframes.splice(index, 1);
+    }
+
+    getKeyframeValue(index: number) {
+        return this._keyframes[index]?.[1];
+    }
+}
+
+function createClip(curves: Record<string, FakeCurve>, sample = 30) {
+    return {
+        sample,
+        _auxiliaryCurveEntries: Object.entries(curves).map(([name, curve]) => ({ name, curve })),
+        getAuxiliaryCurve_experimental(name: string) {
+            return this._auxiliaryCurveEntries.find((entry) => entry.name === name)?.curve || null;
+        },
+        getAuxiliaryCurveNames_experimental() {
+            return this._auxiliaryCurveEntries.map((entry) => entry.name);
+        },
+        hasAuxiliaryCurve_experimental(name: string) {
+            return this._auxiliaryCurveEntries.some((entry) => entry.name === name);
+        },
+        renameAuxiliaryCurve_experimental(name: string, newName: string) {
+            const entry = this._auxiliaryCurveEntries.find((item) => item.name === name);
+            if (entry) {
+                entry.name = newName;
+            }
+        },
+    };
+}
+
+describe('animation keyframe conflict handling', () => {
+    it('copyAuxKey clones the source value before replacing an earlier target frame', () => {
+        const curve = new FakeCurve([[0, 0], [1, 30]]);
+        const clip = createClip({ BlendWeight: curve });
+
+        expect(copyAuxKey(clip as any, 'BlendWeight', 30, 0)).toBe(true);
+
+        expect(curve.keyframes()).toEqual([[0, 30], [1, 30]]);
+    });
+
+    it('moveAuxKeys replaces existing target-frame keys instead of leaving duplicates', () => {
+        const curve = new FakeCurve([[0, 0], [1, 30]]);
+        const clip = createClip({ BlendWeight: curve });
+
+        expect(moveAuxKeys(clip as any, 'BlendWeight', [30], -30)).toBe(true);
+
+        expect(curve.keyframes()).toEqual([[0, 30]]);
+    });
+
+    it('moveCurveKeys replaces existing target-frame keys instead of leaving duplicates', () => {
+        const curve = new FakeCurve([[0, 0], [1, 30]]);
+        const clip = { sample: 30 };
+
+        expect(moveCurveKeys(clip as any, curve as any, [30], -30)).toBe(true);
+
+        expect(curve.keyframes()).toEqual([[0, 30]]);
+    });
+
+    it('renameAuxiliaryCurve rejects duplicate target names without mutating the clip', () => {
+        const clip = createClip({
+            BlendWeight: new FakeCurve([]),
+            ExistingWeight: new FakeCurve([]),
+        });
+
+        expect(renameAuxiliaryCurve(clip as any, 'BlendWeight', 'ExistingWeight')).toBe(false);
+
+        expect(clip.getAuxiliaryCurveNames_experimental()).toEqual(['BlendWeight', 'ExistingWeight']);
+    });
+});

--- a/src/core/scene/test/animation-sampled-state.test.ts
+++ b/src/core/scene/test/animation-sampled-state.test.ts
@@ -1,3 +1,5 @@
+export {};
+
 const mockAttr = jest.fn();
 
 jest.mock('cc', () => {

--- a/src/core/scene/test/animation-sampled-state.test.ts
+++ b/src/core/scene/test/animation-sampled-state.test.ts
@@ -1,0 +1,80 @@
+const mockAttr = jest.fn();
+
+jest.mock('cc', () => {
+    class Asset {
+        _uuid: string;
+
+        constructor(uuid = '') {
+            this._uuid = uuid;
+        }
+
+        clone() {
+            return new Asset();
+        }
+    }
+
+    class Component {
+        uuid = '';
+        node: unknown;
+    }
+
+    class Animation extends Component { }
+
+    class Node {
+        uuid = '';
+        children: Node[] = [];
+        components: Component[] = [];
+        active = true;
+        position = { clone: () => ({ x: 0, y: 0, z: 0 }), set: jest.fn() };
+        rotation = { clone: () => ({ x: 0, y: 0, z: 0, w: 1 }), set: jest.fn() };
+        scale = { clone: () => ({ x: 1, y: 1, z: 1 }), set: jest.fn() };
+    }
+
+    return {
+        Animation,
+        Asset,
+        CCClass: { attr: mockAttr },
+        Component,
+        Node,
+        animation: {},
+    };
+});
+
+describe('Animation sampled state', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        mockAttr.mockReset();
+    });
+
+    it('restores asset references without cloning them into empty placeholder assets', async () => {
+        const { Asset, Component, Node } = require('cc');
+        const {
+            captureAnimationSampledState,
+            restoreAnimationSampledState,
+        } = require('../scene-process/service/animation/sampled-state');
+
+        class SpriteComponent extends Component {
+            uuid = 'sprite-component';
+            spriteFrame = new Asset('sprite-frame-uuid');
+        }
+        (SpriteComponent as any).__props__ = ['spriteFrame'];
+
+        mockAttr.mockImplementation((_ctor: Function, prop: string) => prop === 'spriteFrame'
+            ? { animatable: true, readonly: false }
+            : undefined);
+
+        const node = new Node();
+        node.uuid = 'node';
+        const sprite = new SpriteComponent();
+        sprite.node = node;
+        node.components = [sprite];
+
+        const state = captureAnimationSampledState(node);
+        sprite.spriteFrame = null;
+
+        await restoreAnimationSampledState(node, state);
+
+        expect(sprite.spriteFrame).toBe(state.components[0].properties.spriteFrame);
+        expect(sprite.spriteFrame._uuid).toBe('sprite-frame-uuid');
+    });
+});

--- a/src/core/scene/test/animation-sampled-state.test.ts
+++ b/src/core/scene/test/animation-sampled-state.test.ts
@@ -1,8 +1,19 @@
 export {};
 
 const mockAttr = jest.fn();
+const mockNodePositionSetter = jest.fn();
 
 jest.mock('cc', () => {
+    function createValueType<T extends Record<string, any>>(value: T): T & { clone: () => T; set: jest.Mock } {
+        const result = { ...value } as T & { clone: () => T; set: jest.Mock };
+        result.clone = () => {
+            const { clone, set, ...plain } = result;
+            return createValueType(plain as unknown as T);
+        };
+        result.set = jest.fn((next) => Object.assign(result, next));
+        return result;
+    }
+
     class Asset {
         _uuid: string;
 
@@ -27,9 +38,18 @@ jest.mock('cc', () => {
         children: Node[] = [];
         components: Component[] = [];
         active = true;
-        position = { clone: () => ({ x: 0, y: 0, z: 0 }), set: jest.fn() };
+        private _position = createValueType({ x: 0, y: 0, z: 0 });
         rotation = { clone: () => ({ x: 0, y: 0, z: 0, w: 1 }), set: jest.fn() };
         scale = { clone: () => ({ x: 1, y: 1, z: 1 }), set: jest.fn() };
+
+        get position() {
+            return this._position;
+        }
+
+        set position(value) {
+            mockNodePositionSetter(value);
+            this._position = value;
+        }
     }
 
     return {
@@ -39,6 +59,7 @@ jest.mock('cc', () => {
         Component,
         Node,
         animation: {},
+        __test: { mockNodePositionSetter },
     };
 });
 
@@ -46,6 +67,91 @@ describe('Animation sampled state', () => {
     beforeEach(() => {
         jest.resetModules();
         mockAttr.mockReset();
+        mockNodePositionSetter.mockReset();
+    });
+
+    it('restores node transform through the property setter instead of mutating the current value type in place', async () => {
+        const { Node, __test } = require('cc');
+        const {
+            captureAnimationSampledState,
+            restoreAnimationSampledState,
+        } = require('../scene-process/service/animation/sampled-state');
+
+        const node = new Node();
+        node.uuid = 'node';
+        node.position = { x: 148.3992, y: 0, z: 0, clone: () => ({ x: 148.3992, y: 0, z: 0 }), set: jest.fn() };
+        const state = captureAnimationSampledState(node);
+        __test.mockNodePositionSetter.mockClear();
+
+        node.position = { x: 694.70697, y: 0, z: 0, clone: () => ({ x: 694.70697, y: 0, z: 0 }), set: jest.fn() };
+        __test.mockNodePositionSetter.mockClear();
+
+        await restoreAnimationSampledState(node, state);
+
+        expect(__test.mockNodePositionSetter).toHaveBeenCalledTimes(1);
+        expect(node.position.x).toBeCloseTo(148.3992);
+    });
+
+    it('restores component value-type properties through their property setter', async () => {
+        const { Component, Node } = require('cc');
+        const {
+            captureAnimationSampledState,
+            restoreAnimationSampledState,
+        } = require('../scene-process/service/animation/sampled-state');
+
+        type TintValue = {
+            r: number;
+            g: number;
+            b: number;
+            a: number;
+            clone: () => TintValue;
+            set: jest.Mock;
+        };
+        function createTintValue(value: { r: number; g: number; b: number; a: number }): TintValue {
+            const tint = {
+                ...value,
+                clone: null as unknown as () => TintValue,
+                set: null as unknown as jest.Mock,
+            } as TintValue;
+            tint.clone = () => createTintValue({ r: tint.r, g: tint.g, b: tint.b, a: tint.a });
+            tint.set = jest.fn((next) => Object.assign(tint, next));
+            return tint;
+        }
+
+        const setter = jest.fn();
+        class TintComponent extends Component {
+            uuid = 'tint-component';
+            private _tint = createTintValue({ r: 10, g: 20, b: 30, a: 255 });
+
+            get tint() {
+                return this._tint;
+            }
+
+            set tint(value) {
+                setter(value);
+                this._tint = value;
+            }
+        }
+        (TintComponent as any).__props__ = ['tint'];
+
+        mockAttr.mockImplementation((_ctor: Function, prop: string) => prop === 'tint'
+            ? { animatable: true, readonly: false }
+            : undefined);
+
+        const node = new Node();
+        node.uuid = 'node';
+        const component = new TintComponent();
+        component.node = node;
+        node.components = [component];
+
+        const state = captureAnimationSampledState(node);
+        component.tint = createTintValue({ r: 200, g: 20, b: 30, a: 255 });
+        setter.mockClear();
+
+        await restoreAnimationSampledState(node, state);
+
+        expect(setter).toHaveBeenCalledTimes(1);
+        expect(component.tint.r).toBe(10);
     });
 
     it('restores asset references without cloning them into empty placeholder assets', async () => {

--- a/src/core/scene/test/animation-sampled-state.test.ts
+++ b/src/core/scene/test/animation-sampled-state.test.ts
@@ -154,6 +154,61 @@ describe('Animation sampled state', () => {
         expect(component.tint.r).toBe(10);
     });
 
+    it('skips getter-only component accessor properties in sampled state restore', async () => {
+        const { Component, Node } = require('cc');
+        const {
+            captureAnimationSampledState,
+            restoreAnimationSampledState,
+        } = require('../scene-process/service/animation/sampled-state');
+
+        class WidgetLike extends Component {
+            uuid = 'widget-like';
+            private _alignLeft = false;
+
+            get isAlignLeft() {
+                return this._alignLeft;
+            }
+
+            set isAlignLeft(value: boolean) {
+                this._alignLeft = value;
+            }
+
+            get isStretchWidth() {
+                return true;
+            }
+        }
+        (WidgetLike as any).__props__ = ['isAlignLeft', 'isStretchWidth'];
+
+        mockAttr.mockImplementation((_ctor: Function, prop: string) => prop === 'isAlignLeft' || prop === 'isStretchWidth'
+            ? { animatable: true, readonly: false }
+            : undefined);
+
+        const node = new Node();
+        node.uuid = 'node';
+        const component = new WidgetLike();
+        component.node = node;
+        node.components = [component];
+
+        const state = captureAnimationSampledState(node);
+
+        expect(state.components[0].properties).toEqual({
+            isAlignLeft: false,
+        });
+
+        await expect(restoreAnimationSampledState(node, {
+            ...state,
+            components: [{
+                uuid: component.uuid,
+                properties: {
+                    isAlignLeft: true,
+                    isStretchWidth: false,
+                },
+            }],
+        })).resolves.toBeUndefined();
+        expect(component.isAlignLeft).toBe(true);
+        expect(component.isStretchWidth).toBe(true);
+    });
+
     it('restores asset references without cloning them into empty placeholder assets', async () => {
         const { Asset, Component, Node } = require('cc');
         const {

--- a/src/core/scene/test/animation-service-animatable.test.ts
+++ b/src/core/scene/test/animation-service-animatable.test.ts
@@ -12,6 +12,7 @@ jest.mock('cc', () => {
     class PrimitiveType {
         constructor(public name: string) { }
     }
+    (Component as any).__className = 'cc.Component';
     (Node as any).__className = 'cc.Node';
 
     return {
@@ -57,7 +58,7 @@ describe('AnimationService animatable property metadata', () => {
     });
 
     it('按旧编辑器规则过滤组件属性的 animatable、visible 和 cc.Node 类型', () => {
-        const { Component } = require('cc');
+        const { Component, Node } = require('cc');
         const { queryComponentAnimableProperties } = require('../scene-process/service/animation/property-metadata');
 
         class TestComponent extends Component {
@@ -66,6 +67,8 @@ describe('AnimationService animatable property metadata', () => {
             forcedHiddenNumber = 3;
             disabledNumber = 4;
             nodeRef = {};
+            nodeCtorRef = {};
+            componentCtorRef = {};
             readonlyNumber = 5;
         }
         (TestComponent as any).__className = 'cc.TestComponent';
@@ -75,6 +78,8 @@ describe('AnimationService animatable property metadata', () => {
             'forcedHiddenNumber',
             'disabledNumber',
             'nodeRef',
+            'nodeCtorRef',
+            'componentCtorRef',
             'readonlyNumber',
         ];
 
@@ -84,6 +89,8 @@ describe('AnimationService animatable property metadata', () => {
             forcedHiddenNumber: { type: 'cc.Number', visible: false, animatable: true },
             disabledNumber: { type: 'cc.Number', animatable: false },
             nodeRef: { type: 'cc.Node' },
+            nodeCtorRef: { type: Node },
+            componentCtorRef: { type: Component },
             readonlyNumber: { type: 'cc.Number', readonly: true },
         };
         mockAttr.mockImplementation((_ctor: Function, prop: string) => attrs[prop]);

--- a/src/core/scene/test/animation-service-animatable.test.ts
+++ b/src/core/scene/test/animation-service-animatable.test.ts
@@ -1,0 +1,99 @@
+const mockAttr = jest.fn();
+
+jest.mock('cc', () => {
+    class Component { }
+    class Node { }
+    class Scene extends Node { }
+    class Animation extends Component { }
+    class SkeletalAnimation extends Animation { }
+    class AnimationClip {
+        static WrapMode = { Reverse: 1 };
+    }
+    class PrimitiveType {
+        constructor(public name: string) { }
+    }
+    (Node as any).__className = 'cc.Node';
+
+    return {
+        Animation,
+        AnimationClip,
+        AnimationState: class AnimationState { },
+        CCClass: {
+            attr: mockAttr,
+            Attr: { PrimitiveType },
+        },
+        Component,
+        Node,
+        Scene,
+        SkeletalAnimation,
+        animation: {},
+        editorExtrasTag: '__editorExtras__',
+        js: {
+            getClassName(target: any) {
+                return target?.__className || target?.constructor?.__className || target?.name || '';
+            },
+        },
+    };
+});
+
+jest.mock('cc/editor/embedded-player', () => ({
+    EmbeddedAnimationClipPlayable: class EmbeddedAnimationClipPlayable { },
+    EmbeddedParticleSystemPlayable: class EmbeddedParticleSystemPlayable { },
+    EmbeddedPlayable: class EmbeddedPlayable { },
+    EmbeddedPlayer: class EmbeddedPlayer { },
+    addEmbeddedPlayerTag: Symbol('addEmbeddedPlayerTag'),
+    clearEmbeddedPlayersTag: Symbol('clearEmbeddedPlayersTag'),
+    getEmbeddedPlayersTag: Symbol('getEmbeddedPlayersTag'),
+}));
+
+describe('AnimationService animatable property metadata', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        mockAttr.mockReset();
+        (global as any).EditorExtends = {
+            Node: {},
+        };
+    });
+
+    it('按旧编辑器规则过滤组件属性的 animatable、visible 和 cc.Node 类型', () => {
+        const { Component } = require('cc');
+        const { AnimationService } = require('../scene-process/service/animation');
+
+        class TestComponent extends Component {
+            visibleNumber = 1;
+            hiddenNumber = 2;
+            forcedHiddenNumber = 3;
+            disabledNumber = 4;
+            nodeRef = {};
+            readonlyNumber = 5;
+        }
+        (TestComponent as any).__className = 'cc.TestComponent';
+        (TestComponent as any).__props__ = [
+            'visibleNumber',
+            'hiddenNumber',
+            'forcedHiddenNumber',
+            'disabledNumber',
+            'nodeRef',
+            'readonlyNumber',
+        ];
+
+        const attrs: Record<string, any> = {
+            visibleNumber: { type: 'cc.Number' },
+            hiddenNumber: { type: 'cc.Number', visible: false },
+            forcedHiddenNumber: { type: 'cc.Number', visible: false, animatable: true },
+            disabledNumber: { type: 'cc.Number', animatable: false },
+            nodeRef: { type: 'cc.Node' },
+            readonlyNumber: { type: 'cc.Number', readonly: true },
+        };
+        mockAttr.mockImplementation((_ctor: Function, prop: string) => attrs[prop]);
+
+        const service = new AnimationService();
+        const properties = (service as any)._queryComponentAnimableProperties(new TestComponent());
+        const keys = properties.map((property: any) => property.key);
+
+        expect(keys).toEqual([
+            'cc.TestComponent.visibleNumber',
+            'cc.TestComponent.forcedHiddenNumber',
+        ]);
+    });
+});

--- a/src/core/scene/test/animation-service-animatable.test.ts
+++ b/src/core/scene/test/animation-service-animatable.test.ts
@@ -50,6 +50,7 @@ describe('AnimationService animatable property metadata', () => {
     beforeEach(() => {
         jest.resetModules();
         mockAttr.mockReset();
+        (global as any).cc = require('cc');
         (global as any).EditorExtends = {
             Node: {},
         };

--- a/src/core/scene/test/animation-service-animatable.test.ts
+++ b/src/core/scene/test/animation-service-animatable.test.ts
@@ -57,7 +57,7 @@ describe('AnimationService animatable property metadata', () => {
 
     it('按旧编辑器规则过滤组件属性的 animatable、visible 和 cc.Node 类型', () => {
         const { Component } = require('cc');
-        const { AnimationService } = require('../scene-process/service/animation');
+        const { queryComponentAnimableProperties } = require('../scene-process/service/animation/property-metadata');
 
         class TestComponent extends Component {
             visibleNumber = 1;
@@ -87,8 +87,7 @@ describe('AnimationService animatable property metadata', () => {
         };
         mockAttr.mockImplementation((_ctor: Function, prop: string) => attrs[prop]);
 
-        const service = new AnimationService();
-        const properties = (service as any)._queryComponentAnimableProperties(new TestComponent());
+        const properties = queryComponentAnimableProperties(new TestComponent());
         const keys = properties.map((property: any) => property.key);
 
         expect(keys).toEqual([
@@ -99,7 +98,7 @@ describe('AnimationService animatable property metadata', () => {
 
     it('从 accessor 当前值推导 UITransform 这类组件属性类型', () => {
         const { Component } = require('cc');
-        const { AnimationService } = require('../scene-process/service/animation');
+        const { queryComponentAnimableProperties } = require('../scene-process/service/animation/property-metadata');
 
         class SizeValue { }
         class Vec2Value { }
@@ -119,12 +118,35 @@ describe('AnimationService animatable property metadata', () => {
         };
         mockAttr.mockImplementation((_ctor: Function, prop: string) => attrs[prop]);
 
-        const service = new AnimationService();
-        const properties = (service as any)._queryComponentAnimableProperties(new UITransform());
+        const properties = queryComponentAnimableProperties(new UITransform());
 
         expect(properties).toEqual(expect.arrayContaining([
             expect.objectContaining({ key: 'cc.UITransform.contentSize', type: { value: 'cc.Size' } }),
             expect.objectContaining({ key: 'cc.UITransform.anchorPoint', type: { value: 'cc.Vec2' } }),
+        ]));
+    });
+
+    it('从 attr.ctor 推导当前值为空的 asset 引用属性类型', () => {
+        const { Component } = require('cc');
+        const { queryComponentAnimableProperties } = require('../scene-process/service/animation/property-metadata');
+
+        class SpriteFrame { }
+        (SpriteFrame as any).__className = 'cc.SpriteFrame';
+
+        class AssetRefComponent extends Component {
+            icon = null;
+        }
+        (AssetRefComponent as any).__className = 'cc.AssetRefComponent';
+        (AssetRefComponent as any).__props__ = ['icon'];
+
+        mockAttr.mockImplementation((_target: Function, prop: string) => prop === 'icon'
+            ? { type: 'Object', ctor: SpriteFrame, visible: true }
+            : undefined);
+
+        const properties = queryComponentAnimableProperties(new AssetRefComponent());
+
+        expect(properties).toEqual(expect.arrayContaining([
+            expect.objectContaining({ key: 'cc.AssetRefComponent.icon', type: { value: 'cc.SpriteFrame' } }),
         ]));
     });
 });

--- a/src/core/scene/test/animation-service-animatable.test.ts
+++ b/src/core/scene/test/animation-service-animatable.test.ts
@@ -96,4 +96,35 @@ describe('AnimationService animatable property metadata', () => {
             'cc.TestComponent.forcedHiddenNumber',
         ]);
     });
+
+    it('从 accessor 当前值推导 UITransform 这类组件属性类型', () => {
+        const { Component } = require('cc');
+        const { AnimationService } = require('../scene-process/service/animation');
+
+        class SizeValue { }
+        class Vec2Value { }
+        (SizeValue as any).__className = 'cc.Size';
+        (Vec2Value as any).__className = 'cc.Vec2';
+
+        class UITransform extends Component {
+            contentSize = new SizeValue();
+            anchorPoint = new Vec2Value();
+        }
+        (UITransform as any).__className = 'cc.UITransform';
+        (UITransform as any).__props__ = ['contentSize', 'anchorPoint'];
+
+        const attrs: Record<string, any> = {
+            contentSize: { visible: true },
+            anchorPoint: { visible: true },
+        };
+        mockAttr.mockImplementation((_ctor: Function, prop: string) => attrs[prop]);
+
+        const service = new AnimationService();
+        const properties = (service as any)._queryComponentAnimableProperties(new UITransform());
+
+        expect(properties).toEqual(expect.arrayContaining([
+            expect.objectContaining({ key: 'cc.UITransform.contentSize', type: { value: 'cc.Size' } }),
+            expect.objectContaining({ key: 'cc.UITransform.anchorPoint', type: { value: 'cc.Vec2' } }),
+        ]));
+    });
 });

--- a/src/core/scene/test/animation-service-animatable.test.ts
+++ b/src/core/scene/test/animation-service-animatable.test.ts
@@ -157,4 +157,59 @@ describe('AnimationService animatable property metadata', () => {
             expect.objectContaining({ key: 'cc.AssetRefComponent.icon', type: { value: 'cc.SpriteFrame' } }),
         ]));
     });
+
+    it('从 attr 保留 enumList 元数据', () => {
+        const { Component } = require('cc');
+        const { queryComponentAnimableProperties } = require('../scene-process/service/animation/property-metadata');
+
+        class EnumComponent extends Component {
+            mode = 1;
+        }
+        (EnumComponent as any).__className = 'cc.EnumComponent';
+        (EnumComponent as any).__props__ = ['mode'];
+
+        const enumList = [
+            { name: 'None', value: 0 },
+            { name: 'Add', value: 1 },
+        ];
+        mockAttr.mockImplementation((_target: Function, prop: string) => prop === 'mode'
+            ? { type: 'Enum', enumList, visible: true }
+            : undefined);
+
+        const properties = queryComponentAnimableProperties(new EnumComponent());
+
+        expect(properties).toEqual([
+            expect.objectContaining({
+                key: 'cc.EnumComponent.mode',
+                type: {
+                    value: 'Enum',
+                    enumList,
+                },
+            }),
+        ]);
+    });
+
+    it('只为 Enum 类型暴露 enumList 元数据', () => {
+        const { Component } = require('cc');
+        const { queryComponentAnimableProperties } = require('../scene-process/service/animation/property-metadata');
+
+        class NumberComponent extends Component {
+            amount = 1;
+        }
+        (NumberComponent as any).__className = 'cc.NumberComponent';
+        (NumberComponent as any).__props__ = ['amount'];
+
+        mockAttr.mockImplementation((_target: Function, prop: string) => prop === 'amount'
+            ? { type: 'cc.Number', enumList: [{ name: 'Ignored', value: 1 }], visible: true }
+            : undefined);
+
+        const properties = queryComponentAnimableProperties(new NumberComponent());
+
+        expect(properties).toEqual([
+            expect.objectContaining({
+                key: 'cc.NumberComponent.amount',
+                type: { value: 'cc.Number' },
+            }),
+        ]);
+    });
 });

--- a/src/core/scene/test/animation-service-animatable.test.ts
+++ b/src/core/scene/test/animation-service-animatable.test.ts
@@ -1,3 +1,5 @@
+export {};
+
 const mockAttr = jest.fn();
 
 jest.mock('cc', () => {

--- a/src/core/scene/test/animation-service-animatable.test.ts
+++ b/src/core/scene/test/animation-service-animatable.test.ts
@@ -575,6 +575,15 @@ describe('AnimationService animatable property metadata', () => {
         expect(parsePropertyTrack(track)?.descriptor.propKey).toBe(key);
     });
 
+    it('parsePropertyTrack 忽略没有 path 的引擎轨道', () => {
+        const { animation } = require('cc');
+        const { parsePropertyTrack } = require('../scene-process/service/animation/property-curve-track');
+        const track = new animation.VectorTrack();
+        track.path = null;
+
+        expect(parsePropertyTrack(track)).toBeNull();
+    });
+
     it('dumpPropertyCurves 保留属性轨道添加顺序', () => {
         const { AnimationClip } = require('cc');
         const { addPropertyCurve, dumpPropertyCurves } = require('../scene-process/service/animation/property-curve');

--- a/src/core/scene/test/animation-service-animatable.test.ts
+++ b/src/core/scene/test/animation-service-animatable.test.ts
@@ -11,6 +11,12 @@ jest.mock('cc', () => {
     class AnimationClip {
         static WrapMode = { Reverse: 1 };
     }
+    const gfx = {
+        Type: {
+            FLOAT4: 16,
+            SAMPLER2D: 28,
+        },
+    };
     class PrimitiveType {
         constructor(public name: string) { }
     }
@@ -26,7 +32,13 @@ jest.mock('cc', () => {
             Attr: { PrimitiveType },
         },
         Component,
+        gfx,
         Node,
+        renderer: {
+            Pass: {
+                getTypeFromHandle: (handle: number) => handle,
+            },
+        },
         Scene,
         SkeletalAnimation,
         animation: {},
@@ -104,6 +116,94 @@ describe('AnimationService animatable property metadata', () => {
             'cc.TestComponent.visibleNumber',
             'cc.TestComponent.forcedHiddenNumber',
         ]);
+    });
+
+    it('按旧编辑器 queryProperties 的实际行为保留组件 type 属性', () => {
+        const { Component } = require('cc');
+        const { queryComponentAnimableProperties } = require('../scene-process/service/animation/property-metadata');
+
+        class Sprite extends Component {
+            type = 0;
+            __scriptAsset = null;
+        }
+        (Sprite as any).__className = 'cc.Sprite';
+        (Sprite as any).__props__ = ['type', '__scriptAsset'];
+
+        const enumList = [
+            { name: 'SIMPLE', value: 0 },
+            { name: 'SLICED', value: 1 },
+        ];
+        mockAttr.mockImplementation((_target: Function, prop: string) => {
+            if (prop === 'type') {
+                return { type: 'Enum', enumList, visible: true };
+            }
+            if (prop === '__scriptAsset') {
+                return { type: 'cc.Asset', visible: true };
+            }
+            return undefined;
+        });
+
+        const properties = queryComponentAnimableProperties(new Sprite());
+
+        expect(properties).toEqual([
+            expect.objectContaining({
+                key: 'cc.Sprite.type',
+                name: 'type',
+                type: {
+                    value: 'Enum',
+                    enumList,
+                },
+            }),
+        ]);
+    });
+
+    it('按旧编辑器规则展开材质 pass uniform 属性', () => {
+        const { Component, gfx } = require('cc');
+        const { queryComponentAnimableProperties } = require('../scene-process/service/animation/property-metadata');
+
+        class Sprite extends Component {
+            material = {
+                passes: [
+                    {
+                        properties: {
+                            mainColor: { editor: { type: 'color' } },
+                            mainTexture: {},
+                        },
+                        getHandle(name: string) {
+                            return name === 'mainColor' ? gfx.Type.FLOAT4 : gfx.Type.SAMPLER2D;
+                        },
+                    },
+                ],
+            };
+        }
+        (Sprite as any).__className = 'cc.Sprite';
+        (Sprite as any).__props__ = ['material'];
+
+        mockAttr.mockImplementation((_target: Function, prop: string) => prop === 'material'
+            ? { type: 'cc.MaterialInstance', visible: true }
+            : undefined);
+
+        const properties = queryComponentAnimableProperties(new Sprite());
+
+        expect(properties).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                key: 'cc.Sprite.material.pass.0.mainColor',
+                displayName: 'cc.Sprite.material.pass[0].mainColor',
+                menuName: 'pass[0].mainColor',
+                name: 'mainColor',
+                type: { value: 'cc.Color' },
+                comp: 'cc.Sprite',
+            }),
+            expect.objectContaining({
+                key: 'cc.Sprite.material.pass.0.mainTexture',
+                displayName: 'cc.Sprite.material.pass[0].mainTexture',
+                menuName: 'pass[0].mainTexture',
+                name: 'mainTexture',
+                type: { value: 'cc.TextureBase' },
+                comp: 'cc.Sprite',
+            }),
+        ]));
+        expect(properties.map((property: any) => property.key)).not.toContain('cc.Sprite.material');
     });
 
     it('从 accessor 当前值推导 UITransform 这类组件属性类型', () => {

--- a/src/core/scene/test/animation-service-animatable.test.ts
+++ b/src/core/scene/test/animation-service-animatable.test.ts
@@ -541,6 +541,26 @@ describe('AnimationService animatable property metadata', () => {
         expect(parsePropertyTrack(track)?.descriptor.propKey).toBe(key);
     });
 
+    it('dumpPropertyCurves 保留属性轨道添加顺序', () => {
+        const { AnimationClip } = require('cc');
+        const { addPropertyCurve, dumpPropertyCurves } = require('../scene-process/service/animation/property-curve');
+        const clip = new AnimationClip();
+        const context = {
+            rootNode: {} as any,
+            rootPath: '',
+        };
+
+        expect(addPropertyCurve(clip, context, { type: 'addPropertyCurve', clipUuid: 'clip', propKey: 'position', value: { x: 0, y: 0, z: 0 } })).toBe(true);
+        expect(addPropertyCurve(clip, context, { type: 'addPropertyCurve', clipUuid: 'clip', propKey: 'eulerAngles', value: { x: 0, y: 0, z: 0 } })).toBe(true);
+        expect(addPropertyCurve(clip, context, { type: 'addPropertyCurve', clipUuid: 'clip', propKey: 'scale', value: { x: 1, y: 1, z: 1 } })).toBe(true);
+
+        expect(dumpPropertyCurves(clip).map((curve: any) => curve.key)).toEqual([
+            'position',
+            'eulerAngles',
+            'scale',
+        ]);
+    });
+
     it('按旧编辑器规则把 object track 的 ccClass dump 还原为实例', () => {
         const { AnimationClip, Rect } = require('cc');
         const { createPropertyKey, dumpPropertyCurves } = require('../scene-process/service/animation/property-curve');

--- a/src/core/scene/test/animation-service-animatable.test.ts
+++ b/src/core/scene/test/animation-service-animatable.test.ts
@@ -4,24 +4,202 @@ const mockAttr = jest.fn();
 
 jest.mock('cc', () => {
     class Component { }
-    class Node { }
+    class Renderer extends Component { }
+    class Color {
+        constructor(
+            public r = 0,
+            public g = 0,
+            public b = 0,
+            public a = 255,
+        ) { }
+    }
+    class Vec2 {
+        constructor(public x = 0, public y = 0) { }
+    }
+    class Vec3 {
+        constructor(public x = 0, public y = 0, public z = 0) { }
+    }
+    class Vec4 {
+        constructor(public x = 0, public y = 0, public z = 0, public w = 0) { }
+    }
+    class Mat4 { }
+    class Rect {
+        constructor(
+            public x = 0,
+            public y = 0,
+            public width = 0,
+            public height = 0,
+        ) { }
+    }
+    class Node {
+        components: Component[] = [];
+        children: Node[] = [];
+        name = '';
+
+        constructor(name = '') {
+            this.name = name;
+        }
+
+        getChildByPath(path: string) {
+            return path ? this.children.find((child) => child.name === path) || null : this;
+        }
+    }
     class Scene extends Node { }
     class Animation extends Component { }
     class SkeletalAnimation extends Animation { }
     class AnimationClip {
         static WrapMode = { Reverse: 1 };
+        sample = 60;
+        _tracks: any[] = [];
+
+        addTrack(track: any) {
+            this._tracks.push(track);
+        }
+
+        getTrack(index: number) {
+            return this._tracks[index];
+        }
+
+        removeTrack(index: number) {
+            this._tracks.splice(index, 1);
+        }
     }
     const gfx = {
         Type: {
+            FLOAT: 13,
+            FLOAT2: 14,
+            FLOAT3: 15,
             FLOAT4: 16,
+            MAT4: 24,
+            SAMPLER1D: 27,
             SAMPLER2D: 28,
+            SAMPLER_CUBE: 31,
         },
     };
+    class ComponentPath {
+        constructor(public component: string) { }
+    }
+    class HierarchyPath {
+        constructor(public path: string) { }
+    }
+    class TrackPath {
+        private _paths: any[] = [];
+
+        get length() {
+            return this._paths.length;
+        }
+
+        toHierarchy(path: string) {
+            this._paths.push(new HierarchyPath(path));
+            return this;
+        }
+
+        toComponent(component: string) {
+            this._paths.push(new ComponentPath(component));
+            return this;
+        }
+
+        toProperty(name: string) {
+            this._paths.push(name);
+            return this;
+        }
+
+        toElement(index: number) {
+            this._paths.push(index);
+            return this;
+        }
+
+        isHierarchyAt(index: number) {
+            return this._paths[index] instanceof HierarchyPath;
+        }
+
+        parseHierarchyAt(index: number) {
+            return this._paths[index].path;
+        }
+
+        isComponentAt(index: number) {
+            return this._paths[index] instanceof ComponentPath;
+        }
+
+        parseComponentAt(index: number) {
+            return this._paths[index].component;
+        }
+
+        isPropertyAt(index: number) {
+            return typeof this._paths[index] === 'string';
+        }
+
+        parsePropertyAt(index: number) {
+            return this._paths[index];
+        }
+
+        isElementAt(index: number) {
+            return typeof this._paths[index] === 'number';
+        }
+
+        parseElementAt(index: number) {
+            return this._paths[index];
+        }
+    }
+    class Curve {
+        keyFramesCount = 0;
+        private _keyframes: any[] = [];
+
+        assignSorted(keyframes: any[]) {
+            this._keyframes = keyframes;
+            this.keyFramesCount = keyframes.length;
+        }
+
+        keyframes() {
+            return this._keyframes;
+        }
+    }
+    class Track {
+        path = new TrackPath();
+        proxy: any;
+        protected _channels = [{ curve: new Curve() }];
+
+        channels() {
+            return this._channels;
+        }
+    }
+    class VectorTrack extends Track {
+        set componentsCount(value: number) {
+            this._channels = Array.from({ length: value }, () => ({ curve: new Curve() }));
+        }
+    }
+    class ColorTrack extends Track {
+        protected _channels = Array.from({ length: 4 }, () => ({ curve: new Curve() }));
+    }
+    class SizeTrack extends Track {
+        protected _channels = Array.from({ length: 2 }, () => ({ curve: new Curve() }));
+    }
+    class RealTrack extends Track { }
+    class QuatTrack extends Track { }
+    class ObjectTrack extends Track { }
+    class UniformProxyFactory {
+        passIndex = 0;
+        uniformName = '';
+        channelIndex: number | undefined;
+
+        constructor(uniformName?: string, passIndex?: number) {
+            this.uniformName = uniformName || '';
+            this.passIndex = passIndex || 0;
+        }
+    }
     class PrimitiveType {
         constructor(public name: string) { }
     }
     (Component as any).__className = 'cc.Component';
     (Node as any).__className = 'cc.Node';
+    const classMap: Record<string, any> = {
+        'cc.Color': Color,
+        'cc.Mat4': Mat4,
+        'cc.Rect': Rect,
+        'cc.Vec2': Vec2,
+        'cc.Vec3': Vec3,
+        'cc.Vec4': Vec4,
+    };
 
     return {
         Animation,
@@ -31,9 +209,13 @@ jest.mock('cc', () => {
             attr: mockAttr,
             Attr: { PrimitiveType },
         },
+        Color,
         Component,
         gfx,
+        Mat4,
         Node,
+        Rect,
+        Renderer,
         renderer: {
             Pass: {
                 getTypeFromHandle: (handle: number) => handle,
@@ -41,9 +223,35 @@ jest.mock('cc', () => {
         },
         Scene,
         SkeletalAnimation,
-        animation: {},
+        Vec2,
+        Vec3,
+        Vec4,
+        animation: {
+            ColorTrack,
+            ObjectTrack,
+            QuatTrack,
+            RealTrack,
+            SizeTrack,
+            Track,
+            TrackPath,
+            UniformProxyFactory,
+            VectorTrack,
+        },
         editorExtrasTag: '__editorExtras__',
+        deserialize(value: any) {
+            const ctor = classMap[value?.__type__];
+            if (!ctor) {
+                return value;
+            }
+            const result = new ctor();
+            Object.assign(result, value);
+            delete result.__type__;
+            return result;
+        },
         js: {
+            getClassByName(name: string) {
+                return classMap[name] || null;
+            },
             getClassName(target: any) {
                 return target?.__className || target?.constructor?.__className || target?.name || '';
             },
@@ -204,6 +412,266 @@ describe('AnimationService animatable property metadata', () => {
             }),
         ]));
         expect(properties.map((property: any) => property.key)).not.toContain('cc.Sprite.material');
+    });
+
+    it('按旧编辑器 Renderer 规则从 sharedMaterials 查询 materials 材质实例', () => {
+        const { Renderer, gfx } = require('cc');
+        const { queryComponentAnimableProperties } = require('../scene-process/service/animation/property-metadata');
+
+        const materialInstance = {
+            passes: [
+                {
+                    properties: {
+                        mainColor: { editor: { type: 'color' } },
+                    },
+                    getHandle() {
+                        return gfx.Type.FLOAT4;
+                    },
+                },
+            ],
+        };
+
+        class Sprite extends Renderer {
+            sharedMaterials = [];
+            get materials() {
+                return [materialInstance];
+            }
+        }
+        (Sprite as any).__className = 'cc.Sprite';
+        (Sprite as any).__props__ = ['sharedMaterials'];
+
+        mockAttr.mockImplementation((_target: Function, prop: string) => prop === 'sharedMaterials'
+            ? { type: 'cc.Material', visible: false }
+            : undefined);
+
+        const properties = queryComponentAnimableProperties(new Sprite());
+
+        expect(properties).toEqual([
+            expect.objectContaining({
+                key: 'cc.Sprite.materials.0.pass.0.mainColor',
+                displayName: 'cc.Sprite.materials[0].pass[0].mainColor',
+                menuName: 'pass[0].mainColor',
+                name: 'mainColor',
+                type: { value: 'cc.Color' },
+                comp: 'cc.Sprite',
+            }),
+        ]);
+    });
+
+    it('为 Renderer material uniform 查询 metadata 并读取当前 uniform 值', () => {
+        const { Color, Node, Renderer, gfx } = require('cc');
+        const {
+            queryAnimationPropertyMetadata,
+        } = require('../scene-process/service/animation/property-metadata');
+        const { readPropertyValue } = require('../scene-process/service/animation/scene-node');
+
+        const pass = {
+            properties: {
+                mainColor: { editor: { type: 'color' } },
+            },
+            getHandle() {
+                return gfx.Type.FLOAT4;
+            },
+            getUniform(_handle: number, out: any) {
+                out.r = 12;
+                out.g = 34;
+                out.b = 56;
+                out.a = 255;
+                return out;
+            },
+        };
+        const materialInstance = { passes: [pass] };
+        class Sprite extends Renderer {
+            sharedMaterials = [];
+            get materials() {
+                return [materialInstance];
+            }
+        }
+        (Sprite as any).__className = 'cc.Sprite';
+        (Sprite as any).__props__ = ['sharedMaterials'];
+        mockAttr.mockImplementation((_target: Function, prop: string) => prop === 'sharedMaterials'
+            ? { type: 'cc.Material', visible: false }
+            : undefined);
+
+        const root = new Node('Root');
+        const sprite = new Sprite();
+        root.components = [sprite];
+        const key = 'cc.Sprite.materials.0.pass.0.mainColor';
+
+        expect(queryAnimationPropertyMetadata(root, '', key)).toEqual({
+            type: { value: 'cc.Color' },
+            valueCtor: undefined,
+        });
+        expect(readPropertyValue(root, key)).toBeInstanceOf(Color);
+        expect(readPropertyValue(root, key)).toMatchObject({ r: 12, g: 34, b: 56, a: 255 });
+    });
+
+    it('创建 material uniform key 时生成带 UniformProxyFactory 的材质轨道', () => {
+        const { AnimationClip, animation } = require('cc');
+        const { createPropertyKey } = require('../scene-process/service/animation/property-curve');
+        const { parsePropertyTrack } = require('../scene-process/service/animation/property-curve-track');
+
+        const clip = new AnimationClip();
+        const key = 'cc.Sprite.materials.0.pass.0.mainColor';
+        const result = createPropertyKey(clip, {
+            rootNode: {} as any,
+            rootPath: '',
+            queryPropertyMetadata: () => ({
+                type: { value: 'cc.Color' },
+            }),
+        }, {
+            type: 'createPropertyKey',
+            clipUuid: 'clip',
+            propKey: key,
+            frame: 0,
+            value: { r: 12, g: 34, b: 56, a: 255 },
+        });
+
+        expect(result).toBe(true);
+        expect(clip._tracks).toHaveLength(1);
+        const [track] = clip._tracks;
+        expect(track.proxy).toBeInstanceOf(animation.UniformProxyFactory);
+        expect(track.proxy).toMatchObject({
+            passIndex: 0,
+            uniformName: 'mainColor',
+        });
+        expect(track.path.parseComponentAt(0)).toBe('cc.Sprite');
+        expect(track.path.parsePropertyAt(1)).toBe('materials');
+        expect(track.path.parseElementAt(2)).toBe(0);
+        expect(parsePropertyTrack(track)?.descriptor.propKey).toBe(key);
+    });
+
+    it('按旧编辑器规则把 object track 的 ccClass dump 还原为实例', () => {
+        const { AnimationClip, Rect } = require('cc');
+        const { createPropertyKey, dumpPropertyCurves } = require('../scene-process/service/animation/property-curve');
+        const queryPropertyMetadata = () => ({
+            type: { value: 'cc.Rect' },
+            valueCtor: Rect,
+        });
+
+        const clip = new AnimationClip();
+        const result = createPropertyKey(clip, {
+            rootNode: {} as any,
+            rootPath: '',
+            queryPropertyMetadata,
+        }, {
+            type: 'createPropertyKey',
+            clipUuid: 'clip',
+            propKey: 'cc.Test.rect',
+            frame: 0,
+            value: { x: 1, y: 2, width: 3, height: 4 },
+        });
+
+        expect(result).toBe(true);
+        const value = clip._tracks[0].channels()[0].curve.keyframes()[0][1];
+        expect(value).toBeInstanceOf(Rect);
+        expect(value).toMatchObject({ x: 1, y: 2, width: 3, height: 4 });
+
+        const dumpValue = dumpPropertyCurves(clip, { queryPropertyMetadata })[0].keyframes[0].dump.value;
+        expect(dumpValue).not.toBeInstanceOf(Rect);
+        expect(dumpValue).toEqual({ x: 1, y: 2, width: 3, height: 4 });
+    });
+
+    it('读取 material sampler uniform 时使用 pass index', () => {
+        const { Node, Renderer, gfx } = require('cc');
+        const { readPropertyValue } = require('../scene-process/service/animation/scene-node');
+
+        const passes = [0, 1].map(() => ({
+            properties: {
+                mainTexture: {},
+            },
+            getHandle() {
+                return gfx.Type.SAMPLER2D;
+            },
+        }));
+        const textures = [{ name: 'pass0' }, { name: 'pass1' }];
+        const materialInstance = {
+            passes,
+            getProperty: jest.fn((_name: string, passIndex?: number) => textures[passIndex ?? 0]),
+        };
+        class Sprite extends Renderer {
+            get materials() {
+                return [materialInstance];
+            }
+        }
+        (Sprite as any).__className = 'cc.Sprite';
+
+        const root = new Node('Root');
+        root.components = [new Sprite()];
+
+        expect(readPropertyValue(root, 'cc.Sprite.materials.0.pass.1.mainTexture')).toBe(textures[1]);
+        expect(materialInstance.getProperty).toHaveBeenCalledWith('mainTexture', 1);
+    });
+
+    it('读取 material sampler uniform 时按 pass property type 兼容缺失的 handle type API', () => {
+        const { Node, Renderer, gfx, renderer } = require('cc');
+        const { readPropertyValue } = require('../scene-process/service/animation/scene-node');
+        const originalGetTypeFromHandle = renderer.Pass.getTypeFromHandle;
+
+        renderer.Pass.getTypeFromHandle = undefined;
+        try {
+            const passes = [0, 1].map(() => ({
+                properties: {
+                    mainTexture: { type: gfx.Type.SAMPLER2D },
+                },
+                getHandle() {
+                    return 1;
+                },
+            }));
+            const textures = [{ name: 'pass0' }, { name: 'pass1' }];
+            const materialInstance = {
+                passes,
+                getProperty: jest.fn((_name: string, passIndex?: number) => textures[passIndex ?? 0]),
+            };
+            class Sprite extends Renderer {
+                get materials() {
+                    return [materialInstance];
+                }
+            }
+            (Sprite as any).__className = 'cc.Sprite';
+
+            const root = new Node('Root');
+            root.components = [new Sprite()];
+
+            expect(readPropertyValue(root, 'cc.Sprite.materials.0.pass.1.mainTexture')).toBe(textures[1]);
+            expect(materialInstance.getProperty).toHaveBeenCalledWith('mainTexture', 1);
+        } finally {
+            renderer.Pass.getTypeFromHandle = originalGetTypeFromHandle;
+        }
+    });
+
+    it('按旧编辑器 type map 兼容 lowercase primitive material uniform type', () => {
+        const { Renderer } = require('cc');
+        const { queryComponentAnimableProperties } = require('../scene-process/service/animation/property-metadata');
+
+        const materialInstance = {
+            passes: [
+                {
+                    properties: {
+                        threshold: { type: 'number' },
+                    },
+                },
+            ],
+        };
+        class Sprite extends Renderer {
+            get materials() {
+                return [materialInstance];
+            }
+            sharedMaterials = [];
+        }
+        (Sprite as any).__className = 'cc.Sprite';
+        (Sprite as any).__props__ = ['sharedMaterials'];
+
+        mockAttr.mockImplementation((_target: Function, prop: string) => prop === 'sharedMaterials'
+            ? { type: 'cc.Material', visible: false }
+            : undefined);
+
+        expect(queryComponentAnimableProperties(new Sprite())).toEqual([
+            expect.objectContaining({
+                key: 'cc.Sprite.materials.0.pass.0.threshold',
+                type: { value: 'cc.Number' },
+            }),
+        ]);
     });
 
     it('从 accessor 当前值推导 UITransform 这类组件属性类型', () => {

--- a/src/core/scene/test/animation-service-animatable.test.ts
+++ b/src/core/scene/test/animation-service-animatable.test.ts
@@ -326,6 +326,40 @@ describe('AnimationService animatable property metadata', () => {
         ]);
     });
 
+    it('过滤 getter-only 的组件 accessor 属性', () => {
+        const { Component } = require('cc');
+        const { queryComponentAnimableProperties } = require('../scene-process/service/animation/property-metadata');
+
+        class WidgetLike extends Component {
+            private _alignLeft = false;
+
+            get isAlignLeft() {
+                return this._alignLeft;
+            }
+
+            set isAlignLeft(value: boolean) {
+                this._alignLeft = value;
+            }
+
+            get isStretchWidth() {
+                return this._alignLeft;
+            }
+        }
+        (WidgetLike as any).__className = 'cc.WidgetLike';
+        (WidgetLike as any).__props__ = ['isAlignLeft', 'isStretchWidth'];
+
+        mockAttr.mockImplementation((_ctor: Function, prop: string) => ({
+            type: 'cc.Boolean',
+            visible: true,
+        }));
+
+        const properties = queryComponentAnimableProperties(new WidgetLike());
+
+        expect(properties.map((property: any) => property.key)).toEqual([
+            'cc.WidgetLike.isAlignLeft',
+        ]);
+    });
+
     it('按旧编辑器 queryProperties 的实际行为保留组件 type 属性', () => {
         const { Component } = require('cc');
         const { queryComponentAnimableProperties } = require('../scene-process/service/animation/property-metadata');

--- a/src/core/scene/test/animation-service-enter.test.ts
+++ b/src/core/scene/test/animation-service-enter.test.ts
@@ -89,17 +89,22 @@ describe('AnimationService enter', () => {
     });
 
     it('waits for animation state initialization before sampling time zero', async () => {
+        const { Animation } = require('cc');
         const service = new AnimationService() as any;
-        const rootNode = { uuid: 'root-uuid', name: 'AnimatedRoot', components: [], children: [] };
         const clip = { _uuid: 'clip-uuid', name: 'Idle' };
+        const animComp = new Animation();
+        animComp.clips = [clip];
+        animComp.defaultClip = clip;
+        const rootNode = {
+            uuid: 'root-uuid',
+            name: 'AnimatedRoot',
+            components: [animComp],
+            children: [],
+            getComponent: jest.fn((ctor) => ctor === Animation ? animComp : null),
+        };
         let resolveState!: () => void;
 
-        service._assertEditorOpened = jest.fn();
-        service._resolveNode = jest.fn(() => rootNode);
-        service._queryAnimationRootNode = jest.fn(() => rootNode);
-        service._queryNodeAnimationData = jest.fn(async () => ({ clips: [clip], defaultClip: clip, node: rootNode, animComp: {} }));
-        service._resolveClip = jest.fn(() => clip);
-        service._getNodePath = jest.fn(() => 'Canvas/AnimatedRoot');
+        (globalThis as any).EditorExtends.Node.getNodeByPath.mockReturnValueOnce(rootNode);
         service._getAnimationState = jest.fn(() => new Promise<void>((resolve) => {
             resolveState = resolve;
         }));
@@ -141,19 +146,23 @@ describe('AnimationService enter', () => {
         expect(service._getAnimationState).not.toHaveBeenCalled();
     });
 
-    it('resolves animation state without recovering clip bindings', async () => {
+    it('does not recover clip bindings while resolving animation state', async () => {
+        const { Animation, assetManager } = require('cc');
         const service = new AnimationService() as any;
-        const rootNode = { uuid: 'root-uuid' };
-        const clip = { _uuid: 'clip-uuid', name: 'Idle' };
+        const animComp = new Animation();
+        animComp.clips = [];
+        animComp.defaultClip = null;
+        const rootNode = {
+            uuid: 'root-uuid',
+            getComponent: jest.fn((ctor) => ctor === Animation ? animComp : null),
+        };
 
-        service._session = { clipUuid: 'clip-uuid', rootUuid: 'root-uuid' };
+        service._session = { clipUuid: 'clip-uuid', rootUuid: 'root-uuid', rootPath: 'Canvas/AnimatedRoot' };
         service._getSessionRootNode = jest.fn(() => rootNode);
-        service._queryNodeAnimationData = jest.fn(async () => ({ clips: [clip], defaultClip: clip, node: rootNode, animComp: {} }));
-        service._resolveClip = jest.fn(() => clip);
 
-        await service._getAnimationState('clip-uuid');
+        await expect(service._getAnimationState('clip-uuid')).rejects.toThrow('Animation clips not found');
 
-        expect(service._queryNodeAnimationData).toHaveBeenCalledWith(rootNode, 'clip-uuid');
+        expect(assetManager.loadAny).not.toHaveBeenCalled();
     });
 
     it('returns empty clip info for animation roots without clips', async () => {

--- a/src/core/scene/test/animation-service-enter.test.ts
+++ b/src/core/scene/test/animation-service-enter.test.ts
@@ -27,10 +27,22 @@ jest.mock('cc', () => ({
     CCClass: { attr: jest.fn(), Attr: { PrimitiveType: class PrimitiveType {} } },
     Component: class Component {},
     Node: class Node {},
+    RealCurve: class RealCurve {},
     Scene: class Scene {},
     SkeletalAnimation: class SkeletalAnimation {},
     animation: {},
+    assetManager: { loadAny: jest.fn() },
+    editorExtrasTag: Symbol.for('editorExtrasTag'),
     js: { getClassName: jest.fn(() => 'cc.Component') },
+}));
+
+jest.mock('cc/editor/embedded-player', () => ({
+    EmbeddedAnimationClipPlayable: class EmbeddedAnimationClipPlayable {},
+    EmbeddedParticleSystemPlayable: class EmbeddedParticleSystemPlayable {},
+    EmbeddedPlayer: class EmbeddedPlayer {},
+    addEmbeddedPlayerTag: Symbol.for('addEmbeddedPlayerTag'),
+    clearEmbeddedPlayersTag: Symbol.for('clearEmbeddedPlayersTag'),
+    getEmbeddedPlayersTag: Symbol.for('getEmbeddedPlayersTag'),
 }));
 
 jest.mock('../scene-process/service/core', () => ({

--- a/src/core/scene/test/animation-service-enter.test.ts
+++ b/src/core/scene/test/animation-service-enter.test.ts
@@ -1,0 +1,112 @@
+const mockService = {
+    Editor: {
+        getCurrentEditorType: jest.fn(() => 'scene'),
+        getRootNode: jest.fn(() => ({ name: 'SceneRoot' })),
+    },
+    Selection: {
+        query: jest.fn(() => ['Canvas/Previous']),
+        clear: jest.fn(),
+        select: jest.fn(),
+    },
+    Engine: {
+        repaintInEditMode: jest.fn(async () => undefined),
+        enterAnimationMode: jest.fn(),
+        exitAnimationMode: jest.fn(),
+    },
+    Node: {
+        queryNodeTree: jest.fn(),
+    },
+};
+
+jest.mock('cc', () => ({
+    Animation: class Animation {},
+    AnimationClip: class AnimationClip {
+        static WrapMode: { Reverse: number } = { Reverse: 1 };
+    },
+    AnimationState: class AnimationState {},
+    CCClass: { attr: jest.fn(), Attr: { PrimitiveType: class PrimitiveType {} } },
+    Component: class Component {},
+    Node: class Node {},
+    Scene: class Scene {},
+    SkeletalAnimation: class SkeletalAnimation {},
+    animation: {},
+    js: { getClassName: jest.fn(() => 'cc.Component') },
+}));
+
+jest.mock('../scene-process/service/core', () => ({
+    BaseService: class BaseService {},
+    register: () => (target: unknown) => target,
+    Service: mockService,
+}));
+
+jest.mock('../scene-process/service/dump', () => ({
+    __esModule: true,
+    default: {
+        dumpNode: jest.fn(() => ({ name: 'Root' })),
+        restoreNode: jest.fn(),
+    },
+}));
+
+jest.mock('../scene-process/rpc', () => ({
+    Rpc: {
+        getInstance: jest.fn(() => ({ request: jest.fn() })),
+    },
+}));
+
+(globalThis as any).EditorExtends = {
+    Node: {
+        getNode: jest.fn(),
+        getNodeByPath: jest.fn(),
+        getNodePath: jest.fn(() => 'Canvas/AnimatedRoot'),
+    },
+    serialize: jest.fn(),
+};
+
+const { AnimationService } = require('../scene-process/service/animation');
+
+describe('AnimationService enter', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('waits for animation state initialization before sampling time zero', async () => {
+        const service = new AnimationService() as any;
+        const rootNode = { uuid: 'root-uuid', name: 'AnimatedRoot' };
+        const clip = { _uuid: 'clip-uuid', name: 'Idle' };
+        let resolveState!: () => void;
+
+        service._assertEditorOpened = jest.fn();
+        service._resolveNode = jest.fn(() => rootNode);
+        service._queryAnimationRootNode = jest.fn(() => rootNode);
+        service._queryNodeAnimationData = jest.fn(async () => ({ clips: [clip], defaultClip: clip, node: rootNode, animComp: {} }));
+        service._resolveClip = jest.fn(() => clip);
+        service._getNodePath = jest.fn(() => 'Canvas/AnimatedRoot');
+        service._getAnimationState = jest.fn(() => new Promise<void>((resolve) => {
+            resolveState = resolve;
+        }));
+        service.setTime = jest.fn(async () => true);
+        service.queryState = jest.fn(async () => ({
+            active: true,
+            editorType: 'scene',
+            mode: 'animation',
+            rootUuid: rootNode.uuid,
+            rootPath: 'Canvas/AnimatedRoot',
+            clipUuid: clip._uuid,
+            time: 0,
+            playState: 'stop',
+            selection: [],
+            restoreSelectionOnExit: true,
+        }));
+
+        const enterPromise = service.enter({ rootPath: 'Canvas/AnimatedRoot' });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(service.setTime).not.toHaveBeenCalled();
+
+        resolveState();
+        await enterPromise;
+
+        expect(service.setTime).toHaveBeenCalledWith({ time: 0 });
+    });
+});

--- a/src/core/scene/test/animation-service-enter.test.ts
+++ b/src/core/scene/test/animation-service-enter.test.ts
@@ -23,7 +23,14 @@ jest.mock('cc', () => ({
     AnimationClip: class AnimationClip {
         static WrapMode: { Reverse: number } = { Reverse: 1 };
     },
-    AnimationState: class AnimationState {},
+    AnimationState: class AnimationState {
+        clip: unknown;
+        initialize = jest.fn();
+
+        constructor(clip: unknown) {
+            this.clip = clip;
+        }
+    },
     CCClass: { attr: jest.fn(), Attr: { PrimitiveType: class PrimitiveType {} } },
     Component: class Component {},
     Node: class Node {},
@@ -83,7 +90,7 @@ describe('AnimationService enter', () => {
 
     it('waits for animation state initialization before sampling time zero', async () => {
         const service = new AnimationService() as any;
-        const rootNode = { uuid: 'root-uuid', name: 'AnimatedRoot' };
+        const rootNode = { uuid: 'root-uuid', name: 'AnimatedRoot', components: [], children: [] };
         const clip = { _uuid: 'clip-uuid', name: 'Idle' };
         let resolveState!: () => void;
 
@@ -96,6 +103,7 @@ describe('AnimationService enter', () => {
         service._getAnimationState = jest.fn(() => new Promise<void>((resolve) => {
             resolveState = resolve;
         }));
+        service.broadcast = jest.fn();
         service.setTime = jest.fn(async () => true);
         service.queryState = jest.fn(async () => ({
             active: true,
@@ -120,5 +128,62 @@ describe('AnimationService enter', () => {
         await enterPromise;
 
         expect(service.setTime).toHaveBeenCalledWith({ time: 0 });
+    });
+
+    it('does not resolve or rebind non-current clips from play controls', async () => {
+        const service = new AnimationService() as any;
+        service._session = { clipUuid: 'current-clip' };
+        service._getAnimationState = jest.fn();
+
+        await expect(service.changePlayState({ operate: 'play', clipUuid: 'other-clip' })).rejects.toThrow(
+            "current edit clip: 'current-clip' but you want to operate: 'other-clip'",
+        );
+        expect(service._getAnimationState).not.toHaveBeenCalled();
+    });
+
+    it('resolves animation state without recovering clip bindings', async () => {
+        const service = new AnimationService() as any;
+        const rootNode = { uuid: 'root-uuid' };
+        const clip = { _uuid: 'clip-uuid', name: 'Idle' };
+
+        service._session = { clipUuid: 'clip-uuid', rootUuid: 'root-uuid' };
+        service._getSessionRootNode = jest.fn(() => rootNode);
+        service._queryNodeAnimationData = jest.fn(async () => ({ clips: [clip], defaultClip: clip, node: rootNode, animComp: {} }));
+        service._resolveClip = jest.fn(() => clip);
+
+        await service._getAnimationState('clip-uuid');
+
+        expect(service._queryNodeAnimationData).toHaveBeenCalledWith(rootNode, 'clip-uuid');
+    });
+
+    it('returns empty clip info for animation roots without clips', async () => {
+        const { Animation } = require('cc');
+        const service = new AnimationService() as any;
+        const animComp = new Animation();
+        animComp.clips = [];
+        animComp.defaultClip = null;
+        const rootNode = {
+            uuid: 'root-uuid',
+            getComponent: jest.fn((ctor) => ctor === Animation ? animComp : null),
+        };
+
+        service._resolveRootNode = jest.fn(() => rootNode);
+        service._getNodePath = jest.fn(() => 'Canvas/AnimatedRoot');
+        mockService.Node.queryNodeTree.mockResolvedValue({ name: 'AnimatedRoot' });
+
+        await expect(service.queryClips({ rootPath: 'Canvas/AnimatedRoot' })).resolves.toEqual({
+            rootUuid: 'root-uuid',
+            rootPath: 'Canvas/AnimatedRoot',
+            clipsMenu: [],
+            defaultClip: '',
+        });
+        await expect(service.queryRootInfo({ rootPath: 'Canvas/AnimatedRoot' })).resolves.toMatchObject({
+            rootUuid: 'root-uuid',
+            rootPath: 'Canvas/AnimatedRoot',
+            clipsMenu: [],
+            defaultClip: '',
+            clipDump: null,
+            time: 0,
+        });
     });
 });

--- a/src/core/scene/test/animation-service-enter.test.ts
+++ b/src/core/scene/test/animation-service-enter.test.ts
@@ -93,12 +93,12 @@ jest.mock('../scene-process/service/animation/service-save', () => ({
 };
 
 const { AnimationService } = require('../scene-process/service/animation');
-const { saveAnimationServiceClip } = require('../scene-process/service/animation/service-save');
+const { saveAnimationServiceClip: saveAnimationServiceClipMock } = require('../scene-process/service/animation/service-save');
 
 describe('AnimationService enter', () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        saveAnimationServiceClip.mockResolvedValue(true);
+        saveAnimationServiceClipMock.mockResolvedValue(true);
     });
 
     it('waits for animation state initialization before sampling time zero', async () => {

--- a/src/core/scene/test/animation-service-enter.test.ts
+++ b/src/core/scene/test/animation-service-enter.test.ts
@@ -98,6 +98,9 @@ const { saveAnimationServiceClip: saveAnimationServiceClipMock } = require('../s
 describe('AnimationService enter', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        const { assetManager } = require('cc');
+        assetManager.assets.get.mockReset();
+        assetManager.loadAny.mockReset();
         saveAnimationServiceClipMock.mockResolvedValue(true);
     });
 
@@ -214,6 +217,54 @@ describe('AnimationService enter', () => {
         await expect(service.save()).resolves.toBe(true);
         await service._refreshCurrentClipAsset('clip-uuid');
         await service._refreshCurrentClipAsset('clip-uuid');
+
+        expect(service._animationStates.reset).not.toHaveBeenCalled();
+        expect(service._animationStates.create).not.toHaveBeenCalled();
+        expect(service._broadcastClipChanged).not.toHaveBeenCalledWith('asset-refresh');
+    });
+
+    it('ignores a current clip refresh that started before saving the current clip', async () => {
+        const { Animation, AnimationClip, assetManager } = require('cc');
+        const service = new AnimationService() as any;
+        const currentClip = new AnimationClip();
+        currentClip._uuid = 'clip-uuid';
+        currentClip.name = 'Current';
+        const reloadedClip = new AnimationClip();
+        reloadedClip._uuid = 'clip-uuid';
+        reloadedClip.name = 'Reloaded';
+        const animComp = new Animation();
+        animComp.clips = [currentClip];
+        animComp.defaultClip = currentClip;
+        const rootNode = {
+            uuid: 'root-uuid',
+            getComponent: jest.fn((ctor) => ctor === Animation ? animComp : null),
+        };
+        let finishLoad!: (error: Error | null, clip: typeof reloadedClip) => void;
+
+        assetManager.assets.get.mockReturnValue(undefined);
+        assetManager.loadAny.mockImplementation((_uuid: string, callback: typeof finishLoad) => {
+            finishLoad = callback;
+        });
+        service._session = {
+            clipUuid: 'clip-uuid',
+            rootUuid: rootNode.uuid,
+            rootPath: 'Canvas/AnimatedRoot',
+            undoBaseline: { commandId: null, generation: 0 },
+            globalDirtyAtEnter: false,
+        };
+        service._getSessionRootNode = jest.fn(() => rootNode);
+        service._animationStates.get = jest.fn(() => ({ clip: currentClip }));
+        service._animationStates.reset = jest.fn();
+        service._animationStates.create = jest.fn();
+        service._getAnimationState = jest.fn(async () => ({ clip: currentClip }));
+        service.setTime = jest.fn(async () => true);
+        service._broadcastClipChanged = jest.fn();
+
+        const refreshPromise = service._refreshCurrentClipAsset('clip-uuid');
+        await Promise.resolve();
+        await expect(service.save()).resolves.toBe(true);
+        finishLoad(null, reloadedClip);
+        await refreshPromise;
 
         expect(service._animationStates.reset).not.toHaveBeenCalled();
         expect(service._animationStates.create).not.toHaveBeenCalled();
@@ -407,7 +458,91 @@ describe('AnimationService enter', () => {
         expect(service.setTime).toHaveBeenCalledWith({ time: 0.5 });
     });
 
-    it('keeps the current state registered when undo snapshot restore fails', async () => {
+    it('destroys the current state before restoring a failed-operation snapshot', async () => {
+        const service = new AnimationService() as any;
+        const clip = {
+            _uuid: 'clip-uuid',
+            duration: 1,
+            sample: 30,
+            speed: 1,
+            wrapMode: 1,
+            events: [{ frame: 0.25, func: 'stale', params: [] }],
+        };
+        const snapshot = {
+            duration: 1,
+            sample: 30,
+            speed: 1,
+            wrapMode: 1,
+            curves: [],
+            events: [{ frame: 15, func: 'restored', params: ['ok'] }],
+            embeddedPlayers: [],
+            embeddedPlayerGroups: [],
+            auxiliaryCurves: {},
+        };
+        const state = {};
+        const order: string[] = [];
+        service._animationStates.get = jest.fn(() => state);
+        service._animationStates.reset = jest.fn(() => {
+            order.push(`reset:${clip.events[0]?.func || 'none'}`);
+            clip.events = [{ frame: 99, func: 'destroyed', params: [] }];
+        });
+        service._animationStates.create = jest.fn(() => {
+            order.push(`create:${clip.events[0]?.func || 'none'}`);
+        });
+        service._curEditTime = 0.5;
+        service.setTime = jest.fn(async () => true);
+
+        await expect(service._restoreFailedOperationSnapshot(clip, snapshot, {})).resolves.toBeUndefined();
+
+        expect(order).toEqual(['reset:stale', 'create:restored']);
+        expect(clip.events).toEqual([{ frame: 0.5, func: 'restored', params: ['ok'] }]);
+        expect(service.setTime).toHaveBeenCalledWith({ time: 0.5 });
+    });
+
+    it('destroys the current state before restoring an undo snapshot', async () => {
+        const service = new AnimationService() as any;
+        const clip = {
+            _uuid: 'clip-uuid',
+            duration: 1,
+            sample: 30,
+            speed: 1,
+            wrapMode: 1,
+            events: [{ frame: 0.25, func: 'stale', params: [] }],
+        };
+        const snapshot = {
+            duration: 1,
+            sample: 30,
+            speed: 1,
+            wrapMode: 1,
+            curves: [],
+            events: [{ frame: 15, func: 'restored', params: ['ok'] }],
+            embeddedPlayers: [],
+            embeddedPlayerGroups: [],
+            auxiliaryCurves: {},
+        };
+        const order: string[] = [];
+        service._session = { clipUuid: 'clip-uuid' };
+        service._getAnimationState = jest.fn(async () => ({ clip }));
+        service._animationStates.reset = jest.fn(() => {
+            order.push(`reset:${clip.events[0]?.func || 'none'}`);
+            clip.events = [{ frame: 99, func: 'destroyed', params: [] }];
+        });
+        service._animationStates.create = jest.fn(() => {
+            order.push(`create:${clip.events[0]?.func || 'none'}`);
+        });
+        service._curEditTime = 0.5;
+        service.setTime = jest.fn(async () => true);
+        service._broadcastClipChanged = jest.fn();
+
+        await expect(service._restoreCurrentClipSnapshot('clip-uuid', snapshot)).resolves.toBeUndefined();
+
+        expect(order).toEqual(['reset:stale', 'create:restored']);
+        expect(clip.events).toEqual([{ frame: 0.5, func: 'restored', params: ['ok'] }]);
+        expect(service.setTime).toHaveBeenCalledWith({ time: 0.5 });
+        expect(service._broadcastClipChanged).toHaveBeenCalledWith('undo-redo');
+    });
+
+    it('recreates the current state when undo snapshot restore fails', async () => {
         const service = new AnimationService() as any;
         const clip = {
             _uuid: 'clip-uuid',
@@ -439,8 +574,8 @@ describe('AnimationService enter', () => {
             auxiliaryCurves: {},
         })).rejects.toThrow('Failed to restore animation embedded players.');
 
-        expect(service._animationStates.reset).not.toHaveBeenCalled();
-        expect(service._animationStates.create).not.toHaveBeenCalled();
+        expect(service._animationStates.reset).toHaveBeenCalledWith('clip-uuid');
+        expect(service._animationStates.create).toHaveBeenCalledWith('clip-uuid', clip);
     });
 
     it('returns empty clip info for animation roots without clips', async () => {
@@ -472,5 +607,30 @@ describe('AnimationService enter', () => {
             clipDump: null,
             time: 0,
         });
+    });
+
+    it('returns root tree info for nodes without animation components', async () => {
+        const { Animation } = require('cc');
+        const service = new AnimationService() as any;
+        const rootNode = {
+            uuid: 'root-uuid',
+            getComponent: jest.fn((ctor) => ctor === Animation ? null : null),
+        };
+
+        service._resolveRootNode = jest.fn(() => rootNode);
+        mockService.Node.queryNodeTree.mockResolvedValue({ name: 'AnimatedRoot' });
+
+        await expect(service.queryRootInfo({ rootPath: 'Canvas/AnimatedRoot' })).resolves.toEqual({
+            rootUuid: 'root-uuid',
+            rootPath: 'Canvas/AnimatedRoot',
+            clipsMenu: [],
+            defaultClip: '',
+            nodeTreeDump: { name: 'AnimatedRoot' },
+            clipDump: null,
+            time: 0,
+            state: 'stop',
+            useBakedAnimation: false,
+        });
+        expect(mockService.Node.queryNodeTree).toHaveBeenCalledWith({ path: 'Canvas/AnimatedRoot' });
     });
 });

--- a/src/core/scene/test/animation-service-enter.test.ts
+++ b/src/core/scene/test/animation-service-enter.test.ts
@@ -16,10 +16,15 @@ const mockService = {
     Node: {
         queryNodeTree: jest.fn(),
     },
+    Undo: {
+        createCheckpoint: jest.fn(() => ({ commandId: null, generation: 0 })),
+        isDirty: jest.fn(() => false),
+    },
 };
 
 jest.mock('cc', () => ({
     Animation: class Animation {},
+    Asset: class Asset {},
     AnimationClip: class AnimationClip {
         static WrapMode: { Reverse: number } = { Reverse: 1 };
     },
@@ -163,6 +168,229 @@ describe('AnimationService enter', () => {
         await expect(service._getAnimationState('clip-uuid')).rejects.toThrow('Animation clips not found');
 
         expect(assetManager.loadAny).not.toHaveBeenCalled();
+    });
+
+    it('keeps a running animation state playing after frame value query', async () => {
+        const service = new AnimationService() as any;
+        const rootNode = {
+            uuid: 'root-uuid',
+            position: { x: 4, y: 5, z: 6 },
+            components: [],
+        };
+        let current = 0.4;
+        let isPaused = false;
+        const state = {
+            clip: { sample: 30 },
+            weight: 0,
+            get current() {
+                return current;
+            },
+            get isPlaying() {
+                return true;
+            },
+            get isPaused() {
+                return isPaused;
+            },
+            setTime: jest.fn((time: number) => {
+                current = time;
+            }),
+            pause: jest.fn(() => {
+                isPaused = true;
+            }),
+            resume: jest.fn(() => {
+                isPaused = false;
+            }),
+            sample: jest.fn(() => {
+                rootNode.position = current === 0.5 ? { x: 10, y: 11, z: 12 } : { x: 4, y: 5, z: 6 };
+            }),
+        };
+        (globalThis as any).EditorExtends.Node.getNodeByPath.mockReturnValue(rootNode);
+        service._session = {
+            clipUuid: 'clip-uuid',
+            rootUuid: rootNode.uuid,
+            rootPath: 'Canvas/AnimatedRoot',
+        };
+        service._curEditTime = 0.4;
+        service._getAnimationState = jest.fn(async () => state);
+
+        const value = await service.queryPropertyValueAtFrame({
+            clipUuid: 'clip-uuid',
+            nodePath: 'Canvas/AnimatedRoot',
+            propKey: 'position',
+            frame: 15,
+        });
+
+        expect(value).toEqual({ x: 10, y: 11, z: 12 });
+        expect(state.pause).toHaveBeenCalled();
+        expect(state.resume).toHaveBeenCalled();
+        expect(state.current).toBe(0.4);
+        expect(state.isPaused).toBe(false);
+        expect(service._curEditTime).toBe(0.4);
+    });
+
+    it('keeps edit time unchanged when sampling reverse clips', async () => {
+        const service = new AnimationService() as any;
+        const state = {
+            clip: { wrapMode: 1 },
+            duration: 1,
+            weight: 0,
+            isPaused: false,
+            setTime: jest.fn(),
+            pause: jest.fn(function (this: { isPaused: boolean }) {
+                this.isPaused = true;
+            }),
+            sample: jest.fn(),
+        };
+        service._session = { clipUuid: 'clip-uuid' };
+        service._getAnimationState = jest.fn(async () => state);
+        service._broadcastTimeChanged = jest.fn();
+
+        await service.setTime({ time: 0.25 });
+
+        expect(state.setTime).toHaveBeenCalledWith(0.75);
+        expect(service._curEditTime).toBe(0.25);
+    });
+
+    it('uses the active session clip for root info on the current animation root', async () => {
+        const { Animation } = require('cc');
+        const service = new AnimationService() as any;
+        const defaultClip = { _uuid: 'default-clip', name: 'Default' };
+        const currentClip = { _uuid: 'current-clip', name: 'Current' };
+        const animComp = new Animation();
+        animComp.clips = [defaultClip, currentClip];
+        animComp.defaultClip = defaultClip;
+        const rootNode = {
+            uuid: 'root-uuid',
+            getComponent: jest.fn((ctor) => ctor === Animation ? animComp : null),
+        };
+        service._session = {
+            clipUuid: 'current-clip',
+            rootUuid: rootNode.uuid,
+            rootPath: 'Canvas/AnimatedRoot',
+        };
+        service._resolveRootNode = jest.fn(() => rootNode);
+        service.queryClip = jest.fn(async (options: { clipUuid: string }) => ({ uuid: options.clipUuid }));
+        service.queryTime = jest.fn(async (options: { clipUuid: string }) => options.clipUuid === 'current-clip' ? 0.5 : 0.25);
+        mockService.Node.queryNodeTree.mockResolvedValue({ name: 'AnimatedRoot' });
+
+        const info = await service.queryRootInfo({ rootPath: 'Canvas/AnimatedRoot' });
+
+        expect(info.defaultClip).toBe('default-clip');
+        expect(info.clipDump).toEqual({ uuid: 'current-clip' });
+        expect(info.time).toBe(0.5);
+        expect(service.queryClip).toHaveBeenCalledWith({ rootUuid: rootNode.uuid, clipUuid: 'current-clip' });
+        expect(service.queryTime).toHaveBeenCalledWith({ clipUuid: 'current-clip' });
+    });
+
+    it('reports stop play state for root info outside the active animation session', async () => {
+        const { Animation } = require('cc');
+        const service = new AnimationService() as any;
+        const defaultClip = { _uuid: 'default-clip', name: 'Default' };
+        const animComp = new Animation();
+        animComp.clips = [defaultClip];
+        animComp.defaultClip = defaultClip;
+        const rootNode = {
+            uuid: 'other-root-uuid',
+            getComponent: jest.fn((ctor) => ctor === Animation ? animComp : null),
+        };
+        service._session = {
+            clipUuid: 'current-clip',
+            rootUuid: 'active-root-uuid',
+            rootPath: 'Canvas/ActiveRoot',
+        };
+        service._playState = 'playing';
+        service._resolveRootNode = jest.fn(() => rootNode);
+        service.queryClip = jest.fn(async () => ({ uuid: 'default-clip' }));
+        mockService.Node.queryNodeTree.mockResolvedValue({ name: 'OtherRoot' });
+
+        const info = await service.queryRootInfo({ rootPath: 'Canvas/OtherRoot' });
+
+        expect(info.state).toBe('stop');
+    });
+
+    it('does not report the current edit time for uncached non-current clips', async () => {
+        const service = new AnimationService() as any;
+        service._session = { clipUuid: 'current-clip' };
+        service._curEditTime = 0.75;
+        service._animationStates.get = jest.fn(() => undefined);
+
+        await expect(service.queryTime({ clipUuid: 'other-clip' })).resolves.toBe(0);
+    });
+
+    it('recreates animation state after failed-operation snapshot restore without touching private curve flags', async () => {
+        const service = new AnimationService() as any;
+        const clip = {
+            _uuid: 'clip-uuid',
+            duration: 1,
+            sample: 30,
+            speed: 1,
+            wrapMode: 1,
+            events: [],
+        };
+        const snapshot = {
+            duration: 1,
+            sample: 30,
+            speed: 1,
+            wrapMode: 1,
+            curves: [],
+            events: [],
+            embeddedPlayers: [],
+            embeddedPlayerGroups: [],
+            auxiliaryCurves: {},
+        };
+        const state = {};
+        Object.defineProperty(state, '_curveLoaded', {
+            set() {
+                throw new Error('private curve flag should not be written');
+            },
+        });
+        service._animationStates.get = jest.fn(() => state);
+        service._animationStates.reset = jest.fn();
+        service._animationStates.create = jest.fn();
+        service._curEditTime = 0.5;
+        service.setTime = jest.fn(async () => true);
+
+        await expect(service._restoreFailedOperationSnapshot(clip, snapshot, {})).resolves.toBeUndefined();
+
+        expect(service._animationStates.reset).toHaveBeenCalledWith('clip-uuid');
+        expect(service._animationStates.create).toHaveBeenCalledWith('clip-uuid', clip);
+        expect(service.setTime).toHaveBeenCalledWith({ time: 0.5 });
+    });
+
+    it('keeps the current state registered when undo snapshot restore fails', async () => {
+        const service = new AnimationService() as any;
+        const clip = {
+            _uuid: 'clip-uuid',
+            duration: 1,
+            sample: 30,
+            speed: 1,
+            wrapMode: 1,
+            events: [],
+        };
+        service._session = { clipUuid: 'clip-uuid' };
+        service._getAnimationState = jest.fn(async () => ({ clip }));
+        service._animationStates.reset = jest.fn();
+        service._animationStates.create = jest.fn();
+
+        await expect(service._restoreCurrentClipSnapshot('clip-uuid', {
+            duration: 1,
+            sample: 30,
+            speed: 1,
+            wrapMode: 1,
+            curves: [],
+            events: [],
+            embeddedPlayers: [{
+                begin: 0,
+                end: 30,
+                reconciledSpeed: false,
+                group: 'particle-track',
+            }],
+            embeddedPlayerGroups: [],
+            auxiliaryCurves: {},
+        })).rejects.toThrow('Failed to restore animation embedded players.');
+
+        expect(service._animationStates.reset).not.toHaveBeenCalled();
+        expect(service._animationStates.create).not.toHaveBeenCalled();
     });
 
     it('returns empty clip info for animation roots without clips', async () => {

--- a/src/core/scene/test/animation-service-enter.test.ts
+++ b/src/core/scene/test/animation-service-enter.test.ts
@@ -213,6 +213,7 @@ describe('AnimationService enter', () => {
 
         await expect(service.save()).resolves.toBe(true);
         await service._refreshCurrentClipAsset('clip-uuid');
+        await service._refreshCurrentClipAsset('clip-uuid');
 
         expect(service._animationStates.reset).not.toHaveBeenCalled();
         expect(service._animationStates.create).not.toHaveBeenCalled();

--- a/src/core/scene/test/animation-service-enter.test.ts
+++ b/src/core/scene/test/animation-service-enter.test.ts
@@ -18,7 +18,9 @@ const mockService = {
     },
     Undo: {
         createCheckpoint: jest.fn(() => ({ commandId: null, generation: 0 })),
+        hasDifferenceOutsideScope: jest.fn(() => false),
         isDirty: jest.fn(() => false),
+        markSaved: jest.fn(),
     },
 };
 
@@ -43,7 +45,7 @@ jest.mock('cc', () => ({
     Scene: class Scene {},
     SkeletalAnimation: class SkeletalAnimation {},
     animation: {},
-    assetManager: { loadAny: jest.fn() },
+    assetManager: { assets: { get: jest.fn() }, loadAny: jest.fn() },
     editorExtrasTag: Symbol.for('editorExtrasTag'),
     js: { getClassName: jest.fn(() => 'cc.Component') },
 }));
@@ -77,6 +79,10 @@ jest.mock('../scene-process/rpc', () => ({
     },
 }));
 
+jest.mock('../scene-process/service/animation/service-save', () => ({
+    saveAnimationServiceClip: jest.fn(),
+}));
+
 (globalThis as any).EditorExtends = {
     Node: {
         getNode: jest.fn(),
@@ -87,10 +93,12 @@ jest.mock('../scene-process/rpc', () => ({
 };
 
 const { AnimationService } = require('../scene-process/service/animation');
+const { saveAnimationServiceClip } = require('../scene-process/service/animation/service-save');
 
 describe('AnimationService enter', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        saveAnimationServiceClip.mockResolvedValue(true);
     });
 
     it('waits for animation state initialization before sampling time zero', async () => {
@@ -168,6 +176,47 @@ describe('AnimationService enter', () => {
         await expect(service._getAnimationState('clip-uuid')).rejects.toThrow('Animation clips not found');
 
         expect(assetManager.loadAny).not.toHaveBeenCalled();
+    });
+
+    it('ignores the asset refresh triggered by saving the current clip', async () => {
+        const { Animation, AnimationClip, assetManager } = require('cc');
+        const service = new AnimationService() as any;
+        const currentClip = new AnimationClip();
+        currentClip._uuid = 'clip-uuid';
+        currentClip.name = 'Current';
+        const reloadedClip = new AnimationClip();
+        reloadedClip._uuid = 'clip-uuid';
+        reloadedClip.name = 'Reloaded';
+        const animComp = new Animation();
+        animComp.clips = [currentClip];
+        animComp.defaultClip = currentClip;
+        const rootNode = {
+            uuid: 'root-uuid',
+            getComponent: jest.fn((ctor) => ctor === Animation ? animComp : null),
+        };
+
+        assetManager.assets.get.mockReturnValue(reloadedClip);
+        service._session = {
+            clipUuid: 'clip-uuid',
+            rootUuid: rootNode.uuid,
+            rootPath: 'Canvas/AnimatedRoot',
+            undoBaseline: { commandId: null, generation: 0 },
+            globalDirtyAtEnter: false,
+        };
+        service._getSessionRootNode = jest.fn(() => rootNode);
+        service._animationStates.get = jest.fn(() => ({ clip: currentClip }));
+        service._animationStates.reset = jest.fn();
+        service._animationStates.create = jest.fn();
+        service._getAnimationState = jest.fn(async () => ({ clip: currentClip }));
+        service.setTime = jest.fn(async () => true);
+        service._broadcastClipChanged = jest.fn();
+
+        await expect(service.save()).resolves.toBe(true);
+        await service._refreshCurrentClipAsset('clip-uuid');
+
+        expect(service._animationStates.reset).not.toHaveBeenCalled();
+        expect(service._animationStates.create).not.toHaveBeenCalled();
+        expect(service._broadcastClipChanged).not.toHaveBeenCalledWith('asset-refresh');
     });
 
     it('keeps a running animation state playing after frame value query', async () => {

--- a/src/core/scene/test/animation-service-enter.test.ts
+++ b/src/core/scene/test/animation-service-enter.test.ts
@@ -237,6 +237,46 @@ describe('AnimationService enter', () => {
         expect(service._broadcastClipChanged).not.toHaveBeenCalledWith('asset-refresh');
     });
 
+    it('rebinds the current clip after save when asset refresh replaced the component binding', async () => {
+        const { Animation, AnimationClip } = require('cc');
+        const service = new AnimationService() as any;
+        const currentClip = new AnimationClip();
+        currentClip._uuid = 'clip-uuid';
+        currentClip.name = 'Current';
+        currentClip.events = null;
+        const staleClip = new AnimationClip();
+        staleClip._uuid = 'clip-uuid';
+        staleClip.name = 'Stale';
+        const animComp = new Animation();
+        animComp.clips = [currentClip];
+        animComp.defaultClip = currentClip;
+        const rootNode = {
+            uuid: 'root-uuid',
+            getComponent: jest.fn((ctor) => ctor === Animation ? animComp : null),
+        };
+
+        service._session = {
+            clipUuid: 'clip-uuid',
+            rootUuid: rootNode.uuid,
+            rootPath: 'Canvas/AnimatedRoot',
+            undoBaseline: { commandId: null, generation: 0 },
+            globalDirtyAtEnter: false,
+        };
+        service._getSessionRootNode = jest.fn(() => rootNode);
+        service._getAnimationState = jest.fn(async () => ({ clip: currentClip }));
+        saveAnimationServiceClipMock.mockImplementationOnce(async () => {
+            animComp.clips = [staleClip];
+            animComp.defaultClip = staleClip;
+            return true;
+        });
+
+        await expect(service.save()).resolves.toBe(true);
+
+        expect(animComp.clips).toEqual([currentClip]);
+        expect(animComp.defaultClip).toBe(currentClip);
+        expect(currentClip.events).toEqual([]);
+    });
+
     it('ignores a current clip refresh that started before saving the current clip', async () => {
         const { Animation, AnimationClip, assetManager } = require('cc');
         const service = new AnimationService() as any;

--- a/src/core/scene/test/animation-service-enter.test.ts
+++ b/src/core/scene/test/animation-service-enter.test.ts
@@ -93,6 +93,7 @@ jest.mock('../scene-process/service/animation/service-save', () => ({
 };
 
 const { AnimationService } = require('../scene-process/service/animation');
+const { isCurrentAnimationSessionClipQuery } = require('../scene-process/service/animation/service-target');
 const { saveAnimationServiceClip: saveAnimationServiceClipMock } = require('../scene-process/service/animation/service-save');
 
 describe('AnimationService enter', () => {
@@ -102,6 +103,19 @@ describe('AnimationService enter', () => {
         assetManager.assets.get.mockReset();
         assetManager.loadAny.mockReset();
         saveAnimationServiceClipMock.mockResolvedValue(true);
+    });
+
+    it('matches current clip queries with normalized root paths', () => {
+        const session = {
+            rootUuid: 'root-uuid',
+            rootPath: 'Canvas/AnimatedRoot',
+            clipUuid: 'clip-uuid',
+        };
+
+        expect(isCurrentAnimationSessionClipQuery(session, {
+            rootPath: '/Canvas/AnimatedRoot/',
+            clipUuid: 'clip-uuid',
+        }, 'clip-uuid', true)).toBe(true);
     });
 
     it('waits for animation state initialization before sampling time zero', async () => {

--- a/src/core/scene/test/animation-service-interface.test.ts
+++ b/src/core/scene/test/animation-service-interface.test.ts
@@ -7,10 +7,16 @@ describe('Animation service interface', () => {
             const root = service.queryRoot({ nodePath: 'AnimatedRoot/Child' });
             const properties = service.queryProperties({ nodePath: 'AnimatedRoot' });
             const state = service.queryState();
+            const clip = service.queryClip({ clipUuid: 'clip-uuid' });
+            const frameValue = service.queryPropertyValueAtFrame({ clipUuid: 'clip-uuid', nodePath: 'AnimatedRoot', propKey: 'position', frame: 0 });
+            const operation = service.applyOperation({ operations: [{ funcName: 'changeSample', args: ['clip-uuid', 60] }] });
 
             expect(root).toBeDefined();
             expect(properties).toBeDefined();
             expect(state).toBeDefined();
+            expect(clip).toBeDefined();
+            expect(frameValue).toBeDefined();
+            expect(operation).toBeDefined();
         };
 
         const assertManager = (manager: IServiceManager) => {

--- a/src/core/scene/test/animation-service-interface.test.ts
+++ b/src/core/scene/test/animation-service-interface.test.ts
@@ -15,16 +15,20 @@ describe('Animation service interface', () => {
             const state = service.queryState();
             const clip = service.queryClip({ clipUuid: 'clip-uuid' });
             const frameValue = service.queryPropertyValueAtFrame({ clipUuid: 'clip-uuid', nodePath: 'AnimatedRoot', propKey: 'position', frame: 0 });
+            const auxFrameValue = service.queryAuxiliaryCurveValueAtFrame({ clipUuid: 'clip-uuid', name: 'BlendWeight', frame: 0 });
             const operation = service.applyOperation({ operations: [{ type: 'changeSample', clipUuid: 'clip-uuid', sample: 60 }] });
             const propertyOperation = service.applyOperation({ operations: [{ type: 'createPropertyKey', clipUuid: 'clip-uuid', nodePath: 'AnimatedRoot', propKey: 'position', frame: 0, value: { x: 0, y: 0, z: 0 } }] });
+            const keyDataOperation = service.applyOperation({ operations: [{ type: 'updatePropertyKeyData', clipUuid: 'clip-uuid', nodePath: 'AnimatedRoot', propKey: 'position', frame: 0, channel: 'x', keyData: { broken: true } }] });
 
             expect(root).toBeDefined();
             expect(properties).toBeDefined();
             expect(state).toBeDefined();
             expect(clip).toBeDefined();
             expect(frameValue).toBeDefined();
+            expect(auxFrameValue).toBeDefined();
             expect(operation).toBeDefined();
             expect(propertyOperation).toBeDefined();
+            expect(keyDataOperation).toBeDefined();
         };
 
         const assertRootInfo = (info: IAnimationRootInfo) => {

--- a/src/core/scene/test/animation-service-interface.test.ts
+++ b/src/core/scene/test/animation-service-interface.test.ts
@@ -1,0 +1,23 @@
+import type { IAnimationService } from '../common/animation';
+import type { IServiceManager } from '../scene-process/service/interfaces';
+
+describe('Animation service interface', () => {
+    it('exposes animation APIs on internal scene services', () => {
+        const assertInternal = (service: IAnimationService) => {
+            const root = service.queryRoot({ nodePath: 'AnimatedRoot/Child' });
+            const properties = service.queryProperties({ nodePath: 'AnimatedRoot' });
+            const state = service.queryState();
+
+            expect(root).toBeDefined();
+            expect(properties).toBeDefined();
+            expect(state).toBeDefined();
+        };
+
+        const assertManager = (manager: IServiceManager) => {
+            expect(manager.Animation).toBeDefined();
+        };
+
+        expect(assertInternal).toBeDefined();
+        expect(assertManager).toBeDefined();
+    });
+});

--- a/src/core/scene/test/animation-service-interface.test.ts
+++ b/src/core/scene/test/animation-service-interface.test.ts
@@ -1,4 +1,10 @@
-import type { IAnimationService } from '../common/animation';
+import type {
+    IAnimationClipDump,
+    IAnimationOperationResult,
+    IAnimationRootInfo,
+    IAnimationService,
+    IAnimationValue,
+} from '../common/animation';
 import type { IServiceManager } from '../scene-process/service/interfaces';
 
 describe('Animation service interface', () => {
@@ -9,7 +15,7 @@ describe('Animation service interface', () => {
             const state = service.queryState();
             const clip = service.queryClip({ clipUuid: 'clip-uuid' });
             const frameValue = service.queryPropertyValueAtFrame({ clipUuid: 'clip-uuid', nodePath: 'AnimatedRoot', propKey: 'position', frame: 0 });
-            const operation = service.applyOperation({ operations: [{ funcName: 'changeSample', args: ['clip-uuid', 60] }] });
+            const operation = service.applyOperation({ operations: [{ type: 'changeSample', clipUuid: 'clip-uuid', sample: 60 }] });
 
             expect(root).toBeDefined();
             expect(properties).toBeDefined();
@@ -19,11 +25,42 @@ describe('Animation service interface', () => {
             expect(operation).toBeDefined();
         };
 
+        const assertRootInfo = (info: IAnimationRootInfo) => {
+            const nodeChildren = info.nodeTreeDump?.children ?? [];
+            const clipEvents = info.clipDump?.events ?? [];
+            expect(nodeChildren).toBeDefined();
+            expect(clipEvents).toBeDefined();
+        };
+
+        const assertClipDump = (dump: IAnimationClipDump) => {
+            const curve = dump.curves[0];
+            const keyframe = curve?.keyframes?.[0];
+            const embeddedPlayer = dump.embeddedPlayers[0];
+            const auxiliaryKey = dump.auxiliaryCurves.BlendWeight?.keyframes[0];
+
+            expect(keyframe?.frame).toBeDefined();
+            expect(embeddedPlayer?.playable?.type).toBeDefined();
+            expect(auxiliaryKey?.value).toBeDefined();
+        };
+
+        const assertOperationResult = (result: IAnimationOperationResult) => {
+            const value: boolean = result.result;
+            expect(value).toBeDefined();
+        };
+
+        const assertPropertyValue = (value: IAnimationValue) => {
+            expect(value).toBeDefined();
+        };
+
         const assertManager = (manager: IServiceManager) => {
             expect(manager.Animation).toBeDefined();
         };
 
         expect(assertInternal).toBeDefined();
+        expect(assertRootInfo).toBeDefined();
+        expect(assertClipDump).toBeDefined();
+        expect(assertOperationResult).toBeDefined();
+        expect(assertPropertyValue).toBeDefined();
         expect(assertManager).toBeDefined();
     });
 });

--- a/src/core/scene/test/animation-service-interface.test.ts
+++ b/src/core/scene/test/animation-service-interface.test.ts
@@ -16,6 +16,7 @@ describe('Animation service interface', () => {
             const clip = service.queryClip({ clipUuid: 'clip-uuid' });
             const frameValue = service.queryPropertyValueAtFrame({ clipUuid: 'clip-uuid', nodePath: 'AnimatedRoot', propKey: 'position', frame: 0 });
             const operation = service.applyOperation({ operations: [{ type: 'changeSample', clipUuid: 'clip-uuid', sample: 60 }] });
+            const propertyOperation = service.applyOperation({ operations: [{ type: 'createPropertyKey', clipUuid: 'clip-uuid', nodePath: 'AnimatedRoot', propKey: 'position', frame: 0, value: { x: 0, y: 0, z: 0 } }] });
 
             expect(root).toBeDefined();
             expect(properties).toBeDefined();
@@ -23,6 +24,7 @@ describe('Animation service interface', () => {
             expect(clip).toBeDefined();
             expect(frameValue).toBeDefined();
             expect(operation).toBeDefined();
+            expect(propertyOperation).toBeDefined();
         };
 
         const assertRootInfo = (info: IAnimationRootInfo) => {

--- a/src/core/scene/test/animation-service-interface.test.ts
+++ b/src/core/scene/test/animation-service-interface.test.ts
@@ -16,9 +16,9 @@ describe('Animation service interface', () => {
             const clip = service.queryClip({ clipUuid: 'clip-uuid' });
             const frameValue = service.queryPropertyValueAtFrame({ clipUuid: 'clip-uuid', nodePath: 'AnimatedRoot', propKey: 'position', frame: 0 });
             const auxFrameValue = service.queryAuxiliaryCurveValueAtFrame({ clipUuid: 'clip-uuid', name: 'BlendWeight', frame: 0 });
-            const operation = service.applyOperation({ operations: [{ type: 'changeSample', clipUuid: 'clip-uuid', sample: 60 }] });
-            const propertyOperation = service.applyOperation({ operations: [{ type: 'createPropertyKey', clipUuid: 'clip-uuid', nodePath: 'AnimatedRoot', propKey: 'position', frame: 0, value: { x: 0, y: 0, z: 0 } }] });
-            const keyDataOperation = service.applyOperation({ operations: [{ type: 'updatePropertyKeyData', clipUuid: 'clip-uuid', nodePath: 'AnimatedRoot', propKey: 'position', frame: 0, channel: 'x', keyData: { broken: true } }] });
+            const operation = service.applyOperations({ operations: [{ type: 'changeSample', clipUuid: 'clip-uuid', sample: 60 }] });
+            const propertyOperation = service.applyOperations({ operations: [{ type: 'createPropertyKey', clipUuid: 'clip-uuid', nodePath: 'AnimatedRoot', propKey: 'position', frame: 0, value: { x: 0, y: 0, z: 0 } }] });
+            const keyDataOperation = service.applyOperations({ operations: [{ type: 'updatePropertyKeyData', clipUuid: 'clip-uuid', nodePath: 'AnimatedRoot', propKey: 'position', frame: 0, channel: 'x', keyData: { broken: true } }] });
 
             expect(root).toBeDefined();
             expect(properties).toBeDefined();

--- a/src/core/scene/test/animation-service-playback.test.ts
+++ b/src/core/scene/test/animation-service-playback.test.ts
@@ -1,0 +1,33 @@
+const { AnimationServicePlayback } = require('../scene-process/service/animation/service-playback');
+
+describe('AnimationServicePlayback', () => {
+    it('keeps the playback timer alive when the state is only transiently paused', () => {
+        const state = {
+            current: 0.5,
+            duration: 1,
+            isPaused: true,
+            isPlaying: true,
+            setTime: jest.fn(),
+            sample: jest.fn(),
+        };
+        const playback = new AnimationServicePlayback({
+            getCurrentState: () => state,
+            getEditTime: () => 0.5,
+            getPlayState: () => 'playing',
+            setEditTime: jest.fn(),
+            setPlayState: jest.fn(),
+            enterAnimationMode: jest.fn(),
+            exitAnimationMode: jest.fn(),
+            repaintInEditMode: jest.fn(async () => undefined),
+            broadcastTimeChanged: jest.fn(),
+            broadcastStateChanged: jest.fn(async () => undefined),
+        });
+        const timer = setInterval(() => undefined, 1000);
+        (playback as any)._playbackTimeBroadcastTimer = timer;
+
+        (playback as any)._broadcastPlaybackTimeTick();
+
+        expect((playback as any)._playbackTimeBroadcastTimer).toBe(timer);
+        clearInterval(timer);
+    });
+});

--- a/src/core/scene/test/animation-service-save.test.ts
+++ b/src/core/scene/test/animation-service-save.test.ts
@@ -1,0 +1,63 @@
+const mockRequest = jest.fn();
+
+jest.mock('cc', () => ({
+    AnimationClip: class AnimationClip {},
+    Node: class Node {},
+}));
+
+jest.mock('../scene-process/rpc', () => ({
+    Rpc: {
+        getInstance: jest.fn(() => ({
+            request: mockRequest,
+        })),
+    },
+}));
+
+jest.mock('../scene-process/service/animation/scene-node', () => ({
+    isSkeletonClip: jest.fn(() => false),
+}));
+
+jest.mock('../scene-process/service/animation/skeleton-meta', () => ({
+    saveSkeletonAnimationMeta: jest.fn(),
+}));
+
+(globalThis as any).EditorExtends = {
+    serialize: jest.fn(() => 'serialized-clip'),
+};
+
+const { saveAnimationServiceClip } = require('../scene-process/service/animation/service-save');
+
+describe('saveAnimationServiceClip', () => {
+    beforeEach(() => {
+        mockRequest.mockReset();
+        (globalThis as any).EditorExtends.serialize.mockClear();
+    });
+
+    it('saves an existing clip asset by uuid', async () => {
+        mockRequest
+            .mockResolvedValueOnce({ uuid: 'clip-uuid', url: 'db://assets/anims/Run.anim' })
+            .mockResolvedValueOnce(true);
+
+        await expect(saveAnimationServiceClip({
+            session: { clipUuid: 'clip-uuid' },
+            rootNode: {},
+            clip: { name: 'Run' },
+        })).resolves.toBe(true);
+
+        expect(mockRequest).toHaveBeenNthCalledWith(1, 'assetManager', 'queryAssetInfo', ['clip-uuid']);
+        expect(mockRequest).toHaveBeenNthCalledWith(2, 'assetManager', 'saveAsset', ['clip-uuid', 'serialized-clip']);
+    });
+
+    it('fails instead of creating a clip at a hard-coded fallback path when asset info is missing', async () => {
+        mockRequest.mockResolvedValueOnce(null);
+
+        await expect(saveAnimationServiceClip({
+            session: { clipUuid: 'missing-clip-uuid' },
+            rootNode: {},
+            clip: { name: 'Run' },
+        })).rejects.toThrow('Animation clip asset not found: missing-clip-uuid');
+
+        expect(mockRequest).toHaveBeenCalledTimes(1);
+        expect(mockRequest).toHaveBeenCalledWith('assetManager', 'queryAssetInfo', ['missing-clip-uuid']);
+    });
+});

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -9,6 +9,34 @@ function request<T = any>(method: string, args: any[] = []): Promise<T> {
     return (Rpc.getInstance() as any).request('Animation', method, args) as Promise<T>;
 }
 
+function requestService<T = any>(service: string, method: string, args: any[] = []): Promise<T> {
+    return (Rpc.getInstance() as any).request(service, method, args) as Promise<T>;
+}
+
+const Undo = {
+    clearHistory: () => requestService('Undo', 'clearHistory'),
+    markSaved: () => requestService('Undo', 'markSaved'),
+    isDirty: () => requestService<boolean>('Undo', 'isDirty'),
+    canUndo: () => requestService<boolean>('Undo', 'canUndo'),
+    undo: () => requestService('Undo', 'undo'),
+    canRedo: () => requestService<boolean>('Redo', 'canRedo'),
+    redo: () => requestService('Redo', 'redo'),
+};
+
+function expectUndoSuccess(result: any) {
+    if (!result?.success) {
+        throw new Error(`Undo/Redo command failed: ${JSON.stringify(result)}`);
+    }
+    expect(result.success).toBe(true);
+}
+
+async function ensureAnimationSession(rootPath: string, clipUuid: string): Promise<void> {
+    const state = await request('queryState');
+    if (!state.active || state.rootPath !== rootPath || state.clipUuid !== clipUuid) {
+        await request('enter', [{ rootPath, clipUuid }]);
+    }
+}
+
 function createAnimationClipContent(options: { sample?: number; duration?: number } = {}) {
     return JSON.stringify({
         __type__: 'cc.AnimationClip',
@@ -194,5 +222,63 @@ describe('Animation Service 场景进程测试', () => {
             { frame: 0, value: 0.25 },
             { frame: 60, value: 0.75 },
         ]);
+    });
+
+    it('applyOperation 默认记录 undo/dirty，并支持 undo/redo 恢复真实 AnimationClip', async () => {
+        await ensureAnimationSession(nodePath, clipUuid);
+        await Undo.clearHistory();
+        await Undo.markSaved();
+
+        const before = await request('queryClip', [{ clipUuid }]);
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'changeSpeed', clipUuid, speed: 2.25 },
+                { type: 'addEvent', clipUuid, frame: 12, func: 'onUndoCheck', params: ['undo'] },
+            ],
+        }]);
+        const after = await request('queryClip', [{ clipUuid }]);
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(await Undo.isDirty()).toBe(true);
+        expect(await Undo.canUndo()).toBe(true);
+        expect(await Undo.canRedo()).toBe(false);
+        expect(after.speed).toBe(2.25);
+        expect(after.events).toEqual(expect.arrayContaining([
+            { frame: 12, func: 'onUndoCheck', params: ['undo'] },
+        ]));
+
+        expectUndoSuccess(await Undo.undo());
+        const undoDump = await request('queryClip', [{ clipUuid }]);
+        expect(undoDump.speed).toBe(before.speed);
+        expect(undoDump.events).toEqual(before.events);
+        expect(await Undo.isDirty()).toBe(false);
+        expect(await Undo.canRedo()).toBe(true);
+
+        expectUndoSuccess(await Undo.redo());
+        const redoDump = await request('queryClip', [{ clipUuid }]);
+        expect(redoDump.speed).toBe(after.speed);
+        expect(redoDump.events).toEqual(after.events);
+        expect(await Undo.isDirty()).toBe(true);
+    });
+
+    it('applyOperation recordUndo 为 false 时不写入 undo 栈', async () => {
+        await ensureAnimationSession(nodePath, clipUuid);
+        await Undo.clearHistory();
+        await Undo.markSaved();
+
+        const before = await request('queryClip', [{ clipUuid }]);
+        const result = await request('applyOperation', [{
+            recordUndo: false,
+            operations: [
+                { type: 'changeSpeed', clipUuid, speed: before.speed + 0.125 },
+            ],
+        }]);
+        const after = await request('queryClip', [{ clipUuid }]);
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(after.speed).toBe(before.speed + 0.125);
+        expect(await Undo.isDirty()).toBe(false);
+        expect(await Undo.canUndo()).toBe(false);
+        expect(await Undo.canRedo()).toBe(false);
     });
 });

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -312,6 +312,19 @@ describe('Animation Service 场景进程测试', () => {
         });
     });
 
+    it('setTime 在编辑态允许移动到短 clip 当前 duration 之外', async () => {
+        await ensureAnimationSession(emptyNodePath, emptyClipUuid);
+
+        const before = await request('queryClip', [{ rootPath: emptyNodePath, clipUuid: emptyClipUuid }]);
+        await request('setTime', [{ time: 0.5 }]);
+        const state = await request('queryState');
+        const time = await request<number>('queryTime', [{ clipUuid: emptyClipUuid }]);
+
+        expect(before.duration).toBe(0);
+        expect(state.time).toBe(0.5);
+        expect(time).toBe(0.5);
+    });
+
     it('changePlayState 广播 animation:state-changed 供 UI 订阅', async () => {
         await ensureAnimationSession(nodePath, clipUuid);
         const eventPromise = utils.once<Record<'animation:state-changed', any>>(sceneWorker, 'animation:state-changed');

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -282,6 +282,24 @@ describe('Animation Service 场景进程测试', () => {
         });
     });
 
+    it('play 广播运行态 animation:time-changed 供 UI 同步播放指针', async () => {
+        await ensureAnimationSession(nodePath, clipUuid);
+        await request('setTime', [{ time: 0 }]);
+        const eventPromise = utils.once<Record<'animation:time-changed', any>>(sceneWorker, 'animation:time-changed', 5000);
+
+        await request('changePlayState', [{ operate: 'play' }]);
+        const event = await eventPromise;
+        await request('changePlayState', [{ operate: 'stop' }]);
+
+        expect(event).toMatchObject({
+            reason: 'play-state',
+            rootPath: nodePath,
+            clipUuid,
+            playState: 'playing',
+        });
+        expect(event.time).toBeGreaterThan(0);
+    });
+
     it('applyOperation 在真实 AnimationClip 上应用基础普通 clip 操作', async () => {
         const eventPromise = utils.once<Record<'animation:clip-changed', any>>(sceneWorker, 'animation:clip-changed');
         const result = await request('applyOperation', [{

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -62,9 +62,12 @@ function createAnimationClipContent(options: { sample?: number; duration?: numbe
 describe('Animation Service 场景进程测试', () => {
     const sceneName = 'AnimationServiceScene';
     const clipName = 'AnimationServiceClip';
+    const emptyClipName = 'AnimationServiceEmptyClip';
     let nodePath = '';
     let childNodePath = '';
     let clipUuid = '';
+    let emptyNodePath = '';
+    let emptyClipUuid = '';
 
     beforeAll(async () => {
         await EditorProxy.create({
@@ -83,6 +86,12 @@ describe('Animation Service 场景进程测试', () => {
         });
         clipUuid = clipInfo.uuid;
 
+        const emptyClipInfo = await assetManager.createAssetByType('animation-clip', SceneTestEnv.targetDirectoryURL, emptyClipName, {
+            overwrite: true,
+            content: createAnimationClipContent({ duration: 0 }),
+        });
+        emptyClipUuid = emptyClipInfo.uuid;
+
         const createParams: ICreateByAssetParams = {
             dbURL: clipInfo.url,
             path: '',
@@ -94,6 +103,17 @@ describe('Animation Service 场景进程测试', () => {
             throw new Error('Failed to create animation node.');
         }
         nodePath = node.path;
+
+        const emptyNode = await NodeProxy.createByAsset({
+            dbURL: emptyClipInfo.url,
+            path: '',
+            name: 'AnimationServiceEmptyNode',
+            position: { x: 0, y: 0, z: 0 },
+        });
+        if (!emptyNode) {
+            throw new Error('Failed to create empty animation node.');
+        }
+        emptyNodePath = emptyNode.path;
 
         const childNode = await NodeProxy.createByType({
             path: nodePath,
@@ -274,6 +294,42 @@ describe('Animation Service 场景进程测试', () => {
         ]);
     });
 
+    it('applyOperation 在空 clip 创建属性 key 后重算 duration 并支持 undo/redo', async () => {
+        await ensureAnimationSession(emptyNodePath, emptyClipUuid);
+        await Undo.clearHistory();
+        await Undo.markSaved();
+
+        const before = await request('queryClip', [{ clipUuid: emptyClipUuid }]);
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'createPropertyKey', clipUuid: emptyClipUuid, nodePath: emptyNodePath, propKey: 'position', frame: 30, value: { x: 1, y: 2, z: 3 } },
+            ],
+        }]);
+        const afterCreate = await request('queryClip', [{ clipUuid: emptyClipUuid }]);
+        await request('setTime', [{ time: 1 }]);
+        const time = await request<number>('queryTime', [{ clipUuid: emptyClipUuid }]);
+        const saveResult = await request('save');
+        const afterSave = await request('queryClip', [{ clipUuid: emptyClipUuid }]);
+
+        expect(before.duration).toBe(0);
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(afterCreate.duration).toBe(1);
+        expect(Math.round(afterCreate.duration * afterCreate.sample)).toBe(30);
+        expect(time).toBe(1);
+        expect(saveResult).toBe(true);
+        expect(afterSave.duration).toBe(1);
+
+        expectUndoSuccess(await Undo.undo());
+        const afterUndo = await request('queryClip', [{ clipUuid: emptyClipUuid }]);
+        expect(afterUndo.duration).toBe(0);
+        expect(afterUndo.curves).toEqual(before.curves);
+
+        expectUndoSuccess(await Undo.redo());
+        const afterRedo = await request('queryClip', [{ clipUuid: emptyClipUuid }]);
+        expect(afterRedo.duration).toBe(1);
+        expect(afterRedo.curves).toEqual(afterCreate.curves);
+    });
+
     it('applyOperation 支持分量级属性 keyframe 并保留切线信息', async () => {
         await ensureAnimationSession(nodePath, clipUuid);
 
@@ -295,6 +351,7 @@ describe('Animation Service 场景进程测试', () => {
                         outTangentWeight: 1,
                         interpMode: 2,
                         tangentWeightMode: 1,
+                        broken: true,
                     },
                 },
             ],
@@ -322,11 +379,55 @@ describe('Animation Service 场景进程测试', () => {
                 outTangentWeight: 1,
                 interpMode: 2,
                 tangentWeightMode: 1,
+                broken: true,
             },
         ]);
         expect(scaleCurve.channels.find((channel: any) => channel.key === 'z').keyframes).toEqual([
             { frame: 0, dump: { value: 1, type: 'cc.Number' } },
         ]);
+    });
+
+    it('applyOperation 通过 updatePropertyKey 持久化 RealCurve keyframe broken 状态', async () => {
+        await ensureAnimationSession(nodePath, clipUuid);
+        await Undo.clearHistory();
+        await Undo.markSaved();
+
+        const createResult = await request('applyOperation', [{
+            operations: [
+                { type: 'createPropertyKey', clipUuid, nodePath, propKey: 'scale', frame: 21, value: { x: 1, y: 1, z: 1 } },
+                { type: 'updatePropertyKey', clipUuid, nodePath, propKey: 'scale', frame: 21, channel: 'y', value: 2, keyData: { broken: true } },
+            ],
+        }]);
+        const afterBroken = await request('queryClip', [{ clipUuid }]);
+        const brokenScaleCurve = afterBroken.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'scale');
+        const brokenKey = brokenScaleCurve.channels.find((channel: any) => channel.key === 'y').keyframes.find((keyframe: any) => keyframe.frame === 21);
+
+        expect(createResult).toEqual({ state: 'success', result: true });
+        expect(brokenKey.broken).toBe(true);
+
+        const updateResult = await request('applyOperation', [{
+            operations: [
+                { type: 'updatePropertyKey', clipUuid, nodePath, propKey: 'scale', frame: 21, channel: 'y', value: 2, keyData: { broken: false } },
+            ],
+        }]);
+        const afterLinked = await request('queryClip', [{ clipUuid }]);
+        const linkedScaleCurve = afterLinked.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'scale');
+        const linkedKey = linkedScaleCurve.channels.find((channel: any) => channel.key === 'y').keyframes.find((keyframe: any) => keyframe.frame === 21);
+
+        expect(updateResult).toEqual({ state: 'success', result: true });
+        expect(linkedKey.broken).toBe(false);
+
+        expectUndoSuccess(await Undo.undo());
+        const afterUndo = await request('queryClip', [{ clipUuid }]);
+        const undoScaleCurve = afterUndo.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'scale');
+        const undoKey = undoScaleCurve.channels.find((channel: any) => channel.key === 'y').keyframes.find((keyframe: any) => keyframe.frame === 21);
+        expect(undoKey.broken).toBe(true);
+
+        expectUndoSuccess(await Undo.redo());
+        const afterRedo = await request('queryClip', [{ clipUuid }]);
+        const redoScaleCurve = afterRedo.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'scale');
+        const redoKey = redoScaleCurve.channels.find((channel: any) => channel.key === 'y').keyframes.find((keyframe: any) => keyframe.frame === 21);
+        expect(redoKey.broken).toBe(false);
     });
 
     it('applyOperation 支持 queryProperties 暴露的 rotation 和 active 属性', async () => {

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -4,6 +4,7 @@ import { sceneWorker } from '../main-process/scene-worker';
 import { Rpc } from '../main-process/rpc';
 import { EditorProxy } from '../main-process/proxy/editor-proxy';
 import { NodeProxy } from '../main-process/proxy/node-proxy';
+import { ComponentProxy } from '../main-process/proxy/component-proxy';
 import { SceneTestEnv } from './scene-test-env';
 import * as utils from './utils';
 
@@ -85,6 +86,7 @@ describe('Animation Service 场景进程测试', () => {
     const keyDataClipName = `AnimationServiceKeyDataClip_${testRunId}`;
     const childClipName = `AnimationServiceChildClip_${testRunId}`;
     const rootEditClipName = `AnimationServiceRootEditClip_${testRunId}`;
+    const spriteFrameClipName = `AnimationServiceSpriteFrameClip_${testRunId}`;
     let nodePath = '';
     let childNodePath = '';
     let clipUuid = '';
@@ -97,6 +99,9 @@ describe('Animation Service 场景进程测试', () => {
     let childClipUuid = '';
     let rootEditNodePath = '';
     let rootEditClipUuid = '';
+    let spriteFrameNodePath = '';
+    let spriteFrameClipUuid = '';
+    let spriteFrameUuid = '';
 
     beforeAll(async () => {
         await EditorProxy.create({
@@ -138,6 +143,18 @@ describe('Animation Service 场景进程测试', () => {
             content: createAnimationClipContent({ sample: 60, duration: 0 }),
         });
         rootEditClipUuid = rootEditClipInfo.uuid;
+
+        const spriteFrameClipInfo = await assetManager.createAssetByType('animation-clip', SceneTestEnv.targetDirectoryURL, spriteFrameClipName, {
+            overwrite: true,
+            content: createAnimationClipContent({ sample: 30, duration: 0 }),
+        });
+        spriteFrameClipUuid = spriteFrameClipInfo.uuid;
+
+        const spriteFrameAssets = await assetManager.queryAssetInfos({ pattern: 'db://internal/default_ui/default_editbox_bg.png/spriteFrame' });
+        if (spriteFrameAssets.length === 0 || !spriteFrameAssets[0].uuid) {
+            throw new Error('Failed to query internal SpriteFrame test asset.');
+        }
+        spriteFrameUuid = spriteFrameAssets[0].uuid;
 
         const createParams: ICreateByAssetParams = {
             dbURL: clipInfo.url,
@@ -204,6 +221,18 @@ describe('Animation Service 场景进程测试', () => {
             throw new Error('Failed to create root keyframe editing animation node.');
         }
         rootEditNodePath = rootEditNode.path;
+
+        const spriteFrameNode = await NodeProxy.createByAsset({
+            dbURL: spriteFrameClipInfo.url,
+            path: '',
+            name: 'AnimationServiceSpriteFrameNode',
+            position: { x: 0, y: 0, z: 0 },
+        });
+        if (!spriteFrameNode) {
+            throw new Error('Failed to create sprite frame animation node.');
+        }
+        spriteFrameNodePath = spriteFrameNode.path;
+        await ComponentProxy.add({ nodePath: spriteFrameNodePath, component: 'cc.Sprite' });
 
         const childNode = await NodeProxy.createByType({
             path: nodePath,
@@ -851,6 +880,67 @@ describe('Animation Service 场景进程测试', () => {
                 { frame: 3, dump: { value: false, type: 'cc.Boolean' } },
             ],
         });
+    });
+
+    it('applyOperation 支持 cc.Sprite.spriteFrame 单帧 key 保存重进闭环', async () => {
+        await ensureAnimationSession(spriteFrameNodePath, spriteFrameClipUuid);
+
+        const properties = await request('queryProperties', [{ nodePath: spriteFrameNodePath }]);
+        const spriteFrameProperty = properties.find((item: any) => item.key === 'cc.Sprite.spriteFrame');
+        expect(spriteFrameProperty).toMatchObject({
+            key: 'cc.Sprite.spriteFrame',
+            comp: 'cc.Sprite',
+            type: { value: 'cc.SpriteFrame' },
+        });
+
+        const createResult = await request('applyOperation', [{
+            operations: [
+                { type: 'addPropertyCurve', clipUuid: spriteFrameClipUuid, nodePath: spriteFrameNodePath, propKey: 'cc.Sprite.spriteFrame', value: { uuid: spriteFrameUuid } },
+                { type: 'createPropertyKey', clipUuid: spriteFrameClipUuid, nodePath: spriteFrameNodePath, propKey: 'cc.Sprite.spriteFrame', frame: 0, value: null },
+                { type: 'createPropertyKey', clipUuid: spriteFrameClipUuid, nodePath: spriteFrameNodePath, propKey: 'cc.Sprite.spriteFrame', frame: 30, value: { uuid: spriteFrameUuid } },
+            ],
+            recordUndo: false,
+        }]);
+        const afterCreate = await request('queryClip', [{ rootPath: spriteFrameNodePath, clipUuid: spriteFrameClipUuid }]);
+        const spriteFrameCurve = afterCreate.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'cc.Sprite.spriteFrame');
+        const sampledStart = await request('queryPropertyValueAtFrame', [{
+            clipUuid: spriteFrameClipUuid,
+            nodePath: spriteFrameNodePath,
+            propKey: 'cc.Sprite.spriteFrame',
+            frame: 0,
+        }]);
+        const sampledEnd = await request('queryPropertyValueAtFrame', [{
+            clipUuid: spriteFrameClipUuid,
+            nodePath: spriteFrameNodePath,
+            propKey: 'cc.Sprite.spriteFrame',
+            frame: 30,
+        }]);
+
+        expect(createResult).toEqual({ state: 'success', result: true });
+        expect(Math.round(afterCreate.duration * afterCreate.sample)).toBe(31);
+        expect(spriteFrameCurve).toMatchObject({
+            type: { value: 'cc.SpriteFrame' },
+            isCurveSupport: false,
+            keyframes: [
+                { frame: 0, dump: { value: null, type: 'cc.SpriteFrame' } },
+                { frame: 30, dump: { value: { uuid: spriteFrameUuid }, type: 'cc.SpriteFrame' } },
+            ],
+        });
+        expect(sampledStart).toBeNull();
+        expect(sampledEnd).toMatchObject({ uuid: spriteFrameUuid });
+        expect(await request('save')).toBe(true);
+        const afterSave = await request('queryClip', [{ rootPath: spriteFrameNodePath, clipUuid: spriteFrameClipUuid }]);
+        const savedCurve = afterSave.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'cc.Sprite.spriteFrame');
+
+        expect(savedCurve?.keyframes).toEqual(spriteFrameCurve.keyframes);
+
+        await request('exit', [{ restoreSelection: false, restoreSampledSceneState: false }]);
+        await request('enter', [{ rootPath: spriteFrameNodePath, clipUuid: spriteFrameClipUuid }]);
+        const afterReenter = await request('queryClip', [{ rootPath: spriteFrameNodePath, clipUuid: spriteFrameClipUuid }]);
+        const reenteredCurve = afterReenter.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'cc.Sprite.spriteFrame');
+
+        expect(Math.round(afterReenter.duration * afterReenter.sample)).toBe(31);
+        expect(reenteredCurve?.keyframes).toEqual(spriteFrameCurve.keyframes);
     });
 
     it('applyOperation 支持普通属性曲线的创建、更新、复制、批量删除和 extrapolation', async () => {

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -358,6 +358,58 @@ describe('Animation Service 场景进程测试', () => {
         });
     });
 
+    it('applyOperation 支持普通属性曲线的创建、更新、复制、批量删除和 extrapolation', async () => {
+        await ensureAnimationSession(nodePath, clipUuid);
+
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'addPropertyCurve', clipUuid, nodePath, propKey: 'position' },
+                { type: 'createPropertyKey', clipUuid, nodePath, propKey: 'position', frame: 0, value: { x: 1, y: 2, z: 3 } },
+                { type: 'createPropertyKey', clipUuid, nodePath, propKey: 'position', frame: 15, value: { x: 4, y: 5, z: 6 } },
+                { type: 'updatePropertyKey', clipUuid, nodePath, propKey: 'position', frame: 15, value: { x: 7, y: 8, z: 9 } },
+                { type: 'copyPropertyKeysTo', clipUuid, nodePath, propKey: 'position', frames: [0, 15], dstFrame: 30 },
+                { type: 'removePropertyKeys', clipUuid, nodePath, propKey: 'position', frames: [0, 45] },
+                { type: 'setPropertyCurveExtrapolation', clipUuid, nodePath, propKey: 'position', preExtrap: 1, postExtrap: 2 },
+            ],
+        }]);
+        const dump = await request('queryClip', [{ clipUuid }]);
+        const positionCurve = dump.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'position');
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(positionCurve).toMatchObject({
+            preExtrap: 1,
+            postExtrap: 2,
+        });
+        expect(positionCurve.keyframes).toEqual([
+            { frame: 15, dump: { value: { x: 7, y: 8, z: 9 }, type: 'cc.Vec3' } },
+            { frame: 30, dump: { value: { x: 1, y: 2, z: 3 }, type: 'cc.Vec3' } },
+        ]);
+    });
+
+    it('applyOperation 创建普通属性 key 时 value 可省略并从当前场景采样', async () => {
+        await ensureAnimationSession(nodePath, clipUuid);
+        await request('setTime', [{ time: 0 }]);
+        const sampled = await request('queryPropertyValueAtFrame', [{
+            clipUuid,
+            nodePath,
+            propKey: 'position',
+            frame: 6,
+        }]);
+
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'createPropertyKey', clipUuid, nodePath, propKey: 'position', frame: 6 },
+            ],
+        }]);
+        const dump = await request('queryClip', [{ clipUuid }]);
+        const positionCurve = dump.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'position');
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(positionCurve.keyframes).toEqual(expect.arrayContaining([
+            { frame: 6, dump: { value: sampled, type: 'cc.Vec3' } },
+        ]));
+    });
+
     it('applyOperation 不接受旧 funcName/args 格式', async () => {
         const result = await request('applyOperation', [{
             operations: [{ funcName: 'changeSample', args: [clipUuid, 60] }],

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -325,6 +325,23 @@ describe('Animation Service 场景进程测试', () => {
         expect(time).toBe(0.5);
     });
 
+    it('queryPropertyValueAtFrame 采样短 clip 后保留 duration 外的编辑时间', async () => {
+        await ensureAnimationSession(emptyNodePath, emptyClipUuid);
+
+        await request('setTime', [{ time: 0.5 }]);
+        await request('queryPropertyValueAtFrame', [{
+            clipUuid: emptyClipUuid,
+            nodePath: emptyNodePath,
+            propKey: 'position',
+            frame: 0,
+        }]);
+        const state = await request('queryState');
+        const time = await request<number>('queryTime', [{ clipUuid: emptyClipUuid }]);
+
+        expect(state.time).toBe(0.5);
+        expect(time).toBe(0.5);
+    });
+
     it('changePlayState 广播 animation:state-changed 供 UI 订阅', async () => {
         await ensureAnimationSession(nodePath, clipUuid);
         const eventPromise = utils.once<Record<'animation:state-changed', any>>(sceneWorker, 'animation:state-changed');

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -1,5 +1,5 @@
 import { assetManager } from '../../assets';
-import { ICreateByAssetParams } from '../common';
+import { ICreateByAssetParams, NodeType } from '../common';
 import { sceneWorker } from '../main-process/scene-worker';
 import { Rpc } from '../main-process/rpc';
 import { EditorProxy } from '../main-process/proxy/editor-proxy';
@@ -63,6 +63,7 @@ describe('Animation Service 场景进程测试', () => {
     const sceneName = 'AnimationServiceScene';
     const clipName = 'AnimationServiceClip';
     let nodePath = '';
+    let childNodePath = '';
     let clipUuid = '';
 
     beforeAll(async () => {
@@ -93,6 +94,16 @@ describe('Animation Service 场景进程测试', () => {
             throw new Error('Failed to create animation node.');
         }
         nodePath = node.path;
+
+        const childNode = await NodeProxy.createByType({
+            path: nodePath,
+            name: 'AnimationServiceChild',
+            nodeType: NodeType.EMPTY,
+        });
+        if (!childNode) {
+            throw new Error('Failed to create animation child node.');
+        }
+        childNodePath = childNode.path;
     });
 
     afterAll(async () => {
@@ -261,6 +272,90 @@ describe('Animation Service 场景进程测试', () => {
         expect(removedCurve.keyframes).toEqual([
             { frame: 30, dump: { value: { x: 8, y: 9, z: 10 }, type: 'cc.Vec3' } },
         ]);
+    });
+
+    it('applyOperation 支持分量级属性 keyframe 并保留切线信息', async () => {
+        await ensureAnimationSession(nodePath, clipUuid);
+
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'createPropertyKey', clipUuid, nodePath, propKey: 'scale', frame: 0, value: { x: 1, y: 1, z: 1 } },
+                {
+                    type: 'createPropertyKey',
+                    clipUuid,
+                    nodePath,
+                    propKey: 'scale',
+                    frame: 15,
+                    channel: 'y',
+                    value: 2,
+                    keyData: {
+                        inTangent: 0.25,
+                        outTangent: 0.5,
+                        inTangentWeight: 0.75,
+                        outTangentWeight: 1,
+                        interpMode: 2,
+                        tangentWeightMode: 1,
+                    },
+                },
+            ],
+        }]);
+        const dump = await request('queryClip', [{ clipUuid }]);
+        const scaleCurve = dump.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'scale');
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(scaleCurve.partKeys).toEqual(['x', 'y', 'z']);
+        expect(scaleCurve.keyframes).toEqual([
+            { frame: 0, dump: { value: { x: 1, y: 1, z: 1 }, type: 'cc.Vec3' } },
+            { frame: 15, dump: { value: { x: 1, y: 2, z: 1 }, type: 'cc.Vec3' } },
+        ]);
+        expect(scaleCurve.channels.find((channel: any) => channel.key === 'x').keyframes).toEqual([
+            { frame: 0, dump: { value: 1, type: 'cc.Number' } },
+        ]);
+        expect(scaleCurve.channels.find((channel: any) => channel.key === 'y').keyframes).toEqual([
+            { frame: 0, dump: { value: 1, type: 'cc.Number' } },
+            {
+                frame: 15,
+                dump: { value: 2, type: 'cc.Number' },
+                inTangent: 0.25,
+                outTangent: 0.5,
+                inTangentWeight: 0.75,
+                outTangentWeight: 1,
+                interpMode: 2,
+                tangentWeightMode: 1,
+            },
+        ]);
+        expect(scaleCurve.channels.find((channel: any) => channel.key === 'z').keyframes).toEqual([
+            { frame: 0, dump: { value: 1, type: 'cc.Number' } },
+        ]);
+    });
+
+    it('applyOperation 支持 queryProperties 暴露的 rotation 和 active 属性', async () => {
+        await ensureAnimationSession(nodePath, clipUuid);
+
+        const properties = await request('queryProperties', [{ nodePath: childNodePath }]);
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'createPropertyKey', clipUuid, nodePath, propKey: 'rotation', frame: 3, value: { x: 0, y: 0, z: 0, w: 1 } },
+                { type: 'createPropertyKey', clipUuid, nodePath: childNodePath, propKey: 'active', frame: 3, value: false },
+            ],
+        }]);
+        const dump = await request('queryClip', [{ clipUuid }]);
+
+        expect(properties.map((item: any) => item.key)).toEqual(expect.arrayContaining(['rotation', 'active']));
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(dump.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'rotation')).toMatchObject({
+            type: { value: 'cc.Quat' },
+            keyframes: [
+                { frame: 3, dump: { value: { x: 0, y: 0, z: 0, w: 1 }, type: 'cc.Quat' } },
+            ],
+        });
+        expect(dump.curves.find((curve: any) => curve.nodePath === 'AnimationServiceChild' && curve.key === 'active')).toMatchObject({
+            type: { value: 'cc.Boolean' },
+            isCurveSupport: false,
+            keyframes: [
+                { frame: 3, dump: { value: false, type: 'cc.Boolean' } },
+            ],
+        });
     });
 
     it('applyOperation 不接受旧 funcName/args 格式', async () => {

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -101,11 +101,11 @@ describe('Animation Service 场景进程测试', () => {
     it('applyOperation 在真实 AnimationClip 上应用基础普通 clip 操作', async () => {
         const result = await request('applyOperation', [{
             operations: [
-                { funcName: 'changeSample', args: [clipUuid, 60] },
-                { funcName: 'changeSpeed', args: [clipUuid, 1.5] },
-                { funcName: 'changeWrapMode', args: [clipUuid, 2] },
-                { funcName: 'addEvent', args: [clipUuid, 30, 'onHalf', ['value']] },
-                { funcName: 'moveEvents', args: [clipUuid, [30], 6] },
+                { type: 'changeSample', clipUuid, sample: 60 },
+                { type: 'changeSpeed', clipUuid, speed: 1.5 },
+                { type: 'changeWrapMode', clipUuid, wrapMode: 2 },
+                { type: 'addEvent', clipUuid, frame: 30, func: 'onHalf', params: ['value'] },
+                { type: 'moveEvents', clipUuid, frames: [30], offset: 6 },
             ],
         }]);
         const dump = await request('queryClip', [{ clipUuid }]);
@@ -117,9 +117,21 @@ describe('Animation Service 场景进程测试', () => {
         expect(dump.events).toEqual([{ frame: 36, func: 'onHalf', params: ['value'] }]);
     });
 
+    it('applyOperation 不接受旧 funcName/args 格式', async () => {
+        const result = await request('applyOperation', [{
+            operations: [{ funcName: 'changeSample', args: [clipUuid, 60] }],
+        }]);
+
+        expect(result).toMatchObject({
+            state: 'failure',
+            result: false,
+            reason: 'Animation operation is invalid.',
+        });
+    });
+
     it('applyOperation 对非当前 clip 显式失败', async () => {
         const result = await request('applyOperation', [{
-            operations: [{ funcName: 'changeSample', args: ['other-clip', 60] }],
+            operations: [{ type: 'changeSample', clipUuid: 'other-clip', sample: 60 }],
         }]);
 
         expect(result).toMatchObject({
@@ -127,5 +139,60 @@ describe('Animation Service 场景进程测试', () => {
             result: false,
             reason: `current edit clip: '${clipUuid}' but you want to operate: 'other-clip'`,
         });
+    });
+
+    it('applyOperation 支持真实 AnimationClip 的 embedded player 基础操作', async () => {
+        const result = await request('applyOperation', [{
+            operations: [
+                {
+                    type: 'addEmbeddedPlayerGroup',
+                    clipUuid,
+                    group: { key: 'particle-track', name: 'Particle Track', type: 'particle-system' },
+                },
+                {
+                    type: 'addEmbeddedPlayer',
+                    clipUuid,
+                    embeddedPlayer: {
+                        begin: 12,
+                        end: 30,
+                        reconciledSpeed: true,
+                        group: 'particle-track',
+                        displayName: 'Burst',
+                        playable: { type: 'particle-system', path: 'Particles' },
+                    },
+                },
+            ],
+        }]);
+        const dump = await request('queryClip', [{ clipUuid }]);
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(dump.embeddedPlayerGroups).toEqual([
+            { key: 'particle-track', name: 'Particle Track', type: 'particle-system' },
+        ]);
+        expect(dump.embeddedPlayers).toEqual([{
+            begin: 12,
+            end: 30,
+            reconciledSpeed: true,
+            group: 'particle-track',
+            displayName: 'Burst',
+            playable: { type: 'particle-system', path: 'Particles' },
+        }]);
+    });
+
+    it('applyOperation 支持真实 AnimationClip 的 auxiliary curve 基础操作', async () => {
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'addAuxiliaryCurve', clipUuid, name: 'BlendWeight' },
+                { type: 'createAuxKey', clipUuid, name: 'BlendWeight', frame: 0, value: 0.25 },
+                { type: 'createAuxKey', clipUuid, name: 'BlendWeight', frame: 60, value: 0.75 },
+            ],
+        }]);
+        const dump = await request('queryClip', [{ clipUuid }]);
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(dump.auxiliaryCurves.BlendWeight.keyframes).toEqual([
+            { frame: 0, value: 0.25 },
+            { frame: 60, value: 0.75 },
+        ]);
     });
 });

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -1,0 +1,131 @@
+import { assetManager } from '../../assets';
+import { ICreateByAssetParams } from '../common';
+import { Rpc } from '../main-process/rpc';
+import { EditorProxy } from '../main-process/proxy/editor-proxy';
+import { NodeProxy } from '../main-process/proxy/node-proxy';
+import { SceneTestEnv } from './scene-test-env';
+
+function request<T = any>(method: string, args: any[] = []): Promise<T> {
+    return (Rpc.getInstance() as any).request('Animation', method, args) as Promise<T>;
+}
+
+function createAnimationClipContent(options: { sample?: number; duration?: number } = {}) {
+    return JSON.stringify({
+        __type__: 'cc.AnimationClip',
+        _name: '',
+        _objFlags: 0,
+        _native: '',
+        sample: options.sample ?? 30,
+        speed: 1,
+        wrapMode: 1,
+        events: [],
+        _duration: options.duration ?? 1,
+        _keys: [],
+        _stepness: 0,
+        curveDatas: {},
+        _curves: [],
+        _commonTargets: [],
+        _hash: 0,
+    }, null, 2);
+}
+
+describe('Animation Service 场景进程测试', () => {
+    const sceneName = 'AnimationServiceScene';
+    const clipName = 'AnimationServiceClip';
+    let nodePath = '';
+    let clipUuid = '';
+
+    beforeAll(async () => {
+        await EditorProxy.create({
+            type: 'scene',
+            baseName: sceneName,
+            templateType: '2d',
+            targetDirectory: SceneTestEnv.targetDirectoryURL,
+        });
+        await EditorProxy.open({
+            urlOrUUID: `${SceneTestEnv.targetDirectoryURL}/${sceneName}.scene`,
+        });
+
+        const clipInfo = await assetManager.createAssetByType('animation-clip', SceneTestEnv.targetDirectoryURL, clipName, {
+            overwrite: true,
+            content: createAnimationClipContent(),
+        });
+        clipUuid = clipInfo.uuid;
+
+        const createParams: ICreateByAssetParams = {
+            dbURL: clipInfo.url,
+            path: '',
+            name: 'AnimationServiceNode',
+            position: { x: 2, y: 3, z: 4 },
+        };
+        const node = await NodeProxy.createByAsset(createParams);
+        if (!node) {
+            throw new Error('Failed to create animation node.');
+        }
+        nodePath = node.path;
+    });
+
+    afterAll(async () => {
+        await EditorProxy.close({ save: false });
+    });
+
+    it('queryClip 返回真实 AnimationClip 的基础 dump', async () => {
+        await request('enter', [{ rootPath: nodePath, clipUuid }]);
+
+        const dump = await request('queryClip', [{ clipUuid }]);
+
+        expect(dump.name).toBe(clipName);
+        expect(dump.duration).toBe(1);
+        expect(dump.sample).toBe(30);
+        expect(dump.speed).toBe(1);
+        expect(dump.wrapMode).toBe(1);
+        expect(dump.events).toEqual([]);
+        expect(dump.curves).toEqual([]);
+    });
+
+    it('queryPropertyValueAtFrame 使用真实 AnimationState 采样并恢复时间', async () => {
+        await request('setTime', [{ time: 0.25 }]);
+
+        const value = await request('queryPropertyValueAtFrame', [{
+            clipUuid,
+            nodePath,
+            propKey: 'position',
+            frame: 15,
+        }]);
+        const time = await request<number>('queryTime', [{ clipUuid }]);
+
+        expect(value).toMatchObject({ x: 2, y: 3, z: 4 });
+        expect(time).toBe(0.25);
+    });
+
+    it('applyOperation 在真实 AnimationClip 上应用基础普通 clip 操作', async () => {
+        const result = await request('applyOperation', [{
+            operations: [
+                { funcName: 'changeSample', args: [clipUuid, 60] },
+                { funcName: 'changeSpeed', args: [clipUuid, 1.5] },
+                { funcName: 'changeWrapMode', args: [clipUuid, 2] },
+                { funcName: 'addEvent', args: [clipUuid, 30, 'onHalf', ['value']] },
+                { funcName: 'moveEvents', args: [clipUuid, [30], 6] },
+            ],
+        }]);
+        const dump = await request('queryClip', [{ clipUuid }]);
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(dump.sample).toBe(60);
+        expect(dump.speed).toBe(1.5);
+        expect(dump.wrapMode).toBe(2);
+        expect(dump.events).toEqual([{ frame: 36, func: 'onHalf', params: ['value'] }]);
+    });
+
+    it('applyOperation 对非当前 clip 显式失败', async () => {
+        const result = await request('applyOperation', [{
+            operations: [{ funcName: 'changeSample', args: ['other-clip', 60] }],
+        }]);
+
+        expect(result).toMatchObject({
+            state: 'failure',
+            result: false,
+            reason: `current edit clip: '${clipUuid}' but you want to operate: 'other-clip'`,
+        });
+    });
+});

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -66,6 +66,7 @@ describe('Animation Service 场景进程测试', () => {
     const emptyClipName = `AnimationServiceEmptyClip_${testRunId}`;
     const keyDataClipName = `AnimationServiceKeyDataClip_${testRunId}`;
     const childClipName = `AnimationServiceChildClip_${testRunId}`;
+    const rootEditClipName = `AnimationServiceRootEditClip_${testRunId}`;
     let nodePath = '';
     let childNodePath = '';
     let clipUuid = '';
@@ -76,6 +77,8 @@ describe('Animation Service 场景进程测试', () => {
     let childRootNodePath = '';
     let childTrackNodePath = '';
     let childClipUuid = '';
+    let rootEditNodePath = '';
+    let rootEditClipUuid = '';
 
     beforeAll(async () => {
         await EditorProxy.create({
@@ -111,6 +114,12 @@ describe('Animation Service 场景进程测试', () => {
             content: createAnimationClipContent({ sample: 60, duration: 0 }),
         });
         childClipUuid = childClipInfo.uuid;
+
+        const rootEditClipInfo = await assetManager.createAssetByType('animation-clip', SceneTestEnv.targetDirectoryURL, rootEditClipName, {
+            overwrite: true,
+            content: createAnimationClipContent({ sample: 60, duration: 0 }),
+        });
+        rootEditClipUuid = rootEditClipInfo.uuid;
 
         const createParams: ICreateByAssetParams = {
             dbURL: clipInfo.url,
@@ -166,6 +175,17 @@ describe('Animation Service 场景进程测试', () => {
             throw new Error('Failed to create child sampling target node.');
         }
         childTrackNodePath = childTrackNode.path;
+
+        const rootEditNode = await NodeProxy.createByAsset({
+            dbURL: rootEditClipInfo.url,
+            path: '',
+            name: 'AnimationServiceRootEditNode',
+            position: { x: 0, y: 0, z: 0 },
+        });
+        if (!rootEditNode) {
+            throw new Error('Failed to create root keyframe editing animation node.');
+        }
+        rootEditNodePath = rootEditNode.path;
 
         const childNode = await NodeProxy.createByType({
             path: nodePath,
@@ -407,6 +427,46 @@ describe('Animation Service 场景进程测试', () => {
         await request('setTime', [{ time: 0 }]);
         const resetChildNode = await NodeProxy.query({ path: childTrackNodePath, includeChildren: false, includeComponents: false }) as any;
         expect(resetChildNode?.properties.position).toMatchObject({ x: 0, y: 0, z: 0 });
+    });
+
+    it('setTime 在 root keyframe 编辑保存重进后采样最终曲线', async () => {
+        await ensureAnimationSession(rootEditNodePath, rootEditClipUuid);
+        await Undo.clearHistory();
+        await Undo.markSaved();
+
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'createPropertyKey', clipUuid: rootEditClipUuid, nodePath: rootEditNodePath, propKey: 'position', frame: 0, value: { x: 0, y: 0, z: 0 } },
+                { type: 'createPropertyKey', clipUuid: rootEditClipUuid, nodePath: rootEditNodePath, propKey: 'position', frame: 105, value: { x: 100, y: 0, z: 0 } },
+                { type: 'movePropertyKeys', clipUuid: rootEditClipUuid, nodePath: rootEditNodePath, propKey: 'position', frames: [105], offset: -15 },
+                { type: 'copyPropertyKeysTo', clipUuid: rootEditClipUuid, nodePath: rootEditNodePath, propKey: 'position', frames: [90], dstFrame: 120 },
+                { type: 'movePropertyKeys', clipUuid: rootEditClipUuid, nodePath: rootEditNodePath, propKey: 'position', frames: [120], offset: -15 },
+                { type: 'removePropertyKeys', clipUuid: rootEditClipUuid, nodePath: rootEditNodePath, propKey: 'position', frames: [105] },
+            ],
+        }]);
+        const afterEdit = await request('queryClip', [{ rootPath: rootEditNodePath, clipUuid: rootEditClipUuid }]);
+        const positionCurve = afterEdit.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'position');
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(Math.round(afterEdit.duration * afterEdit.sample)).toBe(90);
+        expect(positionCurve.keyframes).toEqual([
+            { frame: 0, dump: { value: { x: 0, y: 0, z: 0 }, type: 'cc.Vec3' } },
+            { frame: 90, dump: { value: { x: 100, y: 0, z: 0 }, type: 'cc.Vec3' } },
+        ]);
+        expect(await request('save')).toBe(true);
+
+        await request('exit', [{ restoreSelection: false, restoreSampledSceneState: false }]);
+        await request('enter', [{ rootPath: rootEditNodePath, clipUuid: rootEditClipUuid }]);
+        await request('setTime', [{ time: 1.5 }]);
+        const time = await request<number>('queryTime', [{ clipUuid: rootEditClipUuid }]);
+        const sampledEndNode = await NodeProxy.query({ path: rootEditNodePath, includeChildren: false, includeComponents: false }) as any;
+
+        expect(time).toBe(1.5);
+        expect(sampledEndNode?.properties.position).toMatchObject({ x: 100, y: 0, z: 0 });
+
+        await request('setTime', [{ time: 0 }]);
+        const sampledStartNode = await NodeProxy.query({ path: rootEditNodePath, includeChildren: false, includeComponents: false }) as any;
+        expect(sampledStartNode?.properties.position).toMatchObject({ x: 0, y: 0, z: 0 });
     });
 
     it('applyOperation 支持分量级属性 keyframe 并保留切线信息', async () => {

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -63,11 +63,14 @@ describe('Animation Service 场景进程测试', () => {
     const sceneName = 'AnimationServiceScene';
     const clipName = 'AnimationServiceClip';
     const emptyClipName = 'AnimationServiceEmptyClip';
+    const keyDataClipName = 'AnimationServiceKeyDataClip';
     let nodePath = '';
     let childNodePath = '';
     let clipUuid = '';
     let emptyNodePath = '';
     let emptyClipUuid = '';
+    let keyDataNodePath = '';
+    let keyDataClipUuid = '';
 
     beforeAll(async () => {
         await EditorProxy.create({
@@ -92,6 +95,12 @@ describe('Animation Service 场景进程测试', () => {
         });
         emptyClipUuid = emptyClipInfo.uuid;
 
+        const keyDataClipInfo = await assetManager.createAssetByType('animation-clip', SceneTestEnv.targetDirectoryURL, keyDataClipName, {
+            overwrite: true,
+            content: createAnimationClipContent({ duration: 0 }),
+        });
+        keyDataClipUuid = keyDataClipInfo.uuid;
+
         const createParams: ICreateByAssetParams = {
             dbURL: clipInfo.url,
             path: '',
@@ -114,6 +123,17 @@ describe('Animation Service 场景进程测试', () => {
             throw new Error('Failed to create empty animation node.');
         }
         emptyNodePath = emptyNode.path;
+
+        const keyDataNode = await NodeProxy.createByAsset({
+            dbURL: keyDataClipInfo.url,
+            path: '',
+            name: 'AnimationServiceKeyDataNode',
+            position: { x: 0, y: 0, z: 0 },
+        });
+        if (!keyDataNode) {
+            throw new Error('Failed to create key data animation node.');
+        }
+        keyDataNodePath = keyDataNode.path;
 
         const childNode = await NodeProxy.createByType({
             path: nodePath,
@@ -428,6 +448,93 @@ describe('Animation Service 场景进程测试', () => {
         const redoScaleCurve = afterRedo.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'scale');
         const redoKey = redoScaleCurve.channels.find((channel: any) => channel.key === 'y').keyframes.find((keyframe: any) => keyframe.frame === 21);
         expect(redoKey.broken).toBe(false);
+    });
+
+    it('applyOperation 通过 updatePropertyKey 合并并持久化 RealCurve keyData', async () => {
+        await ensureAnimationSession(keyDataNodePath, keyDataClipUuid);
+        await Undo.clearHistory();
+        await Undo.markSaved();
+
+        const queryPositionXKey = async () => {
+            const dump = await request('queryClip', [{ rootPath: keyDataNodePath, clipUuid: keyDataClipUuid }]);
+            const positionCurve = dump.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'position');
+            return positionCurve?.channels
+                .find((channel: any) => channel.key === 'x')?.keyframes
+                .find((keyframe: any) => keyframe.frame === 60);
+        };
+
+        const before = await request('queryClip', [{ rootPath: keyDataNodePath, clipUuid: keyDataClipUuid }]);
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'createPropertyKey', clipUuid: keyDataClipUuid, propKey: 'position', frame: 60, value: { x: 80, y: 9, z: 10 } },
+                { type: 'updatePropertyKey', clipUuid: keyDataClipUuid, propKey: 'position', channel: 'x', frame: 60, keyData: { interpMode: 1 } },
+                { type: 'updatePropertyKey', clipUuid: keyDataClipUuid, propKey: 'position', channel: 'x', frame: 60, keyData: { broken: true } },
+            ],
+        }]);
+        const afterUpdateKey = await queryPositionXKey();
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(afterUpdateKey).toMatchObject({
+            frame: 60,
+            dump: { value: 80, type: 'cc.Number' },
+            interpMode: 1,
+            broken: true,
+        });
+
+        expectUndoSuccess(await Undo.undo());
+        const afterUndo = await request('queryClip', [{ rootPath: keyDataNodePath, clipUuid: keyDataClipUuid }]);
+        expect(afterUndo.curves).toEqual(before.curves);
+
+        expectUndoSuccess(await Undo.redo());
+        const afterRedoKey = await queryPositionXKey();
+        expect(afterRedoKey).toMatchObject({
+            frame: 60,
+            dump: { value: 80, type: 'cc.Number' },
+            interpMode: 1,
+            broken: true,
+        });
+
+        expect(await request('applyOperation', [{
+            operations: [
+                { type: 'updatePropertyKey', clipUuid: keyDataClipUuid, propKey: 'position', channel: 'x', frame: 60, keyData: { broken: false } },
+            ],
+        }])).toEqual({ state: 'success', result: true });
+        const afterBrokenFalseKey = await queryPositionXKey();
+        expect(afterBrokenFalseKey).toMatchObject({
+            frame: 60,
+            dump: { value: 80, type: 'cc.Number' },
+            interpMode: 1,
+            broken: false,
+        });
+
+        expectUndoSuccess(await Undo.undo());
+        const afterBrokenFalseUndoKey = await queryPositionXKey();
+        expect(afterBrokenFalseUndoKey).toMatchObject({
+            frame: 60,
+            dump: { value: 80, type: 'cc.Number' },
+            interpMode: 1,
+            broken: true,
+        });
+
+        expectUndoSuccess(await Undo.redo());
+        const afterBrokenFalseRedoKey = await queryPositionXKey();
+        expect(afterBrokenFalseRedoKey).toMatchObject({
+            frame: 60,
+            dump: { value: 80, type: 'cc.Number' },
+            interpMode: 1,
+            broken: false,
+        });
+
+        expect(await request('save')).toBe(true);
+        await request('exit', [{ restoreSelection: false, restoreSampledSceneState: false }]);
+        await request('enter', [{ rootPath: keyDataNodePath, clipUuid: keyDataClipUuid }]);
+        const afterReenterKey = await queryPositionXKey();
+        expect(afterReenterKey).toMatchObject({
+            frame: 60,
+            dump: { value: 80, type: 'cc.Number' },
+            interpMode: 1,
+            broken: false,
+        });
     });
 
     it('applyOperation 支持 queryProperties 暴露的 rotation 和 active 属性', async () => {

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -1,9 +1,11 @@
 import { assetManager } from '../../assets';
 import { ICreateByAssetParams } from '../common';
+import { sceneWorker } from '../main-process/scene-worker';
 import { Rpc } from '../main-process/rpc';
 import { EditorProxy } from '../main-process/proxy/editor-proxy';
 import { NodeProxy } from '../main-process/proxy/node-proxy';
 import { SceneTestEnv } from './scene-test-env';
+import * as utils from './utils';
 
 function request<T = any>(method: string, args: any[] = []): Promise<T> {
     return (Rpc.getInstance() as any).request('Animation', method, args) as Promise<T>;
@@ -97,8 +99,26 @@ describe('Animation Service 场景进程测试', () => {
         await EditorProxy.close({ save: false });
     });
 
+    it('enter 广播 animation:state-changed 供 UI 订阅', async () => {
+        const eventPromise = utils.once<Record<'animation:state-changed', any>>(sceneWorker, 'animation:state-changed');
+
+        const state = await request('enter', [{ rootPath: nodePath, clipUuid }]);
+        const event = await eventPromise;
+
+        expect(state.active).toBe(true);
+        expect(event).toMatchObject({
+            reason: 'enter',
+            state: {
+                active: true,
+                rootPath: nodePath,
+                clipUuid,
+                playState: 'stop',
+            },
+        });
+    });
+
     it('queryClip 返回真实 AnimationClip 的基础 dump', async () => {
-        await request('enter', [{ rootPath: nodePath, clipUuid }]);
+        await ensureAnimationSession(nodePath, clipUuid);
 
         const dump = await request('queryClip', [{ clipUuid }]);
 
@@ -126,7 +146,41 @@ describe('Animation Service 场景进程测试', () => {
         expect(time).toBe(0.25);
     });
 
+    it('setTime 广播 animation:time-changed 供 UI 订阅', async () => {
+        await ensureAnimationSession(nodePath, clipUuid);
+        const eventPromise = utils.once<Record<'animation:time-changed', any>>(sceneWorker, 'animation:time-changed');
+
+        await request('setTime', [{ time: 0.5 }]);
+        const event = await eventPromise;
+
+        expect(event).toMatchObject({
+            reason: 'set-time',
+            rootPath: nodePath,
+            clipUuid,
+            time: 0.5,
+            playState: 'stop',
+        });
+    });
+
+    it('changePlayState 广播 animation:state-changed 供 UI 订阅', async () => {
+        await ensureAnimationSession(nodePath, clipUuid);
+        const eventPromise = utils.once<Record<'animation:state-changed', any>>(sceneWorker, 'animation:state-changed');
+
+        await request('changePlayState', [{ operate: 'pause' }]);
+        const event = await eventPromise;
+
+        expect(event).toMatchObject({
+            reason: 'play-state',
+            state: {
+                rootPath: nodePath,
+                clipUuid,
+                playState: 'pause',
+            },
+        });
+    });
+
     it('applyOperation 在真实 AnimationClip 上应用基础普通 clip 操作', async () => {
+        const eventPromise = utils.once<Record<'animation:clip-changed', any>>(sceneWorker, 'animation:clip-changed');
         const result = await request('applyOperation', [{
             operations: [
                 { type: 'changeSample', clipUuid, sample: 60 },
@@ -136,13 +190,77 @@ describe('Animation Service 场景进程测试', () => {
                 { type: 'moveEvents', clipUuid, frames: [30], offset: 6 },
             ],
         }]);
+        const event = await eventPromise;
         const dump = await request('queryClip', [{ clipUuid }]);
 
         expect(result).toEqual({ state: 'success', result: true });
+        expect(event).toMatchObject({
+            reason: 'operation',
+            rootPath: nodePath,
+            clipUuid,
+        });
         expect(dump.sample).toBe(60);
         expect(dump.speed).toBe(1.5);
         expect(dump.wrapMode).toBe(2);
         expect(dump.events).toEqual([{ frame: 36, func: 'onHalf', params: ['value'] }]);
+    });
+
+    it('applyOperation 支持普通属性曲线 keyframe 的创建、移动和删除', async () => {
+        await ensureAnimationSession(nodePath, clipUuid);
+        await Undo.clearHistory();
+        await Undo.markSaved();
+
+        const before = await request('queryClip', [{ clipUuid }]);
+        const createResult = await request('applyOperation', [{
+            operations: [
+                { type: 'createPropertyKey', clipUuid, nodePath, propKey: 'position', frame: 0, value: { x: 2, y: 3, z: 4 } },
+                { type: 'createPropertyKey', clipUuid, nodePath, propKey: 'position', frame: 60, value: { x: 8, y: 9, z: 10 } },
+                { type: 'movePropertyKeys', clipUuid, nodePath, propKey: 'position', frames: [60], offset: -30 },
+            ],
+        }]);
+        const afterCreate = await request('queryClip', [{ clipUuid }]);
+        const positionCurve = afterCreate.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'position');
+
+        expect(createResult).toEqual({ state: 'success', result: true });
+        expect(positionCurve).toMatchObject({
+            nodePath: '',
+            key: 'position',
+            displayName: 'position',
+            type: { value: 'cc.Vec3' },
+        });
+        expect(positionCurve.keyframes).toEqual([
+            { frame: 0, dump: { value: { x: 2, y: 3, z: 4 }, type: 'cc.Vec3' } },
+            { frame: 30, dump: { value: { x: 8, y: 9, z: 10 }, type: 'cc.Vec3' } },
+        ]);
+
+        const sampled = await request('queryPropertyValueAtFrame', [{
+            clipUuid,
+            nodePath,
+            propKey: 'position',
+            frame: 30,
+        }]);
+        expect(sampled).toMatchObject({ x: 8, y: 9, z: 10 });
+
+        expectUndoSuccess(await Undo.undo());
+        const afterUndo = await request('queryClip', [{ clipUuid }]);
+        expect(afterUndo.curves).toEqual(before.curves);
+
+        expectUndoSuccess(await Undo.redo());
+        const afterRedo = await request('queryClip', [{ clipUuid }]);
+        expect(afterRedo.curves).toEqual(afterCreate.curves);
+
+        const removeResult = await request('applyOperation', [{
+            operations: [
+                { type: 'removePropertyKey', clipUuid, nodePath, propKey: 'position', frames: [0] },
+            ],
+        }]);
+        const afterRemove = await request('queryClip', [{ clipUuid }]);
+        const removedCurve = afterRemove.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'position');
+
+        expect(removeResult).toEqual({ state: 'success', result: true });
+        expect(removedCurve.keyframes).toEqual([
+            { frame: 30, dump: { value: { x: 8, y: 9, z: 10 }, type: 'cc.Vec3' } },
+        ]);
     });
 
     it('applyOperation 不接受旧 funcName/args 格式', async () => {
@@ -247,15 +365,29 @@ describe('Animation Service 场景进程测试', () => {
             { frame: 12, func: 'onUndoCheck', params: ['undo'] },
         ]));
 
+        const undoEventPromise = utils.once<Record<'animation:clip-changed', any>>(sceneWorker, 'animation:clip-changed');
         expectUndoSuccess(await Undo.undo());
+        const undoEvent = await undoEventPromise;
         const undoDump = await request('queryClip', [{ clipUuid }]);
+        expect(undoEvent).toMatchObject({
+            reason: 'undo-redo',
+            rootPath: nodePath,
+            clipUuid,
+        });
         expect(undoDump.speed).toBe(before.speed);
         expect(undoDump.events).toEqual(before.events);
         expect(await Undo.isDirty()).toBe(false);
         expect(await Undo.canRedo()).toBe(true);
 
+        const redoEventPromise = utils.once<Record<'animation:clip-changed', any>>(sceneWorker, 'animation:clip-changed');
         expectUndoSuccess(await Undo.redo());
+        const redoEvent = await redoEventPromise;
         const redoDump = await request('queryClip', [{ clipUuid }]);
+        expect(redoEvent).toMatchObject({
+            reason: 'undo-redo',
+            rootPath: nodePath,
+            clipUuid,
+        });
         expect(redoDump.speed).toBe(after.speed);
         expect(redoDump.events).toEqual(after.events);
         expect(await Undo.isDirty()).toBe(true);

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -60,10 +60,12 @@ function createAnimationClipContent(options: { sample?: number; duration?: numbe
 }
 
 describe('Animation Service 场景进程测试', () => {
-    const sceneName = 'AnimationServiceScene';
-    const clipName = 'AnimationServiceClip';
-    const emptyClipName = 'AnimationServiceEmptyClip';
-    const keyDataClipName = 'AnimationServiceKeyDataClip';
+    const testRunId = Date.now().toString(36);
+    const sceneName = `AnimationServiceScene_${testRunId}`;
+    const clipName = `AnimationServiceClip_${testRunId}`;
+    const emptyClipName = `AnimationServiceEmptyClip_${testRunId}`;
+    const keyDataClipName = `AnimationServiceKeyDataClip_${testRunId}`;
+    const childClipName = `AnimationServiceChildClip_${testRunId}`;
     let nodePath = '';
     let childNodePath = '';
     let clipUuid = '';
@@ -71,6 +73,9 @@ describe('Animation Service 场景进程测试', () => {
     let emptyClipUuid = '';
     let keyDataNodePath = '';
     let keyDataClipUuid = '';
+    let childRootNodePath = '';
+    let childTrackNodePath = '';
+    let childClipUuid = '';
 
     beforeAll(async () => {
         await EditorProxy.create({
@@ -100,6 +105,12 @@ describe('Animation Service 场景进程测试', () => {
             content: createAnimationClipContent({ duration: 0 }),
         });
         keyDataClipUuid = keyDataClipInfo.uuid;
+
+        const childClipInfo = await assetManager.createAssetByType('animation-clip', SceneTestEnv.targetDirectoryURL, childClipName, {
+            overwrite: true,
+            content: createAnimationClipContent({ sample: 60, duration: 0 }),
+        });
+        childClipUuid = childClipInfo.uuid;
 
         const createParams: ICreateByAssetParams = {
             dbURL: clipInfo.url,
@@ -134,6 +145,27 @@ describe('Animation Service 场景进程测试', () => {
             throw new Error('Failed to create key data animation node.');
         }
         keyDataNodePath = keyDataNode.path;
+
+        const childRootNode = await NodeProxy.createByAsset({
+            dbURL: childClipInfo.url,
+            path: '',
+            name: 'AnimationServiceChildSamplingRoot',
+            position: { x: 0, y: 0, z: 0 },
+        });
+        if (!childRootNode) {
+            throw new Error('Failed to create child sampling animation node.');
+        }
+        childRootNodePath = childRootNode.path;
+
+        const childTrackNode = await NodeProxy.createByType({
+            path: childRootNodePath,
+            name: 'AnimationServiceChildSamplingChild',
+            nodeType: NodeType.EMPTY,
+        });
+        if (!childTrackNode) {
+            throw new Error('Failed to create child sampling target node.');
+        }
+        childTrackNodePath = childTrackNode.path;
 
         const childNode = await NodeProxy.createByType({
             path: nodePath,
@@ -320,6 +352,8 @@ describe('Animation Service 场景进程测试', () => {
         await Undo.markSaved();
 
         const before = await request('queryClip', [{ clipUuid: emptyClipUuid }]);
+        expect(before.duration).toBe(0);
+
         const result = await request('applyOperation', [{
             operations: [
                 { type: 'createPropertyKey', clipUuid: emptyClipUuid, nodePath: emptyNodePath, propKey: 'position', frame: 30, value: { x: 1, y: 2, z: 3 } },
@@ -331,7 +365,6 @@ describe('Animation Service 场景进程测试', () => {
         const saveResult = await request('save');
         const afterSave = await request('queryClip', [{ clipUuid: emptyClipUuid }]);
 
-        expect(before.duration).toBe(0);
         expect(result).toEqual({ state: 'success', result: true });
         expect(afterCreate.duration).toBe(1);
         expect(Math.round(afterCreate.duration * afterCreate.sample)).toBe(30);
@@ -348,6 +381,32 @@ describe('Animation Service 场景进程测试', () => {
         const afterRedo = await request('queryClip', [{ clipUuid: emptyClipUuid }]);
         expect(afterRedo.duration).toBe(1);
         expect(afterRedo.curves).toEqual(afterCreate.curves);
+    });
+
+    it('setTime 对 child nodePath 属性轨道采样到真实子节点', async () => {
+        await ensureAnimationSession(childRootNodePath, childClipUuid);
+
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'createPropertyKey', clipUuid: childClipUuid, nodePath: childTrackNodePath, propKey: 'position', frame: 0, value: { x: 0, y: 0, z: 0 } },
+                { type: 'createPropertyKey', clipUuid: childClipUuid, nodePath: childTrackNodePath, propKey: 'position', frame: 60, value: { x: 100, y: 0, z: 0 } },
+            ],
+            recordUndo: false,
+        }]);
+        const dump = await request('queryClip', [{ rootPath: childRootNodePath, clipUuid: childClipUuid }]);
+        await request('setTime', [{ time: 1 }]);
+        const time = await request<number>('queryTime', [{ clipUuid: childClipUuid }]);
+        const childNode = await NodeProxy.query({ path: childTrackNodePath, includeChildren: false, includeComponents: false }) as any;
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(Math.round(dump.duration * dump.sample)).toBe(60);
+        expect(dump.curves.find((curve: any) => curve.nodePath === 'AnimationServiceChildSamplingChild' && curve.key === 'position')).toBeDefined();
+        expect(time).toBe(1);
+        expect(childNode?.properties.position).toMatchObject({ x: 100, y: 0, z: 0 });
+
+        await request('setTime', [{ time: 0 }]);
+        const resetChildNode = await NodeProxy.query({ path: childTrackNodePath, includeChildren: false, includeComponents: false }) as any;
+        expect(resetChildNode?.properties.position).toMatchObject({ x: 0, y: 0, z: 0 });
     });
 
     it('applyOperation 支持分量级属性 keyframe 并保留切线信息', async () => {
@@ -537,6 +596,118 @@ describe('Animation Service 场景进程测试', () => {
         });
     });
 
+    it('applyOperation 更新 RealCurve keyData 时保留显式 0 值', async () => {
+        await ensureAnimationSession(keyDataNodePath, keyDataClipUuid);
+
+        const queryEulerYKey = async () => {
+            const dump = await request('queryClip', [{ rootPath: keyDataNodePath, clipUuid: keyDataClipUuid }]);
+            const eulerCurve = dump.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'eulerAngles');
+            return eulerCurve?.channels
+                .find((channel: any) => channel.key === 'y')?.keyframes
+                .find((keyframe: any) => keyframe.frame === 84);
+        };
+
+        const result = await request('applyOperation', [{
+            operations: [
+                {
+                    type: 'createPropertyKey',
+                    clipUuid: keyDataClipUuid,
+                    propKey: 'eulerAngles',
+                    channel: 'y',
+                    frame: 84,
+                    value: 84,
+                    keyData: {
+                        inTangent: 0,
+                        outTangent: 0,
+                        inTangentWeight: 0,
+                        outTangentWeight: 0,
+                        interpMode: 0,
+                        tangentWeightMode: 0,
+                        tangentMode: 0,
+                        easingMethod: 0,
+                    },
+                },
+                {
+                    type: 'updatePropertyKeyData',
+                    clipUuid: keyDataClipUuid,
+                    propKey: 'eulerAngles',
+                    channel: 'y',
+                    frame: 84,
+                    keyData: { broken: true },
+                },
+            ],
+        }]);
+        const key = await queryEulerYKey();
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(key).toMatchObject({
+            frame: 84,
+            dump: { value: 84, type: 'cc.Number' },
+            inTangent: 0,
+            outTangent: 0,
+            inTangentWeight: 0,
+            outTangentWeight: 0,
+            interpMode: 0,
+            tangentWeightMode: 0,
+            tangentMode: 0,
+            easingMethod: 0,
+            broken: true,
+        });
+    });
+
+    it('applyOperation 失败时不会留下已执行的 clip 局部修改', async () => {
+        await ensureAnimationSession(keyDataNodePath, keyDataClipUuid);
+        await Undo.clearHistory();
+        await Undo.markSaved();
+
+        const before = await request('queryClip', [{ rootPath: keyDataNodePath, clipUuid: keyDataClipUuid }]);
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'createPropertyKey', clipUuid: keyDataClipUuid, propKey: 'position', frame: 72, value: { x: 72, y: 0, z: 0 } },
+                { type: 'updatePropertyKeyData', clipUuid: keyDataClipUuid, propKey: 'position', channel: 'x', frame: 99, keyData: { interpMode: 1 } },
+            ],
+        }]);
+        const after = await request('queryClip', [{ rootPath: keyDataNodePath, clipUuid: keyDataClipUuid }]);
+
+        expect(result).toMatchObject({ state: 'failure', result: false });
+        expect(after.curves).toEqual(before.curves);
+        expect(after.duration).toBe(before.duration);
+        expect(await Undo.isDirty()).toBe(false);
+    });
+
+    it('applyOperation 更新复合属性 keyData 时不会部分写入分量曲线', async () => {
+        await ensureAnimationSession(keyDataNodePath, keyDataClipUuid);
+
+        const createResult = await request('applyOperation', [{
+            operations: [
+                { type: 'createPropertyKey', clipUuid: keyDataClipUuid, propKey: 'eulerAngles', channel: 'x', frame: 36, value: 1 },
+            ],
+        }]);
+        expect(createResult).toEqual({ state: 'success', result: true });
+
+        const before = await request('queryClip', [{ rootPath: keyDataNodePath, clipUuid: keyDataClipUuid }]);
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'updatePropertyKeyData', clipUuid: keyDataClipUuid, propKey: 'eulerAngles', frame: 36, keyData: { interpMode: 1 } },
+            ],
+            recordUndo: false,
+        }]);
+        const after = await request('queryClip', [{ rootPath: keyDataNodePath, clipUuid: keyDataClipUuid }]);
+
+        const beforeEulerX = before.curves
+            .find((curve: any) => curve.nodePath === '' && curve.key === 'eulerAngles')?.channels
+            .find((channel: any) => channel.key === 'x')?.keyframes
+            .find((keyframe: any) => keyframe.frame === 36);
+        const afterEulerX = after.curves
+            .find((curve: any) => curve.nodePath === '' && curve.key === 'eulerAngles')?.channels
+            .find((channel: any) => channel.key === 'x')?.keyframes
+            .find((keyframe: any) => keyframe.frame === 36);
+
+        expect(result).toMatchObject({ state: 'failure', result: false });
+        expect(beforeEulerX).toEqual({ frame: 36, dump: { value: 1, type: 'cc.Number' } });
+        expect(afterEulerX).toEqual(beforeEulerX);
+    });
+
     it('applyOperation 支持 queryProperties 暴露的 rotation 和 active 属性', async () => {
         await ensureAnimationSession(nodePath, clipUuid);
 
@@ -695,6 +866,50 @@ describe('Animation Service 场景进程测试', () => {
             { frame: 0, value: 0.25 },
             { frame: 60, value: 0.75 },
         ]);
+    });
+
+    it('applyOperation 支持 auxiliary curve keyData 写入读回和按帧采样', async () => {
+        await ensureAnimationSession(nodePath, clipUuid);
+
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'addAuxiliaryCurve', clipUuid, name: 'CurveWeight' },
+                { type: 'createAuxKey', clipUuid, name: 'CurveWeight', frame: 0, value: 0, keyData: { interpMode: 1 } },
+                { type: 'createAuxKey', clipUuid, name: 'CurveWeight', frame: 30, value: 1 },
+                { type: 'updateAuxKeyData', clipUuid, name: 'CurveWeight', frame: 30, keyData: { broken: true, outTangent: 0.5 } },
+            ],
+        }]);
+        const dump = await request('queryClip', [{ clipUuid }]);
+        const sampledStart = await request('queryAuxiliaryCurveValueAtFrame', [{ clipUuid, name: 'CurveWeight', frame: 0 }]);
+        const sampled = await request('queryAuxiliaryCurveValueAtFrame', [{ clipUuid, name: 'CurveWeight', frame: 15 }]);
+        const sampledEnd = await request('queryAuxiliaryCurveValueAtFrame', [{ clipUuid, name: 'CurveWeight', frame: 30 }]);
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(dump.auxiliaryCurves.CurveWeight.keyframes).toEqual([
+            { frame: 0, value: 0, interpMode: 1 },
+            { frame: 30, value: 1, broken: true, outTangent: 0.5 },
+        ]);
+        expect(sampledStart).toEqual({ value: 0, type: 'cc.Number' });
+        expect(sampled.type).toBe('cc.Number');
+        expect(sampled.value).toBeGreaterThanOrEqual(0);
+        expect(sampled.value).toBeLessThanOrEqual(1);
+        expect(sampledEnd).toEqual({ value: 1, type: 'cc.Number' });
+    });
+
+    it('applyOperation 支持 auxiliary curve 编辑后重算 duration', async () => {
+        await ensureAnimationSession(emptyNodePath, emptyClipUuid);
+
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'addAuxiliaryCurve', clipUuid: emptyClipUuid, name: 'DurationWeight' },
+                { type: 'createAuxKey', clipUuid: emptyClipUuid, name: 'DurationWeight', frame: 90, value: 1 },
+            ],
+            recordUndo: false,
+        }]);
+        const dump = await request('queryClip', [{ clipUuid: emptyClipUuid }]);
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(Math.round(dump.duration * dump.sample)).toBeGreaterThanOrEqual(90);
     });
 
     it('applyOperation 默认记录 undo/dirty，并支持 undo/redo 恢复真实 AnimationClip', async () => {

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -39,6 +39,24 @@ async function ensureAnimationSession(rootPath: string, clipUuid: string): Promi
     }
 }
 
+function waitForAnimationPlayState(playState: string, timeout = 5000): Promise<any> {
+    return new Promise((resolve, reject) => {
+        const handler = (event: any) => {
+            if (event?.state?.playState !== playState) {
+                return;
+            }
+            clearTimeout(timer);
+            sceneWorker.off('animation:state-changed', handler);
+            resolve(event);
+        };
+        const timer = setTimeout(() => {
+            sceneWorker.off('animation:state-changed', handler);
+            reject(new Error(`Timeout waiting for animation playState "${playState}"`));
+        }, timeout);
+        sceneWorker.on('animation:state-changed', handler);
+    });
+}
+
 function createAnimationClipContent(options: { sample?: number; duration?: number } = {}) {
     return JSON.stringify({
         __type__: 'cc.AnimationClip',
@@ -298,6 +316,26 @@ describe('Animation Service 场景进程测试', () => {
             playState: 'playing',
         });
         expect(event.time).toBeGreaterThan(0);
+    });
+
+    it('play 自然结束时广播最终时间和 stop 状态', async () => {
+        await ensureAnimationSession(nodePath, clipUuid);
+        await request('setTime', [{ time: 0 }]);
+        const statePromise = waitForAnimationPlayState('stop');
+
+        await request('changePlayState', [{ operate: 'play' }]);
+        const event = await statePromise;
+        const time = await request<number>('queryTime', [{ clipUuid }]);
+
+        expect(event).toMatchObject({
+            reason: 'play-state',
+            state: {
+                rootPath: nodePath,
+                clipUuid,
+                playState: 'stop',
+            },
+        });
+        expect(time).toBeGreaterThanOrEqual(0.95);
     });
 
     it('applyOperation 在真实 AnimationClip 上应用基础普通 clip 操作', async () => {

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -881,6 +881,35 @@ describe('Animation Service 场景进程测试', () => {
         ]);
     });
 
+    it('removePropertyKeys 清空关键帧时保留属性轨道，removePropertyCurve 才移除轨道', async () => {
+        await ensureAnimationSession(emptyNodePath, emptyClipUuid);
+
+        const clearResult = await request('applyOperation', [{
+            operations: [
+                { type: 'addPropertyCurve', clipUuid: emptyClipUuid, nodePath: emptyNodePath, propKey: 'scale' },
+                { type: 'createPropertyKey', clipUuid: emptyClipUuid, nodePath: emptyNodePath, propKey: 'scale', frame: 0, value: { x: 1, y: 1, z: 1 } },
+                { type: 'removePropertyKeys', clipUuid: emptyClipUuid, nodePath: emptyNodePath, propKey: 'scale', frames: [0] },
+            ],
+        }]);
+        const afterClear = await request('queryClip', [{ rootPath: emptyNodePath, clipUuid: emptyClipUuid }]);
+        const scaleCurveAfterClear = afterClear.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'scale');
+
+        expect(clearResult).toEqual({ state: 'success', result: true });
+        expect(scaleCurveAfterClear).toBeDefined();
+        expect(scaleCurveAfterClear.keyframes).toEqual([]);
+        expect(scaleCurveAfterClear.channels.every((channel: any) => channel.keyframes.length === 0)).toBe(true);
+
+        const removeResult = await request('applyOperation', [{
+            operations: [
+                { type: 'removePropertyCurve', clipUuid: emptyClipUuid, nodePath: emptyNodePath, propKey: 'scale' },
+            ],
+        }]);
+        const afterRemove = await request('queryClip', [{ rootPath: emptyNodePath, clipUuid: emptyClipUuid }]);
+
+        expect(removeResult).toEqual({ state: 'success', result: true });
+        expect(afterRemove.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'scale')).toBeUndefined();
+    });
+
     it('applyOperation 创建普通属性 key 时 value 可省略并从当前场景采样', async () => {
         await ensureAnimationSession(nodePath, clipUuid);
         await request('setTime', [{ time: 0 }]);

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -22,6 +22,8 @@ const Undo = {
     isDirty: () => requestService<boolean>('Undo', 'isDirty'),
     canUndo: () => requestService<boolean>('Undo', 'canUndo'),
     canUndoInAnimationScope: () => requestService<boolean>('Undo', 'canUndo', [{ scope: { editorType: 'animation', mode: 'animation' } }]),
+    beginRecording: (uuids: string[], options: any) => requestService<string>('Undo', 'beginRecording', [uuids, options]),
+    endRecording: (id: string) => requestService<boolean>('Undo', 'endRecording', [id]),
     undo: () => requestService('Undo', 'undo'),
     undoInAnimationScope: () => requestService('Undo', 'undo', [{ scope: { editorType: 'animation', mode: 'animation' } }]),
     canRedo: () => requestService<boolean>('Redo', 'canRedo'),
@@ -41,6 +43,26 @@ async function ensureAnimationSession(rootPath: string, clipUuid: string): Promi
     if (!state.active || state.rootPath !== rootPath || state.clipUuid !== clipUuid) {
         await request('enter', [{ rootPath, clipUuid }]);
     }
+}
+
+async function resetRootPositionCurve(rootPath: string, clipUuid: string): Promise<void> {
+    const dump = await request('queryClip', [{ rootPath, clipUuid }]);
+    const hasPositionCurve = dump.curves.some((curve: any) => curve.nodePath === '' && curve.key === 'position');
+    if (hasPositionCurve) {
+        await request('applyOperation', [{
+            operations: [
+                { type: 'removePropertyCurve', clipUuid, propKey: 'position' },
+            ],
+            recordUndo: false,
+        }]);
+    }
+    await request('applyOperation', [{
+        operations: [
+            { type: 'addPropertyCurve', clipUuid, propKey: 'position', value: { x: 0, y: 0, z: 0 } },
+            { type: 'createPropertyKey', clipUuid, propKey: 'position', frame: 0, value: { x: 0, y: 0, z: 0 } },
+        ],
+        recordUndo: false,
+    }]);
 }
 
 function waitForAnimationPlayState(playState: string, timeout = 5000): Promise<any> {
@@ -1367,13 +1389,7 @@ describe('Animation Service 场景进程测试', () => {
 
     it('applyOperation 可把已消费的 scene 属性 undo 合并进 animation scoped undo', async () => {
         await ensureAnimationSession(emptyNodePath, emptyClipUuid);
-        await request('applyOperation', [{
-            operations: [
-                { type: 'addPropertyCurve', clipUuid: emptyClipUuid, propKey: 'position', value: { x: 0, y: 0, z: 0 } },
-                { type: 'createPropertyKey', clipUuid: emptyClipUuid, propKey: 'position', frame: 0, value: { x: 0, y: 0, z: 0 } },
-            ],
-            recordUndo: false,
-        }]);
+        await resetRootPositionCurve(emptyNodePath, emptyClipUuid);
         await Undo.clearHistory();
         await Undo.markSaved();
 
@@ -1419,6 +1435,53 @@ describe('Animation Service 场景进程测试', () => {
         expect(await Undo.isDirty()).toBe(true);
     });
 
+    it('applyOperation 可把 Gizmo snapshot undo 合并进 animation scoped undo', async () => {
+        await ensureAnimationSession(emptyNodePath, emptyClipUuid);
+        await resetRootPositionCurve(emptyNodePath, emptyClipUuid);
+        await Undo.clearHistory();
+        await Undo.markSaved();
+
+        await request('setTime', [{ time: 0.5 }]);
+        const nodeBeforeGizmo = await requestService<any>('Node', 'queryNodeTree', [{ path: emptyNodePath }]);
+        expect(nodeBeforeGizmo?.uuid).toBeTruthy();
+        const recordingId = await Undo.beginRecording([nodeBeforeGizmo.uuid], {
+            label: 'Gizmo position',
+            scope: {
+                editorType: 'scene',
+                nodePath: emptyNodePath,
+                propPath: 'position',
+            },
+        });
+        await NodeProxy.update({
+            path: emptyNodePath,
+            properties: { position: { x: 321, y: 0, z: 0 } },
+        });
+        await Undo.endRecording(recordingId);
+        expect(await Undo.canUndo()).toBe(true);
+        expect(await Undo.canUndoInAnimationScope()).toBe(false);
+
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'createPropertyKey', clipUuid: emptyClipUuid, propKey: 'position', frame: 30, value: { x: 321, y: 0, z: 0 } },
+            ],
+            absorbPreviousScenePropertyUndo: true,
+        }]);
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(await Undo.canUndoInAnimationScope()).toBe(true);
+
+        expectUndoSuccess(await Undo.undoInAnimationScope());
+        const undoDump = await request('queryClip', [{ rootPath: emptyNodePath, clipUuid: emptyClipUuid }]);
+        const undoCurve = undoDump.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'position');
+        const nodeAfterUndo = await NodeProxy.query({ path: emptyNodePath, includeChildren: false, includeComponents: false }) as any;
+        expect(undoCurve.keyframes).toEqual([
+            { frame: 0, dump: { value: { x: 0, y: 0, z: 0 }, type: 'cc.Vec3' } },
+        ]);
+        expect(nodeAfterUndo?.properties.position).toMatchObject({ x: 0, y: 0, z: 0 });
+        expect(await Undo.canUndo()).toBe(false);
+        expect(await Undo.isDirty()).toBe(false);
+    });
+
     it('applyOperation 不应把无关 scene 属性 undo 合并进 animation scoped undo', async () => {
         await ensureAnimationSession(emptyNodePath, emptyClipUuid);
         await request('applyOperation', [{
@@ -1461,13 +1524,7 @@ describe('Animation Service 场景进程测试', () => {
 
     it('applyOperation 混合非属性操作时不应吸收 scene 属性 undo', async () => {
         await ensureAnimationSession(emptyNodePath, emptyClipUuid);
-        await request('applyOperation', [{
-            operations: [
-                { type: 'addPropertyCurve', clipUuid: emptyClipUuid, propKey: 'position', value: { x: 0, y: 0, z: 0 } },
-                { type: 'createPropertyKey', clipUuid: emptyClipUuid, propKey: 'position', frame: 0, value: { x: 0, y: 0, z: 0 } },
-            ],
-            recordUndo: false,
-        }]);
+        await resetRootPositionCurve(emptyNodePath, emptyClipUuid);
         await Undo.clearHistory();
         await Undo.markSaved();
 

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -196,8 +196,8 @@ describe('Animation Service 场景进程测试', () => {
 
     async function createIsolatedSpriteAnimationNode(baseName: string) {
         const target = await createIsolatedAnimationNode(baseName, { sample: 30, duration: 0 });
-        await ComponentProxy.add({ nodePath: target.nodePath, component: 'cc.Sprite' });
-        return target;
+        const sprite = await ComponentProxy.add({ nodePath: target.nodePath, component: 'cc.Sprite' });
+        return { ...target, spriteComponentPath: sprite.path };
     }
 
     beforeAll(async () => {
@@ -1069,6 +1069,43 @@ describe('Animation Service 场景进程测试', () => {
         expect(sampled).toMatchObject({ r: 32, g: 64, b: 128, a: 255 });
     });
 
+    it('queryPropertyValueAtFrame 优先按当前动画 root 解析相对 nodePath', async () => {
+        const { nodePath: rootPath, clipUuid: relativeClipUuid } = await createIsolatedAnimationNode('AnimationServiceRelativePathCase');
+        const childName = `AnimationServiceRelativeTarget_${testRunId}`;
+        const sceneSibling = await NodeProxy.createByType({
+            path: '',
+            name: childName,
+            nodeType: NodeType.EMPTY,
+        });
+        const animationChild = await NodeProxy.createByType({
+            path: rootPath,
+            name: childName,
+            nodeType: NodeType.EMPTY,
+        });
+        if (!sceneSibling || !animationChild) {
+            throw new Error('Failed to create relative path sampling nodes.');
+        }
+        await setNodePositionWithoutUndo(sceneSibling.path, { x: 999, y: 0, z: 0 });
+        await setNodePositionWithoutUndo(animationChild.path, { x: 7, y: 8, z: 9 });
+        await ensureAnimationSession(rootPath, relativeClipUuid);
+
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'createPropertyKey', clipUuid: relativeClipUuid, nodePath: childName, propKey: 'position', frame: 30, value: { x: 7, y: 8, z: 9 } },
+            ],
+            recordUndo: false,
+        }]);
+        const sampled = await request('queryPropertyValueAtFrame', [{
+            clipUuid: relativeClipUuid,
+            nodePath: childName,
+            propKey: 'position',
+            frame: 30,
+        }]);
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(sampled).toMatchObject({ x: 7, y: 8, z: 9 });
+    });
+
     it('applyOperation 支持普通属性曲线的创建、更新、复制、批量删除和 extrapolation', async () => {
         await ensureAnimationSession(nodePath, clipUuid);
 
@@ -1212,7 +1249,44 @@ describe('Animation Service 场景进程测试', () => {
         }]);
     });
 
+    it('deleteEmbeddedPlayer 只删除 playable 匹配的 embedded player', async () => {
+        const { nodePath: embeddedNodePath, clipUuid: embeddedClipUuid } = await createIsolatedAnimationNode('AnimationServiceEmbeddedPlayerDeleteCase');
+        await ensureAnimationSession(embeddedNodePath, embeddedClipUuid);
+        const firstPlayer = {
+            begin: 12,
+            end: 30,
+            reconciledSpeed: true,
+            group: 'particle-track',
+            displayName: 'Burst',
+            playable: { type: 'particle-system' as const, path: 'ParticlesA' },
+        };
+        const secondPlayer = {
+            ...firstPlayer,
+            playable: { type: 'particle-system' as const, path: 'ParticlesB' },
+        };
+
+        const result = await request('applyOperation', [{
+            operations: [
+                {
+                    type: 'addEmbeddedPlayerGroup',
+                    clipUuid: embeddedClipUuid,
+                    group: { key: 'particle-track', name: 'Particle Track', type: 'particle-system' },
+                },
+                { type: 'addEmbeddedPlayer', clipUuid: embeddedClipUuid, embeddedPlayer: firstPlayer },
+                { type: 'addEmbeddedPlayer', clipUuid: embeddedClipUuid, embeddedPlayer: secondPlayer },
+                { type: 'deleteEmbeddedPlayer', clipUuid: embeddedClipUuid, embeddedPlayer: firstPlayer },
+            ],
+            recordUndo: false,
+        }]);
+        const dump = await request('queryClip', [{ clipUuid: embeddedClipUuid }]);
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(dump.embeddedPlayers).toEqual([secondPlayer]);
+    });
+
     it('applyOperation 支持真实 AnimationClip 的 auxiliary curve 基础操作', async () => {
+        await ensureAnimationSession(nodePath, clipUuid);
+
         const result = await request('applyOperation', [{
             operations: [
                 { type: 'addAuxiliaryCurve', clipUuid, name: 'BlendWeight' },
@@ -1554,6 +1628,36 @@ describe('Animation Service 场景进程测试', () => {
         expect(nodeAfterUndo?.properties.position).toMatchObject({ x: 0, y: 0, z: 0 });
         expect(await Undo.canUndo()).toBe(false);
         expect(await Undo.isDirty()).toBe(false);
+    });
+
+    it('applyOperation 可把已消费的组件属性 undo 合并进 animation scoped undo', async () => {
+        const { nodePath: spriteNodePath, clipUuid: spriteClipUuid, spriteComponentPath } = await createIsolatedSpriteAnimationNode('AnimationServiceComponentCommitCase');
+        await ensureAnimationSession(spriteNodePath, spriteClipUuid);
+        await Undo.clearHistory();
+        await Undo.markSaved();
+
+        await ComponentProxy.setProperty({
+            componentPath: spriteComponentPath,
+            properties: { color: { r: 12, g: 34, b: 56, a: 255 } },
+        });
+        expect(await Undo.canUndoInAnimationScope()).toBe(false);
+
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'createPropertyKey', clipUuid: spriteClipUuid, propKey: 'cc.Sprite.color', frame: 30, value: { r: 12, g: 34, b: 56, a: 255 } },
+            ],
+            absorbPreviousScenePropertyUndo: true,
+        }]);
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(await Undo.canUndoInAnimationScope()).toBe(true);
+
+        expectUndoSuccess(await Undo.undoInAnimationScope());
+        const undoDump = await request('queryClip', [{ rootPath: spriteNodePath, clipUuid: spriteClipUuid }]);
+        const undoCurve = undoDump.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'cc.Sprite.color');
+        const componentAfterUndo = await ComponentProxy.query({ path: spriteComponentPath }) as any;
+        expect(undoCurve).toBeUndefined();
+        expect(componentAfterUndo?.properties.color.value).toMatchObject({ r: 255, g: 255, b: 255, a: 255 });
     });
 
     it('applyOperation 不应把无关 scene 属性 undo 合并进 animation scoped undo', async () => {

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -1419,6 +1419,88 @@ describe('Animation Service 场景进程测试', () => {
         expect(await Undo.isDirty()).toBe(true);
     });
 
+    it('applyOperation 不应把无关 scene 属性 undo 合并进 animation scoped undo', async () => {
+        await ensureAnimationSession(emptyNodePath, emptyClipUuid);
+        await request('applyOperation', [{
+            operations: [
+                { type: 'addPropertyCurve', clipUuid: emptyClipUuid, propKey: 'scale', value: { x: 1, y: 1, z: 1 } },
+                { type: 'createPropertyKey', clipUuid: emptyClipUuid, propKey: 'scale', frame: 0, value: { x: 1, y: 1, z: 1 } },
+            ],
+            recordUndo: false,
+        }]);
+        await NodeProxy.update({
+            path: childNodePath,
+            properties: { position: { x: 0, y: 0, z: 0 } },
+        });
+        await Undo.clearHistory();
+        await Undo.markSaved();
+
+        await request('setTime', [{ time: 1 }]);
+        await NodeProxy.update({
+            path: childNodePath,
+            properties: { position: { x: 456, y: 0, z: 0 } },
+        });
+        expect(await Undo.canUndoInAnimationScope()).toBe(false);
+
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'createPropertyKey', clipUuid: emptyClipUuid, propKey: 'scale', frame: 30, value: { x: 2, y: 2, z: 2 } },
+            ],
+            absorbPreviousScenePropertyUndo: true,
+        }]);
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(await Undo.canUndoInAnimationScope()).toBe(true);
+
+        expectUndoSuccess(await Undo.undoInAnimationScope());
+        const childAfterUndo = await NodeProxy.query({ path: childNodePath, includeChildren: false, includeComponents: false }) as any;
+        expect(childAfterUndo?.properties.position).toMatchObject({ x: 456, y: 0, z: 0 });
+        expect(await Undo.canUndo()).toBe(true);
+        expect(await Undo.isDirty()).toBe(true);
+    });
+
+    it('applyOperation 混合非属性操作时不应吸收 scene 属性 undo', async () => {
+        await ensureAnimationSession(emptyNodePath, emptyClipUuid);
+        await request('applyOperation', [{
+            operations: [
+                { type: 'addPropertyCurve', clipUuid: emptyClipUuid, propKey: 'position', value: { x: 0, y: 0, z: 0 } },
+                { type: 'createPropertyKey', clipUuid: emptyClipUuid, propKey: 'position', frame: 0, value: { x: 0, y: 0, z: 0 } },
+            ],
+            recordUndo: false,
+        }]);
+        await Undo.clearHistory();
+        await Undo.markSaved();
+
+        await request('setTime', [{ time: 1 }]);
+        await NodeProxy.update({
+            path: emptyNodePath,
+            properties: { position: { x: 789, y: 0, z: 0 } },
+        });
+        expect(await Undo.canUndoInAnimationScope()).toBe(false);
+
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'createPropertyKey', clipUuid: emptyClipUuid, propKey: 'position', frame: 30, value: { x: 789, y: 0, z: 0 } },
+                { type: 'addEvent', clipUuid: emptyClipUuid, frame: 30, func: 'onMixedCommit', params: ['mixed'] },
+            ],
+            absorbPreviousScenePropertyUndo: true,
+        }]);
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(await Undo.canUndoInAnimationScope()).toBe(true);
+
+        expectUndoSuccess(await Undo.undoInAnimationScope());
+        const undoDump = await request('queryClip', [{ rootPath: emptyNodePath, clipUuid: emptyClipUuid }]);
+        const undoCurve = undoDump.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'position');
+        expect(undoCurve.keyframes).toEqual([
+            { frame: 0, dump: { value: { x: 0, y: 0, z: 0 }, type: 'cc.Vec3' } },
+        ]);
+        expect(undoDump.events).not.toEqual(expect.arrayContaining([
+            { frame: 30, func: 'onMixedCommit', params: ['mixed'] },
+        ]));
+        expect(await Undo.canUndo()).toBe(true);
+    });
+
     it('enter/setTime/queryPropertyValueAtFrame 不写入 undo/dirty', async () => {
         const current = await request('queryState');
         if (current.active) {

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -1486,6 +1486,81 @@ describe('Animation Service 场景进程测试', () => {
         expect(await Undo.isDirty()).toBe(true);
     });
 
+    it('saveScene 选项会同时保存 enter 前已有 scene dirty 和 animation dirty', async () => {
+        const current = await request('queryState');
+        if (current.active) {
+            await request('exit', [{ save: false, restoreSelection: false }]);
+        }
+        await Undo.clearHistory();
+        await Undo.markSaved();
+
+        const dirtyNode = await NodeProxy.createByType({
+            path: '',
+            name: `AnimationServiceSaveSceneDirty_${Date.now()}`,
+            nodeType: NodeType.EMPTY,
+        });
+        expect(dirtyNode).toBeTruthy();
+        expect(await Undo.isDirty()).toBe(true);
+
+        let state = await request('enter', [{ rootPath: emptyNodePath, clipUuid: emptyClipUuid, restoreSelectionOnExit: false }]);
+        expect(state.dirty).toBe(false);
+
+        await request('applyOperation', [{
+            operations: [
+                { type: 'changeSpeed', clipUuid: emptyClipUuid, speed: 1.375 },
+            ],
+        }]);
+        state = await request('queryState');
+        expect(state.dirty).toBe(true);
+        expect(await Undo.isDirty()).toBe(true);
+
+        await request('save', [{ saveScene: true }]);
+        state = await request('queryState');
+        expect(state.dirty).toBe(false);
+        expect(await Undo.isDirty()).toBe(false);
+        expect(await Undo.canUndo()).toBe(true);
+    });
+
+    it('saveScene 保存 scene 时不会持久化当前动画采样值', async () => {
+        const current = await request('queryState');
+        if (current.active) {
+            await request('exit', [{ save: false, restoreSelection: false }]);
+        }
+        const { nodePath: sampledNodePath, clipUuid: sampledClipUuid } = await createIsolatedAnimationNode('AnimationServiceSaveSceneSampled', { sample: 60, duration: 1 });
+        await ensureAnimationSession(sampledNodePath, sampledClipUuid);
+        await Undo.clearHistory();
+        await Undo.markSaved();
+
+        await request('applyOperation', [{
+            operations: [
+                { type: 'addPropertyCurve', clipUuid: sampledClipUuid, propKey: 'position', value: { x: 0, y: 0, z: 0 } },
+                { type: 'createPropertyKey', clipUuid: sampledClipUuid, propKey: 'position', frame: 60, value: { x: 99, y: 0, z: 0 } },
+            ],
+        }]);
+        await request('setTime', [{ time: 1 }]);
+        const sampledBeforeSave = await NodeProxy.query({ path: sampledNodePath, includeChildren: false, includeComponents: false }) as any;
+        expect(sampledBeforeSave?.properties.position).toMatchObject({ x: 99, y: 0, z: 0 });
+
+        await request('save', [{ saveScene: true }]);
+        let state = await request('queryState');
+        expect(state.dirty).toBe(false);
+        expect(await Undo.isDirty()).toBe(false);
+
+        const sampledAfterSave = await NodeProxy.query({ path: sampledNodePath, includeChildren: false, includeComponents: false }) as any;
+        expect(sampledAfterSave?.properties.position).toMatchObject({ x: 99, y: 0, z: 0 });
+
+        await request('exit', [{ restoreSelection: false, restoreSampledSceneState: false }]);
+        await EditorProxy.close({ save: false });
+        await EditorProxy.open({
+            urlOrUUID: `${SceneTestEnv.targetDirectoryURL}/${sceneName}.scene`,
+        });
+
+        state = await request('queryState');
+        expect(state.active).toBe(false);
+        const reopenedNode = await NodeProxy.query({ path: sampledNodePath, includeChildren: false, includeComponents: false }) as any;
+        expect(reopenedNode?.properties.position).toMatchObject({ x: 0, y: 0, z: 0 });
+    });
+
     it('applyOperation 记录 addPropertyCurve 的 undo/redo', async () => {
         const { nodePath: addCurveNodePath, clipUuid: addCurveClipUuid } = await createIsolatedAnimationNode('AnimationServiceAddCurveUndo', { duration: 0 });
         await ensureAnimationSession(addCurveNodePath, addCurveClipUuid);

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -65,6 +65,53 @@ async function resetRootPositionCurve(rootPath: string, clipUuid: string): Promi
     }]);
 }
 
+async function resetPropertyCurves(rootPath: string, clipUuid: string): Promise<void> {
+    await ensureAnimationSession(rootPath, clipUuid);
+    const dump = await request('queryClip', [{ rootPath, clipUuid }]);
+    const operations = dump.curves.map((curve: any) => ({
+        type: 'removePropertyCurve',
+        clipUuid,
+        nodePath: curve.nodePath,
+        propKey: curve.key,
+    }));
+    if (operations.length === 0) {
+        return;
+    }
+
+    const result = await request('applyOperation', [{
+        operations,
+        recordUndo: false,
+    }]);
+    if (result?.state !== 'success') {
+        throw new Error(`Failed to reset animation property curves: ${JSON.stringify(result)}`);
+    }
+
+    const afterReset = await request('queryClip', [{ rootPath, clipUuid }]);
+    if (afterReset.curves.length !== 0) {
+        throw new Error(`Failed to clear animation property curves: ${JSON.stringify(afterReset.curves)}`);
+    }
+}
+
+async function setNodePositionWithoutUndo(nodePath: string, value: { x: number; y: number; z: number }): Promise<void> {
+    const nodeDump = await requestService<any>('Node', 'query', [{ path: nodePath }]);
+    if (!nodeDump?.position) {
+        throw new Error(`Failed to query node position: ${nodePath}`);
+    }
+
+    const result = await requestService<boolean>('Node', 'setProperty', [{
+        nodePath,
+        path: 'position',
+        dump: {
+            ...nodeDump.position,
+            value,
+        },
+        record: false,
+    }]);
+    if (!result) {
+        throw new Error(`Failed to reset node position: ${nodePath}`);
+    }
+}
+
 function waitForAnimationPlayState(playState: string, timeout = 5000): Promise<any> {
     return new Promise((resolve, reject) => {
         const handler = (event: any) => {
@@ -108,25 +155,50 @@ describe('Animation Service 场景进程测试', () => {
     const sceneName = `AnimationServiceScene_${testRunId}`;
     const clipName = `AnimationServiceClip_${testRunId}`;
     const emptyClipName = `AnimationServiceEmptyClip_${testRunId}`;
-    const keyDataClipName = `AnimationServiceKeyDataClip_${testRunId}`;
     const childClipName = `AnimationServiceChildClip_${testRunId}`;
     const rootEditClipName = `AnimationServiceRootEditClip_${testRunId}`;
-    const spriteFrameClipName = `AnimationServiceSpriteFrameClip_${testRunId}`;
     let nodePath = '';
     let childNodePath = '';
     let clipUuid = '';
     let emptyNodePath = '';
     let emptyClipUuid = '';
-    let keyDataNodePath = '';
-    let keyDataClipUuid = '';
     let childRootNodePath = '';
     let childTrackNodePath = '';
     let childClipUuid = '';
     let rootEditNodePath = '';
     let rootEditClipUuid = '';
-    let spriteFrameNodePath = '';
-    let spriteFrameClipUuid = '';
     let spriteFrameUuid = '';
+    let isolatedAssetIndex = 0;
+
+    async function createIsolatedAnimationNode(baseName: string, options: { sample?: number; duration?: number } = {}) {
+        const current = await request('queryState');
+        if (current.active) {
+            await request('exit', [{ save: false, restoreSelection: false }]);
+        }
+
+        isolatedAssetIndex += 1;
+        const name = `${baseName}_${testRunId}_${isolatedAssetIndex}`;
+        const clipInfo = await assetManager.createAssetByType('animation-clip', SceneTestEnv.targetDirectoryURL, name, {
+            overwrite: true,
+            content: createAnimationClipContent(options),
+        });
+        const node = await NodeProxy.createByAsset({
+            dbURL: clipInfo.url,
+            path: '',
+            name,
+            position: { x: 0, y: 0, z: 0 },
+        });
+        if (!node) {
+            throw new Error(`Failed to create isolated animation node: ${name}`);
+        }
+        return { nodePath: node.path, clipUuid: clipInfo.uuid };
+    }
+
+    async function createIsolatedSpriteAnimationNode(baseName: string) {
+        const target = await createIsolatedAnimationNode(baseName, { sample: 30, duration: 0 });
+        await ComponentProxy.add({ nodePath: target.nodePath, component: 'cc.Sprite' });
+        return target;
+    }
 
     beforeAll(async () => {
         await EditorProxy.create({
@@ -151,12 +223,6 @@ describe('Animation Service 场景进程测试', () => {
         });
         emptyClipUuid = emptyClipInfo.uuid;
 
-        const keyDataClipInfo = await assetManager.createAssetByType('animation-clip', SceneTestEnv.targetDirectoryURL, keyDataClipName, {
-            overwrite: true,
-            content: createAnimationClipContent({ duration: 0 }),
-        });
-        keyDataClipUuid = keyDataClipInfo.uuid;
-
         const childClipInfo = await assetManager.createAssetByType('animation-clip', SceneTestEnv.targetDirectoryURL, childClipName, {
             overwrite: true,
             content: createAnimationClipContent({ sample: 60, duration: 0 }),
@@ -168,12 +234,6 @@ describe('Animation Service 场景进程测试', () => {
             content: createAnimationClipContent({ sample: 60, duration: 0 }),
         });
         rootEditClipUuid = rootEditClipInfo.uuid;
-
-        const spriteFrameClipInfo = await assetManager.createAssetByType('animation-clip', SceneTestEnv.targetDirectoryURL, spriteFrameClipName, {
-            overwrite: true,
-            content: createAnimationClipContent({ sample: 30, duration: 0 }),
-        });
-        spriteFrameClipUuid = spriteFrameClipInfo.uuid;
 
         const spriteFrameAssets = await assetManager.queryAssetInfos({ pattern: 'db://internal/default_ui/default_editbox_bg.png/spriteFrame' });
         if (spriteFrameAssets.length === 0 || !spriteFrameAssets[0].uuid) {
@@ -203,17 +263,6 @@ describe('Animation Service 场景进程测试', () => {
             throw new Error('Failed to create empty animation node.');
         }
         emptyNodePath = emptyNode.path;
-
-        const keyDataNode = await NodeProxy.createByAsset({
-            dbURL: keyDataClipInfo.url,
-            path: '',
-            name: 'AnimationServiceKeyDataNode',
-            position: { x: 0, y: 0, z: 0 },
-        });
-        if (!keyDataNode) {
-            throw new Error('Failed to create key data animation node.');
-        }
-        keyDataNodePath = keyDataNode.path;
 
         const childRootNode = await NodeProxy.createByAsset({
             dbURL: childClipInfo.url,
@@ -246,18 +295,6 @@ describe('Animation Service 场景进程测试', () => {
             throw new Error('Failed to create root keyframe editing animation node.');
         }
         rootEditNodePath = rootEditNode.path;
-
-        const spriteFrameNode = await NodeProxy.createByAsset({
-            dbURL: spriteFrameClipInfo.url,
-            path: '',
-            name: 'AnimationServiceSpriteFrameNode',
-            position: { x: 0, y: 0, z: 0 },
-        });
-        if (!spriteFrameNode) {
-            throw new Error('Failed to create sprite frame animation node.');
-        }
-        spriteFrameNodePath = spriteFrameNode.path;
-        await ComponentProxy.add({ nodePath: spriteFrameNodePath, component: 'cc.Sprite' });
 
         const childNode = await NodeProxy.createByType({
             path: nodePath,
@@ -710,6 +747,7 @@ describe('Animation Service 场景进程测试', () => {
     });
 
     it('applyOperation 通过 updatePropertyKey 合并并持久化 RealCurve keyData', async () => {
+        const { nodePath: keyDataNodePath, clipUuid: keyDataClipUuid } = await createIsolatedAnimationNode('AnimationServiceKeyDataMerge');
         await ensureAnimationSession(keyDataNodePath, keyDataClipUuid);
         await Undo.clearHistory();
         await Undo.markSaved();
@@ -797,6 +835,7 @@ describe('Animation Service 场景进程测试', () => {
     });
 
     it('applyOperation 更新 RealCurve keyData 时保留显式 0 值', async () => {
+        const { nodePath: keyDataNodePath, clipUuid: keyDataClipUuid } = await createIsolatedAnimationNode('AnimationServiceKeyDataZero');
         await ensureAnimationSession(keyDataNodePath, keyDataClipUuid);
 
         const queryEulerYKey = async () => {
@@ -856,6 +895,7 @@ describe('Animation Service 场景进程测试', () => {
     });
 
     it('applyOperation 失败时不会留下已执行的 clip 局部修改', async () => {
+        const { nodePath: keyDataNodePath, clipUuid: keyDataClipUuid } = await createIsolatedAnimationNode('AnimationServiceKeyDataRollback');
         await ensureAnimationSession(keyDataNodePath, keyDataClipUuid);
         await Undo.clearHistory();
         await Undo.markSaved();
@@ -876,6 +916,7 @@ describe('Animation Service 场景进程测试', () => {
     });
 
     it('applyOperation 更新复合属性 keyData 时不会部分写入分量曲线', async () => {
+        const { nodePath: keyDataNodePath, clipUuid: keyDataClipUuid } = await createIsolatedAnimationNode('AnimationServiceKeyDataPartial');
         await ensureAnimationSession(keyDataNodePath, keyDataClipUuid);
 
         const createResult = await request('applyOperation', [{
@@ -938,6 +979,7 @@ describe('Animation Service 场景进程测试', () => {
     });
 
     it('applyOperation 支持 cc.Sprite.spriteFrame 单帧 key 保存重进闭环', async () => {
+        const { nodePath: spriteFrameNodePath, clipUuid: spriteFrameClipUuid } = await createIsolatedSpriteAnimationNode('AnimationServiceSpriteFrameCase');
         await ensureAnimationSession(spriteFrameNodePath, spriteFrameClipUuid);
 
         const properties = await request('queryProperties', [{ nodePath: spriteFrameNodePath }]);
@@ -986,7 +1028,6 @@ describe('Animation Service 场景进程测试', () => {
         expect(await request('save')).toBe(true);
         const afterSave = await request('queryClip', [{ rootPath: spriteFrameNodePath, clipUuid: spriteFrameClipUuid }]);
         const savedCurve = afterSave.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'cc.Sprite.spriteFrame');
-
         expect(savedCurve?.keyframes).toEqual(spriteFrameCurve.keyframes);
 
         await request('exit', [{ restoreSelection: false, restoreSampledSceneState: false }]);
@@ -999,6 +1040,7 @@ describe('Animation Service 场景进程测试', () => {
     });
 
     it('queryPropertyValueAtFrame 支持 cc.Sprite.color 采样序列化', async () => {
+        const { nodePath: spriteFrameNodePath, clipUuid: spriteFrameClipUuid } = await createIsolatedSpriteAnimationNode('AnimationServiceSpriteColorCase');
         await ensureAnimationSession(spriteFrameNodePath, spriteFrameClipUuid);
 
         const properties = await request('queryProperties', [{ nodePath: spriteFrameNodePath }]);
@@ -1349,19 +1391,20 @@ describe('Animation Service 场景进程测试', () => {
     });
 
     it('applyOperation 记录 addPropertyCurve 的 undo/redo', async () => {
-        await ensureAnimationSession(emptyNodePath, emptyClipUuid);
+        const { nodePath: addCurveNodePath, clipUuid: addCurveClipUuid } = await createIsolatedAnimationNode('AnimationServiceAddCurveUndo', { duration: 0 });
+        await ensureAnimationSession(addCurveNodePath, addCurveClipUuid);
         await Undo.clearHistory();
         await Undo.markSaved();
 
-        const before = await request('queryClip', [{ clipUuid: emptyClipUuid }]);
+        const before = await request('queryClip', [{ clipUuid: addCurveClipUuid }]);
         expect(before.curves.some((curve: any) => curve.nodePath === '' && curve.key === 'position')).toBe(false);
 
         const result = await request('applyOperation', [{
             operations: [
-                { type: 'addPropertyCurve', clipUuid: emptyClipUuid, propKey: 'position', value: { x: 0, y: 0, z: 0 } },
+                { type: 'addPropertyCurve', clipUuid: addCurveClipUuid, propKey: 'position', value: { x: 0, y: 0, z: 0 } },
             ],
         }]);
-        const after = await request('queryClip', [{ clipUuid: emptyClipUuid }]);
+        const after = await request('queryClip', [{ clipUuid: addCurveClipUuid }]);
 
         expect(result).toEqual({ state: 'success', result: true });
         expect(after.curves.some((curve: any) => curve.nodePath === '' && curve.key === 'position')).toBe(true);
@@ -1369,17 +1412,19 @@ describe('Animation Service 场景进程测试', () => {
         expect(await Undo.canUndo()).toBe(true);
 
         expectUndoSuccess(await Undo.undo());
-        const undoDump = await request('queryClip', [{ clipUuid: emptyClipUuid }]);
+        const undoDump = await request('queryClip', [{ clipUuid: addCurveClipUuid }]);
         expect(undoDump.curves.some((curve: any) => curve.nodePath === '' && curve.key === 'position')).toBe(false);
         expect(await Undo.canRedo()).toBe(true);
 
         expectUndoSuccess(await Undo.redo());
-        const redoDump = await request('queryClip', [{ clipUuid: emptyClipUuid }]);
+        const redoDump = await request('queryClip', [{ clipUuid: addCurveClipUuid }]);
         expect(redoDump.curves.some((curve: any) => curve.nodePath === '' && curve.key === 'position')).toBe(true);
     });
 
     it('applyOperation 记录 child addPropertyCurve 的 undo/redo', async () => {
         await ensureAnimationSession(childRootNodePath, childClipUuid);
+        await resetPropertyCurves(childRootNodePath, childClipUuid);
+        await setNodePositionWithoutUndo(childTrackNodePath, { x: 0, y: 0, z: 0 });
         await Undo.clearHistory();
         await Undo.markSaved();
 
@@ -1592,6 +1637,8 @@ describe('Animation Service 场景进程测试', () => {
         if (current.active) {
             await request('exit', [{ save: false, restoreSelection: false }]);
         }
+        await resetPropertyCurves(childRootNodePath, childClipUuid);
+        await setNodePositionWithoutUndo(childTrackNodePath, { x: 0, y: 0, z: 0 });
         await Undo.clearHistory();
         await Undo.markSaved();
 

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -21,8 +21,11 @@ const Undo = {
     markSaved: () => requestService('Undo', 'markSaved'),
     isDirty: () => requestService<boolean>('Undo', 'isDirty'),
     canUndo: () => requestService<boolean>('Undo', 'canUndo'),
+    canUndoInAnimationScope: () => requestService<boolean>('Undo', 'canUndo', [{ scope: { editorType: 'animation', mode: 'animation' } }]),
     undo: () => requestService('Undo', 'undo'),
+    undoInAnimationScope: () => requestService('Undo', 'undo', [{ scope: { editorType: 'animation', mode: 'animation' } }]),
     canRedo: () => requestService<boolean>('Redo', 'canRedo'),
+    redoInAnimationScope: () => requestService('Redo', 'redo', [{ scope: { editorType: 'animation', mode: 'animation' } }]),
     redo: () => requestService('Redo', 'redo'),
 };
 
@@ -1294,6 +1297,60 @@ describe('Animation Service 场景进程测试', () => {
         expectUndoSuccess(await Undo.redo());
         const redoDump = await request('queryClip', [{ rootPath: childRootNodePath, clipUuid: childClipUuid }]);
         expect(redoDump.curves.some((curve: any) => curve.nodePath === childRelativePath && curve.key === 'position')).toBe(true);
+    });
+
+    it('applyOperation 可把已消费的 scene 属性 undo 合并进 animation scoped undo', async () => {
+        await ensureAnimationSession(emptyNodePath, emptyClipUuid);
+        await request('applyOperation', [{
+            operations: [
+                { type: 'addPropertyCurve', clipUuid: emptyClipUuid, propKey: 'position', value: { x: 0, y: 0, z: 0 } },
+                { type: 'createPropertyKey', clipUuid: emptyClipUuid, propKey: 'position', frame: 0, value: { x: 0, y: 0, z: 0 } },
+            ],
+            recordUndo: false,
+        }]);
+        await Undo.clearHistory();
+        await Undo.markSaved();
+
+        await request('setTime', [{ time: 1 }]);
+        await NodeProxy.update({
+            path: emptyNodePath,
+            properties: { position: { x: 123, y: 0, z: 0 } },
+        });
+        expect(await Undo.canUndoInAnimationScope()).toBe(false);
+
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'createPropertyKey', clipUuid: emptyClipUuid, propKey: 'position', frame: 30, value: { x: 123, y: 0, z: 0 } },
+            ],
+            absorbPreviousScenePropertyUndo: true,
+        }]);
+        const after = await request('queryClip', [{ rootPath: emptyNodePath, clipUuid: emptyClipUuid }]);
+        const positionCurve = after.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'position');
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(positionCurve.keyframes).toEqual([
+            { frame: 0, dump: { value: { x: 0, y: 0, z: 0 }, type: 'cc.Vec3' } },
+            { frame: 30, dump: { value: { x: 123, y: 0, z: 0 }, type: 'cc.Vec3' } },
+        ]);
+        expect(await Undo.canUndoInAnimationScope()).toBe(true);
+
+        expectUndoSuccess(await Undo.undoInAnimationScope());
+        const undoDump = await request('queryClip', [{ rootPath: emptyNodePath, clipUuid: emptyClipUuid }]);
+        const undoCurve = undoDump.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'position');
+        const nodeAfterUndo = await NodeProxy.query({ path: emptyNodePath, includeChildren: false, includeComponents: false }) as any;
+        expect(undoCurve.keyframes).toEqual([
+            { frame: 0, dump: { value: { x: 0, y: 0, z: 0 }, type: 'cc.Vec3' } },
+        ]);
+        expect(nodeAfterUndo?.properties.position).toMatchObject({ x: 0, y: 0, z: 0 });
+        expect(await Undo.isDirty()).toBe(false);
+
+        expectUndoSuccess(await Undo.redoInAnimationScope());
+        const redoDump = await request('queryClip', [{ rootPath: emptyNodePath, clipUuid: emptyClipUuid }]);
+        const redoCurve = redoDump.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'position');
+        const nodeAfterRedo = await NodeProxy.query({ path: emptyNodePath, includeChildren: false, includeComponents: false }) as any;
+        expect(redoCurve.keyframes).toEqual(positionCurve.keyframes);
+        expect(nodeAfterRedo?.properties.position).toMatchObject({ x: 123, y: 0, z: 0 });
+        expect(await Undo.isDirty()).toBe(true);
     });
 
     it('enter/setTime/queryPropertyValueAtFrame 不写入 undo/dirty', async () => {

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -49,14 +49,14 @@ async function resetRootPositionCurve(rootPath: string, clipUuid: string): Promi
     const dump = await request('queryClip', [{ rootPath, clipUuid }]);
     const hasPositionCurve = dump.curves.some((curve: any) => curve.nodePath === '' && curve.key === 'position');
     if (hasPositionCurve) {
-        await request('applyOperation', [{
+        await request('applyOperations', [{
             operations: [
                 { type: 'removePropertyCurve', clipUuid, propKey: 'position' },
             ],
             recordUndo: false,
         }]);
     }
-    await request('applyOperation', [{
+    await request('applyOperations', [{
         operations: [
             { type: 'addPropertyCurve', clipUuid, propKey: 'position', value: { x: 0, y: 0, z: 0 } },
             { type: 'createPropertyKey', clipUuid, propKey: 'position', frame: 0, value: { x: 0, y: 0, z: 0 } },
@@ -78,7 +78,7 @@ async function resetPropertyCurves(rootPath: string, clipUuid: string): Promise<
         return;
     }
 
-    const result = await request('applyOperation', [{
+    const result = await request('applyOperations', [{
         operations,
         recordUndo: false,
     }]);
@@ -459,9 +459,9 @@ describe('Animation Service 场景进程测试', () => {
         expect(time).toBeGreaterThanOrEqual(0.95);
     });
 
-    it('applyOperation 在真实 AnimationClip 上应用基础普通 clip 操作', async () => {
+    it('applyOperations 在真实 AnimationClip 上应用基础普通 clip 操作', async () => {
         const eventPromise = utils.once<Record<'animation:clip-changed', any>>(sceneWorker, 'animation:clip-changed');
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'changeSample', clipUuid, sample: 60 },
                 { type: 'changeSpeed', clipUuid, speed: 1.5 },
@@ -485,13 +485,13 @@ describe('Animation Service 场景进程测试', () => {
         expect(dump.events).toEqual([{ frame: 36, func: 'onHalf', params: ['value'] }]);
     });
 
-    it('applyOperation 支持普通属性曲线 keyframe 的创建、移动和删除', async () => {
+    it('applyOperations 支持普通属性曲线 keyframe 的创建、移动和删除', async () => {
         await ensureAnimationSession(nodePath, clipUuid);
         await Undo.clearHistory();
         await Undo.markSaved();
 
         const before = await request('queryClip', [{ clipUuid }]);
-        const createResult = await request('applyOperation', [{
+        const createResult = await request('applyOperations', [{
             operations: [
                 { type: 'createPropertyKey', clipUuid, nodePath, propKey: 'position', frame: 0, value: { x: 2, y: 3, z: 4 } },
                 { type: 'createPropertyKey', clipUuid, nodePath, propKey: 'position', frame: 60, value: { x: 8, y: 9, z: 10 } },
@@ -529,7 +529,7 @@ describe('Animation Service 场景进程测试', () => {
         const afterRedo = await request('queryClip', [{ clipUuid }]);
         expect(afterRedo.curves).toEqual(afterCreate.curves);
 
-        const removeResult = await request('applyOperation', [{
+        const removeResult = await request('applyOperations', [{
             operations: [
                 { type: 'removePropertyKey', clipUuid, nodePath, propKey: 'position', frames: [0] },
             ],
@@ -543,7 +543,7 @@ describe('Animation Service 场景进程测试', () => {
         ]);
     });
 
-    it('applyOperation 在空 clip 创建属性 key 后重算 duration 并支持 undo/redo', async () => {
+    it('applyOperations 在空 clip 创建属性 key 后重算 duration 并支持 undo/redo', async () => {
         await ensureAnimationSession(emptyNodePath, emptyClipUuid);
         await Undo.clearHistory();
         await Undo.markSaved();
@@ -551,7 +551,7 @@ describe('Animation Service 场景进程测试', () => {
         const before = await request('queryClip', [{ clipUuid: emptyClipUuid }]);
         expect(before.duration).toBe(0);
 
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'createPropertyKey', clipUuid: emptyClipUuid, nodePath: emptyNodePath, propKey: 'position', frame: 30, value: { x: 1, y: 2, z: 3 } },
             ],
@@ -583,7 +583,7 @@ describe('Animation Service 场景进程测试', () => {
     it('setTime 对 child nodePath 属性轨道采样到真实子节点', async () => {
         await ensureAnimationSession(childRootNodePath, childClipUuid);
 
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'createPropertyKey', clipUuid: childClipUuid, nodePath: childTrackNodePath, propKey: 'position', frame: 0, value: { x: 0, y: 0, z: 0 } },
                 { type: 'createPropertyKey', clipUuid: childClipUuid, nodePath: childTrackNodePath, propKey: 'position', frame: 60, value: { x: 100, y: 0, z: 0 } },
@@ -611,7 +611,7 @@ describe('Animation Service 场景进程测试', () => {
         await Undo.clearHistory();
         await Undo.markSaved();
 
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'createPropertyKey', clipUuid: rootEditClipUuid, nodePath: rootEditNodePath, propKey: 'position', frame: 0, value: { x: 0, y: 0, z: 0 } },
                 { type: 'createPropertyKey', clipUuid: rootEditClipUuid, nodePath: rootEditNodePath, propKey: 'position', frame: 105, value: { x: 100, y: 0, z: 0 } },
@@ -646,10 +646,10 @@ describe('Animation Service 场景进程测试', () => {
         expect(sampledStartNode?.properties.position).toMatchObject({ x: 0, y: 0, z: 0 });
     });
 
-    it('applyOperation 支持分量级属性 keyframe 并保留切线信息', async () => {
+    it('applyOperations 支持分量级属性 keyframe 并保留切线信息', async () => {
         await ensureAnimationSession(nodePath, clipUuid);
 
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'createPropertyKey', clipUuid, nodePath, propKey: 'scale', frame: 0, value: { x: 1, y: 1, z: 1 } },
                 {
@@ -703,12 +703,12 @@ describe('Animation Service 场景进程测试', () => {
         ]);
     });
 
-    it('applyOperation 通过 updatePropertyKey 持久化 RealCurve keyframe broken 状态', async () => {
+    it('applyOperations 通过 updatePropertyKey 持久化 RealCurve keyframe broken 状态', async () => {
         await ensureAnimationSession(nodePath, clipUuid);
         await Undo.clearHistory();
         await Undo.markSaved();
 
-        const createResult = await request('applyOperation', [{
+        const createResult = await request('applyOperations', [{
             operations: [
                 { type: 'createPropertyKey', clipUuid, nodePath, propKey: 'scale', frame: 21, value: { x: 1, y: 1, z: 1 } },
                 { type: 'updatePropertyKey', clipUuid, nodePath, propKey: 'scale', frame: 21, channel: 'y', value: 2, keyData: { broken: true } },
@@ -721,7 +721,7 @@ describe('Animation Service 场景进程测试', () => {
         expect(createResult).toEqual({ state: 'success', result: true });
         expect(brokenKey.broken).toBe(true);
 
-        const updateResult = await request('applyOperation', [{
+        const updateResult = await request('applyOperations', [{
             operations: [
                 { type: 'updatePropertyKey', clipUuid, nodePath, propKey: 'scale', frame: 21, channel: 'y', value: 2, keyData: { broken: false } },
             ],
@@ -746,7 +746,7 @@ describe('Animation Service 场景进程测试', () => {
         expect(redoKey.broken).toBe(false);
     });
 
-    it('applyOperation 通过 updatePropertyKey 合并并持久化 RealCurve keyData', async () => {
+    it('applyOperations 通过 updatePropertyKey 合并并持久化 RealCurve keyData', async () => {
         const { nodePath: keyDataNodePath, clipUuid: keyDataClipUuid } = await createIsolatedAnimationNode('AnimationServiceKeyDataMerge');
         await ensureAnimationSession(keyDataNodePath, keyDataClipUuid);
         await Undo.clearHistory();
@@ -761,7 +761,7 @@ describe('Animation Service 场景进程测试', () => {
         };
 
         const before = await request('queryClip', [{ rootPath: keyDataNodePath, clipUuid: keyDataClipUuid }]);
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'createPropertyKey', clipUuid: keyDataClipUuid, propKey: 'position', frame: 60, value: { x: 80, y: 9, z: 10 } },
                 { type: 'updatePropertyKey', clipUuid: keyDataClipUuid, propKey: 'position', channel: 'x', frame: 60, keyData: { interpMode: 1 } },
@@ -791,7 +791,7 @@ describe('Animation Service 场景进程测试', () => {
             broken: true,
         });
 
-        expect(await request('applyOperation', [{
+        expect(await request('applyOperations', [{
             operations: [
                 { type: 'updatePropertyKey', clipUuid: keyDataClipUuid, propKey: 'position', channel: 'x', frame: 60, keyData: { broken: false } },
             ],
@@ -834,7 +834,7 @@ describe('Animation Service 场景进程测试', () => {
         });
     });
 
-    it('applyOperation 更新 RealCurve keyData 时保留显式 0 值', async () => {
+    it('applyOperations 更新 RealCurve keyData 时保留显式 0 值', async () => {
         const { nodePath: keyDataNodePath, clipUuid: keyDataClipUuid } = await createIsolatedAnimationNode('AnimationServiceKeyDataZero');
         await ensureAnimationSession(keyDataNodePath, keyDataClipUuid);
 
@@ -846,7 +846,7 @@ describe('Animation Service 场景进程测试', () => {
                 .find((keyframe: any) => keyframe.frame === 84);
         };
 
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 {
                     type: 'createPropertyKey',
@@ -894,14 +894,14 @@ describe('Animation Service 场景进程测试', () => {
         });
     });
 
-    it('applyOperation 失败时不会留下已执行的 clip 局部修改', async () => {
+    it('applyOperations 失败时不会留下已执行的 clip 局部修改', async () => {
         const { nodePath: keyDataNodePath, clipUuid: keyDataClipUuid } = await createIsolatedAnimationNode('AnimationServiceKeyDataRollback');
         await ensureAnimationSession(keyDataNodePath, keyDataClipUuid);
         await Undo.clearHistory();
         await Undo.markSaved();
 
         const before = await request('queryClip', [{ rootPath: keyDataNodePath, clipUuid: keyDataClipUuid }]);
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'createPropertyKey', clipUuid: keyDataClipUuid, propKey: 'position', frame: 72, value: { x: 72, y: 0, z: 0 } },
                 { type: 'updatePropertyKeyData', clipUuid: keyDataClipUuid, propKey: 'position', channel: 'x', frame: 99, keyData: { interpMode: 1 } },
@@ -915,11 +915,11 @@ describe('Animation Service 场景进程测试', () => {
         expect(await Undo.isDirty()).toBe(false);
     });
 
-    it('applyOperation 更新复合属性 keyData 时不会部分写入分量曲线', async () => {
+    it('applyOperations 更新复合属性 keyData 时不会部分写入分量曲线', async () => {
         const { nodePath: keyDataNodePath, clipUuid: keyDataClipUuid } = await createIsolatedAnimationNode('AnimationServiceKeyDataPartial');
         await ensureAnimationSession(keyDataNodePath, keyDataClipUuid);
 
-        const createResult = await request('applyOperation', [{
+        const createResult = await request('applyOperations', [{
             operations: [
                 { type: 'createPropertyKey', clipUuid: keyDataClipUuid, propKey: 'eulerAngles', channel: 'x', frame: 36, value: 1 },
             ],
@@ -927,7 +927,7 @@ describe('Animation Service 场景进程测试', () => {
         expect(createResult).toEqual({ state: 'success', result: true });
 
         const before = await request('queryClip', [{ rootPath: keyDataNodePath, clipUuid: keyDataClipUuid }]);
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'updatePropertyKeyData', clipUuid: keyDataClipUuid, propKey: 'eulerAngles', frame: 36, keyData: { interpMode: 1 } },
             ],
@@ -949,11 +949,11 @@ describe('Animation Service 场景进程测试', () => {
         expect(afterEulerX).toEqual(beforeEulerX);
     });
 
-    it('applyOperation 支持 queryProperties 暴露的 rotation 和 active 属性', async () => {
+    it('applyOperations 支持 queryProperties 暴露的 rotation 和 active 属性', async () => {
         await ensureAnimationSession(nodePath, clipUuid);
 
         const properties = await request('queryProperties', [{ nodePath: childNodePath }]);
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'createPropertyKey', clipUuid, nodePath, propKey: 'rotation', frame: 3, value: { x: 0, y: 0, z: 0, w: 1 } },
                 { type: 'createPropertyKey', clipUuid, nodePath: childNodePath, propKey: 'active', frame: 3, value: false },
@@ -978,7 +978,7 @@ describe('Animation Service 场景进程测试', () => {
         });
     });
 
-    it('applyOperation 支持 cc.Sprite.spriteFrame 单帧 key 保存重进闭环', async () => {
+    it('applyOperations 支持 cc.Sprite.spriteFrame 单帧 key 保存重进闭环', async () => {
         const { nodePath: spriteFrameNodePath, clipUuid: spriteFrameClipUuid } = await createIsolatedSpriteAnimationNode('AnimationServiceSpriteFrameCase');
         await ensureAnimationSession(spriteFrameNodePath, spriteFrameClipUuid);
 
@@ -990,7 +990,7 @@ describe('Animation Service 场景进程测试', () => {
             type: { value: 'cc.SpriteFrame' },
         });
 
-        const createResult = await request('applyOperation', [{
+        const createResult = await request('applyOperations', [{
             operations: [
                 { type: 'addPropertyCurve', clipUuid: spriteFrameClipUuid, nodePath: spriteFrameNodePath, propKey: 'cc.Sprite.spriteFrame', value: { uuid: spriteFrameUuid } },
                 { type: 'createPropertyKey', clipUuid: spriteFrameClipUuid, nodePath: spriteFrameNodePath, propKey: 'cc.Sprite.spriteFrame', frame: 0, value: null },
@@ -1051,7 +1051,7 @@ describe('Animation Service 场景进程测试', () => {
             type: { value: 'cc.Color' },
         });
 
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'addPropertyCurve', clipUuid: spriteFrameClipUuid, nodePath: spriteFrameNodePath, propKey: 'cc.Sprite.color', value: { r: 255, g: 255, b: 255, a: 255 } },
                 { type: 'createPropertyKey', clipUuid: spriteFrameClipUuid, nodePath: spriteFrameNodePath, propKey: 'cc.Sprite.color', frame: 0, value: { r: 32, g: 64, b: 128, a: 255 } },
@@ -1089,7 +1089,7 @@ describe('Animation Service 场景进程测试', () => {
         await setNodePositionWithoutUndo(animationChild.path, { x: 7, y: 8, z: 9 });
         await ensureAnimationSession(rootPath, relativeClipUuid);
 
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'createPropertyKey', clipUuid: relativeClipUuid, nodePath: childName, propKey: 'position', frame: 30, value: { x: 7, y: 8, z: 9 } },
             ],
@@ -1106,10 +1106,10 @@ describe('Animation Service 场景进程测试', () => {
         expect(sampled).toMatchObject({ x: 7, y: 8, z: 9 });
     });
 
-    it('applyOperation 支持普通属性曲线的创建、更新、复制、批量删除和 extrapolation', async () => {
+    it('applyOperations 支持普通属性曲线的创建、更新、复制、批量删除和 extrapolation', async () => {
         await ensureAnimationSession(nodePath, clipUuid);
 
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'addPropertyCurve', clipUuid, nodePath, propKey: 'position' },
                 { type: 'createPropertyKey', clipUuid, nodePath, propKey: 'position', frame: 0, value: { x: 1, y: 2, z: 3 } },
@@ -1138,7 +1138,7 @@ describe('Animation Service 场景进程测试', () => {
         await ensureAnimationSession(emptyNodePath, emptyClipUuid);
         await resetPropertyCurves(emptyNodePath, emptyClipUuid);
 
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'addPropertyCurve', clipUuid: emptyClipUuid, nodePath: emptyNodePath, propKey: 'position', value: { x: 0, y: 0, z: 0 } },
                 { type: 'addPropertyCurve', clipUuid: emptyClipUuid, nodePath: emptyNodePath, propKey: 'cc.Sprite.color', value: { r: 255, g: 255, b: 255, a: 255 } },
@@ -1159,7 +1159,7 @@ describe('Animation Service 场景进程测试', () => {
     it('removePropertyKeys 清空关键帧时保留属性轨道，removePropertyCurve 才移除轨道', async () => {
         await ensureAnimationSession(emptyNodePath, emptyClipUuid);
 
-        const clearResult = await request('applyOperation', [{
+        const clearResult = await request('applyOperations', [{
             operations: [
                 { type: 'addPropertyCurve', clipUuid: emptyClipUuid, nodePath: emptyNodePath, propKey: 'scale' },
                 { type: 'createPropertyKey', clipUuid: emptyClipUuid, nodePath: emptyNodePath, propKey: 'scale', frame: 0, value: { x: 1, y: 1, z: 1 } },
@@ -1174,7 +1174,7 @@ describe('Animation Service 场景进程测试', () => {
         expect(scaleCurveAfterClear.keyframes).toEqual([]);
         expect(scaleCurveAfterClear.channels.every((channel: any) => channel.keyframes.length === 0)).toBe(true);
 
-        const removeResult = await request('applyOperation', [{
+        const removeResult = await request('applyOperations', [{
             operations: [
                 { type: 'removePropertyCurve', clipUuid: emptyClipUuid, nodePath: emptyNodePath, propKey: 'scale' },
             ],
@@ -1185,7 +1185,7 @@ describe('Animation Service 场景进程测试', () => {
         expect(afterRemove.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'scale')).toBeUndefined();
     });
 
-    it('applyOperation 创建普通属性 key 时 value 可省略并从当前场景采样', async () => {
+    it('applyOperations 创建普通属性 key 时 value 可省略并从当前场景采样', async () => {
         await ensureAnimationSession(nodePath, clipUuid);
         await request('setTime', [{ time: 0 }]);
         const sampled = await request('queryPropertyValueAtFrame', [{
@@ -1195,7 +1195,7 @@ describe('Animation Service 场景进程测试', () => {
             frame: 6,
         }]);
 
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'createPropertyKey', clipUuid, nodePath, propKey: 'position', frame: 6 },
             ],
@@ -1209,8 +1209,8 @@ describe('Animation Service 场景进程测试', () => {
         ]));
     });
 
-    it('applyOperation 不接受旧 funcName/args 格式', async () => {
-        const result = await request('applyOperation', [{
+    it('applyOperations 不接受旧 funcName/args 格式', async () => {
+        const result = await request('applyOperations', [{
             operations: [{ funcName: 'changeSample', args: [clipUuid, 60] }],
         }]);
 
@@ -1221,8 +1221,8 @@ describe('Animation Service 场景进程测试', () => {
         });
     });
 
-    it('applyOperation 对非当前 clip 显式失败', async () => {
-        const result = await request('applyOperation', [{
+    it('applyOperations 对非当前 clip 显式失败', async () => {
+        const result = await request('applyOperations', [{
             operations: [{ type: 'changeSample', clipUuid: 'other-clip', sample: 60 }],
         }]);
 
@@ -1233,8 +1233,8 @@ describe('Animation Service 场景进程测试', () => {
         });
     });
 
-    it('applyOperation 支持真实 AnimationClip 的 embedded player 基础操作', async () => {
-        const result = await request('applyOperation', [{
+    it('applyOperations 支持真实 AnimationClip 的 embedded player 基础操作', async () => {
+        const result = await request('applyOperations', [{
             operations: [
                 {
                     type: 'addEmbeddedPlayerGroup',
@@ -1287,7 +1287,7 @@ describe('Animation Service 场景进程测试', () => {
             playable: { type: 'particle-system' as const, path: 'ParticlesB' },
         };
 
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 {
                     type: 'addEmbeddedPlayerGroup',
@@ -1306,10 +1306,10 @@ describe('Animation Service 场景进程测试', () => {
         expect(dump.embeddedPlayers).toEqual([secondPlayer]);
     });
 
-    it('applyOperation 支持真实 AnimationClip 的 auxiliary curve 基础操作', async () => {
+    it('applyOperations 支持真实 AnimationClip 的 auxiliary curve 基础操作', async () => {
         await ensureAnimationSession(nodePath, clipUuid);
 
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'addAuxiliaryCurve', clipUuid, name: 'BlendWeight' },
                 { type: 'createAuxKey', clipUuid, name: 'BlendWeight', frame: 0, value: 0.25 },
@@ -1325,10 +1325,10 @@ describe('Animation Service 场景进程测试', () => {
         ]);
     });
 
-    it('applyOperation 支持 auxiliary curve keyData 写入读回和按帧采样', async () => {
+    it('applyOperations 支持 auxiliary curve keyData 写入读回和按帧采样', async () => {
         await ensureAnimationSession(nodePath, clipUuid);
 
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'addAuxiliaryCurve', clipUuid, name: 'CurveWeight' },
                 { type: 'createAuxKey', clipUuid, name: 'CurveWeight', frame: 0, value: 0, keyData: { interpMode: 1 } },
@@ -1353,10 +1353,10 @@ describe('Animation Service 场景进程测试', () => {
         expect(sampledEnd).toEqual({ value: 1, type: 'cc.Number' });
     });
 
-    it('applyOperation 支持 auxiliary curve 编辑后重算 duration', async () => {
+    it('applyOperations 支持 auxiliary curve 编辑后重算 duration', async () => {
         await ensureAnimationSession(emptyNodePath, emptyClipUuid);
 
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'addAuxiliaryCurve', clipUuid: emptyClipUuid, name: 'DurationWeight' },
                 { type: 'createAuxKey', clipUuid: emptyClipUuid, name: 'DurationWeight', frame: 90, value: 1 },
@@ -1369,13 +1369,13 @@ describe('Animation Service 场景进程测试', () => {
         expect(Math.round(dump.duration * dump.sample)).toBeGreaterThanOrEqual(90);
     });
 
-    it('applyOperation 默认记录 undo/dirty，并支持 undo/redo 恢复真实 AnimationClip', async () => {
+    it('applyOperations 默认记录 undo/dirty，并支持 undo/redo 恢复真实 AnimationClip', async () => {
         await ensureAnimationSession(nodePath, clipUuid);
         await Undo.clearHistory();
         await Undo.markSaved();
 
         const before = await request('queryClip', [{ clipUuid }]);
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'changeSpeed', clipUuid, speed: 2.25 },
                 { type: 'addEvent', clipUuid, frame: 12, func: 'onUndoCheck', params: ['undo'] },
@@ -1432,7 +1432,7 @@ describe('Animation Service 场景进程测试', () => {
         expect(state.dirty).toBe(false);
         expect(await Undo.isDirty()).toBe(false);
 
-        await request('applyOperation', [{
+        await request('applyOperations', [{
             operations: [
                 { type: 'changeSpeed', clipUuid: emptyClipUuid, speed: 1.125 },
             ],
@@ -1471,7 +1471,7 @@ describe('Animation Service 场景进程测试', () => {
         let state = await request('enter', [{ rootPath: emptyNodePath, clipUuid: emptyClipUuid, restoreSelectionOnExit: false }]);
         expect(state.dirty).toBe(false);
 
-        await request('applyOperation', [{
+        await request('applyOperations', [{
             operations: [
                 { type: 'changeSpeed', clipUuid: emptyClipUuid, speed: 1.25 },
             ],
@@ -1505,7 +1505,7 @@ describe('Animation Service 场景进程测试', () => {
         let state = await request('enter', [{ rootPath: emptyNodePath, clipUuid: emptyClipUuid, restoreSelectionOnExit: false }]);
         expect(state.dirty).toBe(false);
 
-        await request('applyOperation', [{
+        await request('applyOperations', [{
             operations: [
                 { type: 'changeSpeed', clipUuid: emptyClipUuid, speed: 1.375 },
             ],
@@ -1531,7 +1531,7 @@ describe('Animation Service 场景进程测试', () => {
         await Undo.clearHistory();
         await Undo.markSaved();
 
-        await request('applyOperation', [{
+        await request('applyOperations', [{
             operations: [
                 { type: 'addPropertyCurve', clipUuid: sampledClipUuid, propKey: 'position', value: { x: 0, y: 0, z: 0 } },
                 { type: 'createPropertyKey', clipUuid: sampledClipUuid, propKey: 'position', frame: 60, value: { x: 99, y: 0, z: 0 } },
@@ -1561,7 +1561,7 @@ describe('Animation Service 场景进程测试', () => {
         expect(reopenedNode?.properties.position).toMatchObject({ x: 0, y: 0, z: 0 });
     });
 
-    it('applyOperation 记录 addPropertyCurve 的 undo/redo', async () => {
+    it('applyOperations 记录 addPropertyCurve 的 undo/redo', async () => {
         const { nodePath: addCurveNodePath, clipUuid: addCurveClipUuid } = await createIsolatedAnimationNode('AnimationServiceAddCurveUndo', { duration: 0 });
         await ensureAnimationSession(addCurveNodePath, addCurveClipUuid);
         await Undo.clearHistory();
@@ -1570,7 +1570,7 @@ describe('Animation Service 场景进程测试', () => {
         const before = await request('queryClip', [{ clipUuid: addCurveClipUuid }]);
         expect(before.curves.some((curve: any) => curve.nodePath === '' && curve.key === 'position')).toBe(false);
 
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'addPropertyCurve', clipUuid: addCurveClipUuid, propKey: 'position', value: { x: 0, y: 0, z: 0 } },
             ],
@@ -1592,7 +1592,7 @@ describe('Animation Service 场景进程测试', () => {
         expect(redoDump.curves.some((curve: any) => curve.nodePath === '' && curve.key === 'position')).toBe(true);
     });
 
-    it('applyOperation 记录 child addPropertyCurve 的 undo/redo', async () => {
+    it('applyOperations 记录 child addPropertyCurve 的 undo/redo', async () => {
         await ensureAnimationSession(childRootNodePath, childClipUuid);
         await resetPropertyCurves(childRootNodePath, childClipUuid);
         await setNodePositionWithoutUndo(childTrackNodePath, { x: 0, y: 0, z: 0 });
@@ -1610,7 +1610,7 @@ describe('Animation Service 场景进程测试', () => {
         const before = await request('queryClip', [{ rootPath: childRootNodePath, clipUuid: childClipUuid }]);
         expect(before.curves.some((curve: any) => curve.nodePath === childRelativePath && curve.key === 'position')).toBe(false);
 
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'addPropertyCurve', clipUuid: childClipUuid, nodePath: childRelativePath, propKey: 'position', value },
             ],
@@ -1632,7 +1632,7 @@ describe('Animation Service 场景进程测试', () => {
         expect(redoDump.curves.some((curve: any) => curve.nodePath === childRelativePath && curve.key === 'position')).toBe(true);
     });
 
-    it('applyOperation 可把已消费的 scene 属性 undo 合并进 animation scoped undo', async () => {
+    it('applyOperations 可把已消费的 scene 属性 undo 合并进 animation scoped undo', async () => {
         await ensureAnimationSession(emptyNodePath, emptyClipUuid);
         await resetRootPositionCurve(emptyNodePath, emptyClipUuid);
         await Undo.clearHistory();
@@ -1645,7 +1645,7 @@ describe('Animation Service 场景进程测试', () => {
         });
         expect(await Undo.canUndoInAnimationScope()).toBe(false);
 
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'createPropertyKey', clipUuid: emptyClipUuid, propKey: 'position', frame: 30, value: { x: 123, y: 0, z: 0 } },
             ],
@@ -1680,7 +1680,7 @@ describe('Animation Service 场景进程测试', () => {
         expect(await Undo.isDirty()).toBe(true);
     });
 
-    it('applyOperation 可把 Gizmo snapshot undo 合并进 animation scoped undo', async () => {
+    it('applyOperations 可把 Gizmo snapshot undo 合并进 animation scoped undo', async () => {
         await ensureAnimationSession(emptyNodePath, emptyClipUuid);
         await resetRootPositionCurve(emptyNodePath, emptyClipUuid);
         await Undo.clearHistory();
@@ -1705,7 +1705,7 @@ describe('Animation Service 场景进程测试', () => {
         expect(await Undo.canUndo()).toBe(true);
         expect(await Undo.canUndoInAnimationScope()).toBe(false);
 
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'createPropertyKey', clipUuid: emptyClipUuid, propKey: 'position', frame: 30, value: { x: 321, y: 0, z: 0 } },
             ],
@@ -1727,7 +1727,7 @@ describe('Animation Service 场景进程测试', () => {
         expect(await Undo.isDirty()).toBe(false);
     });
 
-    it('applyOperation 可把已消费的组件属性 undo 合并进 animation scoped undo', async () => {
+    it('applyOperations 可把已消费的组件属性 undo 合并进 animation scoped undo', async () => {
         const { nodePath: spriteNodePath, clipUuid: spriteClipUuid, spriteComponentPath } = await createIsolatedSpriteAnimationNode('AnimationServiceComponentCommitCase');
         await ensureAnimationSession(spriteNodePath, spriteClipUuid);
         await Undo.clearHistory();
@@ -1739,7 +1739,7 @@ describe('Animation Service 场景进程测试', () => {
         });
         expect(await Undo.canUndoInAnimationScope()).toBe(false);
 
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'createPropertyKey', clipUuid: spriteClipUuid, propKey: 'cc.Sprite.color', frame: 30, value: { r: 12, g: 34, b: 56, a: 255 } },
             ],
@@ -1757,9 +1757,9 @@ describe('Animation Service 场景进程测试', () => {
         expect(componentAfterUndo?.properties.color.value).toMatchObject({ r: 255, g: 255, b: 255, a: 255 });
     });
 
-    it('applyOperation 不应把无关 scene 属性 undo 合并进 animation scoped undo', async () => {
+    it('applyOperations 不应把无关 scene 属性 undo 合并进 animation scoped undo', async () => {
         await ensureAnimationSession(emptyNodePath, emptyClipUuid);
-        await request('applyOperation', [{
+        await request('applyOperations', [{
             operations: [
                 { type: 'addPropertyCurve', clipUuid: emptyClipUuid, propKey: 'scale', value: { x: 1, y: 1, z: 1 } },
                 { type: 'createPropertyKey', clipUuid: emptyClipUuid, propKey: 'scale', frame: 0, value: { x: 1, y: 1, z: 1 } },
@@ -1780,7 +1780,7 @@ describe('Animation Service 场景进程测试', () => {
         });
         expect(await Undo.canUndoInAnimationScope()).toBe(false);
 
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'createPropertyKey', clipUuid: emptyClipUuid, propKey: 'scale', frame: 30, value: { x: 2, y: 2, z: 2 } },
             ],
@@ -1797,7 +1797,7 @@ describe('Animation Service 场景进程测试', () => {
         expect(await Undo.isDirty()).toBe(true);
     });
 
-    it('applyOperation 混合非属性操作时不应吸收 scene 属性 undo', async () => {
+    it('applyOperations 混合非属性操作时不应吸收 scene 属性 undo', async () => {
         await ensureAnimationSession(emptyNodePath, emptyClipUuid);
         await resetRootPositionCurve(emptyNodePath, emptyClipUuid);
         await Undo.clearHistory();
@@ -1810,7 +1810,7 @@ describe('Animation Service 场景进程测试', () => {
         });
         expect(await Undo.canUndoInAnimationScope()).toBe(false);
 
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             operations: [
                 { type: 'createPropertyKey', clipUuid: emptyClipUuid, propKey: 'position', frame: 30, value: { x: 789, y: 0, z: 0 } },
                 { type: 'addEvent', clipUuid: emptyClipUuid, frame: 30, func: 'onMixedCommit', params: ['mixed'] },
@@ -1865,13 +1865,13 @@ describe('Animation Service 场景进程测试', () => {
         expect(await Undo.canRedo()).toBe(false);
     });
 
-    it('applyOperation recordUndo 为 false 时不写入 undo 栈', async () => {
+    it('applyOperations recordUndo 为 false 时不写入 undo 栈', async () => {
         await ensureAnimationSession(nodePath, clipUuid);
         await Undo.clearHistory();
         await Undo.markSaved();
 
         const before = await request('queryClip', [{ clipUuid }]);
-        const result = await request('applyOperation', [{
+        const result = await request('applyOperations', [{
             recordUndo: false,
             operations: [
                 { type: 'changeSpeed', clipUuid, speed: before.speed + 0.125 },

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -998,6 +998,35 @@ describe('Animation Service 场景进程测试', () => {
         expect(reenteredCurve?.keyframes).toEqual(spriteFrameCurve.keyframes);
     });
 
+    it('queryPropertyValueAtFrame 支持 cc.Sprite.color 采样序列化', async () => {
+        await ensureAnimationSession(spriteFrameNodePath, spriteFrameClipUuid);
+
+        const properties = await request('queryProperties', [{ nodePath: spriteFrameNodePath }]);
+        const colorProperty = properties.find((item: any) => item.key === 'cc.Sprite.color');
+        expect(colorProperty).toMatchObject({
+            key: 'cc.Sprite.color',
+            comp: 'cc.Sprite',
+            type: { value: 'cc.Color' },
+        });
+
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'addPropertyCurve', clipUuid: spriteFrameClipUuid, nodePath: spriteFrameNodePath, propKey: 'cc.Sprite.color', value: { r: 255, g: 255, b: 255, a: 255 } },
+                { type: 'createPropertyKey', clipUuid: spriteFrameClipUuid, nodePath: spriteFrameNodePath, propKey: 'cc.Sprite.color', frame: 0, value: { r: 32, g: 64, b: 128, a: 255 } },
+            ],
+            recordUndo: false,
+        }]);
+        const sampled = await request('queryPropertyValueAtFrame', [{
+            clipUuid: spriteFrameClipUuid,
+            nodePath: spriteFrameNodePath,
+            propKey: 'cc.Sprite.color',
+            frame: 0,
+        }]);
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(sampled).toMatchObject({ r: 32, g: 64, b: 128, a: 255 });
+    });
+
     it('applyOperation 支持普通属性曲线的创建、更新、复制、批量删除和 extrapolation', async () => {
         await ensureAnimationSession(nodePath, clipUuid);
 

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -1134,6 +1134,28 @@ describe('Animation Service 场景进程测试', () => {
         ]);
     });
 
+    it('queryClip 按属性轨道添加顺序返回 curves', async () => {
+        await ensureAnimationSession(emptyNodePath, emptyClipUuid);
+        await resetPropertyCurves(emptyNodePath, emptyClipUuid);
+
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'addPropertyCurve', clipUuid: emptyClipUuid, nodePath: emptyNodePath, propKey: 'position', value: { x: 0, y: 0, z: 0 } },
+                { type: 'addPropertyCurve', clipUuid: emptyClipUuid, nodePath: emptyNodePath, propKey: 'cc.Sprite.color', value: { r: 255, g: 255, b: 255, a: 255 } },
+                { type: 'addPropertyCurve', clipUuid: emptyClipUuid, nodePath: emptyNodePath, propKey: 'scale', value: { x: 1, y: 1, z: 1 } },
+            ],
+            recordUndo: false,
+        }]);
+        const dump = await request('queryClip', [{ rootPath: emptyNodePath, clipUuid: emptyClipUuid }]);
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(dump.curves.map((curve: any) => curve.key)).toEqual([
+            'position',
+            'cc.Sprite.color',
+            'scale',
+        ]);
+    });
+
     it('removePropertyKeys 清空关键帧时保留属性轨道，removePropertyCurve 才移除轨道', async () => {
         await ensureAnimationSession(emptyNodePath, emptyClipUuid);
 

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -1231,6 +1231,72 @@ describe('Animation Service 场景进程测试', () => {
         expect(await Undo.isDirty()).toBe(true);
     });
 
+    it('save 只在没有其他 scene 变更时清理 animation dirty', async () => {
+        const current = await request('queryState');
+        if (current.active) {
+            await request('exit', [{ save: false, restoreSelection: false }]);
+        }
+        await Undo.clearHistory();
+        await Undo.markSaved();
+
+        let state = await request('enter', [{ rootPath: emptyNodePath, clipUuid: emptyClipUuid, restoreSelectionOnExit: false }]);
+        expect(state.dirty).toBe(false);
+        expect(await Undo.isDirty()).toBe(false);
+
+        await request('applyOperation', [{
+            operations: [
+                { type: 'changeSpeed', clipUuid: emptyClipUuid, speed: 1.125 },
+            ],
+        }]);
+        state = await request('queryState');
+        expect(state.dirty).toBe(true);
+        expect(await Undo.isDirty()).toBe(true);
+
+        await request('save');
+        state = await request('queryState');
+        expect(state.dirty).toBe(false);
+        expect(await Undo.isDirty()).toBe(false);
+
+        expectUndoSuccess(await Undo.undoInAnimationScope());
+        state = await request('queryState');
+        expect(state.dirty).toBe(true);
+        expect(await Undo.isDirty()).toBe(true);
+    });
+
+    it('enter 前已有 scene dirty 时不会把它当作 animation dirty，也不会在 animation save 后清掉', async () => {
+        const current = await request('queryState');
+        if (current.active) {
+            await request('exit', [{ save: false, restoreSelection: false }]);
+        }
+        await Undo.clearHistory();
+        await Undo.markSaved();
+
+        const dirtyNode = await NodeProxy.createByType({
+            path: '',
+            name: `AnimationServicePreDirty_${Date.now()}`,
+            nodeType: NodeType.EMPTY,
+        });
+        expect(dirtyNode).toBeTruthy();
+        expect(await Undo.isDirty()).toBe(true);
+
+        let state = await request('enter', [{ rootPath: emptyNodePath, clipUuid: emptyClipUuid, restoreSelectionOnExit: false }]);
+        expect(state.dirty).toBe(false);
+
+        await request('applyOperation', [{
+            operations: [
+                { type: 'changeSpeed', clipUuid: emptyClipUuid, speed: 1.25 },
+            ],
+        }]);
+        state = await request('queryState');
+        expect(state.dirty).toBe(true);
+        expect(await Undo.isDirty()).toBe(true);
+
+        await request('save');
+        state = await request('queryState');
+        expect(state.dirty).toBe(false);
+        expect(await Undo.isDirty()).toBe(true);
+    });
+
     it('applyOperation 记录 addPropertyCurve 的 undo/redo', async () => {
         await ensureAnimationSession(emptyNodePath, emptyClipUuid);
         await Undo.clearHistory();

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -1228,6 +1228,104 @@ describe('Animation Service 场景进程测试', () => {
         expect(await Undo.isDirty()).toBe(true);
     });
 
+    it('applyOperation 记录 addPropertyCurve 的 undo/redo', async () => {
+        await ensureAnimationSession(emptyNodePath, emptyClipUuid);
+        await Undo.clearHistory();
+        await Undo.markSaved();
+
+        const before = await request('queryClip', [{ clipUuid: emptyClipUuid }]);
+        expect(before.curves.some((curve: any) => curve.nodePath === '' && curve.key === 'position')).toBe(false);
+
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'addPropertyCurve', clipUuid: emptyClipUuid, propKey: 'position', value: { x: 0, y: 0, z: 0 } },
+            ],
+        }]);
+        const after = await request('queryClip', [{ clipUuid: emptyClipUuid }]);
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(after.curves.some((curve: any) => curve.nodePath === '' && curve.key === 'position')).toBe(true);
+        expect(await Undo.isDirty()).toBe(true);
+        expect(await Undo.canUndo()).toBe(true);
+
+        expectUndoSuccess(await Undo.undo());
+        const undoDump = await request('queryClip', [{ clipUuid: emptyClipUuid }]);
+        expect(undoDump.curves.some((curve: any) => curve.nodePath === '' && curve.key === 'position')).toBe(false);
+        expect(await Undo.canRedo()).toBe(true);
+
+        expectUndoSuccess(await Undo.redo());
+        const redoDump = await request('queryClip', [{ clipUuid: emptyClipUuid }]);
+        expect(redoDump.curves.some((curve: any) => curve.nodePath === '' && curve.key === 'position')).toBe(true);
+    });
+
+    it('applyOperation 记录 child addPropertyCurve 的 undo/redo', async () => {
+        await ensureAnimationSession(childRootNodePath, childClipUuid);
+        await Undo.clearHistory();
+        await Undo.markSaved();
+
+        const childRelativePath = 'AnimationServiceChildSamplingChild';
+        await request('setTime', [{ time: 0.5 }]);
+        const value = await request('queryPropertyValueAtFrame', [{
+            clipUuid: childClipUuid,
+            nodePath: childRelativePath,
+            propKey: 'position',
+            frame: 30,
+        }]);
+        const before = await request('queryClip', [{ rootPath: childRootNodePath, clipUuid: childClipUuid }]);
+        expect(before.curves.some((curve: any) => curve.nodePath === childRelativePath && curve.key === 'position')).toBe(false);
+
+        const result = await request('applyOperation', [{
+            operations: [
+                { type: 'addPropertyCurve', clipUuid: childClipUuid, nodePath: childRelativePath, propKey: 'position', value },
+            ],
+        }]);
+        const after = await request('queryClip', [{ rootPath: childRootNodePath, clipUuid: childClipUuid }]);
+
+        expect(result).toEqual({ state: 'success', result: true });
+        expect(after.curves.some((curve: any) => curve.nodePath === childRelativePath && curve.key === 'position')).toBe(true);
+        expect(await Undo.isDirty()).toBe(true);
+        expect(await Undo.canUndo()).toBe(true);
+
+        expectUndoSuccess(await Undo.undo());
+        const undoDump = await request('queryClip', [{ rootPath: childRootNodePath, clipUuid: childClipUuid }]);
+        expect(undoDump.curves.some((curve: any) => curve.nodePath === childRelativePath && curve.key === 'position')).toBe(false);
+        expect(await Undo.canRedo()).toBe(true);
+
+        expectUndoSuccess(await Undo.redo());
+        const redoDump = await request('queryClip', [{ rootPath: childRootNodePath, clipUuid: childClipUuid }]);
+        expect(redoDump.curves.some((curve: any) => curve.nodePath === childRelativePath && curve.key === 'position')).toBe(true);
+    });
+
+    it('enter/setTime/queryPropertyValueAtFrame 不写入 undo/dirty', async () => {
+        const current = await request('queryState');
+        if (current.active) {
+            await request('exit', [{ save: false, restoreSelection: false }]);
+        }
+        await Undo.clearHistory();
+        await Undo.markSaved();
+
+        await request('enter', [{ rootPath: childRootNodePath, clipUuid: childClipUuid, restoreSelectionOnExit: false }]);
+        expect(await Undo.isDirty()).toBe(false);
+        expect(await Undo.canUndo()).toBe(false);
+        expect(await Undo.canRedo()).toBe(false);
+
+        await request('setTime', [{ time: 0.5 }]);
+        expect(await Undo.isDirty()).toBe(false);
+        expect(await Undo.canUndo()).toBe(false);
+        expect(await Undo.canRedo()).toBe(false);
+
+        const value = await request('queryPropertyValueAtFrame', [{
+            clipUuid: childClipUuid,
+            nodePath: 'AnimationServiceChildSamplingChild',
+            propKey: 'position',
+            frame: 30,
+        }]);
+        expect(value).toMatchObject({ x: 0, y: 0, z: 0 });
+        expect(await Undo.isDirty()).toBe(false);
+        expect(await Undo.canUndo()).toBe(false);
+        expect(await Undo.canRedo()).toBe(false);
+    });
+
     it('applyOperation recordUndo 为 false 时不写入 undo 栈', async () => {
         await ensureAnimationSession(nodePath, clipUuid);
         await Undo.clearHistory();

--- a/src/core/scene/test/animation-snapshot-undo.test.ts
+++ b/src/core/scene/test/animation-snapshot-undo.test.ts
@@ -1,0 +1,124 @@
+const mockReplacePropertyCurves = jest.fn((clip: any, curves: any[]) => {
+    clip.__curves = JSON.parse(JSON.stringify(curves));
+    return true;
+});
+
+const mockReplaceAuxiliaryCurves = jest.fn((clip: any, curves: Record<string, unknown>) => {
+    clip.__auxiliaryCurves = JSON.parse(JSON.stringify(curves));
+    return true;
+});
+
+jest.mock('cc', () => ({
+    AnimationClip: class AnimationClip {},
+    assetManager: {
+        loadAny: jest.fn(),
+    },
+    editorExtrasTag: Symbol.for('editorExtrasTag'),
+}));
+
+jest.mock('cc/editor/embedded-player', () => ({
+    EmbeddedAnimationClipPlayable: class EmbeddedAnimationClipPlayable {},
+    EmbeddedParticleSystemPlayable: class EmbeddedParticleSystemPlayable {},
+    EmbeddedPlayer: class EmbeddedPlayer {},
+    addEmbeddedPlayerTag: Symbol.for('addEmbeddedPlayerTag'),
+    clearEmbeddedPlayersTag: Symbol.for('clearEmbeddedPlayersTag'),
+    getEmbeddedPlayersTag: Symbol.for('getEmbeddedPlayersTag'),
+}));
+
+jest.mock('../scene-process/service/animation/property-curve', () => ({
+    dumpPropertyCurves: jest.fn(() => []),
+    replacePropertyCurves: (clip: any, curves: any[]) => mockReplacePropertyCurves(clip, curves),
+}));
+
+jest.mock('../scene-process/service/animation/auxiliary-curve', () => ({
+    dumpAuxiliaryCurves: jest.fn(() => ({})),
+    replaceAuxiliaryCurves: (clip: any, curves: Record<string, unknown>) => mockReplaceAuxiliaryCurves(clip, curves),
+}));
+
+import { editorExtrasTag } from 'cc';
+import { SceneUndoManager } from '../scene-process/service/undo/scene-undo-manager';
+import { restoreAnimationClipSnapshot, type IAnimationClipSnapshot } from '../scene-process/service/animation/clip-snapshot';
+import { AnimationClipSnapshotCommand } from '../scene-process/service/animation/undo';
+
+function createSnapshot(partial: Partial<IAnimationClipSnapshot> = {}): IAnimationClipSnapshot {
+    return {
+        duration: 0,
+        sample: 60,
+        speed: 1,
+        wrapMode: 1,
+        curves: [],
+        events: [],
+        embeddedPlayers: [],
+        embeddedPlayerGroups: [],
+        auxiliaryCurves: {},
+        ...partial,
+    };
+}
+
+function createClip(snapshot: IAnimationClipSnapshot): any {
+    return {
+        duration: snapshot.duration,
+        sample: snapshot.sample,
+        speed: snapshot.speed,
+        wrapMode: snapshot.wrapMode,
+        events: [],
+        __curves: JSON.parse(JSON.stringify(snapshot.curves)),
+        __auxiliaryCurves: JSON.parse(JSON.stringify(snapshot.auxiliaryCurves)),
+        [editorExtrasTag]: {
+            embeddedPlayerGroups: JSON.parse(JSON.stringify(snapshot.embeddedPlayerGroups)),
+        },
+    };
+}
+
+describe('Animation clip snapshot undo', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('treats empty embedded players as a restorable state for zero-duration child addPropertyCurve undo/redo', async () => {
+        const before = createSnapshot();
+        const after = createSnapshot({
+            curves: [{
+                nodePath: 'AnimationServiceChildSamplingChild',
+                key: 'position',
+                keyframes: [],
+            } as any],
+        });
+        const clip = createClip(after);
+        const manager = new SceneUndoManager();
+
+        manager.push(new AnimationClipSnapshotCommand({
+            clipUuid: 'child-clip-uuid',
+            before,
+            after,
+            applySnapshot: (snapshot) => restoreAnimationClipSnapshot(clip, snapshot),
+        }));
+
+        await expect(manager.undo()).resolves.toMatchObject({
+            success: true,
+            label: 'Animation Operation',
+        });
+        expect(clip.__curves).toEqual(before.curves);
+        expect(manager.canRedo()).toBe(true);
+
+        await expect(manager.redo()).resolves.toMatchObject({
+            success: true,
+            label: 'Animation Operation',
+        });
+        expect(clip.__curves).toEqual(after.curves);
+        expect(manager.canRedo()).toBe(false);
+    });
+
+    it('still fails loudly when restoring non-empty embedded players without host APIs', async () => {
+        const clip = createClip(createSnapshot());
+
+        await expect(restoreAnimationClipSnapshot(clip, createSnapshot({
+            embeddedPlayers: [{
+                begin: 0,
+                end: 0,
+                reconciledSpeed: false,
+                group: 'particle-track',
+            }],
+        }))).rejects.toThrow('Failed to restore animation embedded players.');
+    });
+});

--- a/src/core/scene/test/animation-snapshot-undo.test.ts
+++ b/src/core/scene/test/animation-snapshot-undo.test.ts
@@ -26,12 +26,12 @@ jest.mock('cc/editor/embedded-player', () => ({
 }));
 
 jest.mock('../scene-process/service/animation/property-curve', () => ({
-    dumpPropertyCurves: jest.fn(() => []),
+    dumpPropertyCurves: jest.fn((clip: any) => JSON.parse(JSON.stringify(clip.__curves || []))),
     replacePropertyCurves: (clip: any, curves: any[]) => mockReplacePropertyCurves(clip, curves),
 }));
 
 jest.mock('../scene-process/service/animation/auxiliary-curve', () => ({
-    dumpAuxiliaryCurves: jest.fn(() => ({})),
+    dumpAuxiliaryCurves: jest.fn((clip: any) => JSON.parse(JSON.stringify(clip.__auxiliaryCurves || {}))),
     replaceAuxiliaryCurves: (clip: any, curves: Record<string, unknown>) => mockReplaceAuxiliaryCurves(clip, curves),
 }));
 
@@ -120,5 +120,54 @@ describe('Animation clip snapshot undo', () => {
                 group: 'particle-track',
             }],
         }))).rejects.toThrow('Failed to restore animation embedded players.');
+    });
+
+    it('restores the original clip data when snapshot restore fails partway', async () => {
+        const original = createSnapshot({
+            duration: 1,
+            sample: 30,
+            speed: 1,
+            wrapMode: 1,
+            curves: [{
+                nodePath: '',
+                key: 'position',
+                keyframes: [{ frame: 0, dump: { value: { x: 1, y: 2, z: 3 }, type: 'cc.Vec3' } }],
+            } as any],
+            embeddedPlayerGroups: [{ key: 'old-group', name: 'Old Group', type: 'particle-system' }],
+            auxiliaryCurves: {
+                OldWeight: { keyframes: [{ frame: 0, value: 0.25 }] } as any,
+            },
+        });
+        const clip = createClip(original);
+
+        await expect(restoreAnimationClipSnapshot(clip, createSnapshot({
+            duration: 2,
+            sample: 60,
+            speed: 2,
+            wrapMode: 2,
+            curves: [{
+                nodePath: '',
+                key: 'scale',
+                keyframes: [{ frame: 0, dump: { value: { x: 4, y: 5, z: 6 }, type: 'cc.Vec3' } }],
+            } as any],
+            embeddedPlayerGroups: [{ key: 'new-group', name: 'New Group', type: 'particle-system' }],
+            embeddedPlayers: [{
+                begin: 0,
+                end: 30,
+                reconciledSpeed: false,
+                group: 'new-group',
+            }],
+            auxiliaryCurves: {
+                NewWeight: { keyframes: [{ frame: 0, value: 1 }] } as any,
+            },
+        }))).rejects.toThrow('Failed to restore animation embedded players.');
+
+        expect(clip.duration).toBe(original.duration);
+        expect(clip.sample).toBe(original.sample);
+        expect(clip.speed).toBe(original.speed);
+        expect(clip.wrapMode).toBe(original.wrapMode);
+        expect(clip.__curves).toEqual(original.curves);
+        expect(clip[editorExtrasTag].embeddedPlayerGroups).toEqual(original.embeddedPlayerGroups);
+        expect(clip.__auxiliaryCurves).toEqual(original.auxiliaryCurves);
     });
 });

--- a/src/core/scene/test/animation-state-registry.test.ts
+++ b/src/core/scene/test/animation-state-registry.test.ts
@@ -37,4 +37,14 @@ describe('AnimationStateRegistry', () => {
         expect(state).toBe(constructedState);
         expect(state.initialize).toHaveBeenCalledWith(rootNode);
     });
+
+    it('normalizes null clip events before initializing animation state', () => {
+        const rootNode = {};
+        const clip = { events: null };
+        const registry = new AnimationStateRegistry(() => rootNode, async () => clip);
+
+        registry.create('clip-uuid', clip);
+
+        expect(clip.events).toEqual([]);
+    });
 });

--- a/src/core/scene/test/animation-state-registry.test.ts
+++ b/src/core/scene/test/animation-state-registry.test.ts
@@ -1,0 +1,40 @@
+let constructedState: any = null;
+
+jest.mock('cc', () => ({
+    AnimationClip: class AnimationClip {},
+    Node: class Node {},
+    AnimationState: class AnimationState {
+        clip: unknown;
+        initialize = jest.fn();
+        destroy = jest.fn();
+
+        constructor(clip: unknown) {
+            this.clip = clip;
+            constructedState = this;
+            Object.defineProperty(this, '_curveLoaded', {
+                set() {
+                    throw new Error('private curve flag should not be written');
+                },
+            });
+        }
+    },
+}));
+
+const { AnimationStateRegistry } = require('../scene-process/service/animation/state-registry');
+
+describe('AnimationStateRegistry', () => {
+    beforeEach(() => {
+        constructedState = null;
+    });
+
+    it('creates and initializes animation state without touching private curve flags', () => {
+        const rootNode = {};
+        const clip = {};
+        const registry = new AnimationStateRegistry(() => rootNode, async () => clip);
+
+        const state = registry.create('clip-uuid', clip);
+
+        expect(state).toBe(constructedState);
+        expect(state.initialize).toHaveBeenCalledWith(rootNode);
+    });
+});

--- a/src/core/scene/test/animation-utils.test.ts
+++ b/src/core/scene/test/animation-utils.test.ts
@@ -1,0 +1,54 @@
+jest.mock('cc', () => ({
+    Asset: class Asset {},
+}));
+
+const { Asset } = require('cc');
+const { cloneValue } = require('../scene-process/service/animation/utils');
+
+describe('animation utils', () => {
+    it('deep-clones plain containers without cloning asset objects', () => {
+        class SpriteAsset extends Asset {
+            uuid = 'asset-uuid';
+        }
+        const asset = new SpriteAsset();
+        const source = {
+            keyframes: [{ frame: 0, value: 1 }],
+            asset,
+        };
+
+        const cloned = cloneValue(source);
+
+        expect(cloned).not.toBe(source);
+        expect(cloned.keyframes).not.toBe(source.keyframes);
+        expect(cloned.keyframes[0]).not.toBe(source.keyframes[0]);
+        expect(cloned).toMatchObject({ keyframes: [{ frame: 0, value: 1 }] });
+        expect(cloned.asset).toBe(asset);
+    });
+
+    it('deep-clones plain uuid descriptors instead of treating them as assets', () => {
+        const source = {
+            asset: { uuid: 'asset-uuid' },
+        };
+
+        const cloned = cloneValue(source);
+
+        expect(cloned.asset).not.toBe(source.asset);
+        expect(cloned.asset).toEqual({ uuid: 'asset-uuid' });
+    });
+
+    it('clones engine value-like objects via clone() without sharing the original reference', () => {
+        class ValueLike {
+            constructor(public x: number, public y: number, public z: number) {}
+            clone() {
+                return new ValueLike(this.x, this.y, this.z);
+            }
+        }
+        const source = new ValueLike(1, 2, 3);
+
+        const cloned = cloneValue(source);
+
+        expect(cloned).not.toBe(source);
+        expect(cloned).toBeInstanceOf(ValueLike);
+        expect(cloned).toMatchObject({ x: 1, y: 2, z: 3 });
+    });
+});

--- a/src/core/scene/test/gizmo-base-animation-commit.test.ts
+++ b/src/core/scene/test/gizmo-base-animation-commit.test.ts
@@ -1,0 +1,47 @@
+const broadcasts: Array<[string, unknown]> = [];
+
+jest.mock('cc', () => {
+    class Node {
+        uuid = 'node-uuid';
+    }
+    class Component {
+        node = new Node();
+    }
+    return { Component, Node };
+});
+
+jest.mock('../scene-process/service/core/decorator', () => ({
+    Service: {
+        broadcast: (event: string, payload: unknown) => broadcasts.push([event, payload]),
+    },
+}));
+
+describe('GizmoBase animation property commit event', () => {
+    beforeEach(() => {
+        broadcasts.length = 0;
+        (globalThis as any).EditorExtends = {
+            Node: {
+                getNodePath: (node: { uuid: string }) => `Canvas/${node.uuid}`,
+            },
+        };
+        (globalThis as any).cc = {};
+    });
+
+    it('broadcasts normalized committed property payload on control end', () => {
+        const GizmoBase = require('../scene-process/service/gizmo/base/gizmo-base').default;
+        class TestGizmo extends GizmoBase {
+            get nodes() {
+                return [{ uuid: 'Hero' }];
+            }
+        }
+
+        new (TestGizmo as any)(null).onControlEnd('_components.0.size');
+
+        expect(broadcasts).toContainEqual(['gizmo:control-end', '_components.0.size']);
+        expect(broadcasts).toContainEqual(['animation:property-committed', {
+            nodePath: 'Canvas/Hero',
+            propPath: '__comps__.0.size',
+            source: 'engine',
+        }]);
+    });
+});

--- a/src/core/scene/test/gizmo-base-animation-commit.test.ts
+++ b/src/core/scene/test/gizmo-base-animation-commit.test.ts
@@ -19,12 +19,22 @@ jest.mock('../scene-process/service/core/decorator', () => ({
 describe('GizmoBase animation property commit event', () => {
     beforeEach(() => {
         broadcasts.length = 0;
+        const { globalEventEmitter } = require('../scene-process/service/core/global-events');
+        globalEventEmitter.removeAllListeners('animation:property-committed');
+        globalEventEmitter.on('animation:property-committed', (payload: unknown) => {
+            broadcasts.push(['animation:property-committed', payload]);
+        });
         (globalThis as any).EditorExtends = {
             Node: {
                 getNodePath: (node: { uuid: string }) => `Canvas/${node.uuid}`,
             },
         };
         (globalThis as any).cc = {};
+    });
+
+    afterEach(() => {
+        const { globalEventEmitter } = require('../scene-process/service/core/global-events');
+        globalEventEmitter.removeAllListeners('animation:property-committed');
     });
 
     it('broadcasts normalized committed property payload on control end', () => {

--- a/src/core/scene/test/gizmo-base-animation-commit.test.ts
+++ b/src/core/scene/test/gizmo-base-animation-commit.test.ts
@@ -1,5 +1,4 @@
 const broadcasts: Array<[string, unknown]> = [];
-let throwLegacyBroadcast = false;
 let endRecordingPromise: Promise<unknown> | null = null;
 let endRecordingResolve: (() => void) | null = null;
 
@@ -24,26 +23,23 @@ jest.mock('../scene-process/service/core/decorator', () => ({
                 return Promise.resolve();
             }),
         },
-        broadcast: (event: string, payload: unknown) => {
-            if (throwLegacyBroadcast && event === 'gizmo:control-end') {
-                throw new Error('legacy gizmo broadcast failed');
-            }
-            broadcasts.push([event, payload]);
-        },
     },
 }));
 
 describe('GizmoBase animation property commit event', () => {
     beforeEach(() => {
         broadcasts.length = 0;
-        throwLegacyBroadcast = false;
         endRecordingPromise = null;
         endRecordingResolve = null;
         const { Service } = require('../scene-process/service/core/decorator');
         Service.Undo.beginRecording.mockClear();
         Service.Undo.endRecording.mockClear();
         const { globalEventEmitter } = require('../scene-process/service/core/global-events');
+        globalEventEmitter.removeAllListeners('gizmo:control-end');
         globalEventEmitter.removeAllListeners('animation:property-committed');
+        globalEventEmitter.on('gizmo:control-end', (payload: unknown) => {
+            broadcasts.push(['gizmo:control-end', payload]);
+        });
         globalEventEmitter.on('animation:property-committed', (payload: unknown) => {
             broadcasts.push(['animation:property-committed', payload]);
         });
@@ -57,6 +53,7 @@ describe('GizmoBase animation property commit event', () => {
 
     afterEach(() => {
         const { globalEventEmitter } = require('../scene-process/service/core/global-events');
+        globalEventEmitter.removeAllListeners('gizmo:control-end');
         globalEventEmitter.removeAllListeners('animation:property-committed');
     });
 
@@ -80,6 +77,14 @@ describe('GizmoBase animation property commit event', () => {
 
     it('still broadcasts animation commit when the legacy gizmo end event fails', async () => {
         const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const { ServiceEvents } = require('../scene-process/service/core/global-events');
+        const originalBroadcast = ServiceEvents.broadcast.bind(ServiceEvents);
+        const broadcastSpy = jest.spyOn(ServiceEvents, 'broadcast').mockImplementation((event: unknown, ...args: unknown[]) => {
+            if (event === 'gizmo:control-end') {
+                throw new Error('legacy gizmo broadcast failed');
+            }
+            return originalBroadcast(event as string, ...args);
+        });
         const GizmoBase = require('../scene-process/service/gizmo/base/gizmo-base').default;
         class TestGizmo extends GizmoBase {
             get nodes() {
@@ -88,7 +93,6 @@ describe('GizmoBase animation property commit event', () => {
         }
 
         try {
-            throwLegacyBroadcast = true;
             await new (TestGizmo as any)(null).onControlEnd('position');
 
             expect(warnSpy).toHaveBeenCalled();
@@ -98,6 +102,7 @@ describe('GizmoBase animation property commit event', () => {
                 source: 'engine',
             }]);
         } finally {
+            broadcastSpy.mockRestore();
             warnSpy.mockRestore();
         }
     });

--- a/src/core/scene/test/gizmo-base-animation-commit.test.ts
+++ b/src/core/scene/test/gizmo-base-animation-commit.test.ts
@@ -1,5 +1,7 @@
 const broadcasts: Array<[string, unknown]> = [];
 let throwLegacyBroadcast = false;
+let endRecordingPromise: Promise<unknown> | null = null;
+let endRecordingResolve: (() => void) | null = null;
 
 jest.mock('cc', () => {
     class Node {
@@ -13,6 +15,15 @@ jest.mock('cc', () => {
 
 jest.mock('../scene-process/service/core/decorator', () => ({
     Service: {
+        Undo: {
+            beginRecording: jest.fn(() => 'recording-1'),
+            endRecording: jest.fn(() => {
+                if (endRecordingPromise) {
+                    return endRecordingPromise;
+                }
+                return Promise.resolve();
+            }),
+        },
         broadcast: (event: string, payload: unknown) => {
             if (throwLegacyBroadcast && event === 'gizmo:control-end') {
                 throw new Error('legacy gizmo broadcast failed');
@@ -26,6 +37,11 @@ describe('GizmoBase animation property commit event', () => {
     beforeEach(() => {
         broadcasts.length = 0;
         throwLegacyBroadcast = false;
+        endRecordingPromise = null;
+        endRecordingResolve = null;
+        const { Service } = require('../scene-process/service/core/decorator');
+        Service.Undo.beginRecording.mockClear();
+        Service.Undo.endRecording.mockClear();
         const { globalEventEmitter } = require('../scene-process/service/core/global-events');
         globalEventEmitter.removeAllListeners('animation:property-committed');
         globalEventEmitter.on('animation:property-committed', (payload: unknown) => {
@@ -44,7 +60,7 @@ describe('GizmoBase animation property commit event', () => {
         globalEventEmitter.removeAllListeners('animation:property-committed');
     });
 
-    it('broadcasts normalized committed property payload on control end', () => {
+    it('broadcasts normalized committed property payload on control end', async () => {
         const GizmoBase = require('../scene-process/service/gizmo/base/gizmo-base').default;
         class TestGizmo extends GizmoBase {
             get nodes() {
@@ -52,7 +68,7 @@ describe('GizmoBase animation property commit event', () => {
             }
         }
 
-        new (TestGizmo as any)(null).onControlEnd('_components.0.size');
+        await new (TestGizmo as any)(null).onControlEnd('_components.0.size');
 
         expect(broadcasts).toContainEqual(['gizmo:control-end', '_components.0.size']);
         expect(broadcasts).toContainEqual(['animation:property-committed', {
@@ -62,7 +78,7 @@ describe('GizmoBase animation property commit event', () => {
         }]);
     });
 
-    it('still broadcasts animation commit when the legacy gizmo end event fails', () => {
+    it('still broadcasts animation commit when the legacy gizmo end event fails', async () => {
         const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
         const GizmoBase = require('../scene-process/service/gizmo/base/gizmo-base').default;
         class TestGizmo extends GizmoBase {
@@ -73,7 +89,7 @@ describe('GizmoBase animation property commit event', () => {
 
         try {
             throwLegacyBroadcast = true;
-            new (TestGizmo as any)(null).onControlEnd('position');
+            await new (TestGizmo as any)(null).onControlEnd('position');
 
             expect(warnSpy).toHaveBeenCalled();
             expect(broadcasts).toContainEqual(['animation:property-committed', {
@@ -84,5 +100,46 @@ describe('GizmoBase animation property commit event', () => {
         } finally {
             warnSpy.mockRestore();
         }
+    });
+
+    it('waits for the scene undo recording before broadcasting animation commit', async () => {
+        endRecordingPromise = new Promise((resolve) => {
+            endRecordingResolve = () => resolve(undefined);
+        });
+        const GizmoBase = require('../scene-process/service/gizmo/base/gizmo-base').default;
+        class TestGizmo extends GizmoBase {
+            get nodes() {
+                return [{ uuid: 'Hero' }];
+            }
+        }
+
+        const gizmo = new (TestGizmo as any)(null);
+        gizmo.onControlBegin('position');
+        const { Service } = require('../scene-process/service/core/decorator');
+        expect(Service.Undo.beginRecording).toHaveBeenCalledWith(['Hero'], {
+            label: 'Gizmo position',
+            scope: {
+                editorType: 'scene',
+                nodePath: 'Canvas/Hero',
+                propPath: 'position',
+            },
+        });
+        const controlEnd = gizmo.onControlEnd('position');
+
+        await Promise.resolve();
+        expect(broadcasts).not.toContainEqual(['animation:property-committed', {
+            nodePath: 'Canvas/Hero',
+            propPath: 'position',
+            source: 'engine',
+        }]);
+
+        endRecordingResolve?.();
+        await controlEnd;
+
+        expect(broadcasts).toContainEqual(['animation:property-committed', {
+            nodePath: 'Canvas/Hero',
+            propPath: 'position',
+            source: 'engine',
+        }]);
     });
 });

--- a/src/core/scene/test/gizmo-base-animation-commit.test.ts
+++ b/src/core/scene/test/gizmo-base-animation-commit.test.ts
@@ -1,4 +1,5 @@
 const broadcasts: Array<[string, unknown]> = [];
+let throwLegacyBroadcast = false;
 
 jest.mock('cc', () => {
     class Node {
@@ -12,13 +13,19 @@ jest.mock('cc', () => {
 
 jest.mock('../scene-process/service/core/decorator', () => ({
     Service: {
-        broadcast: (event: string, payload: unknown) => broadcasts.push([event, payload]),
+        broadcast: (event: string, payload: unknown) => {
+            if (throwLegacyBroadcast && event === 'gizmo:control-end') {
+                throw new Error('legacy gizmo broadcast failed');
+            }
+            broadcasts.push([event, payload]);
+        },
     },
 }));
 
 describe('GizmoBase animation property commit event', () => {
     beforeEach(() => {
         broadcasts.length = 0;
+        throwLegacyBroadcast = false;
         const { globalEventEmitter } = require('../scene-process/service/core/global-events');
         globalEventEmitter.removeAllListeners('animation:property-committed');
         globalEventEmitter.on('animation:property-committed', (payload: unknown) => {
@@ -53,5 +60,29 @@ describe('GizmoBase animation property commit event', () => {
             propPath: '__comps__.0.size',
             source: 'engine',
         }]);
+    });
+
+    it('still broadcasts animation commit when the legacy gizmo end event fails', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const GizmoBase = require('../scene-process/service/gizmo/base/gizmo-base').default;
+        class TestGizmo extends GizmoBase {
+            get nodes() {
+                return [{ uuid: 'Hero' }];
+            }
+        }
+
+        try {
+            throwLegacyBroadcast = true;
+            new (TestGizmo as any)(null).onControlEnd('position');
+
+            expect(warnSpy).toHaveBeenCalled();
+            expect(broadcasts).toContainEqual(['animation:property-committed', {
+                nodePath: 'Canvas/Hero',
+                propPath: 'position',
+                source: 'engine',
+            }]);
+        } finally {
+            warnSpy.mockRestore();
+        }
     });
 });

--- a/src/core/scene/test/real-curve-key-data.test.ts
+++ b/src/core/scene/test/real-curve-key-data.test.ts
@@ -1,0 +1,68 @@
+jest.mock('cc', () => ({
+    editorExtrasTag: '__editorExtras__',
+}), { virtual: true });
+
+import {
+    createMergedRealCurveValue,
+    dumpRealKeyData,
+} from '../scene-process/service/animation/real-curve-key-data';
+
+describe('RealCurve key data helpers', () => {
+    it('keeps public dumps compact while allowing internal zero-preserving dumps', () => {
+        const value = {
+            value: 12,
+            leftTangent: 0,
+            rightTangent: 0,
+            leftTangentWeight: 0,
+            rightTangentWeight: 0,
+            interpolationMode: 0,
+            tangentWeightMode: 0,
+            easingMethod: 0,
+            __editorExtras__: { tangentMode: 0 },
+        };
+
+        expect(dumpRealKeyData(value)).toEqual({});
+        expect(dumpRealKeyData(value, { includeDefaults: true })).toMatchObject({
+            inTangent: 0,
+            outTangent: 0,
+            inTangentWeight: 0,
+            outTangentWeight: 0,
+            interpMode: 0,
+            tangentWeightMode: 0,
+            tangentMode: 0,
+            easingMethod: 0,
+        });
+    });
+
+    it('preserves existing zero key data without relying on explicit key markers when merging', () => {
+        const existed = {
+            value: 84,
+            leftTangent: 0,
+            rightTangent: 0,
+            leftTangentWeight: 0,
+            rightTangentWeight: 0,
+            interpolationMode: 0,
+            tangentWeightMode: 0,
+            easingMethod: 0,
+            __editorExtras__: { tangentMode: 0 },
+        };
+
+        expect(createMergedRealCurveValue(84, existed, { broken: true })).toMatchObject({
+            value: 84,
+            leftTangent: 0,
+            rightTangent: 0,
+            leftTangentWeight: 0,
+            rightTangentWeight: 0,
+            interpolationMode: 0,
+            tangentWeightMode: 0,
+            easingMethod: 0,
+            __editorExtras__: {
+                tangentMode: 0,
+                broken: true,
+            },
+        });
+        expect(dumpRealKeyData(createMergedRealCurveValue(84, existed, { broken: true }))).toEqual({
+            broken: true,
+        });
+    });
+});

--- a/src/core/scene/test/scene.test.ts
+++ b/src/core/scene/test/scene.test.ts
@@ -34,4 +34,5 @@ import './prefab-proxy.testcase';
 import './script-proxy.testcase';
 import './engine-proxy.testcase';
 import './undo-redo.testcase';
+import './animation-service.testcase';
 import './scene-exit.testcase';

--- a/src/core/scene/test/scene.test.ts
+++ b/src/core/scene/test/scene.test.ts
@@ -15,6 +15,8 @@ beforeAll(async () => {
     console.log('创建场景测试目录:', SceneTestEnv.cacheDirectory);
     const TestUtils = await import('../../test/global-setup');
     await TestUtils.globalSetup();
+    const { assetManager } = await import('../../assets');
+    await assetManager.refreshAsset(SceneTestEnv.cacheDirectory);
     const { loadSceneI18n } = await import('../index');
     await loadSceneI18n();
 });

--- a/src/core/scene/test/service-core/event-dedup.test.ts
+++ b/src/core/scene/test/service-core/event-dedup.test.ts
@@ -974,6 +974,13 @@ describe('场景事件契约测试', () => {
                 expect(count).toBe(1);
             });
 
+            it('onControlEnd 应提交动画属性 committed 事件', () => {
+                const body = extractMethodBody(source, /onControlEnd\(/);
+                expect(body.length).toBeGreaterThan(0);
+                const count = (body.match(/broadcastAnimationPropertyCommitted/g) || []).length;
+                expect(count).toBe(1);
+            });
+
             it('onControlBegin 不应同时 emit gizmo:control-begin', () => {
                 const body = extractMethodBody(source, /onControlBegin\(/);
                 expect(body).not.toMatch(/\.emit\(\s*['"]gizmo:control-begin['"]/);
@@ -982,6 +989,12 @@ describe('场景事件契约测试', () => {
             it('onControlEnd 不应同时 emit gizmo:control-end', () => {
                 const body = extractMethodBody(source, /onControlEnd\(/);
                 expect(body).not.toMatch(/\.emit\(\s*['"]gizmo:control-end['"]/);
+            });
+
+            it('broadcastAnimationPropertyCommitted 应 broadcast animation:property-committed 1 次', () => {
+                expect(source).toMatch(/broadcastAnimationPropertyCommitted\(/);
+                const count = (source.match(/broadcast\?\.\(['"]animation:property-committed['"]/g) || []).length;
+                expect(count).toBe(1);
             });
         });
 

--- a/src/core/scene/test/service-core/event-dedup.test.ts
+++ b/src/core/scene/test/service-core/event-dedup.test.ts
@@ -959,6 +959,7 @@ describe('场景事件契约测试', () => {
 
         describe('GizmoBase (gizmo/base/gizmo-base.ts)', () => {
             const source = readSourceFile('gizmo/base/gizmo-base.ts');
+            const commitEventSource = readSourceFile('animation/property-commit-event.ts');
 
             it('onControlBegin 应 broadcast gizmo:control-begin 1 次', () => {
                 const body = extractMethodBody(source, /onControlBegin\(/);
@@ -991,9 +992,10 @@ describe('场景事件契约测试', () => {
                 expect(body).not.toMatch(/\.emit\(\s*['"]gizmo:control-end['"]/);
             });
 
-            it('broadcastAnimationPropertyCommitted 应 broadcast animation:property-committed 1 次', () => {
+            it('broadcastAnimationPropertyCommitted 应通过共享 helper 提交 animation:property-committed', () => {
                 expect(source).toMatch(/broadcastAnimationPropertyCommitted\(/);
-                const count = (source.match(/broadcast\?\.\(['"]animation:property-committed['"]/g) || []).length;
+                expect(source).not.toMatch(/broadcast\?\.\(['"]animation:property-committed['"]/);
+                const count = (commitEventSource.match(/ServiceEvents\.broadcast\(\s*['"]animation:property-committed['"]/g) || []).length;
                 expect(count).toBe(1);
             });
         });

--- a/src/core/scene/test/service-core/event-dedup.test.ts
+++ b/src/core/scene/test/service-core/event-dedup.test.ts
@@ -853,13 +853,13 @@ describe('场景事件契约测试', () => {
             });
 
             it('undo 应 broadcast undo:changed 1 次', () => {
-                const body = extractMethodBody(source, /async undo\(\)/);
+                const body = extractMethodBody(source, /async undo\(/);
                 expect(body.length).toBeGreaterThan(0);
                 expect(countEmitCalls(body, 'undo:changed')).toBe(1);
             });
 
             it('redo 应 broadcast undo:changed 1 次', () => {
-                const body = extractMethodBody(source, /async redo\(\)/);
+                const body = extractMethodBody(source, /async redo\(/);
                 expect(body.length).toBeGreaterThan(0);
                 expect(countEmitCalls(body, 'undo:changed')).toBe(1);
             });
@@ -877,8 +877,8 @@ describe('场景事件契约测试', () => {
             });
 
             it('undo/redo 不应同时 emit 和 broadcast undo:changed', () => {
-                const undoBody = extractMethodBody(source, /async undo\(\)/);
-                const redoBody = extractMethodBody(source, /async redo\(\)/);
+                const undoBody = extractMethodBody(source, /async undo\(/);
+                const redoBody = extractMethodBody(source, /async redo\(/);
                 expect(undoBody).not.toMatch(/this\.emit\(\s*['"]undo:changed['"]/);
                 expect(redoBody).not.toMatch(/this\.emit\(\s*['"]undo:changed['"]/);
             });

--- a/src/core/scene/test/service-core/message-callsite.test.ts
+++ b/src/core/scene/test/service-core/message-callsite.test.ts
@@ -444,6 +444,105 @@ describe('ServiceEvents 事件发射集成测试', () => {
 
             expect(listener).toHaveBeenCalledWith(node, expect.objectContaining({ propPath: 'name' }));
         });
+
+        it('setProperty(position) 成功后应 broadcast animation:property-committed', async () => {
+            const listener = jest.fn();
+            globalEventEmitter.on('animation:property-committed', listener);
+
+            const nodeMgr = require('../../scene-process/service/node/index').default;
+            const setPropertySpy = jest.spyOn(nodeMgr, 'setProperty').mockResolvedValueOnce(true);
+            const { NodeService } = require('../../scene-process/service/node');
+            const nodeService = new NodeService();
+
+            const { Node: MockNode } = require('cc');
+            const node = new MockNode();
+            node.uuid = 'position-change';
+            node.name = 'TestNode';
+
+            nodeService._undo = {
+                recordNodeSnapshot: jest.fn((_node: any, _opts: any, callback: any) => callback()),
+            };
+
+            const NodeMgr = (global as any).EditorExtends.Node;
+            NodeMgr.getNodeByPath = jest.fn(() => node);
+
+            try {
+                await nodeService.setProperty({
+                    nodePath: '/TestNode',
+                    path: 'position',
+                    dump: { type: 'cc.Vec3', value: { x: 1, y: 2, z: 3 } },
+                });
+
+                expect(listener).toHaveBeenCalledWith({
+                    nodePath: '/TestNode',
+                    propPath: 'position',
+                    source: 'editor',
+                });
+            } finally {
+                setPropertySpy.mockRestore();
+            }
+        });
+
+        it('previewSetProperty 不应 broadcast animation:property-committed', async () => {
+            const listener = jest.fn();
+            globalEventEmitter.on('animation:property-committed', listener);
+
+            const nodeMgr = require('../../scene-process/service/node/index').default;
+            const previewSpy = jest.spyOn(nodeMgr, 'previewSetNodeProperty').mockResolvedValueOnce(true);
+            const { NodeService } = require('../../scene-process/service/node');
+            const nodeService = new NodeService();
+
+            const { Node: MockNode } = require('cc');
+            const node = new MockNode();
+            node.uuid = 'preview-position-change';
+            node.name = 'TestNode';
+
+            const NodeMgr = (global as any).EditorExtends.Node;
+            NodeMgr.getNodeByPath = jest.fn(() => node);
+
+            try {
+                await nodeService.previewSetProperty({
+                    nodePath: '/TestNode',
+                    path: 'position',
+                    dump: { type: 'cc.Vec3', value: { x: 1, y: 2, z: 3 } },
+                });
+
+                expect(listener).not.toHaveBeenCalled();
+            } finally {
+                previewSpy.mockRestore();
+            }
+        });
+    });
+
+    describe('ComponentService (component.ts)', () => {
+        it('setProperty(__comps__) 成功后应 broadcast animation:property-committed', async () => {
+            const listener = jest.fn();
+            globalEventEmitter.on('animation:property-committed', listener);
+
+            const { ComponentService } = require('../../scene-process/service/component');
+            const componentService = new ComponentService();
+            componentService._recordComponentPropertySnapshot = jest.fn((_node: any, _opts: any, callback: any) => callback());
+
+            const { Node: MockNode } = require('cc');
+            const node = new MockNode();
+            node.uuid = 'component-property-change';
+            node.name = 'TestNode';
+
+            const NodeMgr = (global as any).EditorExtends.Node;
+            NodeMgr.getNodeByPath = jest.fn(() => node);
+
+            await componentService.setProperty({
+                nodePath: '/TestNode',
+                path: '__comps__.0.enabled',
+                dump: { type: 'cc.Boolean', value: false },
+            });
+
+            expect(listener).toHaveBeenCalledWith({
+                nodePath: '/TestNode',
+                propPath: '__comps__.0.enabled',
+                source: 'editor',
+            });
+        });
     });
 
     // ── PrefabService: filterChild / filterPart / canModifySibling → ServiceEvents ──

--- a/src/core/scene/test/service-core/message-callsite.test.ts
+++ b/src/core/scene/test/service-core/message-callsite.test.ts
@@ -483,6 +483,41 @@ describe('ServiceEvents 事件发射集成测试', () => {
             }
         });
 
+        it('setProperty(position) record:false 不应 broadcast animation:property-committed', async () => {
+            const listener = jest.fn();
+            globalEventEmitter.on('animation:property-committed', listener);
+
+            const nodeMgr = require('../../scene-process/service/node/index').default;
+            const setPropertySpy = jest.spyOn(nodeMgr, 'setProperty').mockResolvedValueOnce(true);
+            const { NodeService } = require('../../scene-process/service/node');
+            const nodeService = new NodeService();
+
+            const { Node: MockNode } = require('cc');
+            const node = new MockNode();
+            node.uuid = 'position-change-record-false';
+            node.name = 'TestNode';
+
+            nodeService._undo = {
+                recordNodeSnapshot: jest.fn((_node: any, _opts: any, callback: any) => callback()),
+            };
+
+            const NodeMgr = (global as any).EditorExtends.Node;
+            NodeMgr.getNodeByPath = jest.fn(() => node);
+
+            try {
+                await nodeService.setProperty({
+                    nodePath: '/TestNode',
+                    path: 'position',
+                    dump: { type: 'cc.Vec3', value: { x: 1, y: 2, z: 3 } },
+                    record: false,
+                });
+
+                expect(listener).not.toHaveBeenCalled();
+            } finally {
+                setPropertySpy.mockRestore();
+            }
+        });
+
         it('previewSetProperty 不应 broadcast animation:property-committed', async () => {
             const listener = jest.fn();
             globalEventEmitter.on('animation:property-committed', listener);
@@ -542,6 +577,32 @@ describe('ServiceEvents 事件发射集成测试', () => {
                 propPath: '__comps__.0.enabled',
                 source: 'editor',
             });
+        });
+
+        it('setProperty(__comps__) record:false 不应 broadcast animation:property-committed', async () => {
+            const listener = jest.fn();
+            globalEventEmitter.on('animation:property-committed', listener);
+
+            const { ComponentService } = require('../../scene-process/service/component');
+            const componentService = new ComponentService();
+            componentService._recordComponentPropertySnapshot = jest.fn((_node: any, _opts: any, callback: any) => callback());
+
+            const { Node: MockNode } = require('cc');
+            const node = new MockNode();
+            node.uuid = 'component-property-change-record-false';
+            node.name = 'TestNode';
+
+            const NodeMgr = (global as any).EditorExtends.Node;
+            NodeMgr.getNodeByPath = jest.fn(() => node);
+
+            await componentService.setProperty({
+                nodePath: '/TestNode',
+                path: '__comps__.0.enabled',
+                dump: { type: 'cc.Boolean', value: false },
+                record: false,
+            });
+
+            expect(listener).not.toHaveBeenCalled();
         });
     });
 

--- a/src/core/scene/test/service-core/service-manager-forwarding.test.ts
+++ b/src/core/scene/test/service-core/service-manager-forwarding.test.ts
@@ -42,6 +42,7 @@ const SERVICE_MAP_EVENTS = [
 
 const MESSAGE_ONLY_EVENTS = [
     'dirty:changed',
+    'animation:state-changed', 'animation:time-changed', 'animation:clip-changed',
     'gizmo:coordinate-changed', 'gizmo:pivot-changed', 'gizmo:view-mode-changed', 'gizmo:tool-changed',
     'scene:dimension-changed',
     'camera:mode-change', 'camera:projection-changed', 'camera:fov-changed',

--- a/src/core/scene/test/service-core/service-manager-forwarding.test.ts
+++ b/src/core/scene/test/service-core/service-manager-forwarding.test.ts
@@ -42,7 +42,7 @@ const SERVICE_MAP_EVENTS = [
 
 const MESSAGE_ONLY_EVENTS = [
     'dirty:changed',
-    'animation:state-changed', 'animation:time-changed', 'animation:clip-changed',
+    'animation:state-changed', 'animation:time-changed', 'animation:clip-changed', 'animation:property-committed',
     'gizmo:coordinate-changed', 'gizmo:pivot-changed', 'gizmo:view-mode-changed', 'gizmo:tool-changed',
     'scene:dimension-changed',
     'camera:mode-change', 'camera:projection-changed', 'camera:fov-changed',

--- a/src/core/scene/test/undo-manager.test.ts
+++ b/src/core/scene/test/undo-manager.test.ts
@@ -303,14 +303,89 @@ describe('SceneUndoManager', () => {
         });
         expect(animationCommand.calls).toEqual(['undo:animation-command', 'redo:animation-command']);
     });
+
+    it('merges a consumed scene property command into the animation undo scope', async () => {
+        const manager = new SceneUndoManager();
+        const sceneCommand = new ControlledCommand('scene-property-command', true, { editorType: 'scene', mode: 'general' }, 'node:set-property');
+        const animationCommand = new ControlledCommand('animation-command', true, { editorType: 'animation', mode: 'animation' }, 'animation:clip-snapshot');
+
+        manager.push(sceneCommand);
+        manager.pushWithPrevious(animationCommand, {
+            label: 'Animation Property Commit',
+            type: 'animation:property-commit',
+            scope: { editorType: 'animation', mode: 'animation' },
+            previousScope: { editorType: 'scene' },
+            previousTypes: ['node:set-property', 'component:set-property'],
+        });
+
+        expect(manager.canUndo({ scope: { editorType: 'animation', mode: 'animation' } })).toBe(true);
+        expect(manager.getHistoryForTesting()).toHaveLength(1);
+
+        await expect(manager.undo({ scope: { editorType: 'animation', mode: 'animation' } })).resolves.toMatchObject({
+            success: true,
+        });
+        expect(animationCommand.calls).toEqual(['undo:animation-command']);
+        expect(sceneCommand.calls).toEqual(['undo:scene-property-command']);
+
+        await expect(manager.redo({ scope: { editorType: 'animation', mode: 'animation' } })).resolves.toMatchObject({
+            success: true,
+        });
+        expect(sceneCommand.calls).toEqual(['undo:scene-property-command', 'redo:scene-property-command']);
+        expect(animationCommand.calls).toEqual(['undo:animation-command', 'redo:animation-command']);
+    });
+
+    it('does not absorb a previous command with the wrong type', async () => {
+        const manager = new SceneUndoManager();
+        const sceneCommand = new ControlledCommand('scene-create-command', true, { editorType: 'scene', mode: 'general' }, 'node:create');
+        const animationCommand = new ControlledCommand('animation-command', true, { editorType: 'animation', mode: 'animation' }, 'animation:clip-snapshot');
+
+        manager.push(sceneCommand);
+        manager.pushWithPrevious(animationCommand, {
+            type: 'animation:property-commit',
+            scope: { editorType: 'animation', mode: 'animation' },
+            previousScope: { editorType: 'scene' },
+            previousTypes: ['node:set-property', 'component:set-property'],
+        });
+
+        expect(manager.getHistoryForTesting()).toHaveLength(2);
+        await expect(manager.undo({ scope: { editorType: 'animation', mode: 'animation' } })).resolves.toMatchObject({
+            success: true,
+        });
+        expect(animationCommand.calls).toEqual(['undo:animation-command']);
+        expect(sceneCommand.calls).toEqual([]);
+    });
+
+    it('does not search past the stack top when absorbing previous commands', async () => {
+        const manager = new SceneUndoManager();
+        const sceneCommand = new ControlledCommand('scene-property-command', true, { editorType: 'scene', mode: 'general' }, 'node:set-property');
+        const unrelatedCommand = new ControlledCommand('unrelated-command', true, { editorType: 'scene', mode: 'general' }, 'node:create');
+        const animationCommand = new ControlledCommand('animation-command', true, { editorType: 'animation', mode: 'animation' }, 'animation:clip-snapshot');
+
+        manager.push(sceneCommand);
+        manager.push(unrelatedCommand);
+        manager.pushWithPrevious(animationCommand, {
+            type: 'animation:property-commit',
+            scope: { editorType: 'animation', mode: 'animation' },
+            previousScope: { editorType: 'scene' },
+            previousTypes: ['node:set-property', 'component:set-property'],
+        });
+
+        expect(manager.getHistoryForTesting()).toHaveLength(3);
+        await expect(manager.undo({ scope: { editorType: 'animation', mode: 'animation' } })).resolves.toMatchObject({
+            success: true,
+        });
+        expect(animationCommand.calls).toEqual(['undo:animation-command']);
+        expect(unrelatedCommand.calls).toEqual([]);
+        expect(sceneCommand.calls).toEqual([]);
+    });
 });
 
 class ControlledCommand implements IUndoCommand {
     meta: IUndoCommandMeta;
     calls: string[] = [];
 
-    constructor(id: string, private ok = true, scope: IUndoCommandMeta['scope'] = {}) {
-        this.meta = { id, label: id, type: 'test', scope, timestamp: Date.now() };
+    constructor(id: string, private ok = true, scope: IUndoCommandMeta['scope'] = {}, type = 'test') {
+        this.meta = { id, label: id, type, scope, timestamp: Date.now() };
     }
 
     async undo(): Promise<IUndoRedoResult> {

--- a/src/core/scene/test/undo-manager.test.ts
+++ b/src/core/scene/test/undo-manager.test.ts
@@ -101,6 +101,25 @@ describe('SceneUndoManager', () => {
         expect(manager.isDirty()).toBe(false);
     });
 
+    it('checks scoped differences on both sides of an undo checkpoint', async () => {
+        const manager = new SceneUndoManager();
+        const sceneCommand = new ControlledCommand('scene-command', true, { editorType: 'scene', mode: 'general' }, 'node:create');
+        const animationCommand = new ControlledCommand('animation-command', true, { editorType: 'animation', mode: 'animation', assetUuid: 'clip-1' }, 'animation:clip-snapshot');
+
+        manager.push(sceneCommand);
+        const baseline = manager.createCheckpoint();
+        expect(manager.hasScopedDifference(baseline, { editorType: 'animation', mode: 'animation', assetUuid: 'clip-1' })).toBe(false);
+
+        manager.push(animationCommand);
+        expect(manager.hasScopedDifference(baseline, { editorType: 'animation', mode: 'animation', assetUuid: 'clip-1' })).toBe(true);
+        const savedAnimation = manager.createCheckpoint();
+        expect(manager.hasScopedDifference(savedAnimation, { editorType: 'animation', mode: 'animation', assetUuid: 'clip-1' })).toBe(false);
+
+        await manager.undo({ scope: { editorType: 'animation', mode: 'animation' } });
+        expect(manager.hasScopedDifference(savedAnimation, { editorType: 'animation', mode: 'animation', assetUuid: 'clip-1' })).toBe(true);
+        expect(manager.hasScopedDifference(baseline, { editorType: 'animation', mode: 'animation', assetUuid: 'clip-1' })).toBe(false);
+    });
+
     it('groups child commands into one composite command', async () => {
         const manager = new SceneUndoManager();
         const first = new ControlledCommand('cmd-1');

--- a/src/core/scene/test/undo-manager.test.ts
+++ b/src/core/scene/test/undo-manager.test.ts
@@ -384,6 +384,38 @@ describe('SceneUndoManager', () => {
         expect(animationCommand.calls).toEqual(['undo:animation-command', 'redo:animation-command']);
     });
 
+    it('merges consecutive consumed scene property commands into one animation undo scope', async () => {
+        const manager = new SceneUndoManager();
+        const firstSceneCommand = new ControlledCommand('scene-property-command-1', true, { editorType: 'scene', mode: 'general' }, 'node:set-property');
+        const secondSceneCommand = new ControlledCommand('scene-property-command-2', true, { editorType: 'scene', mode: 'general' }, 'node:set-property');
+        const animationCommand = new ControlledCommand('animation-command', true, { editorType: 'animation', mode: 'animation' }, 'animation:clip-snapshot');
+
+        manager.push(firstSceneCommand);
+        manager.push(secondSceneCommand);
+        manager.pushWithPrevious(animationCommand, {
+            label: 'Animation Property Commit',
+            type: 'animation:property-commit',
+            scope: { editorType: 'animation', mode: 'animation' },
+            previousScope: { editorType: 'scene' },
+            previousTypes: ['node:set-property', 'component:set-property'],
+        });
+
+        expect(manager.getHistoryForTesting()).toHaveLength(1);
+        await expect(manager.undo({ scope: { editorType: 'animation', mode: 'animation' } })).resolves.toMatchObject({
+            success: true,
+        });
+        expect(animationCommand.calls).toEqual(['undo:animation-command']);
+        expect(secondSceneCommand.calls).toEqual(['undo:scene-property-command-2']);
+        expect(firstSceneCommand.calls).toEqual(['undo:scene-property-command-1']);
+
+        await expect(manager.redo({ scope: { editorType: 'animation', mode: 'animation' } })).resolves.toMatchObject({
+            success: true,
+        });
+        expect(firstSceneCommand.calls).toEqual(['undo:scene-property-command-1', 'redo:scene-property-command-1']);
+        expect(secondSceneCommand.calls).toEqual(['undo:scene-property-command-2', 'redo:scene-property-command-2']);
+        expect(animationCommand.calls).toEqual(['undo:animation-command', 'redo:animation-command']);
+    });
+
     it('does not absorb a previous command with the wrong type', async () => {
         const manager = new SceneUndoManager();
         const sceneCommand = new ControlledCommand('scene-create-command', true, { editorType: 'scene', mode: 'general' }, 'node:create');

--- a/src/core/scene/test/undo-manager.test.ts
+++ b/src/core/scene/test/undo-manager.test.ts
@@ -209,12 +209,20 @@ describe('SceneUndoManager', () => {
             },
         });
 
-        const recordingId = manager.beginRecording(['node-1'], { label: 'Move Node' });
+        const recordingId = manager.beginRecording(['node-1'], {
+            label: 'Move Node',
+            scope: { editorType: 'scene', nodePath: 'Canvas/Hero', propPath: 'position' },
+        });
         snapshots.set('node-1', { x: 1 });
         snapshots.set('node-2', { x: 20 });
 
         expect(await manager.endRecording(recordingId)).toBe(true);
         expect(manager.canUndo()).toBe(true);
+        expect(manager.getHistoryForTesting()[0].meta.scope).toEqual({
+            editorType: 'scene',
+            nodePath: 'Canvas/Hero',
+            propPath: 'position',
+        });
 
         await manager.undo();
         expect(applied).toEqual([[['node-1', { x: 0 }]]]);
@@ -265,6 +273,29 @@ describe('SceneUndoManager', () => {
         expect(manager.hasActiveRecording('node-1')).toBe(true);
 
         expect(await manager.endRecording(secondId)).toBe(false);
+        expect(manager.hasActiveRecording('node-1')).toBe(false);
+    });
+
+    it('releases active recording state when ending a snapshot recording throws', async () => {
+        let captureCount = 0;
+        const manager = new SceneUndoManager({
+            snapshotAdapter: {
+                capture: (uuids: string[]) => {
+                    captureCount++;
+                    if (captureCount === 2) {
+                        throw new Error('capture after failed');
+                    }
+                    return new Map(uuids.map(uuid => [uuid, { x: 0 }]));
+                },
+                apply: async () => ({ success: true }),
+                equals: () => false,
+            },
+        });
+
+        const recordingId = manager.beginRecording(['node-1'], { label: 'Move Node' });
+        expect(manager.hasActiveRecording('node-1')).toBe(true);
+
+        await expect(manager.endRecording(recordingId)).rejects.toThrow('capture after failed');
         expect(manager.hasActiveRecording('node-1')).toBe(false);
     });
 

--- a/src/core/scene/test/undo-manager.test.ts
+++ b/src/core/scene/test/undo-manager.test.ts
@@ -272,14 +272,45 @@ describe('SceneUndoManager', () => {
 
         expect(customCommand.calls).toEqual(['undo:custom-recording', 'redo:custom-recording']);
     });
+
+    it('does not undo the stack top when it is outside the requested scope', async () => {
+        const manager = new SceneUndoManager();
+        const animationCommand = new ControlledCommand('animation-command', true, { editorType: 'animation', mode: 'animation' });
+        const sceneCommand = new ControlledCommand('scene-command', true, { editorType: 'scene', mode: 'general' });
+
+        manager.push(animationCommand);
+        manager.push(sceneCommand);
+
+        await expect(manager.undo({ scope: { editorType: 'animation', mode: 'animation' } })).resolves.toMatchObject({
+            success: false,
+            reason: 'Cannot undo',
+        });
+        expect(animationCommand.calls).toEqual([]);
+        expect(sceneCommand.calls).toEqual([]);
+
+        await expect(manager.undo()).resolves.toMatchObject({ success: true, commandId: 'scene-command' });
+        expect(sceneCommand.calls).toEqual(['undo:scene-command']);
+
+        await expect(manager.undo({ scope: { editorType: 'animation', mode: 'animation' } })).resolves.toMatchObject({
+            success: true,
+            commandId: 'animation-command',
+        });
+        expect(animationCommand.calls).toEqual(['undo:animation-command']);
+
+        await expect(manager.redo({ scope: { editorType: 'animation', mode: 'animation' } })).resolves.toMatchObject({
+            success: true,
+            commandId: 'animation-command',
+        });
+        expect(animationCommand.calls).toEqual(['undo:animation-command', 'redo:animation-command']);
+    });
 });
 
 class ControlledCommand implements IUndoCommand {
     meta: IUndoCommandMeta;
     calls: string[] = [];
 
-    constructor(id: string, private ok = true) {
-        this.meta = { id, label: id, type: 'test', scope: {}, timestamp: Date.now() };
+    constructor(id: string, private ok = true, scope: IUndoCommandMeta['scope'] = {}) {
+        this.meta = { id, label: id, type: 'test', scope, timestamp: Date.now() };
     }
 
     async undo(): Promise<IUndoRedoResult> {

--- a/src/core/scene/test/undo-redo.testcase.ts
+++ b/src/core/scene/test/undo-redo.testcase.ts
@@ -37,6 +37,7 @@ import {
     NodeType,
     INodeInfo,
     ISetPropertyOptionsInfo,
+    IUndoOperationOptions,
     PrefabState,
 } from '../common';
 import { Rpc } from '../main-process/rpc';
@@ -82,12 +83,12 @@ function toComponentInfo(dump: any): any {
 
 // Undo/Redo 是 scene-process service 命名空间，不是 main-process / MCP 代理。
 const Undo = {
-    undo: () => request('Undo', 'undo'),
-    redo: () => request('Redo', 'redo'),
+    undo: (options?: IUndoOperationOptions) => request('Undo', 'undo', options === undefined ? [] : [options]),
+    redo: (options?: IUndoOperationOptions) => request('Redo', 'redo', options === undefined ? [] : [options]),
     clearHistory: () => request('Undo', 'clearHistory'),
     isDirty: () => request<boolean>('Undo', 'isDirty'),
-    canUndo: () => request<boolean>('Undo', 'canUndo'),
-    canRedo: () => request<boolean>('Redo', 'canRedo'),
+    canUndo: (options?: IUndoOperationOptions) => request<boolean>('Undo', 'canUndo', options === undefined ? [] : [options]),
+    canRedo: (options?: IUndoOperationOptions) => request<boolean>('Redo', 'canRedo', options === undefined ? [] : [options]),
     markSaved: () => request('Undo', 'markSaved'),
     beginGroup: (options?: { label?: string }) => request('Undo', 'beginGroup', [options]),
     endGroup: (groupId: string) => request('Undo', 'endGroup', [groupId]),
@@ -522,9 +523,11 @@ describe('Undo/Redo 集成测试', () => {
     describe('Component setProperty (snapshot)', () => {
         const path = 'UndoComponentSetProperty';
         const compPath = `${path}/cc.Label`;
+        const spriteSplashPath = 'UndoSpriteSplashSetProperty';
 
         beforeEach(async () => {
             await safeDelete(path);
+            await safeDelete(spriteSplashPath);
             await Node.createByType({ path, nodeType: NodeType.EMPTY });
             await Component.add({ nodePath: path, component: 'cc.Label' });
             await Undo.clearHistory();
@@ -532,6 +535,7 @@ describe('Undo/Redo 集成测试', () => {
 
         afterEach(async () => {
             await safeDelete(path);
+            await safeDelete(spriteSplashPath);
             await Undo.clearHistory();
         });
 
@@ -553,6 +557,40 @@ describe('Undo/Redo 集成测试', () => {
             const redoResult = await Undo.redo();
             expectUndoSuccess(redoResult);
             expect((await queryComp(compPath))!.properties.string.value).toBe('undo-redo-label');
+        });
+
+        it('setProperty undo restores SpriteSplash default SpriteFrame instead of null', async () => {
+            const created = await Node.createByType({ path: '/', name: spriteSplashPath, nodeType: NodeType.SPRITE_SPLASH });
+            if (!created) {
+                throw new Error('Failed to create SpriteSplash test node.');
+            }
+            const spriteSplashCompPath = `${created.path}/cc.Sprite`;
+            const before = await queryComp(spriteSplashCompPath);
+            const originalUuid = before?.properties.spriteFrame?.value?.uuid;
+            expect(typeof originalUuid).toBe('string');
+            expect(originalUuid).not.toBe('');
+
+            const spriteFrameAssets = await assetManager.queryAssetInfos({ pattern: 'db://internal/default_ui/default_editbox_bg.png/spriteFrame' });
+            if (spriteFrameAssets.length === 0 || !spriteFrameAssets[0].uuid) {
+                throw new Error('Failed to query internal SpriteFrame test asset.');
+            }
+            const nextUuid = spriteFrameAssets[0].uuid;
+            expect(nextUuid).not.toBe(originalUuid);
+
+            expect(await Component.setProperty({
+                componentPath: spriteSplashCompPath,
+                properties: { spriteFrame: { uuid: nextUuid } },
+            })).toBe(true);
+            expect((await queryComp(spriteSplashCompPath))!.properties.spriteFrame.value.uuid).toBe(nextUuid);
+
+            expect(await Undo.undo({ scope: { editorType: 'animation', mode: 'animation' } })).toMatchObject({
+                success: false,
+                reason: 'Cannot undo',
+            });
+            expect((await queryComp(spriteSplashCompPath))!.properties.spriteFrame.value.uuid).toBe(nextUuid);
+
+            expectUndoSuccess(await Undo.undo());
+            expect((await queryComp(spriteSplashCompPath))!.properties.spriteFrame.value.uuid).toBe(originalUuid);
         });
     });
 

--- a/workflow/build-scene-bundle.js
+++ b/workflow/build-scene-bundle.js
@@ -155,6 +155,32 @@ async function buildSceneBundle() {
                                 export var readJson = _gfs.readJson;
                             `;
                         }
+                        if (originalId === 'cc/mods-mgr') {
+                            return `
+                                function _createDeferredModule(id) {
+                                    return new Proxy({}, {
+                                        get: function(target, prop) {
+                                            if (typeof System !== 'undefined' && System.get) {
+                                                var real = System.get(id);
+                                                if (real) return real[prop];
+                                            }
+                                            return undefined;
+                                        },
+                                        has: function(target, prop) {
+                                            if (typeof System !== 'undefined' && System.get) {
+                                                var real = System.get(id);
+                                                if (real) return prop in real;
+                                            }
+                                            return false;
+                                        }
+                                    });
+                                }
+                                export function syncImport(id) {
+                                    return _createDeferredModule(id);
+                                }
+                                export default { syncImport: syncImport };
+                            `;
+                        }
                         if (originalId === 'proper-lockfile') {
                             return `
                                 const _lockfile = {


### PR DESCRIPTION
## 变更说明
- 新增 scene-process 内部 `AnimationService` 与 typed animation API，覆盖动画编辑 session 进入/退出、状态/root/clip/properties/time 查询、编辑时间采样、播放控制、切换编辑 clip、批量应用操作和保存。
- 补齐 `queryClip` / `applyOperations` 的 clip 数据读写闭环，支持 clip 基础属性、property curves、keyframe `keyData`、events、embedded players、auxiliary curves、材质 uniform 属性，以及 root path 归一化、duration 同步和骨骼动画可编辑操作限制。
- 接入 animation authoring 的 dirty / undo / redo 语义：批量操作失败回滚 clip snapshot，动画属性提交可合并前序 scene property undo，保存后刷新 dirty baseline，并处理 asset refresh/delete 与 self-save refresh。
- 完善编辑期事件链路与转发，新增/接入 `animation:state-changed`、`animation:time-changed`、`animation:clip-changed`、`animation:property-committed`，并补齐 preview bundle、service forwarding、DTS snapshot 和迁移文档。
- 增加动画编辑相关测试覆盖，包含 service enter/playback/save、animatable/property metadata、sampled state、clip operations、keyframe conflicts、snapshot undo、gizmo property commit、real curve key data 和 undo manager 等场景。

## 范围边界
- 本 PR 聚焦 scene-process 后端能力，不迁移 animator / Pink UI，不补 MCP/API/main-process proxy，也不完整复刻旧编辑器消息总线。
- 旧编辑器的结构型 property/node 操作、`spacingKeys`、`clearKeys`、embedded player 菜单查询等未覆盖项，以 `docs/dev/scene/animation-cli-capability-matrix.md` 为准。

## 测试覆盖
- 新增/更新 `src/core/scene/test/animation-*.test.ts`、`src/core/scene/test/gizmo-base-animation-commit.test.ts`、`src/core/scene/test/real-curve-key-data.test.ts`、`src/core/scene/test/undo-manager.test.ts` 等用例。
