### PR TITLE
[break] fix: support joint texture layout preview

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -3351,6 +3351,14 @@ export declare interface IRedirectInfo {
     type: string;
     uuid: string;
 }
+export declare interface IResolvedChunkContent {
+    skeleton: number;
+    clips: number[];
+}
+export declare interface IResolvedCustomJointTextureLayout {
+    textureLength: number;
+    contents: IResolvedChunkContent[];
+}
 export declare interface IScriptInfo {
     file: string;
     uuid: string;
@@ -3444,7 +3452,7 @@ export declare interface ISettings {
     };
     splashScreen?: ISplashSetting;
     animation: {
-        customJointTextureLayouts?: ICustomJointTextureLayout[];
+        customJointTextureLayouts?: IResolvedCustomJointTextureLayout[];
     };
     profiling?: {
         showFPS: boolean;
@@ -7233,6 +7241,24 @@ export declare interface IInitEngineInfo {
     writablePath: string;
     serverURL?: string;
 }
+export declare interface IJointTextureLayoutDeviceTip {
+    level: JointTextureLayoutDeviceTipLevel;
+    message: string;
+}
+export declare interface IJointTextureLayoutPreviewItem {
+    index: number;
+    textureLength: number;
+    calculatedTextureLength: number;
+    fallbackTextureLength?: number;
+    resolvedLayout: IResolvedCustomJointTextureLayout | null;
+    tip: IJointTextureLayoutDeviceTip;
+    missingAssets: string[];
+}
+export declare interface IJointTextureLayoutPreviewResult {
+    layouts: IJointTextureLayoutPreviewItem[];
+    resolvedLayouts: IResolvedCustomJointTextureLayout[];
+    missingAssets: string[];
+}
 export declare interface IModuleConfig {
     moduleTreeDump: {
         default: IModules;
@@ -7277,6 +7303,14 @@ export declare interface IPhysicsMaterial {
     spinningFriction: number;
     restitution: number;
 }
+export declare interface IResolvedChunkContent {
+    skeleton: number;
+    clips: number[];
+}
+export declare interface IResolvedCustomJointTextureLayout {
+    textureLength: number;
+    contents: IResolvedChunkContent[];
+}
 export declare interface ISplashBackgroundColor {
     x: number;
     y: number;
@@ -7305,6 +7339,7 @@ export declare interface IVec3Like {
     y: number;
     z: number;
 }
+export declare type JointTextureLayoutDeviceTipLevel = 'valid' | 'warning' | 'error';
 export declare type MacroItem = {
     key: string;
     value: boolean;
@@ -7321,6 +7356,7 @@ export declare interface ModuleRenderConfig {
     version: string;
     migrationScript?: string;
 }
+export declare function queryJointTextureLayoutPreview(): Promise<IJointTextureLayoutPreviewResult>;
 export declare function queryLayerBuiltin(): Promise<{
     name: string;
     value: number;
@@ -7735,6 +7771,7 @@ export declare namespace Engine {
         getInfo,
         getConfig,
         getRenderConfig,
+        queryJointTextureLayoutPreview,
         initEngine,
         startEngineCompilation,
         queryLayerBuiltin,
@@ -7748,6 +7785,12 @@ export declare namespace Engine {
         IPhysicsMaterial,
         ICustomJointTextureLayout,
         IChunkContent,
+        IResolvedCustomJointTextureLayout,
+        IResolvedChunkContent,
+        JointTextureLayoutDeviceTipLevel,
+        IJointTextureLayoutDeviceTip,
+        IJointTextureLayoutPreviewItem,
+        IJointTextureLayoutPreviewResult,
         MacroItem,
         ISplashBackgroundColor,
         ISplashSetting,
@@ -8198,6 +8241,24 @@ export declare interface IInitEngineInfo {
     writablePath: string;
     serverURL?: string;
 }
+export declare interface IJointTextureLayoutDeviceTip {
+    level: JointTextureLayoutDeviceTipLevel;
+    message: string;
+}
+export declare interface IJointTextureLayoutPreviewItem {
+    index: number;
+    textureLength: number;
+    calculatedTextureLength: number;
+    fallbackTextureLength?: number;
+    resolvedLayout: IResolvedCustomJointTextureLayout | null;
+    tip: IJointTextureLayoutDeviceTip;
+    missingAssets: string[];
+}
+export declare interface IJointTextureLayoutPreviewResult {
+    layouts: IJointTextureLayoutPreviewItem[];
+    resolvedLayouts: IResolvedCustomJointTextureLayout[];
+    missingAssets: string[];
+}
 export declare interface ImageAssetUserData {
     type: ImageImportType;
     flipVertical?: boolean;
@@ -8345,6 +8406,14 @@ export declare interface IRedirectInfo {
     type: string;
     uuid: string;
 }
+export declare interface IResolvedChunkContent {
+    skeleton: number;
+    clips: number[];
+}
+export declare interface IResolvedCustomJointTextureLayout {
+    textureLength: number;
+    contents: IResolvedChunkContent[];
+}
 export declare interface ISocketConfig {
     connection: (socket: any) => void;
     disconnect: (socket: any) => void;
@@ -8424,6 +8493,7 @@ export declare interface IVirtualAssetUserData {
     [key: string]: any;
 }
 export declare type JavaScriptAssetUserData = ScriptModuleUserData | PluginScriptUserData;
+export declare type JointTextureLayoutDeviceTipLevel = 'valid' | 'warning' | 'error';
 export declare interface JsonAssetUserData {
     json5?: boolean;
 }
@@ -8715,6 +8785,7 @@ export declare type QueryAssetType = 'asset' | 'script' | 'all';
 export declare function queryAssetUserDataConfig(urlOrUuidOrPath: string): Promise<false | Record<string, IUerDataConfigItem> | undefined>;
 export declare function queryAssetUsers(uuidOrUrl: string, type?: QueryAssetType): Promise<string[]>;
 export declare function queryCreateMap(): Promise<ICreateMenuInfo[]>;
+export declare function queryJointTextureLayoutPreview(): Promise<IJointTextureLayoutPreviewResult>;
 export declare function queryLayerBuiltin(): Promise<{
     name: string;
     value: number;

--- a/src/core/assets/utils.ts
+++ b/src/core/assets/utils.ts
@@ -275,6 +275,7 @@ export async function getRawInstanceFromImportFile(path: string, assetInfo: { uu
     result.asset = deserializedAsset;
     result.detail = deserializeDetails;
     // this.depend[asset.uuid] = [...new Set(deserializeDetails.uuidList)] as string[];
+    return result;
 }
 
 async function transformCCON(path: string) {

--- a/src/core/builder/@types/public/build-result.ts
+++ b/src/core/builder/@types/public/build-result.ts
@@ -2,7 +2,7 @@
  * settings.js 里定义的数据
  */
 
-import { ICustomJointTextureLayout, ISplashSetting } from '../../../engine/@types/public';
+import { IResolvedCustomJointTextureLayout, ISplashSetting } from '../../../engine/@types/public';
 import { UUID, IPhysicsConfig, IOrientation } from './options';
 import { ITextureCompressType, ITextureCompressFormatType, ICustomConfig } from './texture-compress';
 // ****************************** settings ************************************************
@@ -73,7 +73,7 @@ export interface ISettings {
     };
     splashScreen?: ISplashSetting;
     animation: {
-        customJointTextureLayouts?: ICustomJointTextureLayout[];
+        customJointTextureLayouts?: IResolvedCustomJointTextureLayout[];
     };
     profiling?: {
         showFPS: boolean;

--- a/src/core/builder/worker/builder/tasks/setting-task/utils/project-options.ts
+++ b/src/core/builder/worker/builder/tasks/setting-task/utils/project-options.ts
@@ -8,6 +8,7 @@ import { ISettings, IPhysicsConfig } from '../../../../../@types';
 import { IInternalBuildOptions } from '../../../../../@types/protected';
 import utils from '../../../../../../base/utils';
 import { Engine } from '../../../../../../engine';
+import { resolveCustomJointTextureLayouts } from '../../../../../../engine/joint-texture-layout';
 import { configurationManager } from '../../../../../../configuration';
 import { ISplashSetting } from '../../../../../../engine/@types/config';
 import { GlobalPaths } from '../../../../../../../global';
@@ -43,7 +44,7 @@ export async function patchOptionsToSettings(options: IInternalBuildOptions, set
     settings.rendering.renderPipeline = options.renderPipeline === defaultPipeline ? '' : options.renderPipeline;
     settings.rendering.customPipeline = options.customPipeline;
     const { customJointTextureLayouts, downloadMaxConcurrency } = Engine.getConfig();
-    settings.animation.customJointTextureLayouts = customJointTextureLayouts || [];
+    settings.animation.customJointTextureLayouts = await resolveCustomJointTextureLayouts(customJointTextureLayouts);
     if (options.includeModules.includes('custom-pipeline')) {
         settings.rendering.effectSettingsPath = 'src/effect.bin';
     }

--- a/src/core/configuration/test/metadata.test.ts
+++ b/src/core/configuration/test/metadata.test.ts
@@ -83,13 +83,31 @@ describe('configuration metadata', () => {
         await runtime.Engine.init(TestGlobalEnv.engineRoot);
 
         const nodes = await runtime.getMetadata();
+        const engineRenderingNode = findNode(nodes, 'engine.rendering');
+        const engineJointTextureLayoutNode = findNode(nodes, 'engine.jointTextureLayout');
         const engineModuleNode = findNode(nodes, 'engine.moduleConfig');
         const engineMacroNode = findNode(nodes, 'engine.macroConfig');
+        const jointTextureLayoutsProperty = findProperty(engineJointTextureLayoutNode, 'engine.customJointTextureLayouts');
         const globalConfigKeyProperty = findProperty(engineModuleNode, 'engine.globalConfigKey');
         const configsProperty = findProperty(engineModuleNode, 'engine.configs');
         const macroProperty = findProperty(engineMacroNode, 'engine.macroConfig.ENABLE_TILEDMAP_CULLING');
         const configItemSchema = configsProperty.additionalProperties as ICocosConfigurationPropertySchema | undefined;
+        const jointTextureLayoutItemSchema = Array.isArray(jointTextureLayoutsProperty.items)
+            ? jointTextureLayoutsProperty.items[0]
+            : jointTextureLayoutsProperty.items;
+        const jointTextureContentSchema = jointTextureLayoutItemSchema?.properties?.contents;
+        const jointTextureContentItemSchema = Array.isArray(jointTextureContentSchema?.items)
+            ? jointTextureContentSchema.items[0]
+            : jointTextureContentSchema?.items;
 
+        expect(engineRenderingNode.properties['engine.customJointTextureLayouts']).toBeUndefined();
+        expect(jointTextureLayoutsProperty.type).toBe('array');
+        expect(jointTextureLayoutItemSchema?.type).toBe('object');
+        expect(jointTextureLayoutItemSchema?.properties?.textureLength?.type).toBe('number');
+        expect(jointTextureContentSchema?.type).toBe('array');
+        expect(jointTextureContentItemSchema?.type).toBe('object');
+        expect(jointTextureContentItemSchema?.properties?.skeleton?.type).toBe('string');
+        expect(jointTextureContentItemSchema?.properties?.clips?.type).toBe('array');
         expect(engineModuleNode.properties['engine.includeModules']).toBeUndefined();
         expect(engineModuleNode.properties['engine.flags.LOAD_PHYSX_MANUALLY']).toBeUndefined();
         expect(engineModuleNode.properties['engine.noDeprecatedFeatures']).toBeUndefined();

--- a/src/core/engine/@types/config.d.ts
+++ b/src/core/engine/@types/config.d.ts
@@ -49,6 +49,39 @@ export interface IChunkContent {
     skeleton: null | string;
     clips: string[];
 }
+
+export interface IResolvedCustomJointTextureLayout {
+    textureLength: number;
+    contents: IResolvedChunkContent[];
+}
+
+export interface IResolvedChunkContent {
+    skeleton: number;
+    clips: number[];
+}
+
+export type JointTextureLayoutDeviceTipLevel = 'valid' | 'warning' | 'error';
+
+export interface IJointTextureLayoutDeviceTip {
+    level: JointTextureLayoutDeviceTipLevel;
+    message: string;
+}
+
+export interface IJointTextureLayoutPreviewItem {
+    index: number;
+    textureLength: number;
+    calculatedTextureLength: number;
+    fallbackTextureLength?: number;
+    resolvedLayout: IResolvedCustomJointTextureLayout | null;
+    tip: IJointTextureLayoutDeviceTip;
+    missingAssets: string[];
+}
+
+export interface IJointTextureLayoutPreviewResult {
+    layouts: IJointTextureLayoutPreviewItem[];
+    resolvedLayouts: IResolvedCustomJointTextureLayout[];
+    missingAssets: string[];
+}
 export type MacroItem = {
     key: string;
     value: boolean;

--- a/src/core/engine/index.ts
+++ b/src/core/engine/index.ts
@@ -1,7 +1,7 @@
 import fse from 'fs-extra';
 import { existsSync, readdirSync, statSync } from 'fs';
 import { EngineInfo } from './@types/public';
-import { IEngineConfig, IEngineProjectConfig, IInitEngineInfo } from './@types/config';
+import { IEngineConfig, IEngineProjectConfig, IInitEngineInfo, IJointTextureLayoutPreviewResult } from './@types/config';
 import { IModuleConfig, ModuleRenderConfig } from './@types/modules';
 import { join } from 'path';
 import { cloneDeep, merge } from 'lodash';
@@ -10,6 +10,10 @@ import { assetManager } from '../assets';
 import { getEngineDynamicConfigContribution, getEngineRenderConfig, getLocalizedEngineRenderConfig } from './dynamic-metadata';
 import { createEngineMetadataNodes } from './metadata';
 import i18n from '../base/i18n';
+import {
+    queryJointTextureLayoutPreview as createJointTextureLayoutPreview,
+    resolveCustomJointTextureLayouts,
+} from './joint-texture-layout';
 
 /**
  * 整合 engine 的一些编译、配置读取等功能
@@ -22,6 +26,7 @@ export interface IEngine {
     initEngine(info: IInitEngineInfo): Promise<this>;
     queryRenderConfig(): ModuleRenderConfig;
     queryLocalizedRenderConfig(): ModuleRenderConfig;
+    queryJointTextureLayoutPreview(): Promise<IJointTextureLayoutPreviewResult>;
     queryLayerBuiltin(): Promise<{ name: string; value: number }[]>;
     querySortingLayerBuiltin(): Promise<ReadonlyArray<{ id: number; name: string; value: number }>>;
 }
@@ -384,9 +389,10 @@ class EngineManager implements IEngine {
         await this.initEditorExtensions();
 
         const modules = this.getConfig().includeModules || [];
-        const { physicsConfig, macroConfig, customLayers, sortingLayers, highQuality, renderPipeline } = this.getConfig();
+        const { physicsConfig, macroConfig, customLayers, sortingLayers, highQuality, renderPipeline, customJointTextureLayouts } = this.getConfig();
         const bundles = assetManager.queryAssets({ isBundle: true }).map((item: any) => item.meta?.userData?.bundleName ?? item.name);
         const builtinAssets = info.serverURL && await this.queryInternalAssetList(this.getInfo().typescript.path);
+        const resolvedCustomJointTextureLayouts = await resolveCustomJointTextureLayouts(customJointTextureLayouts);
         const defaultConfig = {
             debugMode: cc.debug.DebugMode.WARN,
             overrideSettings: {
@@ -413,6 +419,9 @@ class EngineManager implements IEngine {
                     renderMode: 3,
                     renderPipeline,
                     highQualityMode: highQuality,
+                },
+                animation: {
+                    customJointTextureLayouts: resolvedCustomJointTextureLayouts,
                 },
                 physics: {
                     ...physicsConfig,
@@ -460,9 +469,10 @@ class EngineManager implements IEngine {
     }
 
     async getGameConfig(serverURL: string, importBase: string, nativeBase: string, isPreview?: boolean) {
-        const { physicsConfig, macroConfig, customLayers, sortingLayers, highQuality, renderPipeline, customPipeline } = this.getConfig();
+        const { physicsConfig, macroConfig, customLayers, sortingLayers, highQuality, renderPipeline, customPipeline, customJointTextureLayouts } = this.getConfig();
         const bundles = assetManager.queryAssets({ isBundle: true }).map((item: any) => item.meta?.userData?.bundleName ?? item.name);
         const builtinAssets = serverURL && await this.queryInternalAssetList(this.getInfo().typescript.path);
+        const resolvedCustomJointTextureLayouts = await resolveCustomJointTextureLayouts(customJointTextureLayouts);
         return {
             debugMode: cc.debug.DebugMode.WARN,
             overrideSettings: {
@@ -492,6 +502,9 @@ class EngineManager implements IEngine {
                     customPipeline,
                     highQualityMode: highQuality,
                     ...(customPipeline ? { effectSettingsPath: `${serverURL}/scripting/engine/effect-settings` } : {}),
+                },
+                animation: {
+                    customJointTextureLayouts: resolvedCustomJointTextureLayouts,
                 },
                 physics: {
                     ...physicsConfig,
@@ -545,6 +558,11 @@ class EngineManager implements IEngine {
             throw new Error('Engine not init');
         }
         return getLocalizedEngineRenderConfig(this._info.typescript.path);
+    }
+
+    async queryJointTextureLayoutPreview(): Promise<IJointTextureLayoutPreviewResult> {
+        const { customJointTextureLayouts } = this.getConfig();
+        return createJointTextureLayoutPreview(customJointTextureLayouts);
     }
 
     async queryLayerBuiltin() {

--- a/src/core/engine/joint-texture-layout.ts
+++ b/src/core/engine/joint-texture-layout.ts
@@ -1,0 +1,330 @@
+import { existsSync } from 'fs';
+import type {
+    ICustomJointTextureLayout,
+    IJointTextureLayoutDeviceTip,
+    IJointTextureLayoutPreviewItem,
+    IJointTextureLayoutPreviewResult,
+    IResolvedCustomJointTextureLayout,
+} from './@types/config';
+
+type JointTextureLayoutAssetId = string | number | null | undefined;
+
+interface IJointTextureLayoutContentInput {
+    skeleton?: JointTextureLayoutAssetId;
+    clips?: JointTextureLayoutAssetId[];
+}
+
+interface IJointTextureLayoutInput {
+    textureLength?: number;
+    contents?: IJointTextureLayoutContentInput[];
+}
+
+export interface IJointTextureLayoutAssetState {
+    hash?: number;
+    sample?: number;
+    duration?: number;
+    jointsLength?: number;
+}
+
+export interface IJointTextureLayoutResolver {
+    readAssetState?: (uuid: string) => Promise<IJointTextureLayoutAssetState | null>;
+    warn?: (message: string) => void;
+    onMissingAsset?: (uuid: string) => void;
+}
+
+const JOINT_TEXTURE_LENGTH_ALIGN = 12;
+
+export function getJointTextureLayoutDeviceTip(textureLength: number): IJointTextureLayoutDeviceTip {
+    if (textureLength < 1024) {
+        return {
+            level: 'valid',
+            message: 'Valid on all devices',
+        };
+    }
+    if (textureLength < 2048) {
+        return {
+            level: 'warning',
+            message: 'May exceeds max texture size limit on devices with no float texture support',
+        };
+    }
+    return {
+        level: 'error',
+        message: 'May exceeds max texture size limit on many mobile devices',
+    };
+}
+
+export async function resolveCustomJointTextureLayouts(
+    layouts: readonly ICustomJointTextureLayout[] | null | undefined,
+    resolver: IJointTextureLayoutResolver = {}
+): Promise<IResolvedCustomJointTextureLayout[]> {
+    return (await queryJointTextureLayoutPreview(layouts, resolver)).resolvedLayouts;
+}
+
+export async function queryJointTextureLayoutPreview(
+    layouts: readonly ICustomJointTextureLayout[] | null | undefined,
+    resolver: IJointTextureLayoutResolver = {}
+): Promise<IJointTextureLayoutPreviewResult> {
+    if (!Array.isArray(layouts) || layouts.length === 0) {
+        return {
+            layouts: [],
+            resolvedLayouts: [],
+            missingAssets: [],
+        };
+    }
+
+    const readAssetState = createCachedAssetStateReader(resolver.readAssetState ?? readJointTextureLayoutAssetState);
+    const previewLayouts: IJointTextureLayoutPreviewItem[] = [];
+    const resolvedLayouts: IResolvedCustomJointTextureLayout[] = [];
+    const allMissingAssets = new Set<string>();
+
+    for (const [index, layout] of (layouts as readonly IJointTextureLayoutInput[]).entries()) {
+        if (!layout || !Array.isArray(layout.contents) || layout.contents.length === 0) {
+            previewLayouts.push(createEmptyPreviewItem(index));
+            continue;
+        }
+
+        const layoutMissingAssets = new Set<string>();
+        const previewResolver: IJointTextureLayoutResolver = {
+            ...resolver,
+            onMissingAsset: (uuid: string) => {
+                const alreadyMissing = allMissingAssets.has(uuid);
+                layoutMissingAssets.add(uuid);
+                allMissingAssets.add(uuid);
+                if (!alreadyMissing) {
+                    resolver.onMissingAsset?.(uuid);
+                }
+            },
+        };
+
+        const contents = await Promise.all(
+            layout.contents.map((content) => resolveChunkContent(content, readAssetState, previewResolver))
+        );
+        const resolvedContents = contents.filter((content): content is IResolvedCustomJointTextureLayout['contents'][number] => !!content);
+        resolvedContents.sort((a, b) => a.skeleton - b.skeleton);
+
+        const calculatedTextureLength = await calculateJointTextureLength(layout.contents, readAssetState, previewResolver);
+        const fallbackTextureLength = normalizePositiveInteger(layout.textureLength);
+        const textureLength = calculatedTextureLength || fallbackTextureLength || 0;
+        const resolvedLayout = textureLength && resolvedContents.length > 0
+            ? {
+                textureLength,
+                contents: resolvedContents,
+            }
+            : null;
+
+        if (resolvedLayout) {
+            resolvedLayouts.push(resolvedLayout);
+        }
+
+        previewLayouts.push({
+            index,
+            textureLength,
+            calculatedTextureLength,
+            fallbackTextureLength,
+            resolvedLayout,
+            tip: getJointTextureLayoutDeviceTip(textureLength),
+            missingAssets: Array.from(layoutMissingAssets),
+        });
+    }
+
+    return {
+        layouts: previewLayouts,
+        resolvedLayouts,
+        missingAssets: Array.from(allMissingAssets),
+    };
+}
+
+export async function calculateJointTextureLength(
+    contents: readonly IJointTextureLayoutContentInput[],
+    readAssetState: (uuid: string) => Promise<IJointTextureLayoutAssetState | null> = readJointTextureLayoutAssetState,
+    resolver: IJointTextureLayoutResolver = {}
+): Promise<number> {
+    let pixels = 0;
+
+    for (const content of contents) {
+        const joints = await resolveJointsLength(content?.skeleton, readAssetState, resolver);
+        if (!joints) {
+            continue;
+        }
+
+        for (const clip of content.clips ?? []) {
+            const clipState = await resolveUuidState(clip, readAssetState, resolver);
+            const sample = normalizePositiveNumber(clipState?.sample);
+            const duration = normalizeNonNegativeNumber(clipState?.duration);
+            if (!sample || duration === undefined) {
+                continue;
+            }
+            const frames = Math.ceil(sample * duration) + 1;
+            pixels += joints * frames * 3;
+        }
+        pixels += joints * 3;
+    }
+
+    return pixels > 0
+        ? Math.ceil(Math.sqrt(pixels) / JOINT_TEXTURE_LENGTH_ALIGN) * JOINT_TEXTURE_LENGTH_ALIGN
+        : 0;
+}
+
+export async function readJointTextureLayoutAssetState(uuid: string): Promise<IJointTextureLayoutAssetState | null> {
+    const { assetManager } = await import('../assets');
+    const meta = assetManager.queryAssetMeta(uuid);
+    const jointsLength = normalizePositiveInteger(meta?.userData && (meta.userData as { jointsLength?: unknown }).jointsLength);
+    const info = assetManager.queryAssetInfo(uuid);
+    if (!info) {
+        return jointsLength ? { jointsLength } : null;
+    }
+
+    const libraryPath = findImportLibraryPath(info.library);
+    if (!libraryPath) {
+        return jointsLength ? { jointsLength } : null;
+    }
+
+    try {
+        const { getRawInstanceFromImportFile } = await import('../assets/utils');
+        const rawInstanceResult = await getRawInstanceFromImportFile(libraryPath, {
+            uuid: info.uuid,
+            url: info.url,
+        });
+        const asset = rawInstanceResult?.asset;
+        if (!asset) {
+            return jointsLength ? { jointsLength } : null;
+        }
+
+        const instance = asset as {
+            hash?: unknown;
+            sample?: unknown;
+            duration?: unknown;
+            joints?: unknown;
+        };
+
+        return {
+            hash: normalizePositiveInteger(instance.hash),
+            sample: normalizePositiveNumber(instance.sample),
+            duration: normalizeNonNegativeNumber(instance.duration),
+            jointsLength: jointsLength || (Array.isArray(instance.joints) ? instance.joints.length : undefined),
+        };
+    } catch (error) {
+        console.error(error);
+        return jointsLength ? { jointsLength } : null;
+    }
+}
+
+async function resolveChunkContent(
+    content: IJointTextureLayoutContentInput,
+    readAssetState: (uuid: string) => Promise<IJointTextureLayoutAssetState | null>,
+    resolver: IJointTextureLayoutResolver
+): Promise<IResolvedCustomJointTextureLayout['contents'][number] | null> {
+    const skeleton = await resolveAssetHash(content?.skeleton, readAssetState, resolver);
+    if (!skeleton) {
+        return null;
+    }
+
+    const clips: number[] = [];
+    for (const clip of content.clips ?? []) {
+        const hash = await resolveAssetHash(clip, readAssetState, resolver);
+        if (hash) {
+            clips.push(hash);
+        }
+    }
+    clips.sort();
+
+    return {
+        skeleton,
+        clips,
+    };
+}
+
+async function resolveAssetHash(
+    value: JointTextureLayoutAssetId,
+    readAssetState: (uuid: string) => Promise<IJointTextureLayoutAssetState | null>,
+    resolver: IJointTextureLayoutResolver
+): Promise<number | null> {
+    if (typeof value === 'number') {
+        return normalizePositiveInteger(value) ?? null;
+    }
+
+    const state = await resolveUuidState(value, readAssetState, resolver);
+    return normalizePositiveInteger(state?.hash) ?? null;
+}
+
+async function resolveJointsLength(
+    value: JointTextureLayoutAssetId,
+    readAssetState: (uuid: string) => Promise<IJointTextureLayoutAssetState | null>,
+    resolver: IJointTextureLayoutResolver
+): Promise<number> {
+    const state = await resolveUuidState(value, readAssetState, resolver);
+    return normalizePositiveInteger(state?.jointsLength) ?? 0;
+}
+
+async function resolveUuidState(
+    value: JointTextureLayoutAssetId,
+    readAssetState: (uuid: string) => Promise<IJointTextureLayoutAssetState | null>,
+    resolver: IJointTextureLayoutResolver
+): Promise<IJointTextureLayoutAssetState | null> {
+    if (typeof value !== 'string' || !value.trim()) {
+        return null;
+    }
+
+    const state = await readAssetState(value);
+    if (!state) {
+        resolver.onMissingAsset?.(value);
+        resolver.warn?.(`Failed to resolve Joint Texture Layout asset: ${value}`);
+    }
+    return state;
+}
+
+function createEmptyPreviewItem(index: number): IJointTextureLayoutPreviewItem {
+    return {
+        index,
+        textureLength: 0,
+        calculatedTextureLength: 0,
+        resolvedLayout: null,
+        tip: getJointTextureLayoutDeviceTip(0),
+        missingAssets: [],
+    };
+}
+
+function findImportLibraryPath(library: Record<string, string> | undefined): string {
+    if (!library) {
+        return '';
+    }
+
+    for (const ext of ['.json', '.bin', '.cconb']) {
+        const file = library[ext];
+        if (file && existsSync(file)) {
+            return file;
+        }
+    }
+    return '';
+}
+
+function createCachedAssetStateReader(
+    readAssetState: (uuid: string) => Promise<IJointTextureLayoutAssetState | null>
+): (uuid: string) => Promise<IJointTextureLayoutAssetState | null> {
+    const cache = new Map<string, Promise<IJointTextureLayoutAssetState | null>>();
+    return (uuid: string) => {
+        if (!cache.has(uuid)) {
+            cache.set(uuid, readAssetState(uuid));
+        }
+        return cache.get(uuid)!;
+    };
+}
+
+function normalizePositiveInteger(value: unknown): number | undefined {
+    const numberValue = normalizePositiveNumber(value);
+    return numberValue === undefined ? undefined : Math.trunc(numberValue);
+}
+
+function normalizePositiveNumber(value: unknown): number | undefined {
+    if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+        return undefined;
+    }
+    return value;
+}
+
+function normalizeNonNegativeNumber(value: unknown): number | undefined {
+    if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+        return undefined;
+    }
+    return value;
+}

--- a/src/core/engine/metadata.ts
+++ b/src/core/engine/metadata.ts
@@ -222,13 +222,48 @@ export function createEngineMetadataNodes(options: IEngineMetadataOptions): ICoc
                 minimum: 1,
                 title: 'i18n:configuration.engine.rendering.downloadMaxConcurrency.title',
             },
-            'engine.customJointTextureLayouts': {
-                type: 'array',
-                default: options.defaultConfig.customJointTextureLayouts,
-                title: 'i18n:configuration.engine.rendering.customJointTextureLayouts.title',
-                description: 'i18n:configuration.engine.rendering.customJointTextureLayouts.description',
-            },
         }, 5),
+
+        createNode('engine.jointTextureLayout', 'i18n:configuration.engine.jointTextureLayout.title', 'engine', {
+            'engine.customJointTextureLayouts': arraySchema(objectSchema({
+                textureLength: {
+                    type: 'number',
+                    default: 0,
+                    minimum: 0,
+                    title: 'i18n:configuration.engine.jointTextureLayout.customJointTextureLayouts.textureLength.title',
+                    description: 'i18n:configuration.engine.jointTextureLayout.customJointTextureLayouts.textureLength.description',
+                },
+                contents: arraySchema(objectSchema({
+                    skeleton: {
+                        type: 'string',
+                        default: '',
+                        title: 'i18n:configuration.engine.jointTextureLayout.customJointTextureLayouts.contents.skeleton.title',
+                        description: 'i18n:configuration.engine.jointTextureLayout.customJointTextureLayouts.contents.skeleton.description',
+                    },
+                    clips: arraySchema({
+                        type: 'string',
+                        default: '',
+                        title: 'i18n:configuration.engine.jointTextureLayout.customJointTextureLayouts.contents.clips.itemTitle',
+                    }, {
+                        title: 'i18n:configuration.engine.jointTextureLayout.customJointTextureLayouts.contents.clips.title',
+                        description: 'i18n:configuration.engine.jointTextureLayout.customJointTextureLayouts.contents.clips.description',
+                    }),
+                }, {
+                    title: 'i18n:configuration.engine.jointTextureLayout.customJointTextureLayouts.contents.itemTitle',
+                    required: ['skeleton', 'clips'],
+                }), {
+                    title: 'i18n:configuration.engine.jointTextureLayout.customJointTextureLayouts.contents.title',
+                    description: 'i18n:configuration.engine.jointTextureLayout.customJointTextureLayouts.contents.description',
+                }),
+            }, {
+                title: 'i18n:configuration.engine.jointTextureLayout.customJointTextureLayouts.itemTitle',
+                required: ['textureLength', 'contents'],
+            }), {
+                default: options.defaultConfig.customJointTextureLayouts,
+                title: 'i18n:configuration.engine.jointTextureLayout.customJointTextureLayouts.title',
+                description: 'i18n:configuration.engine.jointTextureLayout.customJointTextureLayouts.description',
+            }),
+        }, 6),
 
         createNode('engine.macroConfig', 'i18n:configuration.engine.macroConfig.title', 'engine', {
             ...prefixProperties('engine.macroConfig', dynamicMetadata.macroProperties),
@@ -249,7 +284,7 @@ export function createEngineMetadataNodes(options: IEngineMetadataOptions): ICoc
                 title: 'i18n:configuration.engine.macroConfig.macroCustom.title',
                 description: 'i18n:configuration.engine.macroConfig.macroCustom.description',
             }),
-        }, 6),
+        }, 7),
 
         createNode('engine.customLayers', 'i18n:configuration.engine.layers.customLayers.title', 'engine', {
             'engine.customLayers': {
@@ -258,7 +293,7 @@ export function createEngineMetadataNodes(options: IEngineMetadataOptions): ICoc
                 title: 'i18n:configuration.engine.layers.customLayers.title',
                 description: 'i18n:configuration.engine.layers.customLayers.description',
             },
-        }, 7),
+        }, 8),
 
         createNode('engine.sortingLayers', 'i18n:configuration.engine.layers.sortingLayers.title', 'engine', {
             'engine.sortingLayers': {
@@ -267,7 +302,7 @@ export function createEngineMetadataNodes(options: IEngineMetadataOptions): ICoc
                 title: 'i18n:configuration.engine.layers.sortingLayers.title',
                 description: 'i18n:configuration.engine.layers.sortingLayers.description',
             },
-        }, 8),
+        }, 9),
     ];
 }
 

--- a/src/core/engine/test/joint-texture-layout.test.ts
+++ b/src/core/engine/test/joint-texture-layout.test.ts
@@ -1,0 +1,153 @@
+import {
+    getJointTextureLayoutDeviceTip,
+    queryJointTextureLayoutPreview,
+    resolveCustomJointTextureLayouts,
+} from '../joint-texture-layout';
+
+describe('joint texture layout', () => {
+    it('resolves UUID layouts to runtime hashes and calculates textureLength', async () => {
+        const layouts = await resolveCustomJointTextureLayouts([{
+            textureLength: 12,
+            contents: [
+                { skeleton: 'skeleton-b', clips: ['clip-b', 'clip-a'] },
+                { skeleton: 'skeleton-a', clips: ['clip-a'] },
+            ],
+        }], {
+            readAssetState: async (uuid) => ({
+                'skeleton-a': { hash: 100, jointsLength: 10 },
+                'skeleton-b': { hash: 50, jointsLength: 20 },
+                'clip-a': { hash: 7, sample: 30, duration: 1 },
+                'clip-b': { hash: 3, sample: 10, duration: 2.5 },
+            })[uuid] ?? null,
+        });
+
+        expect(layouts).toEqual([{
+            textureLength: 72,
+            contents: [
+                { skeleton: 50, clips: [3, 7] },
+                { skeleton: 100, clips: [7] },
+            ],
+        }]);
+    });
+
+    it('keeps already-resolved numeric hashes with manual textureLength fallback', async () => {
+        const layouts = await resolveCustomJointTextureLayouts([{
+            textureLength: 96,
+            contents: [
+                { skeleton: 123 as unknown as string, clips: [456 as unknown as string] },
+            ],
+        }]);
+
+        expect(layouts).toEqual([{
+            textureLength: 96,
+            contents: [
+                { skeleton: 123, clips: [456] },
+            ],
+        }]);
+    });
+
+    it('counts zero-duration clips as one frame when calculating textureLength', async () => {
+        const layouts = await resolveCustomJointTextureLayouts([{
+            textureLength: 0,
+            contents: [
+                { skeleton: 'skeleton', clips: ['idle-pose'] },
+            ],
+        }], {
+            readAssetState: async (uuid) => ({
+                skeleton: { hash: 1, jointsLength: 10 },
+                'idle-pose': { hash: 2, sample: 30, duration: 0 },
+            })[uuid] ?? null,
+        });
+
+        expect(layouts).toEqual([{
+            textureLength: 12,
+            contents: [
+                { skeleton: 1, clips: [2] },
+            ],
+        }]);
+    });
+
+    it('sorts clip hashes with Creator default array sort', async () => {
+        const layouts = await resolveCustomJointTextureLayouts([{
+            textureLength: 12,
+            contents: [
+                { skeleton: 'skeleton', clips: ['clip-small', 'clip-large'] },
+            ],
+        }], {
+            readAssetState: async (uuid) => ({
+                skeleton: { hash: 1, jointsLength: 1 },
+                'clip-small': { hash: 7, sample: 1, duration: 1 },
+                'clip-large': { hash: 100, sample: 1, duration: 1 },
+            })[uuid] ?? null,
+        });
+
+        expect(layouts[0].contents[0].clips).toEqual([100, 7]);
+    });
+
+    it('queries preview data for UI consumption', async () => {
+        const onMissingAsset = jest.fn();
+
+        const preview = await queryJointTextureLayoutPreview([
+            {
+                textureLength: 0,
+                contents: [
+                    { skeleton: 'skeleton', clips: ['idle-pose', 'missing-clip'] },
+                ],
+            },
+            {
+                textureLength: 2048,
+                contents: [
+                    { skeleton: 10 as unknown as string, clips: [20 as unknown as string] },
+                ],
+            },
+        ], {
+            readAssetState: async (uuid) => ({
+                skeleton: { hash: 1, jointsLength: 10 },
+                'idle-pose': { hash: 2, sample: 30, duration: 0 },
+            })[uuid] ?? null,
+            onMissingAsset,
+        });
+
+        expect(preview.resolvedLayouts).toEqual([
+            {
+                textureLength: 12,
+                contents: [
+                    { skeleton: 1, clips: [2] },
+                ],
+            },
+            {
+                textureLength: 2048,
+                contents: [
+                    { skeleton: 10, clips: [20] },
+                ],
+            },
+        ]);
+        expect(preview.missingAssets).toEqual(['missing-clip']);
+        expect(preview.layouts[0]).toMatchObject({
+            index: 0,
+            textureLength: 12,
+            calculatedTextureLength: 12,
+            missingAssets: ['missing-clip'],
+            tip: { level: 'valid' },
+        });
+        expect(preview.layouts[1]).toMatchObject({
+            index: 1,
+            textureLength: 2048,
+            calculatedTextureLength: 0,
+            fallbackTextureLength: 2048,
+            tip: { level: 'error' },
+            missingAssets: [],
+        });
+        expect(onMissingAsset).toHaveBeenCalledTimes(1);
+        expect(onMissingAsset).toHaveBeenCalledWith('missing-clip');
+    });
+
+    it('matches Creator device-size tips', () => {
+        expect(getJointTextureLayoutDeviceTip(1023)).toEqual({
+            level: 'valid',
+            message: 'Valid on all devices',
+        });
+        expect(getJointTextureLayoutDeviceTip(1024).level).toBe('warning');
+        expect(getJointTextureLayoutDeviceTip(2048).level).toBe('error');
+    });
+});

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -562,6 +562,8 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         const session = requireAnimationSession(this._session);
         const state = await this._getAnimationState(session.clipUuid);
         const rootNode = this._getSessionRootNode();
+        const propertyMetadataContext = createAnimationPropertyCurveMetadataContext(rootNode);
+        const savedSnapshot = captureAnimationClipSnapshot(state.clip, propertyMetadataContext);
         ensureClipEvents(state.clip);
         this._markSelfSavedClipRefresh(session.clipUuid);
         let saved = false;
@@ -576,9 +578,11 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             throw error;
         }
         if (saved) {
+            await this._restoreCurrentClipAfterSelfSave(session.clipUuid, state.clip, savedSnapshot, propertyMetadataContext);
+            const currentState = await this._getAnimationState(session.clipUuid);
             const animComp = queryAnimationComponent(rootNode);
             if (animComp instanceof Animation) {
-                rebindAnimationComponentClip(animComp, state.clip);
+                rebindAnimationComponentClip(animComp, currentState.clip);
             }
             this._markSelfSavedClipRefresh(session.clipUuid);
             if (options.saveScene === true) {
@@ -663,6 +667,26 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         await this._restoreClipSnapshotWithStateRecreation(uuid, clip, snapshot, true);
         await this.setTime({ time: this._curEditTime });
         this._broadcastClipChanged('undo-redo');
+    }
+
+    private async _restoreCurrentClipAfterSelfSave(
+        uuid: string,
+        clip: AnimationClip,
+        snapshot: IAnimationClipSnapshot,
+        propertyMetadataContext: ReturnType<typeof createAnimationPropertyCurveMetadataContext>,
+    ): Promise<void> {
+        const currentState = this._animationStates.get(uuid);
+        if (!currentState || currentState.clip !== clip) {
+            return;
+        }
+
+        const currentSnapshot = captureAnimationClipSnapshot(clip, propertyMetadataContext);
+        if (animationClipSnapshotsEqual(currentSnapshot, snapshot)) {
+            return;
+        }
+
+        await this._restoreClipSnapshotWithStateRecreation(uuid, clip, snapshot, true);
+        await this.setTime({ time: this._curEditTime });
     }
 
     private async _restoreClipSnapshotWithStateRecreation(

--- a/src/core/scene/test/animation-service-enter.test.ts
+++ b/src/core/scene/test/animation-service-enter.test.ts
@@ -277,6 +277,63 @@ describe('AnimationService enter', () => {
         expect(currentClip.events).toEqual([]);
     });
 
+    it('restores the current clip snapshot when self save mutates the editing clip', async () => {
+        const { Animation, AnimationClip } = require('cc');
+        const service = new AnimationService() as any;
+        const currentClip = new AnimationClip();
+        currentClip._uuid = 'clip-uuid';
+        currentClip.name = 'Current';
+        currentClip.events = [{ frame: 0, func: 'before-save', params: ['ok'] }];
+        const animComp = new Animation();
+        animComp.clips = [currentClip];
+        animComp.defaultClip = currentClip;
+        const rootNode = {
+            uuid: 'root-uuid',
+            getComponent: jest.fn((ctor) => ctor === Animation ? animComp : null),
+        };
+
+        service._session = {
+            clipUuid: 'clip-uuid',
+            rootUuid: rootNode.uuid,
+            rootPath: 'Canvas/AnimatedRoot',
+            undoBaseline: { commandId: null, generation: 0 },
+            globalDirtyAtEnter: false,
+        };
+        service._getSessionRootNode = jest.fn(() => rootNode);
+        service._getAnimationState = jest.fn(async () => ({ clip: currentClip }));
+        service._animationStates.get = jest.fn(() => ({ clip: currentClip }));
+        service._animationStates.reset = jest.fn();
+        service._animationStates.create = jest.fn();
+        service._restoreClipSnapshotWithStateRecreation = jest.fn(async (uuid: string, clip: any, snapshot: any) => {
+            service._animationStates.reset(uuid);
+            const restoredEvents = snapshot.events.map((event: any) => ({
+                frame: event.frame,
+                func: event.func,
+                params: event.params,
+            }));
+            clip.events = restoredEvents;
+            clip._events = restoredEvents;
+            service._animationStates.create(uuid, clip);
+        });
+        service.setTime = jest.fn(async () => true);
+        saveAnimationServiceClipMock.mockImplementationOnce(async () => {
+            currentClip.events = [];
+            return true;
+        });
+
+        await expect(service.save()).resolves.toBe(true);
+
+        expect(service._restoreClipSnapshotWithStateRecreation).toHaveBeenCalledWith('clip-uuid', currentClip, expect.objectContaining({
+            events: [{ frame: 0, func: 'before-save', params: ['ok'] }],
+        }), true);
+        expect(service._animationStates.reset).toHaveBeenCalledWith('clip-uuid');
+        expect(service._animationStates.create).toHaveBeenCalledWith('clip-uuid', currentClip);
+        expect(service.setTime).toHaveBeenCalledWith({ time: 0 });
+        expect(animComp.clips).toEqual([currentClip]);
+        expect(animComp.defaultClip).toBe(currentClip);
+        expect(currentClip.events).toEqual([{ frame: 0, func: 'before-save', params: ['ok'] }]);
+    });
+
     it('ignores a current clip refresh that started before saving the current clip', async () => {
         const { Animation, AnimationClip, assetManager } = require('cc');
         const service = new AnimationService() as any;

--- a/src/lib/engine/engine.ts
+++ b/src/lib/engine/engine.ts
@@ -21,6 +21,11 @@ export async function getRenderConfig() {
     return Engine.queryLocalizedRenderConfig();
 }
 
+export async function queryJointTextureLayoutPreview() {
+    const { Engine } = await import('../../core/engine');
+    return Engine.queryJointTextureLayoutPreview();
+}
+
 export async function initEngine(enginePath: string, projectPath: string, serverURL?: string) {
     const { initEngine } = await import('../../core/engine');
     return await initEngine(enginePath, projectPath, serverURL);

--- a/static/i18n/en/configuration.json
+++ b/static/i18n/en/configuration.json
@@ -238,6 +238,32 @@
         "description": "Custom skeletal animation texture layouts"
       }
     },
+    "jointTextureLayout": {
+      "title": "Animation / Joint Texture Layout",
+      "customJointTextureLayouts": {
+        "title": "Custom Joint Texture Layouts",
+        "description": "Organize skeletal animation joint texture layouts by skeleton and animation clips. Build and preview automatically calculate texture size and convert asset UUIDs to runtime hashes.",
+        "itemTitle": "Joint Texture Layout",
+        "textureLength": {
+          "title": "Texture Length",
+          "description": "Automatically calculated from joint count, animation frames, and default pose. Below 1024 is usually valid on all devices, below 2048 may affect devices without float texture support, and 2048 or above may affect many mobile devices."
+        },
+        "contents": {
+          "title": "Layout Contents",
+          "description": "Each item contains one skeleton asset and a list of animation clip assets.",
+          "itemTitle": "Skeleton Content",
+          "skeleton": {
+            "title": "Skeleton UUID",
+            "description": "UUID of a cc.Skeleton asset."
+          },
+          "clips": {
+            "title": "Animation Clip UUIDs",
+            "description": "UUID list of cc.AnimationClip assets.",
+            "itemTitle": "Animation Clip UUID"
+          }
+        }
+      }
+    },
     "macroConfig": {
       "title": "Macro Settings",
       "macroCustom": {

--- a/static/i18n/zh/configuration.json
+++ b/static/i18n/zh/configuration.json
@@ -238,6 +238,32 @@
         "description": "自定义骨骼动画贴图布局"
       }
     },
+    "jointTextureLayout": {
+      "title": "动画 / 骨骼贴图布局",
+      "customJointTextureLayouts": {
+        "title": "自定义骨骼贴图布局",
+        "description": "按骨骼和动画剪辑组织骨骼贴图布局。构建和预览时会自动计算贴图尺寸，并把资源 UUID 转换为运行时 hash。",
+        "itemTitle": "骨骼贴图布局",
+        "textureLength": {
+          "title": "贴图边长",
+          "description": "由骨骼数量、动画帧数和默认姿势自动计算；小于 1024 通常适用于所有设备，小于 2048 可能影响不支持浮点贴图的设备，2048 及以上可能影响较多移动设备。"
+        },
+        "contents": {
+          "title": "布局内容",
+          "description": "每项包含一个骨骼资源和一组动画剪辑资源。",
+          "itemTitle": "骨骼内容",
+          "skeleton": {
+            "title": "骨骼 UUID",
+            "description": "cc.Skeleton 资源 UUID。"
+          },
+          "clips": {
+            "title": "动画剪辑 UUID",
+            "description": "cc.AnimationClip 资源 UUID 列表。",
+            "itemTitle": "动画剪辑 UUID"
+          }
+        }
+      }
+    },
     "macroConfig": {
       "title": "宏配置",
       "macroCustom": {

--- a/tests/engine-lib.test.ts
+++ b/tests/engine-lib.test.ts
@@ -1,6 +1,7 @@
 jest.mock('../src/core/engine', () => ({
     Engine: {
         queryLocalizedRenderConfig: jest.fn(),
+        queryJointTextureLayoutPreview: jest.fn(),
     },
 }));
 
@@ -27,5 +28,21 @@ describe('engine lib api', () => {
 
         await expect(getRenderConfig()).resolves.toEqual(expectedRenderConfig);
         expect(Engine.queryLocalizedRenderConfig).toHaveBeenCalledTimes(1);
+    });
+
+    it('should delegate queryJointTextureLayoutPreview to Engine.queryJointTextureLayoutPreview', async () => {
+        const expectedPreview = {
+            layouts: [],
+            resolvedLayouts: [],
+            missingAssets: [],
+        };
+
+        const { Engine } = require('../src/core/engine') as typeof import('../src/core/engine');
+        Engine.queryJointTextureLayoutPreview = jest.fn().mockResolvedValue(expectedPreview);
+
+        const { queryJointTextureLayoutPreview } = require('../src/lib/engine/engine') as typeof import('../src/lib/engine/engine');
+
+        await expect(queryJointTextureLayoutPreview()).resolves.toEqual(expectedPreview);
+        expect(Engine.queryJointTextureLayoutPreview).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
### 变更说明

本 PR 为 `customJointTextureLayouts` 补齐 Creator 对齐逻辑和 UI 可消费的预览查询能力：

- 新增 Joint Texture Layout 解析模块，构建/预览时将资源 UUID 转换为运行时 hash。
- 对齐 Creator 的 `textureLength` 自动计算：
  - `frames = Math.ceil(sample * duration) + 1`
  - 零时长 clip 也按 1 帧计算。
- 对齐 Creator 的 clip hash 默认排序行为：使用 `Array.sort()`。
- 构建 settings 写入 resolved 后的 joint texture layout。
- 配置 UI 分组从“渲染”移动到“动画 / 骨骼贴图布局”。

### PinK 接入说明

P2 的设备尺寸提示已提供生产消费入口，PinK customView 可调用：

- `Engine.queryJointTextureLayoutPreview()`
- 或 lib API：`queryJointTextureLayoutPreview()`

返回结构中重点字段：

- `layouts[].tip.level`: `valid | warning | error`
- `layouts[].tip.message`: 设备尺寸提示文案
- `layouts[].calculatedTextureLength`: 自动计算结果
- `layouts[].fallbackTextureLength`: 配置兜底值
- `layouts[].missingAssets`: 当前 layout 缺失资源
- `resolvedLayouts`: 构建/运行时实际使用的 hash layout