### PR TITLE
fix(builder): respect engine module config key

### DIFF
--- a/src/core/builder/index.ts
+++ b/src/core/builder/index.ts
@@ -13,7 +13,6 @@ import utils from '../base/utils';
 import { middlewareService } from '../../server/middleware/core';
 import BuildMiddleware from './build.middleware';
 import { BuildGlobalInfo } from './share/global';
-import { fillIncludeModulesFromProjectConfig } from './share/common-options-validator';
 export { clearCache } from './cache';
 export type { BuildCacheScope, ClearCacheResult } from './cache';
 
@@ -75,9 +74,7 @@ export async function createBuildTask<P extends Platform>(platform: P, options?:
         realOptions = rightOptions;
     }
 
-    // 从项目配置中补充 includeModules
     realOptions.logDest = options.logDest;
-    await fillIncludeModulesFromProjectConfig(realOptions);
 
     const { BuildTask } = await import('./worker/builder');
     return new BuildTask(options.taskId, realOptions);

--- a/src/core/builder/share/common-options-validator.ts
+++ b/src/core/builder/share/common-options-validator.ts
@@ -467,26 +467,22 @@ export async function checkProjectSetting(options: IInternalBuildOptions | IInte
 
 }
 
-function getSelectedIncludeModulesFromEngineConfig(engineConfig: Record<string, any> | undefined): string[] | undefined {
+function getSelectedIncludeModulesFromEngineConfig(engineConfig: Record<string, any> | undefined, engineModulesConfigKey?: string): string[] | undefined {
     if (!engineConfig || typeof engineConfig !== 'object') {
         return undefined;
     }
 
-    if (Array.isArray(engineConfig.includeModules) && engineConfig.includeModules.length) {
-        return [...engineConfig.includeModules];
-    }
-
-    const configs = engineConfig.configs || engineConfig.modules?.configs;
+    const configs = engineConfig.configs;
     if (!configs || typeof configs !== 'object') {
         return undefined;
     }
 
-    const globalConfigKey = engineConfig.globalConfigKey || engineConfig.modules?.globalConfigKey || Object.keys(configs)[0];
-    const includeModules = globalConfigKey ? configs[globalConfigKey]?.includeModules : undefined;
+    const selectedConfigKey = engineModulesConfigKey || engineConfig.globalConfigKey;
+    const includeModules = selectedConfigKey ? configs[selectedConfigKey]?.includeModules : undefined;
     return Array.isArray(includeModules) && includeModules.length ? [...includeModules] : undefined;
 }
 
-async function loadIncludeModulesFromCocosConfig(): Promise<string[] | undefined> {
+async function loadIncludeModulesFromCocosConfig(engineModulesConfigKey?: string): Promise<string[] | undefined> {
     const configPath = join(builderConfig.projectRoot, 'cocos.config.json');
     console.log(`[Build] 尝试从 cocos.config.json 中加载引擎配置: ${configPath}`);
     if (!(await pathExists(configPath))) {
@@ -495,7 +491,7 @@ async function loadIncludeModulesFromCocosConfig(): Promise<string[] | undefined
 
     try {
         const config = await readJSON(configPath);
-        return getSelectedIncludeModulesFromEngineConfig(config?.engine);
+        return getSelectedIncludeModulesFromEngineConfig(config?.engine, engineModulesConfigKey);
     } catch (error) {
         console.warn(`[Build] 加载 cocos.config.json 中的引擎配置失败，将尝试旧配置: ${error}`);
         return undefined;
@@ -510,7 +506,7 @@ async function loadIncludeModulesFromCocosConfig(): Promise<string[] | undefined
 export async function fillIncludeModulesFromProjectConfig(options: IInternalBuildOptions | IInternalBundleBuildOptions | IBuildTaskOption): Promise<void> {
     if (!options.includeModules || !options.includeModules.length) {
         try {
-            const includeModules = await loadIncludeModulesFromCocosConfig();
+            const includeModules = await loadIncludeModulesFromCocosConfig(options.engineModulesConfigKey);
             if (includeModules?.length) {
                 console.log(`[Build] 从 cocos.config.json 中补充 includeModules: ${JSON.stringify(includeModules)}`);
                 options.includeModules = includeModules;
@@ -524,7 +520,7 @@ export async function fillIncludeModulesFromProjectConfig(options: IInternalBuil
             
             if (engineConfig?.modules?.configs) {
                 const configs = engineConfig.modules.configs;
-                const globalConfigKey = engineConfig.modules.globalConfigKey || Object.keys(configs)[0];
+                const globalConfigKey = options.engineModulesConfigKey || engineConfig.modules.globalConfigKey || Object.keys(configs)[0];
                 
                 if (globalConfigKey && configs[globalConfigKey]?.includeModules) {
                     options.includeModules = configs[globalConfigKey].includeModules;

--- a/src/core/builder/share/common-options-validator.ts
+++ b/src/core/builder/share/common-options-validator.ts
@@ -3,7 +3,6 @@
  */
 
 import { basename, isAbsolute, join } from 'path';
-import { pathExists, readJSON } from 'fs-extra';
 import { BundleCompressionTypes } from './bundle-utils';
 import { NATIVE_PLATFORM } from './platforms-options';
 import { IBuildSceneItem, IBuildTaskItemJSON, IBuildTaskOption } from '../@types';
@@ -15,7 +14,6 @@ import assetManager from '../../assets/manager/asset';
 import { Engine } from '../../engine';
 import builderConfig from './builder-config';
 import { validatorManager } from './validator-manager';
-import { CocosConfigLoader } from '../../configuration/migration/cocos-config-loader';
 interface ModuleConfig {
     match: (module: string) => boolean;
     default: string | boolean;
@@ -399,10 +397,35 @@ export function handleOverwriteProjectSettings(options: IBuildTaskOption) {
     }
 }
 
+function resolveIncludeModulesFromEngineConfig(
+    engineConfig: ReturnType<typeof Engine.getConfig> & {
+        configs?: Record<string, { includeModules?: string[] }>;
+        globalConfigKey?: string;
+    },
+    engineModulesConfigKey?: string,
+) {
+    if (engineModulesConfigKey) {
+        const includeModules = engineConfig.configs?.[engineModulesConfigKey]?.includeModules;
+        if (!includeModules?.length) {
+            throw new Error(`Invalid engineModulesConfigKey: ${engineModulesConfigKey}`);
+        }
+        return [...includeModules];
+    }
+
+    if (engineConfig.includeModules?.length) {
+        return [...engineConfig.includeModules];
+    }
+
+    const selectedConfigKey = engineConfig.globalConfigKey || Object.keys(engineConfig.configs || {})[0];
+    const includeModules = selectedConfigKey ? engineConfig.configs?.[selectedConfigKey]?.includeModules : undefined;
+    return includeModules?.length ? [...includeModules] : [];
+}
+
 export async function checkProjectSetting(options: IInternalBuildOptions | IInternalBundleBuildOptions) {
     options.engineInfo = options.engineInfo || Engine.getInfo();
 
-    const { designResolution, renderPipeline, physicsConfig, customLayers, sortingLayers, macroConfig, includeModules } = Engine.getConfig();
+    const engineConfig = Engine.getConfig();
+    const { designResolution, renderPipeline, physicsConfig, customLayers, sortingLayers, macroConfig } = engineConfig;
     // 默认 Canvas 设置
     if (!options.designResolution) {
         options.designResolution = designResolution;
@@ -443,7 +466,7 @@ export async function checkProjectSetting(options: IInternalBuildOptions | IInte
     }
 
     if (!options.includeModules || !options.includeModules.length) {
-        options.includeModules = includeModules;
+        options.includeModules = resolveIncludeModulesFromEngineConfig(engineConfig, options.engineModulesConfigKey);
     }
 
     // 确保 includeModules 中包含 'debug-renderer'
@@ -467,67 +490,3 @@ export async function checkProjectSetting(options: IInternalBuildOptions | IInte
 
 }
 
-function getSelectedIncludeModulesFromEngineConfig(engineConfig: Record<string, any> | undefined, engineModulesConfigKey?: string): string[] | undefined {
-    if (!engineConfig || typeof engineConfig !== 'object') {
-        return undefined;
-    }
-
-    const configs = engineConfig.configs;
-    if (!configs || typeof configs !== 'object') {
-        return undefined;
-    }
-
-    const selectedConfigKey = engineModulesConfigKey || engineConfig.globalConfigKey;
-    const includeModules = selectedConfigKey ? configs[selectedConfigKey]?.includeModules : undefined;
-    return Array.isArray(includeModules) && includeModules.length ? [...includeModules] : undefined;
-}
-
-async function loadIncludeModulesFromCocosConfig(engineModulesConfigKey?: string): Promise<string[] | undefined> {
-    const configPath = join(builderConfig.projectRoot, 'cocos.config.json');
-    console.log(`[Build] 尝试从 cocos.config.json 中加载引擎配置: ${configPath}`);
-    if (!(await pathExists(configPath))) {
-        return undefined;
-    }
-
-    try {
-        const config = await readJSON(configPath);
-        return getSelectedIncludeModulesFromEngineConfig(config?.engine, engineModulesConfigKey);
-    } catch (error) {
-        console.warn(`[Build] 加载 cocos.config.json 中的引擎配置失败，将尝试旧配置: ${error}`);
-        return undefined;
-    }
-}
-
-/**
- * 从项目配置中补充 includeModules
- * 优先使用项目根目录 cocos.config.json 中的 engine 配置；不存在时回退到 settings/v2/packages/engine.json
- * @param options 构建选项
- */
-export async function fillIncludeModulesFromProjectConfig(options: IInternalBuildOptions | IInternalBundleBuildOptions | IBuildTaskOption): Promise<void> {
-    if (!options.includeModules || !options.includeModules.length) {
-        try {
-            const includeModules = await loadIncludeModulesFromCocosConfig(options.engineModulesConfigKey);
-            if (includeModules?.length) {
-                console.log(`[Build] 从 cocos.config.json 中补充 includeModules: ${JSON.stringify(includeModules)}`);
-                options.includeModules = includeModules;
-                return;
-            }
-
-            const projectPath = builderConfig.projectRoot;
-            const configLoader = new CocosConfigLoader();
-            configLoader.initialize(projectPath);
-            const engineConfig = await configLoader.loadConfig('project', 'engine');
-            
-            if (engineConfig?.modules?.configs) {
-                const configs = engineConfig.modules.configs;
-                const globalConfigKey = options.engineModulesConfigKey || engineConfig.modules.globalConfigKey || Object.keys(configs)[0];
-                
-                if (globalConfigKey && configs[globalConfigKey]?.includeModules) {
-                    options.includeModules = configs[globalConfigKey].includeModules;
-                }
-            }
-        } catch (error) {
-            console.warn(`[Build] 加载项目引擎配置失败，将使用默认配置: ${error}`);
-        }
-    }
-}

--- a/src/core/builder/test/common-options-validator.spec.ts
+++ b/src/core/builder/test/common-options-validator.spec.ts
@@ -1,77 +1,126 @@
-import { pathExists, readJSON } from 'fs-extra';
+const mockGetConfig = jest.fn();
+const mockGetInfo = jest.fn();
 
-jest.mock('fs-extra', () => ({
-    pathExists: jest.fn(),
-    readJSON: jest.fn(),
-}));
-
-jest.mock('../share/builder-config', () => ({
-    __esModule: true,
-    default: {
-        projectRoot: 'E:/test-project',
+jest.mock('../../engine', () => ({
+    Engine: {
+        getConfig: mockGetConfig,
+        getInfo: mockGetInfo,
     },
 }));
 
-describe('common-options-validator', () => {
-    const pathExistsMock = pathExists as jest.Mock;
-    const readJSONMock = readJSON as jest.Mock;
+jest.mock('../../assets/manager/asset', () => ({
+    __esModule: true,
+    default: {
+        queryAsset: jest.fn(),
+        queryAssets: jest.fn(() => []),
+        queryUrl: jest.fn(),
+    },
+}));
 
+function createEngineConfig(overrides: Record<string, any> = {}) {
+    return {
+        designResolution: { width: 960, height: 640 },
+        renderPipeline: '',
+        physicsConfig: { defaultMaterial: '' },
+        customLayers: [],
+        sortingLayers: [],
+        macroConfig: {},
+        includeModules: ['default-module'],
+        splashScreen: {},
+        ...overrides,
+    };
+}
+
+describe('common-options-validator', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        mockGetInfo.mockReturnValue({ version: 'test' });
     });
 
-    describe('fillIncludeModulesFromProjectConfig', () => {
-        it('uses engineModulesConfigKey to select includeModules from cocos.config.json', async () => {
-            pathExistsMock.mockResolvedValue(true);
-            readJSONMock.mockResolvedValue({
-                engine: {
-                    configs: {
-                        defaultConfig: {
-                            includeModules: ['default-module'],
-                        },
-                        migrationsConfig: {
-                            includeModules: ['migration-module'],
-                        },
-                        'custom-config-97fe9ed0-e4b5-4f54-a122-959feba4586e': {
-                            includeModules: ['base', 'gfx-webgl', 'webview'],
-                        },
+    describe('checkProjectSetting', () => {
+        it('uses engineModulesConfigKey to select includeModules from Engine config', async () => {
+            mockGetConfig.mockReturnValue(createEngineConfig({
+                configs: {
+                    defaultConfig: {
+                        includeModules: ['default-module'],
                     },
-                    globalConfigKey: 'migrationsConfig',
+                    migrationsConfig: {
+                        includeModules: ['migration-module'],
+                    },
+                    'custom-config-97fe9ed0-e4b5-4f54-a122-959feba4586e': {
+                        includeModules: ['base', 'gfx-webgl', 'webview'],
+                    },
                 },
-            });
+                globalConfigKey: 'migrationsConfig',
+            }));
 
-            const { fillIncludeModulesFromProjectConfig } = await import('../share/common-options-validator');
+            const { checkProjectSetting } = await import('../share/common-options-validator');
             const options = {
                 engineModulesConfigKey: 'custom-config-97fe9ed0-e4b5-4f54-a122-959feba4586e',
             } as any;
 
-            await fillIncludeModulesFromProjectConfig(options);
+            await checkProjectSetting(options);
 
-            expect(options.includeModules).toEqual(['base', 'gfx-webgl', 'webview']);
+            expect(options.includeModules).toEqual(['base', 'gfx-webgl', 'webview', 'debug-renderer']);
         });
 
-        it('falls back to globalConfigKey when engineModulesConfigKey is not specified', async () => {
-            pathExistsMock.mockResolvedValue(true);
-            readJSONMock.mockResolvedValue({
-                engine: {
-                    configs: {
-                        defaultConfig: {
-                            includeModules: ['default-module'],
-                        },
-                        migrationsConfig: {
-                            includeModules: ['2d', '3d', 'base'],
-                        },
+        it('uses Engine includeModules when engineModulesConfigKey is not specified', async () => {
+            mockGetConfig.mockReturnValue(createEngineConfig({
+                includeModules: ['2d', '3d', 'base'],
+                configs: {
+                    defaultConfig: {
+                        includeModules: ['default-module'],
                     },
-                    globalConfigKey: 'migrationsConfig',
+                    migrationsConfig: {
+                        includeModules: ['migration-module'],
+                    },
                 },
-            });
+                globalConfigKey: 'migrationsConfig',
+            }));
 
-            const { fillIncludeModulesFromProjectConfig } = await import('../share/common-options-validator');
+            const { checkProjectSetting } = await import('../share/common-options-validator');
             const options = {} as any;
 
-            await fillIncludeModulesFromProjectConfig(options);
+            await checkProjectSetting(options);
 
-            expect(options.includeModules).toEqual(['2d', '3d', 'base']);
+            expect(options.includeModules).toEqual(['2d', '3d', 'base', 'debug-renderer']);
+        });
+
+        it('does not override explicitly provided includeModules', async () => {
+            mockGetConfig.mockReturnValue(createEngineConfig({
+                configs: {
+                    custom: {
+                        includeModules: ['custom-module'],
+                    },
+                },
+            }));
+
+            const { checkProjectSetting } = await import('../share/common-options-validator');
+            const options = {
+                engineModulesConfigKey: 'custom',
+                includeModules: ['explicit-module'],
+            } as any;
+
+            await checkProjectSetting(options);
+
+            expect(options.includeModules).toEqual(['explicit-module', 'debug-renderer']);
+        });
+
+        it('throws when engineModulesConfigKey does not exist', async () => {
+            mockGetConfig.mockReturnValue(createEngineConfig({
+                configs: {
+                    custom: {
+                        includeModules: ['custom-module'],
+                    },
+                },
+            }));
+
+            const { checkProjectSetting } = await import('../share/common-options-validator');
+            const options = {
+                engineModulesConfigKey: 'missing',
+            } as any;
+
+            await expect(checkProjectSetting(options)).rejects.toThrow('Invalid engineModulesConfigKey: missing');
         });
     });
 });

--- a/src/core/builder/test/common-options-validator.spec.ts
+++ b/src/core/builder/test/common-options-validator.spec.ts
@@ -1,0 +1,77 @@
+import { pathExists, readJSON } from 'fs-extra';
+
+jest.mock('fs-extra', () => ({
+    pathExists: jest.fn(),
+    readJSON: jest.fn(),
+}));
+
+jest.mock('../share/builder-config', () => ({
+    __esModule: true,
+    default: {
+        projectRoot: 'E:/test-project',
+    },
+}));
+
+describe('common-options-validator', () => {
+    const pathExistsMock = pathExists as jest.Mock;
+    const readJSONMock = readJSON as jest.Mock;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('fillIncludeModulesFromProjectConfig', () => {
+        it('uses engineModulesConfigKey to select includeModules from cocos.config.json', async () => {
+            pathExistsMock.mockResolvedValue(true);
+            readJSONMock.mockResolvedValue({
+                engine: {
+                    configs: {
+                        defaultConfig: {
+                            includeModules: ['default-module'],
+                        },
+                        migrationsConfig: {
+                            includeModules: ['migration-module'],
+                        },
+                        'custom-config-97fe9ed0-e4b5-4f54-a122-959feba4586e': {
+                            includeModules: ['base', 'gfx-webgl', 'webview'],
+                        },
+                    },
+                    globalConfigKey: 'migrationsConfig',
+                },
+            });
+
+            const { fillIncludeModulesFromProjectConfig } = await import('../share/common-options-validator');
+            const options = {
+                engineModulesConfigKey: 'custom-config-97fe9ed0-e4b5-4f54-a122-959feba4586e',
+            } as any;
+
+            await fillIncludeModulesFromProjectConfig(options);
+
+            expect(options.includeModules).toEqual(['base', 'gfx-webgl', 'webview']);
+        });
+
+        it('falls back to globalConfigKey when engineModulesConfigKey is not specified', async () => {
+            pathExistsMock.mockResolvedValue(true);
+            readJSONMock.mockResolvedValue({
+                engine: {
+                    configs: {
+                        defaultConfig: {
+                            includeModules: ['default-module'],
+                        },
+                        migrationsConfig: {
+                            includeModules: ['2d', '3d', 'base'],
+                        },
+                    },
+                    globalConfigKey: 'migrationsConfig',
+                },
+            });
+
+            const { fillIncludeModulesFromProjectConfig } = await import('../share/common-options-validator');
+            const options = {} as any;
+
+            await fillIncludeModulesFromProjectConfig(options);
+
+            expect(options.includeModules).toEqual(['2d', '3d', 'base']);
+        });
+    });
+});


### PR DESCRIPTION
Use build options.engineModulesConfigKey when selecting includeModules from cocos.config.json engine.configs.

Keep cocos.config.json handling focused on the migrated engine.configs/globalConfigKey structure, while preserving the legacy engine.json fallback path.

Add unit coverage for selecting a custom engine module config and falling back to engine.globalConfigKey.