### PR TITLE
fix(preview): add missing fillIncludeModulesFromProjectConfig; add tsc type-check to PR CI

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -95,6 +95,10 @@ jobs:
         env:
           MINIMAL_DOWNLOAD_TOOLS: 'true'
 
+      - name: Type check
+        id: type-check
+        run: npx tsc -b
+
       - name: Run unit tests
         id: unit-tests
         run: npm run test:quiet

--- a/src/core/builder/share/common-options-validator.ts
+++ b/src/core/builder/share/common-options-validator.ts
@@ -421,8 +421,20 @@ function resolveIncludeModulesFromEngineConfig(
     return includeModules?.length ? [...includeModules] : [];
 }
 
-export async function checkProjectSetting(options: IInternalBuildOptions | IInternalBundleBuildOptions) {
-    options.engineInfo = options.engineInfo || Engine.getInfo();
+/**
+ * Fill `options.includeModules` from the project engine config (cocos.config.json) when it is empty,
+ * so the preview path produces the same `includeModules` as a formal build (checkProjectSetting).
+ * Does not override an already non-empty `includeModules`.
+ */
+export async function fillIncludeModulesFromProjectConfig(
+    options: { includeModules?: string[]; engineModulesConfigKey?: string },
+): Promise<void> {
+    if (!options.includeModules || !options.includeModules.length) {
+        options.includeModules = resolveIncludeModulesFromEngineConfig(Engine.getConfig(), options.engineModulesConfigKey);
+    }
+}
+
+export async function checkProjectSetting(options: IInternalBuildOptions | IInternalBundleBuildOptions) {    options.engineInfo = options.engineInfo || Engine.getInfo();
 
     const engineConfig = Engine.getConfig();
     const { designResolution, renderPipeline, physicsConfig, customLayers, sortingLayers, macroConfig } = engineConfig;


### PR DESCRIPTION
## Summary

Fix a `tsc -b` break on `main` and close the CI gap that let it through.

## Problem

`src/core/preview/preview-settings.ts` (and two build specs) reference `fillIncludeModulesFromProjectConfig`, but that function was **never defined/exported** in `common-options-validator.ts`, so a full `tsc -b` fails with:

```
preview-settings.ts:23 - error TS2339: Property 'fillIncludeModulesFromProjectConfig' does not exist ...
```

It was introduced by #717 but slipped through PR CI because:
- the specs `jest.mock('../share/common-options-validator', { fillIncludeModulesFromProjectConfig: jest.fn() })`, so they never touch the real (missing) export;
- `preview-settings.ts` is not in any unit test's import graph, so ts-jest never type-checked it;
- `pr-test.yml` only runs `npm run test:quiet` (jest) — it does not run `tsc -b`.

## Changes

- **common-options-validator**: add `fillIncludeModulesFromProjectConfig`, which fills `options.includeModules` from the engine project config using the existing `resolveIncludeModulesFromEngineConfig` (the same source the formal build uses in `checkProjectSetting`). It does not override an already non-empty `includeModules`.
- **.github/workflows/pr-test.yml**: add a `tsc -b` type-check step before the unit tests, so full-project type errors are caught in PR CI instead of only surfacing in a local build/publish.

## Test

- `npx tsc -b` passes.
- Existing unit tests unaffected (they mock the module).
