### PR TITLE
fix(scene): refresh component paths after node path changes

### DIFF
--- a/src/core/engine/editor-extends/index.ts
+++ b/src/core/engine/editor-extends/index.ts
@@ -21,8 +21,8 @@ import ComponentManager from './manager/component';
 export const UuidUtils = utils.UUID;
 
 export const Script = new ScriptManager();
-export const Node = new NodeManager();
 export const Component = new ComponentManager();
+export const Node = new NodeManager(Component);
 
 export let GeometryUtils: any;
 export let PrefabUtils: any;

--- a/src/core/engine/editor-extends/manager/component.ts
+++ b/src/core/engine/editor-extends/manager/component.ts
@@ -108,6 +108,32 @@ export default class ComponentManager extends EventEmitter {
         this._uuidToPath.set(component.uuid, path);
     }
 
+    remapNodeTreeComponents(node: any) {
+        if (!this.allow || !node) {
+            return;
+        }
+
+        const remap = (target: any) => {
+            if (Array.isArray(target?.components)) {
+                for (const component of target.components) {
+                    if (!component?.uuid || !this._map[component.uuid]) {
+                        continue;
+                    }
+                    this._removeComponentPath(component.uuid);
+                    this._mapComponentToPath(component);
+                }
+            }
+
+            if (Array.isArray(target?.children)) {
+                for (const child of target.children) {
+                    remap(child);
+                }
+            }
+        };
+
+        remap(node);
+    }
+
     _removeComponentPath(uuid: any) {
         if (!this._uuidToPath.has(uuid)) {
             return;
@@ -179,6 +205,9 @@ export default class ComponentManager extends EventEmitter {
             return;
         }
         this._map = {};
+        this._pathToUuid.clear();
+        this._caseInsensitivePathMap.clear();
+        this._uuidToPath.clear();
         // this._recycle = {};
 
     }

--- a/src/core/engine/editor-extends/manager/node.ts
+++ b/src/core/engine/editor-extends/manager/node.ts
@@ -6,6 +6,7 @@ import { EventEmitter } from 'events';
 import * as ObjectWalker from '../missing-reporter/object-walker';
 import utils from '../../../base/utils';
 import pathManager from './node-path-manager';
+import type ComponentManager from './component';
 
 const lodash = require('lodash');
 
@@ -16,6 +17,10 @@ export default class NodeManager extends EventEmitter {
     _map: { [index: string]: any } = {};
 
     private _parentChildren: Map<string, Set<string>> = new Map(); // 父节点UUID -> 子节点UUID集合
+
+    constructor(private readonly _componentManager?: ComponentManager) {
+        super();
+    }
 
     // 被删除节点集合,为了undo，编辑器不会把Node删除
     // _recycle: { [index: string]: any } = {};
@@ -111,6 +116,7 @@ export default class NodeManager extends EventEmitter {
 
         // 更新节点对象的名称
         node.name = newName;
+        this._componentManager?.remapNodeTreeComponents(node);
     }
 
     /**
@@ -147,6 +153,8 @@ export default class NodeManager extends EventEmitter {
         if (finalName && node.name !== finalName) {
             node.name = finalName;
         }
+
+        this._componentManager?.remapNodeTreeComponents(node);
 
         return newPath;
     }

--- a/src/core/engine/test/component-manager-change-uuid.test.ts
+++ b/src/core/engine/test/component-manager-change-uuid.test.ts
@@ -45,3 +45,29 @@ describe('ComponentManager.changeUUID', () => {
         expect(manager.getComponentFromPath(pathBefore)).toBe(manager.getComponent('comp-new'));
     });
 });
+
+describe('ComponentManager.clear', () => {
+    let manager: ComponentManager;
+
+    beforeEach(() => {
+        manager = new ComponentManager();
+        manager.allow = true;
+    });
+
+    function addComponent(uuid: string, nodeUuid: string) {
+        const comp = { uuid, _id: uuid, _className: 'TestComp', node: { uuid: nodeUuid } } as any;
+        manager.add(uuid, comp);
+        return comp;
+    }
+
+    it('clears component path indexes', () => {
+        addComponent('comp-old', 'node-1');
+
+        manager.clear();
+        const comp = addComponent('comp-new', 'node-1');
+
+        expect(manager.getPathFromUuid('comp-old')).toBe('');
+        expect(manager.getPathFromUuid('comp-new')).toBe('/node-1/TestComp');
+        expect(manager.getComponentFromPath('/node-1/TestComp')).toBe(comp);
+    });
+});

--- a/src/core/engine/test/node-manager-change-uuid.test.ts
+++ b/src/core/engine/test/node-manager-change-uuid.test.ts
@@ -1,5 +1,12 @@
 import NodeManager from '../editor-extends/manager/node';
+import ComponentManager from '../editor-extends/manager/component';
 import pathManager from '../editor-extends/manager/node-path-manager';
+
+(globalThis as any).cc = {
+    js: {
+        getClassName: (target: any) => target._className ?? 'UnknownComponent',
+    },
+};
 
 describe('NodeManager.changeNodeUUID', () => {
     let manager: NodeManager;
@@ -81,5 +88,74 @@ describe('NodeManager.updateNodeName', () => {
         expect(manager.getNodeByPath('C/B/D')).toBe(grandchild);
         expect(manager.getNodeByPath('A/B')).toBeNull();
         expect(manager.getNodeByPath('A/B/D')).toBeNull();
+    });
+});
+
+describe('NodeManager component path sync', () => {
+    let nodeManager: NodeManager;
+    let componentManager: ComponentManager;
+    let nodes: Record<string, any>;
+
+    beforeEach(() => {
+        componentManager = new ComponentManager();
+        componentManager.allow = true;
+        nodeManager = new NodeManager(componentManager);
+        nodeManager.allow = true;
+        nodes = {};
+        pathManager.clear();
+    });
+
+    function addNode(uuid: string, name: string, parentUuid?: string) {
+        const node = {
+            uuid,
+            name,
+            _id: uuid,
+            parent: parentUuid ? { uuid: parentUuid } : null,
+            children: [],
+            components: [],
+        } as any;
+        nodes[uuid] = node;
+        if (parentUuid && nodes[parentUuid]) {
+            nodes[parentUuid].children.push(node);
+            node.parent = nodes[parentUuid];
+        }
+        nodeManager.add(uuid, node);
+        return node;
+    }
+
+    function addComponent(uuid: string, node: any, className = 'cc.Button') {
+        const component = { uuid, _id: uuid, _className: className, node } as any;
+        node.components.push(component);
+        componentManager.add(uuid, component);
+        return component;
+    }
+
+    it('updates component paths under renamed node subtrees', () => {
+        addNode('parent', 'A', 'scene');
+        const child = addNode('child', 'B', 'parent');
+        const button = addComponent('button', child);
+
+        expect(componentManager.getPathFromUuid('button')).toBe('A/B/cc.Button');
+
+        nodeManager.updateNodeName('parent', 'C');
+
+        expect(componentManager.getPathFromUuid('button')).toBe('C/B/cc.Button');
+        expect(componentManager.getComponentFromPath('C/B/cc.Button')).toBe(button);
+        expect((componentManager as any)._pathToUuid.has('A/B/cc.Button')).toBe(false);
+    });
+
+    it('updates component paths under reparented node subtrees', () => {
+        addNode('target', 'A', 'scene');
+        addNode('moving', 'B', 'scene');
+        const child = addNode('child', 'C', 'moving');
+        const button = addComponent('button', child);
+
+        expect(componentManager.getPathFromUuid('button')).toBe('B/C/cc.Button');
+
+        nodeManager.updateNodeParent('moving', 'target');
+
+        expect(componentManager.getPathFromUuid('button')).toBe('A/B/C/cc.Button');
+        expect(componentManager.getComponentFromPath('A/B/C/cc.Button')).toBe(button);
+        expect((componentManager as any)._pathToUuid.has('B/C/cc.Button')).toBe(false);
     });
 });

--- a/src/core/scene/test/node-hierarchy.testcase.ts
+++ b/src/core/scene/test/node-hierarchy.testcase.ts
@@ -12,6 +12,7 @@ import {
     NodeType,
 } from '../common';
 import { NodeProxy } from '../main-process/proxy/node-proxy';
+import { ComponentProxy } from '../main-process/proxy/component-proxy';
 import { EditorProxy } from '../main-process/proxy/editor-proxy';
 import { Rpc } from '../main-process/rpc';
 import { SceneTestEnv } from './scene-test-env';
@@ -242,6 +243,32 @@ describe('Node 层级操作测试', () => {
 
             const afterChildren = await getChildNames(parent!.path);
             expect(afterChildren.length).toBe(beforeChildren.length + 2);
+        });
+
+        it('duplicate Button 后首次 query 使用副本组件路径和 target', async () => {
+            const button = await NodeProxy.createByType({ path: parent!.path, name: 'DupImmediateButton', nodeType: NodeType.BUTTON });
+            expect(button).toBeTruthy();
+
+            const [duplicatedPath] = await duplicate({ paths: [button!.path] });
+            expect(duplicatedPath).toBeTruthy();
+
+            const duplicatedDump = await rpcRequest('query', [{
+                path: duplicatedPath,
+                includeChildren: false,
+                includeComponents: true,
+            }]) as any;
+            expect(duplicatedDump).toBeTruthy();
+
+            const duplicatedButtonPath = `${duplicatedPath}/cc.Button`;
+            const buttonDump = duplicatedDump.__comps__?.find((comp: any) => comp.type === 'cc.Button');
+            expect(buttonDump).toBeTruthy();
+            expect(buttonDump.component_path).toBe(duplicatedButtonPath);
+            expect(buttonDump.value?.target?.value?.uuid).toBe(duplicatedDump.uuid.value);
+
+            const duplicatedButton = await ComponentProxy.query({ path: duplicatedButtonPath }) as any;
+            expect(duplicatedButton).toBeTruthy();
+            expect(duplicatedButton.path).toBe(duplicatedButtonPath);
+            expect((duplicatedButton.properties.target.value as any)?.uuid).toBe(duplicatedDump.uuid.value);
         });
     });
 


### PR DESCRIPTION
## 变更说明

- 撤回原先 scene-process 事件转发/排序补丁，不再在 API 层处理临时 clone 事件。
- 在 EditorExtends.Node 的 rename/reparent 路径变化后，递归刷新对应节点子树的组件路径索引。
- ComponentManager.clear() 同步清理组件路径索引，避免组件路径缓存跨场景生命周期残留。
- 增加 engine 层路径同步单测，以及 duplicate Button 后首次 query 的 scene 层回归测试。

## QA 验证步骤

1. 打开含 Button 的场景。
2. 复制或 duplicate 一个 Button 节点。
3. 立即选中新生成的 Button 节点，检查 Inspector 中 Button 组件的 Target 指向副本节点，且不显示 missing。