### PR TITLE
fix(scene): live-sync design resolution to the scene view

### DIFF
--- a/src/core/preview/scripting-routes.ts
+++ b/src/core/preview/scripting-routes.ts
@@ -231,6 +231,34 @@ export const scriptingRoutes = [
         },
     },
     {
+        // 轻量接口：返回当前工程的设计分辨率，供场景进程在每次打开场景前刷新 cc.view。
+        // 直接读磁盘上的 cocos.config.json（配置真相源），绕开主进程配置缓存——
+        // configurationManager.reload() 的 load() 不会把新值同步回已注册的配置实例，
+        // Engine._config 也只在 configuration:save 时刷新，两者都可能慢一拍（改分辨率后要新建两次才生效的根因）。
+        url: '/scripting/engine/design-resolution',
+        async handler(req: Request, res: Response) {
+            const { Engine } = await import('../engine');
+            // 兜底：缓存/默认合并值
+            let dr = Engine.getConfig().designResolution as { width?: number; height?: number; fitWidth?: boolean; fitHeight?: boolean };
+            try {
+                const { configurationManager } = await import('../configuration');
+                const fse = await import('fs-extra');
+                const configPath = await configurationManager.getConfigPath();
+                if (await fse.pathExists(configPath)) {
+                    const json = await fse.readJSON(configPath);
+                    const disk = json?.engine?.designResolution;
+                    if (disk && typeof disk.width === 'number' && typeof disk.height === 'number') {
+                        // 以磁盘为准，缺失字段用缓存/默认补齐
+                        dr = { ...dr, ...disk };
+                    }
+                }
+            } catch (error) {
+                console.debug('[design-resolution] read cocos.config.json failed, fallback to cached:', error);
+            }
+            res.json(dr);
+        },
+    },
+    {
         url: '/scripting/engine/modules',
         async handler(req: Request, res: Response) {
             const { Engine } = await import('../engine');

--- a/src/core/scene/index.ts
+++ b/src/core/scene/index.ts
@@ -40,6 +40,36 @@ export async function init() {
     middlewareService.register('SceneScripting', SceneScriptingMiddleware);
     middlewareService.register('Scene', SceneMiddleware);
     await sceneConfigInstance.init();
+    await watchDesignResolutionChange();
+}
+
+let _designResolutionWatched = false;
+/**
+ * 监听工程设计分辨率变更，推送到浏览器场景刷新 cc.view。
+ *
+ * web 预览下场景跑在浏览器，主进程无法通过 RPC 反向调用浏览器 service（浏览器是 setWebTransport 客户端、
+ * 未 register(Service)）。因此改用 socket.io（live-reload 同款的 server→browser 通道）通知浏览器调用
+ * 它自己的 Engine.syncDesignResolution —— 等价于 Rpc.request('Engine','syncDesignResolution',[])。
+ * 对齐 cocos-editor 的 project:change-design-resolution 推送。
+ */
+async function watchDesignResolutionChange() {
+    if (_designResolutionWatched) {
+        return;
+    }
+    _designResolutionWatched = true;
+    const { configurationManager } = await import('../configuration');
+    const { MessageType } = await import('../configuration/script/interface');
+    const { socketService } = await import('../../server/socket');
+    const push = () => {
+        socketService.io?.emit('scene:invoke', { module: 'Engine', method: 'syncDesignResolution', args: [] });
+    };
+    // 进程内变更（PinK/调用方走 cli 配置系统 set/reload 时触发）
+    configurationManager.on(MessageType.Update, (key: string) => {
+        if (typeof key === 'string' && key.startsWith('engine.designResolution')) {
+            push();
+        }
+    });
+    configurationManager.on(MessageType.Reload, () => push());
 }
 
 /**

--- a/src/core/scene/scene-process/engine-bootstrap.ts
+++ b/src/core/scene/scene-process/engine-bootstrap.ts
@@ -146,4 +146,55 @@ export async function startup(options: {
             engine: DecoratorService.Engine,
         });
     }
+
+    await setupBrowserInvokeChannel(serverURL);
+}
+
+/**
+ * 建立主进程 → 浏览器场景的反向调用通道。
+ *
+ * web 预览下主进程无法通过 RPC 直接调浏览器 service（浏览器是 setWebTransport 客户端、未 register），
+ * 改用 socket.io：主进程 emit('scene:invoke', {module, method, args}) → 这里派发到对应场景 service。
+ * 放在场景 bundle 里（而非某个宿主页如 scene-editor.ejs），保证 cocos-cli 预览与 PinK 等所有宿主都生效；
+ * socket.io 客户端从服务端托管的 /socket.io/socket.io.js 动态加载，不依赖宿主页。
+ */
+async function setupBrowserInvokeChannel(serverURL: string) {
+    try {
+        await new Promise<void>((resolve) => {
+            if ((globalThis as any).io) {
+                resolve();
+                return;
+            }
+            const s = document.createElement('script');
+            s.src = `${serverURL}/socket.io/socket.io.js`;
+            s.onload = () => resolve();
+            s.onerror = () => resolve();
+            document.head.appendChild(s);
+        });
+        const io = (globalThis as any).io;
+        if (!io) {
+            console.warn('[engine-bootstrap] socket.io client unavailable, skip browser-invoke channel');
+            return;
+        }
+        const socket = io(serverURL);
+        const invoke = (module: string, method: string, args?: any[]) => {
+            try {
+                const svc = (DecoratorService as any)[module];
+                if (svc && typeof svc[method] === 'function') {
+                    svc[method](...(args || []));
+                }
+            } catch (e) {
+                console.warn('[scene:invoke] failed:', e);
+            }
+        };
+        socket.on('scene:invoke', (msg: { module?: string; method?: string; args?: any[] }) => {
+            if (msg && msg.module && msg.method) {
+                invoke(msg.module, msg.method, msg.args);
+            }
+        });
+        // 连接建立时同步一次设计分辨率（首次进入 / 断线重连时补齐错过的变更）
+        socket.on('connect', () => invoke('Engine', 'syncDesignResolution', []));
+    } catch (e) {
+        console.warn('[engine-bootstrap] setup browser-invoke channel failed:', e);
+    }
 }

--- a/src/core/scene/scene-process/service/engine.ts
+++ b/src/core/scene/scene-process/service/engine.ts
@@ -89,6 +89,59 @@ export class EngineService extends BaseService<IEngineEvents> implements IEngine
         }
     }
 
