### PR TITLE
Fix(preview): honor live project config (internal assets, physics backend, pipeline, spine)

### DIFF
--- a/packages/engine-compiler/src/core/compiler.ts
+++ b/packages/engine-compiler/src/core/compiler.ts
@@ -85,25 +85,13 @@ export class EngineCompiler {
         // Spine Hack Begin
         // 先移除 spine 所有版本
         allFeatures = allFeatures.filter((f) => !f.startsWith('spine-'));
-        //todo:暂时只打包 spine 3.8，迁移差不多完成后再支持其他版本
+        // dev-cli 预览 / 场景编辑器引擎：同时编入 spine-3.8 与 spine-4.2，配合 cc.config.json 的
+        // moduleOverrides（SPINE_3_8 && SPINE_4_2 → spine-*-dynamic.ts）实现运行时按 cocos.config.json
+        // 选定 spine 版本（改配置 + 硬刷新即生效，无需重编引擎）。两份 spine WASM/asm external 都会被编入。
+        // 注意：这里是 dev-cli 引擎编译器，与项目构建引擎（src/core/builder/.../separate-engine.ts）是
+        // 两条独立管线；项目构建仍按 includeModules 编译期单版本，产物包体不受影响。
         allFeatures.push('spine-3.8');
-        /* if (Editor) {
-            // 编辑器状态下，可以选择切换 spine 版本
-            const engineModule = (await Editor.Profile.getProject('engine', 'modules'));
-            const moduleConfig = engineModule?.configs[engineModule.globalConfigKey];
-
-            const includeModules: string[] | undefined = moduleConfig?.includeModules ?? [];
-            const spineVersion = includeModules?.find((m) => m.startsWith('spine-'));
-            if (spineVersion) {
-                allFeatures.push(spineVersion);
-            } else {
-                // Fallback to spine 3.8
-                allFeatures.push('spine-3.8');
-            }
-        } else {
-            编辑器打包默认只打 spine 3.8 版本
-            allFeatures.push('spine-3.8');
-        } */
+        allFeatures.push('spine-4.2');
         // Spine Hack End
         const env: StatsQuery.ConstantManager.ConstantOptions = {
             platform: 'NODEJS',

--- a/src/core/builder/worker/builder/asset-handler/bundle/index.ts
+++ b/src/core/builder/worker/builder/asset-handler/bundle/index.ts
@@ -476,7 +476,14 @@ export class BundleManager extends BuildTaskBase implements IBundleManager {
     private async initBundleRootAssets() {
         this.updateProcess('Init bundle root assets start...');
         if (this.bundleMap[INTERNAL]) {
-            const internalAssets = await queryPreloadAssetList(this.options.includeModules, this.options.engineInfo.typescript.path);
+            const enginePath = this.options.engineInfo.typescript.path;
+            // 预览用完整引擎，会初始化所有子系统（例如即便项目只用 2D 物理，3D PhysicsSystem 仍会构造并
+            // 加载其默认材质 default-physics-material）。因此预览下内置资源不按 includeModules 裁剪，
+            // 取「全部」feature 的 dependentAssets，与场景编辑器 Engine.queryInternalAssetList / 编辑器内置包
+            // 行为一致；否则会漏掉未选模块的内置资源，运行时报 "Failed to load builtinMaterial"。
+            const internalAssets = this.options.preview
+                ? await queryAllPreloadAssetList(enginePath)
+                : await queryPreloadAssetList(this.options.includeModules, enginePath);
             // 添加引擎依赖的预加载内置资源/脚本到 internal 包内
             console.debug(`Query preload assets/scripts from cc.config.json`);
             internalAssets.forEach((uuid) => {
@@ -944,6 +951,17 @@ async function queryPreloadAssetList(features: string[], enginePath: string) {
     preloadAssets.length = 0;
     traversalDependencies(features, featuresInJson);
     return Array.from(new Set(preloadAssets));
+}
+
+/**
+ * 查询「全部」内置预加载资源（不按 includeModules 裁剪）。
+ * 预览使用完整引擎，任何子系统都可能初始化并加载其内置资源，需保证全部可用，
+ * 与场景编辑器 Engine.queryInternalAssetList 行为一致。
+ */
+async function queryAllPreloadAssetList(enginePath: string) {
+    const ccConfigJson = await readJSON(join(enginePath, 'cc.config.json'));
+    const featureNames = Object.keys(ccConfigJson.features || {});
+    return queryPreloadAssetList(featureNames, enginePath);
 }
 
 /**

--- a/src/core/preview/live-reload.ts
+++ b/src/core/preview/live-reload.ts
@@ -15,8 +15,10 @@ let registered = false;
 // 保存已注册的监听源与回调，供 unregisterLiveReload 精确解绑，避免预览重启后监听泄漏。
 let scriptingRef: { off?: Function; removeListener?: Function } | null = null;
 let assetDBRef: { off?: Function; removeListener?: Function } | null = null;
+let configRef: { off?: Function; removeListener?: Function } | null = null;
 let onCompiled: (() => void) | null = null;
 let onRefreshFinish: (() => void) | null = null;
+let onConfigChanged: (() => void) | null = null;
 
 function removeListener(emitter: { off?: Function; removeListener?: Function } | null, event: string, fn: Function | null): void {
     if (!emitter || !fn) {
@@ -57,16 +59,25 @@ export async function registerLiveReload(): Promise<void> {
 
     const { default: scripting } = await import('../scripting');
     const { assetDBManager } = await import('../assets');
+    const { configurationManager } = await import('../configuration');
+    const { MessageType } = await import('../configuration/script/interface');
 
     onCompiled = () => scheduleReload();
     onRefreshFinish = () => scheduleReload();
+    // 工程配置变更（如切换物理后端 = 改 engine.includeModules）会影响预览 settings，
+    // 需清缓存并重载，否则预览仍用旧模块集（漏掉新后端的内置资源，报 builtinMaterial 加载失败）。
+    onConfigChanged = () => scheduleReload();
     scriptingRef = scripting as any;
     assetDBRef = assetDBManager as any;
+    configRef = configurationManager as any;
 
     // 脚本重编译成功
     scripting.on('compiled', onCompiled);
     // 资源批量刷新结束
     assetDBManager.on('assets:refresh-finish', onRefreshFinish);
+    // 工程配置变更（set / reload）
+    configurationManager.on(MessageType.Update, onConfigChanged);
+    configurationManager.on(MessageType.Reload, onConfigChanged);
 }
 
 /**
@@ -82,9 +93,14 @@ export function unregisterLiveReload(): void {
     }
     removeListener(scriptingRef, 'compiled', onCompiled);
     removeListener(assetDBRef, 'assets:refresh-finish', onRefreshFinish);
+    // MessageType.Update / MessageType.Reload
+    removeListener(configRef, 'configuration:update', onConfigChanged);
+    removeListener(configRef, 'configuration:reload', onConfigChanged);
     scriptingRef = null;
     assetDBRef = null;
+    configRef = null;
     onCompiled = null;
     onRefreshFinish = null;
+    onConfigChanged = null;
     registered = false;
 }

--- a/src/core/preview/preview-settings.ts
+++ b/src/core/preview/preview-settings.ts
@@ -20,7 +20,15 @@ export async function getCachedPreviewSettings(startScene = ''): Promise<IPrevie
     }
     const { getPreviewSettings, queryDefaultBuildConfigByPlatform } = await import('../builder');
     const { assetManager } = await import('../assets');
+    const { fillIncludeModulesFromProjectConfig } = await import('../builder/share/common-options-validator');
     const options = await queryDefaultBuildConfigByPlatform('web-desktop');
+    // 与正式构建（builder createBuildTask）保持一致：从 cocos.config.json 补全 includeModules。
+    // 预览路径原本不补全，options.includeModules 为空/默认时，内置资源包会漏掉当前模块（尤其是所选
+    // 物理后端 physics-cannon/ammo/physx/builtin）的 dependentAssets，比如内置物理材质
+    // default-physics-material (ba21476f)。运行时 PhysicsSystem.initDefaultMaterial() 便会
+    // builtinResMgr.get 到 null，报 "Failed to load builtinMaterial"(errorID 9642)。
+    // 同时这也让浏览器预览真正按项目配置的物理后端运行（切后端后能生效）。
+    await fillIncludeModulesFromProjectConfig(options as any);
     // 解析有效启动场景：显式入参 > 构建配置（扁平或 packages 嵌套）> 项目首个场景。
     // 预览模式下 builder 不会校验/补全 startScene（见 setting-task/asset.ts），
     // 留空或指向已删除的场景都会导致前端请求 /scene/<uuid>.json 404。

--- a/src/core/preview/scripting-routes.ts
+++ b/src/core/preview/scripting-routes.ts
@@ -262,7 +262,35 @@ export const scriptingRoutes = [
         url: '/scripting/engine/modules',
         async handler(req: Request, res: Response) {
             const { Engine } = await import('../engine');
-            const modules = Engine.getModules();
+            // 兜底：Engine 缓存的 includeModules
+            let modules = Engine.getModules();
+            // 直接读磁盘上的 cocos.config.json（配置真相源），绕开主进程配置缓存。
+            // 原因同 design-resolution 路由：configurationManager.reload() 不会把新值同步回已注册的配置实例，
+            // Engine._config 也只在 configuration:save 时刷新，改物理后端（= 改 engine.includeModules）后
+            // 不重启就拿不到新值，导致预览 game-boot 按旧模块列表选物理后端、切不过去。
+            try {
+                const { configurationManager } = await import('../configuration');
+                const fse = await import('fs-extra');
+                const configPath = await configurationManager.getConfigPath();
+                if (await fse.pathExists(configPath)) {
+                    const json = await fse.readJSON(configPath);
+                    const engineCfg = json?.engine;
+                    if (engineCfg) {
+                        // 与 Engine.syncConfig 的解析一致：优先 engine.includeModules，
+                        // 否则取选中的模块配置 engine.configs[globalConfigKey].includeModules。
+                        let disk = engineCfg.includeModules;
+                        if (!disk && engineCfg.configs) {
+                            const key = engineCfg.globalConfigKey || Object.keys(engineCfg.configs)[0];
+                            disk = engineCfg.configs?.[key]?.includeModules;
+                        }
+                        if (Array.isArray(disk)) {
+                            modules = disk;
+                        }
+                    }
+                }
+            } catch (error) {
+                console.debug('[engine/modules] read cocos.config.json failed, fallback to cached:', error);
+            }
             res.json(modules);
         },
     },

--- a/src/core/scene/scene-process/engine-bootstrap.ts
+++ b/src/core/scene/scene-process/engine-bootstrap.ts
@@ -95,6 +95,9 @@ export async function startup(options: {
     await Rpc.startup({ serverURL });
     await initLocalI18n();
 
+    // Spine 版本：dev-cli 引擎同时编入 spine-3.8 与 spine-4.2，按项目 includeModules 选定。
+    // 必须在 game.init（spine WASM 实例化 + spine-define patch）之前写入全局，供 spine-instantiate-dynamic 读取。
+    (globalThis as any)._CC_SPINE_VERSION = features.includes('spine-4.2') ? '4.2' : '3.8';
     cc.physics.selector.runInEditor = true;
     await cc.game.init(config);
 

--- a/static/web/game-boot.js
+++ b/static/web/game-boot.js
@@ -172,24 +172,6 @@ export default async function gameBoot() {
         await cc.game.run(async () => {
             cc.game.pause();
 
-            // 加载项目脚本（对齐场景编辑器 engine-bootstrap：在 game.run 之后、
-            // director.root / 渲染管线已就绪时才导入）。
-            // - 时机：必须在 game.run 之后。root 是在 run 触发首帧时创建的，若在 game.init 的
-            //   ProjectDataInitialization 阶段（如 settings.scripting.scriptPackages）导入，项目脚本
-            //   依赖图里的 custom-pipeline 模块会在 director.root 为 null 时构造 BuiltinPipelineBuilder
-            //   （读 root.pipelineEvent）而崩溃。此处 root 已就绪，不会崩。
-            // - 顺序：必须在 loadWithJson 之前。场景反序列化要用到已注册的用户组件类。
-            // - 入口：cce:/internal/x/prerequisite-imports 是 QuickPack 的项目脚本聚合入口（仅项目脚本，
-            //   import 'cc' 已被 pack import-map 重定向到全局 cc，见 scripting-routes.ts），执行它即
-            //   注册所有用户组件、并跑脚本的模块级副作用。此时 game 已 _inited，physics-settings 等
-            //   game.on(EVENT_GAME_INITED) 回调会在注册时立即触发（见 game.ts canRegisterEvent），
-            //   例如 2D 物理 debugDrawFlags 得以生效。
-            try {
-                await System.import('cce:/internal/x/prerequisite-imports');
-            } catch (e) {
-                console.warn('[Game Preview] load project scripts failed:', e);
-            }
-
             const json = await (await fetch(`${env.serverURL}/scene/${encodeURIComponent(launchScene)}.json`)).json();
             try {
                 launchScene = json[1]._id;

--- a/static/web/game-boot.js
+++ b/static/web/game-boot.js
@@ -71,6 +71,78 @@ export default async function gameBoot() {
             renderMode: 2,
         });
 
+        // 物理后端选择：预览用完整引擎（box2d / box2d-wasm / builtin 等所有后端都会在
+        // EVENT_PRE_SUBSYSTEM_INIT 时各自 register），默认后端只是「最后注册的那个」，未必等于项目实际
+        // 启用的后端，必须显式指定。模块列表取自 /scripting/engine/modules（= 项目 includeModules）。
+        //
+        // 关键时机与做法：物理世界在 game.init 内的 director.init() 首次创建（game.ts:
+        // emit(EVENT_PRE_SUBSYSTEM_INIT) → director.init() → DirectorEvent.INIT → PhysicsSystem2D
+        // 构造函数 createPhysicsWorld），用的是当时选定的后端。若在 game.init 之后再 switchTo，等于「先在
+        // 默认后端建好世界、再切换重建」，项目脚本在 EVENT_GAME_INITED 里设置的状态（如 2D 物理
+        // debugDrawFlags）会落到随后被丢弃的旧世界上而失效。
+        // 而 selector.switchTo 只有在世界「已存在」时才会真正改后端（世界为 null 时只重建、不改后端），
+        // 无法在世界创建前用它选后端。因此这里改为：在 game.init 之前注册 EVENT_PRE_SUBSYSTEM_INIT 回调，
+        // 该回调在各后端 register 之后、世界创建之前触发，用 register(id, wrapper) 把项目后端设为默认
+        // （register 在世界未创建时会把 selector 的 id/wrapper 指向该后端）。这样构造函数一次性就在正确
+        // 后端上创建世界、之后不再重建，无需事后 re-emit EVENT_GAME_INITED。
+        const Backends = {
+            'physics-cannon': 'cannon.js',
+            'physics-ammo': 'bullet',
+            'physics-builtin': 'builtin',
+            'physics-physx': 'physx',
+        };
+        const Backends2D = {
+            'physics-2d-box2d': 'box2d',
+            'physics-2d-box2d-wasm': 'box2d-wasm',
+            'physics-2d-builtin': 'builtin',
+        };
+        let backend = 'builtin';
+        let backend2d = 'builtin';
+        let includeModules = null;
+        try {
+            includeModules = await (await fetch(`${env.serverURL}/scripting/engine/modules`)).json();
+            (includeModules || []).forEach((m) => {
+                if (m in Backends) backend = Backends[m];
+                else if (m in Backends2D) backend2d = Backends2D[m];
+            });
+        } catch (e) {
+            console.warn('[Game Preview] query engine modules failed, use default physics backend:', e);
+        }
+        // 自定义渲染管线：customPipeline = includeModules 是否含 'custom-pipeline'（与 Engine.syncConfig 的推导
+        // 一致）。game.init 会读 settings.rendering.customPipeline 来建管线（game.ts:789）。这里用 disk-fresh 的
+        // includeModules 覆盖该值，使切换「自定义/内置管线」后 reload 即生效（无需重启），与物理后端同一数据源。
+        // 仅在成功取到 modules 时覆盖，避免请求失败时误把项目的自定义管线关掉。
+        if (Array.isArray(includeModules)) {
+            option.overrideSettings.rendering = Object.assign({}, option.overrideSettings.rendering, {
+                customPipeline: includeModules.includes('custom-pipeline'),
+            });
+        }
+
+        // Spine 版本：dev-cli 预览引擎同时编入 spine-3.8 与 spine-4.2（见 engine-compiler / cc.config.json
+        // dynamic override），运行时按项目 includeModules 选定。必须在引擎初始化（spine WASM 实例化 +
+        // spine-define patch）之前写入全局，供 spine-instantiate-dynamic.ts 读取。改配置 + 硬刷新即切换，
+        // 无需重编引擎/重启。真机构建走独立管线、编译期单版本，不受影响。
+        if (Array.isArray(includeModules)) {
+            globalThis._CC_SPINE_VERSION = includeModules.includes('spine-4.2') ? '4.2' : '3.8';
+        }
+        // selector 走全局 cc：System.import('cc') 是公开 ES 导出，不含 internal（cc.internal 为 undefined）；
+        // 引擎加载后把完整命名空间（含 internal.physics2d.selector）挂在 window.cc / globalThis.cc 上。
+        const ccGlobal = (typeof window !== 'undefined' && window.cc) || globalThis.cc || cc;
+        cc.game.once(cc.Game.EVENT_PRE_SUBSYSTEM_INIT, () => {
+            // 用已注册的 wrapper 重新 register，把项目后端设为默认（此时世界尚未创建）。
+            const seed = (selector, id) => {
+                if (selector && selector.backend && selector.backend[id]) {
+                    selector.register(id, selector.backend[id]);
+                }
+            };
+            try {
+                seed(ccGlobal.physics && ccGlobal.physics.selector, backend);
+                seed(ccGlobal.internal && ccGlobal.internal.physics2d && ccGlobal.internal.physics2d.selector, backend2d);
+            } catch (e) {
+                console.warn('[Game Preview] seed physics backend failed:', e);
+            }
+        });
+
         await cc.game.init(option);
 
         // 分辨率适配策略（仅浏览器预览）：按项目 designResolution 设置套用 ResolutionPolicy，
@@ -99,6 +171,25 @@ export default async function gameBoot() {
 
         await cc.game.run(async () => {
             cc.game.pause();
+
+            // 加载项目脚本（对齐场景编辑器 engine-bootstrap：在 game.run 之后、
+            // director.root / 渲染管线已就绪时才导入）。
+            // - 时机：必须在 game.run 之后。root 是在 run 触发首帧时创建的，若在 game.init 的
+            //   ProjectDataInitialization 阶段（如 settings.scripting.scriptPackages）导入，项目脚本
+            //   依赖图里的 custom-pipeline 模块会在 director.root 为 null 时构造 BuiltinPipelineBuilder
+            //   （读 root.pipelineEvent）而崩溃。此处 root 已就绪，不会崩。
+            // - 顺序：必须在 loadWithJson 之前。场景反序列化要用到已注册的用户组件类。
+            // - 入口：cce:/internal/x/prerequisite-imports 是 QuickPack 的项目脚本聚合入口（仅项目脚本，
+            //   import 'cc' 已被 pack import-map 重定向到全局 cc，见 scripting-routes.ts），执行它即
+            //   注册所有用户组件、并跑脚本的模块级副作用。此时 game 已 _inited，physics-settings 等
+            //   game.on(EVENT_GAME_INITED) 回调会在注册时立即触发（见 game.ts canRegisterEvent），
+            //   例如 2D 物理 debugDrawFlags 得以生效。
+            try {
+                await System.import('cce:/internal/x/prerequisite-imports');
+            } catch (e) {
+                console.warn('[Game Preview] load project scripts failed:', e);
+            }
+
             const json = await (await fetch(`${env.serverURL}/scene/${encodeURIComponent(launchScene)}.json`)).json();
             try {
                 launchScene = json[1]._id;


### PR DESCRIPTION
## Summary

Preview / scene-editor fixes so the full-engine preview honors the project's **live configuration**: internal builtin assets, physics backend, render pipeline, and spine version.

## Changes

### Full internal builtin assets
- The preview uses the full prebuilt engine, so preload **all** features' internal builtin assets (`queryAllPreloadAssetList`) instead of cropping by `includeModules`. Fixes missing internal dependent assets (e.g. the 3D `default-physics-material`) when a project enables only a subset of modules.

### Backend / pipeline / spine selection from live project config
- **game-boot**
  - Seed the 2D/3D physics backend at `EVENT_PRE_SUBSYSTEM_INIT` (before the physics world is created in `director.init`) so the world is built on the correct backend once and never rebuilt. `selector.switchTo` only switches when a world already exists, so it can't be used before creation; running it after `game.init` rebuilds the world and drops state such as 2D physics `debugDrawFlags`.
  - Derive `customPipeline` and the spine version from `includeModules` and apply them before `game.init`.
- **engine-bootstrap** (scene editor): inject the selected spine version before `game.init`.
- **scripting-routes**: `/scripting/engine/modules` reads `cocos.config.json` from disk, so backend / pipeline / spine changes apply on a browser refresh **without restarting the cli** (the in-process config cache is not refreshed on reload).
- **engine-compiler**: compile both `spine-3.8` and `spine-4.2` into the dev-cli engine so the preview / scene editor can select the version at runtime.

## Dependency

The spine runtime selection also needs the engine-side change (dynamic `moduleOverride` + dynamic spine files): **cocos/cocos4#184**. The two should land together.

Project builds are unaffected — they keep compile-time single-version spine selection (one wasm, minimal package size).

## Test

- Build `web-desktop`: engine internal assets resolve; the output bundles a single spine version.
- Preview: change the physics backend / render pipeline / spine version in `cocos.config.json`, then hard-refresh — the change applies without restarting the cli. 2D physics debug draw appears for projects that enable it.
