### PR TITLE
Fix prefab state restoration for node undo

### DIFF
--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -180,7 +180,8 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             resultNode.name = name;
         }
         // 挂到 prefab instance 下时，setParent 相关流程可能重新补回模板 prefab 信息。
-        if (shouldUnlinkPrefab) {
+        // 但在 prefab asset 编辑器中，新节点需要保留 setParent 补齐的 prefab 元数据。
+        if (shouldUnlinkPrefab && Service.Editor.getCurrentEditorType() !== 'prefab') {
             Service.Prefab.removePrefabInfoFromNode(resultNode, true);
         }
         if (checkUITransform) {

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -145,7 +145,8 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
          * 有 nodeType 说明是内置资源创建的，需要移除 prefab info
          * createByAsset 时，如果 assetType 不是 cc.Prefab 或者 unlinkPrefab 为 true，也需要移除
          */
-        if ('nodeType' in params || assetType !== 'cc.Prefab' || params.unlinkPrefab) {
+        const shouldUnlinkPrefab = 'nodeType' in params || assetType !== 'cc.Prefab' || params.unlinkPrefab;
+        if (shouldUnlinkPrefab) {
             Service.Prefab.removePrefabInfoFromNode(resultNode, true);
         }
 
@@ -177,6 +178,10 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         const name = path.split('/').pop();
         if (name && resultNode.name !== name) {
             resultNode.name = name;
+        }
+        // 挂到 prefab instance 下时，setParent 相关流程可能重新补回模板 prefab 信息。
+        if (shouldUnlinkPrefab) {
+            Service.Prefab.removePrefabInfoFromNode(resultNode, true);
         }
         if (checkUITransform) {
             nodeMgr.ensureUITransformComponent(resultNode);

--- a/src/core/scene/scene-process/service/undo/commands/node-structure-command-utils.ts
+++ b/src/core/scene/scene-process/service/undo/commands/node-structure-command-utils.ts
@@ -1,5 +1,6 @@
-import { editorExtrasTag, Node } from 'cc';
+import { Node } from 'cc';
 import { NodeEventType, type IUndoCommandMeta, type IUndoRedoResult } from '../../../../common';
+import { Service } from '../../core';
 import nodeMgr from '../../node/index';
 import { editorPrefabUtils } from '../../prefab/prefab-editor-utils';
 import {
@@ -27,6 +28,7 @@ export interface INodeStructureSnapshot {
     parentPath: string;
     siblingIndex: number;
     serializedJson: string;
+    prefabAssetUuid?: string;
     /** 子树 uuid 树（前序遍历的树根），用于 deserialize 后修复整棵树的 uuid */
     uuidTree: INodeUuidSnapshot;
 }
@@ -79,6 +81,7 @@ export function captureNodeStructureSnapshot(
         parentPath: parent ? getNodePath(parent) : '/',
         siblingIndex: node.getSiblingIndex(),
         serializedJson,
+        prefabAssetUuid: getPrefabAssetUuid(node),
         uuidTree: captureUuidTree(node),
     };
 }
@@ -105,19 +108,7 @@ function hasPrefabData(node: Node): boolean {
         return true;
     }
 
-    if (hasMountedRoot(node)) {
-        return true;
-    }
-
-    if ((node.components ?? []).some(component => component.__prefab || hasMountedRoot(component))) {
-        return true;
-    }
-
     return (node.children ?? []).some(child => hasPrefabData(child));
-}
-
-function hasMountedRoot(target: unknown): boolean {
-    return Boolean((target as any)?.[editorExtrasTag]?.mountedRoot);
 }
 
 function captureUuidTree(node: Node): INodeUuidSnapshot {
@@ -144,6 +135,7 @@ export async function restoreNodeStructureSnapshot(snapshot: INodeStructureSnaps
     }
 
     try {
+        await relinkPrefabAsset(restoredNode, snapshot);
         nodeMgr.emit('node:before-add', restoredNode);
         nodeMgr.emit('node:before-change', parent);
 
@@ -159,6 +151,27 @@ export async function restoreNodeStructureSnapshot(snapshot: INodeStructureSnaps
     } catch (error) {
         return failure(meta, error instanceof Error ? error.message : String(error));
     }
+}
+
+function getPrefabAssetUuid(node: Node): string | undefined {
+    const prefabInfo = node['_prefab'];
+    if (!prefabInfo?.instance) {
+        return undefined;
+    }
+
+    const asset = prefabInfo.asset as { _uuid?: string; uuid?: string } | undefined;
+    return asset?._uuid || asset?.uuid || undefined;
+}
+
+async function relinkPrefabAsset(node: Node, snapshot: INodeStructureSnapshot): Promise<void> {
+    if (!snapshot.prefabAssetUuid) {
+        return;
+    }
+
+    const prefabService = Service.Prefab as unknown as {
+        linkNodeWithPrefabAsset: (node: Node, assetUuid: string) => Promise<void>;
+    };
+    await prefabService.linkNodeWithPrefabAsset(node, snapshot.prefabAssetUuid);
 }
 
 export function removeNodeStructureSnapshot(

--- a/src/core/scene/test/undo-node-structure-serialization.test.ts
+++ b/src/core/scene/test/undo-node-structure-serialization.test.ts
@@ -41,6 +41,7 @@ jest.mock('../scene-process/service/undo/commands/command-utils-shared', () => (
     getNodePath: mockGetNodePath,
 }));
 
+import { editorExtrasTag } from 'cc';
 import { captureNodeStructureSnapshot } from '../scene-process/service/undo/commands/node-structure-command-utils';
 
 describe('captureNodeStructureSnapshot serialization', () => {
@@ -84,6 +85,26 @@ describe('captureNodeStructureSnapshot serialization', () => {
         expect((global as any).EditorExtends.serialize).not.toHaveBeenCalled();
         expect(JSON.parse(snapshot!.serializedJson)).toMatchObject({
             __type__: 'cc.Prefab',
+        });
+    });
+
+    it('serializes mounted plain nodes as node JSON instead of prefab JSON', () => {
+        const prefabRoot = new MockNode('prefab-root', 'PrefabRoot');
+        const node = new MockNode('mounted-button', 'Button') as MockNode & {
+            [editorExtrasTag]?: { mountedRoot?: MockNode };
+        };
+        node.path = '/PrefabRoot/Button';
+        node[editorExtrasTag] = { mountedRoot: prefabRoot };
+        node.components.push({ uuid: 'button-comp', __prefab: { fileId: 'button-comp-file-id' } });
+
+        const snapshot = captureNodeStructureSnapshot(node as any);
+
+        expect(snapshot).not.toBeNull();
+        expect((global as any).EditorExtends.serialize).toHaveBeenCalledWith(node);
+        expect(mockPrefabSerialize).not.toHaveBeenCalled();
+        expect(JSON.parse(snapshot!.serializedJson)).toMatchObject({
+            __type__: 'cc.Node',
+            uuid: 'mounted-button',
         });
     });
 

--- a/src/core/scene/test/undo-redo.testcase.ts
+++ b/src/core/scene/test/undo-redo.testcase.ts
@@ -27,6 +27,7 @@
 
 import {
     ICreateByNodeTypeParams,
+    ICreateByAssetParams,
     IDeleteNodeParams,
     IAddComponentOptions,
     IRemoveComponentOptions,
@@ -36,6 +37,7 @@ import {
     NodeType,
     INodeInfo,
     ISetPropertyOptionsInfo,
+    PrefabState,
 } from '../common';
 import { Rpc } from '../main-process/rpc';
 import { sceneWorker } from '../main-process/scene-worker';
@@ -99,6 +101,10 @@ const Undo = {
 const Node = {
     async createByType(params: ICreateByNodeTypeParams): Promise<INodeInfo | null> {
         const result = await request<any>('Node', 'createByType', [params]);
+        return result ? toNodeInfo(result) : null;
+    },
+    async createByAsset(params: ICreateByAssetParams): Promise<INodeInfo | null> {
+        const result = await request<any>('Node', 'createByAsset', [params]);
         return result ? toNodeInfo(result) : null;
     },
     delete: (params: IDeleteNodeParams) => request('Node', 'delete', [params]),
@@ -374,14 +380,17 @@ describe('Undo/Redo 集成测试', () => {
     // ========================================================================
     describe('CreateNode', () => {
         const path = 'UndoCreateNode';
+        const buttonName = 'UndoCreateButton';
 
         beforeEach(async () => {
             await safeDelete(path);
+            await safeDelete(`Canvas/${buttonName}`);
             await Undo.clearHistory();
         });
 
         afterEach(async () => {
             await safeDelete(path);
+            await safeDelete(`Canvas/${buttonName}`);
             await Undo.clearHistory();
         });
 
@@ -404,6 +413,19 @@ describe('Undo/Redo 集成测试', () => {
             expect(await queryNode(path)).not.toBeNull();
             expect(await Undo.canUndo()).toBe(true);
             expect(await Undo.canRedo()).toBe(false);
+        });
+
+        it('create Button by node type unlinks prefab metadata from the created node', async () => {
+            const created = await Node.createByType({ path: '/', name: buttonName, nodeType: NodeType.BUTTON });
+            expect(created).not.toBeNull();
+
+            const dump = await queryNodeDump(created!.path);
+
+            expect(dump.__prefab__).toBeNull();
+            expect((dump.__comps__ ?? []).map((comp: any) => comp.__compPrefab__)).toEqual(
+                expect.arrayContaining([null]),
+            );
+            expect((dump.__comps__ ?? []).every((comp: any) => comp.__compPrefab__ === null)).toBe(true);
         });
     });
 
@@ -1341,11 +1363,17 @@ describe('Undo/Redo 集成测试', () => {
         const unpackPath = 'UndoPrefabUnpack';
         const unlinkPath = 'UndoPrefabUnlink';
         const revertPath = 'UndoPrefabRevert';
+        const mountedButtonRootPath = 'UndoPrefabMountedButtonRoot';
+        const mountedButtonName = 'UndoPrefabMountedButton';
+        const deletePrefabAssetPath = 'UndoPrefabDeleteAsset';
+        const deletePrefabInstanceName = 'UndoPrefabDeleteInstance';
         const createURL = `${SceneTestEnv.targetDirectoryURL}/UndoPrefabCreate.prefab`;
         const applyURL = `${SceneTestEnv.targetDirectoryURL}/UndoPrefabApply.prefab`;
         const unpackURL = `${SceneTestEnv.targetDirectoryURL}/UndoPrefabUnpack.prefab`;
         const unlinkURL = `${SceneTestEnv.targetDirectoryURL}/UndoPrefabUnlink.prefab`;
         const revertURL = `${SceneTestEnv.targetDirectoryURL}/UndoPrefabRevert.prefab`;
+        const mountedButtonURL = `${SceneTestEnv.targetDirectoryURL}/${mountedButtonRootPath}.prefab`;
+        const deletePrefabURL = `${SceneTestEnv.targetDirectoryURL}/${deletePrefabAssetPath}.prefab`;
 
         afterEach(async () => {
             await safeDelete(createPath);
@@ -1353,6 +1381,9 @@ describe('Undo/Redo 集成测试', () => {
             await safeDelete(unpackPath);
             await safeDelete(unlinkPath);
             await safeDelete(revertPath);
+            await safeDelete(mountedButtonRootPath);
+            await safeDelete(deletePrefabAssetPath);
+            await safeDelete(deletePrefabInstanceName);
             await Undo.clearHistory();
         });
 
@@ -1507,6 +1538,82 @@ describe('Undo/Redo 集成测试', () => {
             expect(await Undo.canUndo()).toBe(true);
             const reverted = await queryNode(revertPath);
             expect(reverted?.properties.scale).toEqual({ x: 1, y: 1, z: 1 });
+        });
+
+        it('delete undo restores a prefab instance without losing its prefab asset', async () => {
+            const source = await Node.createByType({ path: '/', name: deletePrefabAssetPath, nodeType: NodeType.EMPTY });
+            expect(source).not.toBeNull();
+            await Prefab.createPrefabFromNode({
+                nodePath: source!.path,
+                dbURL: deletePrefabURL,
+                overwrite: true,
+            });
+            const created = await Node.createByAsset({
+                dbURL: deletePrefabURL,
+                path: '/',
+                name: deletePrefabInstanceName,
+            });
+            expect(created).not.toBeNull();
+            await expectPrefabInstance(created!.path, true, 'before deleting prefab instance');
+            const createdTree = await Node.queryNodeTree({ path: created!.path });
+            expect(createdTree.prefab.state).toBe(PrefabState.PrefabInstance);
+            await Undo.clearHistory();
+
+            const ok = await Node.delete({ path: created!.path, keepWorldTransform: false });
+            expect(ok).not.toBeNull();
+            expect(await queryNode(created!.path)).toBeNull();
+
+            const undoResult = await Undo.undo();
+            expectUndoSuccess(undoResult);
+
+            await expectPrefabInstance(created!.path, true, 'after undo deleting prefab instance');
+            const restoredTree = await Node.queryNodeTree({ path: created!.path });
+            expect(restoredTree.prefab.state).toBe(PrefabState.PrefabInstance);
+        });
+
+        it('mounted Button created under a prefab instance stays a plain added child after delete undo', async () => {
+            const root = await Node.createByType({ path: '/', name: mountedButtonRootPath, nodeType: NodeType.EMPTY });
+            expect(root).not.toBeNull();
+            const rootPath = root!.path;
+            await Component.add({ nodePath: rootPath, component: 'cc.Canvas' });
+            await Prefab.createPrefabFromNode({
+                nodePath: rootPath,
+                dbURL: mountedButtonURL,
+                overwrite: true,
+            });
+            await expectPrefabInstance(rootPath, true, 'before creating mounted button');
+            await Undo.clearHistory();
+
+            const created = await Node.createByType({
+                path: rootPath,
+                name: mountedButtonName,
+                nodeType: NodeType.BUTTON,
+            });
+            expect(created).not.toBeNull();
+
+            const createdDump = await queryNodeDump(created!.path);
+            const createdTree = await Node.queryNodeTree({ path: created!.path });
+            expect(createdDump.__prefab__).toBeNull();
+            expect((createdDump.__comps__ ?? []).every((comp: any) => comp.__compPrefab__ === null)).toBe(true);
+            expect(createdDump.mountedRoot).toBeTruthy();
+            expect(createdTree.prefab.state).toBe(PrefabState.NotAPrefab);
+            expect(createdTree.prefab.isAddedChild).toBe(true);
+
+            await Undo.clearHistory();
+            const ok = await Node.delete({ path: created!.path, keepWorldTransform: false });
+            expect(ok).not.toBeNull();
+            expect(await queryNode(created!.path)).toBeNull();
+
+            const undoResult = await Undo.undo();
+            expectUndoSuccess(undoResult);
+
+            const restoredDump = await queryNodeDump(created!.path);
+            const restoredTree = await Node.queryNodeTree({ path: created!.path });
+            expect(restoredDump.__prefab__).toBeNull();
+            expect((restoredDump.__comps__ ?? []).every((comp: any) => comp.__compPrefab__ === null)).toBe(true);
+            expect(restoredDump.mountedRoot).toBeTruthy();
+            expect(restoredTree.prefab.state).toBe(PrefabState.NotAPrefab);
+            expect(restoredTree.prefab.isAddedChild).toBe(true);
         });
     });
 


### PR DESCRIPTION
## 变更说明

- 创建内置 Button 或非 Prefab 资源节点时，在挂载父节点前后都清理 prefab info，避免挂到 Prefab instance 下后重新带上模板 prefab 数据。
- Undo 节点结构快照时，不再因为 mountedRoot 或组件 __prefab 把普通 mounted child 当 Prefab 序列化；仅真实节点级 _prefab 走 Prefab 序列化。
- 删除真实 Prefab instance 后 Undo 时记录并恢复 prefab asset uuid，避免恢复后进入 PrefabLostAsset（红色）状态。
- 补充普通 Button、Prefab instance 下新增 Button、真实 Prefab 删除 Undo 的回归覆盖。

## QA 验证步骤

1. 在场景中创建 Button，删除 Button 后执行 Undo，确认恢复后的 Button 仍是普通 added child，不显示红色 PrefabLostAsset 状态。
2. 在场景中实例化一个 Prefab，删除该 Prefab instance 后执行 Undo，确认节点恢复后仍关联原 Prefab asset，不显示红色 PrefabLostAsset 状态。