+    /**
+     * 从服务端拉取当前工程的设计分辨率，同步到 cc.view 并重排已打开场景里的 Canvas。
+     *
+     * 为什么必须手动重排：编辑器模式（EDITOR_NOT_IN_PREVIEW）下 cc.Canvas 不会注册
+     * 'design-resolution-changed' 监听（只有预览/运行模式才注册），只在场景实例化的 __preload 里
+     * 调 fitDesignResolution_EDITOR 对齐一次。因此改分辨率后：新实例化的场景会自动对齐，但
+     * 已打开、未重新实例化的场景不会更新——需要在这里手动调 fitDesignResolution_EDITOR
+     * （与 cocos-editor startup.initDesignResolution 的重排逻辑一致）。
+     *
+     * 在打开场景、重开同一场景、以及选中节点时都会调用：由于浏览器场景收不到主进程的配置变更推送，
+     * 只能在这些交互时机主动拉取比对。cc.view 未变化时直接返回（每次仅一次极小的读取），
+     * 变化时才更新并重排——因为 cc.view 每次变化都会连同重排当前场景，故不会出现“已更新但场景未重排”的情况。
+     */
+    public async syncDesignResolution() {
+        try {
+            const view = (cc as any).view;
+            if (!view || typeof fetch !== 'function') {
+                return;
+            }
+            const res = await fetch('/scripting/engine/design-resolution');
+            const dr = await res.json();
+            const width = Number(dr?.width);
+            const height = Number(dr?.height);
+            if (Number.isNaN(width) || Number.isNaN(height)) {
+                return;
+            }
+            const size = view.getDesignResolutionSize();
+            if (size && size.width === width && size.height === height) {
+                return; // 未变化，无需处理
+            }
+            // 保持与场景进程启动时一致的 ResolutionPolicy
+            view.setDesignResolutionSize(width, height, view.getResolutionPolicy());
+            // 手动对齐已打开场景里的 Canvas（编辑器模式不会自动响应 design-resolution-changed）
+            const scene = director.getScene();
+            if (scene) {
+                const canvases = (scene as any).getComponentsInChildren('cc.Canvas') as any[];
+                canvases.forEach((canvas) => {
+                    if (!canvas || !canvas.node) {
+                        return;
+                    }
+                    // 带 Widget 的 Canvas 由 Widget 对齐；未激活/未启用的跳过
+                    if (canvas.node.getComponent('cc.Widget') || !canvas.node.active || !canvas.enabled) {
+                        return;
+                    }
+                    canvas.fitDesignResolution_EDITOR?.();
+                });
+            }
+            void this.repaintInEditMode();
+        } catch (error) {
+            console.debug('[Engine] syncDesignResolution failed:', error);
+        }
+    }
+
     public async initCustomLayer(layers?: ICustomLayerConfig[]) {
         if (!Array.isArray(layers)) {
             return;

--- a/src/server/socket.ts
+++ b/src/server/socket.ts
@@ -11,7 +11,12 @@ export class SocketService {
      * @param server http 服务器
      */
     startup(server: HTTPServer | HTTPSServer) {
-        this.io = new Server(server);
+        // 允许跨域连接：PinK 的场景宿主是 vscode-webview://... 与本服务不同源，
+        // socket.io 有独立于 express 的 CORS 配置，不开这里 webview 会被浏览器拦截连接。
+        // 与 HTTP 路由的 CORS（server.ts 的 app.use(cors)，Access-Control-Allow-Origin: *）保持一致。
+        this.io = new Server(server, {
+            cors: { origin: '*', methods: ['GET', 'POST'] },
+        });
         this.io.on('connection', (socket: any) => {
             console.log(`socket ${socket.id} connected`);
             middlewareService.middlewareSocket.forEach((middleware) => {


### PR DESCRIPTION
Related issue:  https://zentao.sud.center/index.php?m=bug&f=view&bugID=439


## Summary
The scene view's design resolution (`cc.view`) was set only once at scene-process
startup. After changing the project design resolution, the editor `Canvas` kept
re-fitting its `UITransform.contentSize` to the stale value — a newly created/opened
scene showed the old size, and it only corrected after creating a scene a second time.

This propagates design-resolution changes to the browser scene process and refreshes
`cc.view` live, matching cocos-editor's behavior.

## Root cause
- In editor mode `cc.Canvas` overwrites `contentSize` from `cc.view.getDesignResolutionSize()`
  on `__preload` (scene instantiation) and does **not** subscribe to `design-resolution-changed`
  (only preview/runtime mode does).
- `cc.view`'s design resolution was set once at `engine-bootstrap` startup and never refreshed.
- In web preview the scene runs in the **browser**; the main process is a detached RPC
  endpoint and cannot call browser services directly, so there was no channel to notify it.

## Changes
- **`Engine.syncDesignResolution()`** (scene process): re-reads the current design resolution
  and re-applies it — `setDesignResolutionSize` + manual `fitDesignResolution_EDITOR()` on open
  Canvases + repaint (mirrors cocos-editor `initDesignResolution`).
- **`GET /scripting/engine/design-resolution`**: returns the value read directly from
  `cocos.config.json`, bypassing the main-process config cache (stale after a `reload`).
- **Main process** (`scene/index.ts`): on `engine.designResolution` change
  (`configurationManager` Update/Reload) notifies the browser scene over **socket.io** (`scene:invoke`).
- **Scene bundle** (`engine-bootstrap.ts`): sets up the socket listener itself and loads the
  socket.io client from the server, so it works under **any host** (cocos-cli preview and
  external IDEs such as PinK), not only the cli's own `scene-editor` page.
- **socket.io CORS** (`server/socket.ts`): enabled so cross-origin hosts (`vscode-webview://`) can connect.

## Testing
- Change the design resolution while a scene is open -> Canvas `contentSize` updates live (no reopen, no reselection).
- Create/open a scene after changing the resolution -> correct on the first try.
- Verified in PinK (vscode-webview host) after enabling socket.io CORS.
