### PR TITLE
fix: localize asset config map

### DIFF
--- a/src/core/assets/manager/asset-handler.ts
+++ b/src/core/assets/manager/asset-handler.ts
@@ -7,7 +7,7 @@ import fg from 'fast-glob';
 
 import i18n from '../../base/i18n';
 import { IAsset, IExportData } from '../@types/protected/asset';
-import { AssetHandler, CustomHandler, CustomAssetHandler, ICreateMenuInfo, CreateAssetOptions, IExportOptions, IAssetConfig, ImporterHook, ThumbnailInfo, ThumbnailSize } from '../@types/protected/asset-handler';
+import { AssetHandler, CustomHandler, CustomAssetHandler, ICreateMenuInfo, CreateAssetOptions, IExportOptions, IAssetConfig, ImporterHook, ThumbnailInfo, ThumbnailSize, IUerDataConfigItem } from '../@types/protected/asset-handler';
 import type { AssetHandlerInfo } from '../asset-handler/config';
 import assetConfig from '../asset-config';
 import { copyPath, createDirectoryPath, writePath } from './filesystem';
@@ -493,7 +493,9 @@ class AssetHandlerManager {
     /**
      * 查询各个资源的基本配置 MAP
      */
-    async queryAssetConfigMap(): Promise<Record<string, IAssetConfig>> {
+    async queryRawAssetConfigMap(): Promise<Record<string, IAssetConfig>> {
+        await this.activateRegisterAll();
+
         const result: Record<string, IAssetConfig> = {};
         for (const importer of Object.keys(this.name2handler)) {
             const handler = this.name2handler[importer];
@@ -509,6 +511,14 @@ class AssetHandlerManager {
             result[importer] = config;
         }
         return result;
+    }
+
+    /**
+     * Query localized asset config map.
+     */
+    async queryAssetConfigMap(): Promise<Record<string, IAssetConfig>> {
+        const rawConfigMap = await this.queryRawAssetConfigMap();
+        return localizeAssetConfigMap(rawConfigMap);
     }
 
     queryThumbnailHandlers(): string[] {
@@ -691,6 +701,79 @@ class AssetHandlerManager {
 const assetHandlerManager = new AssetHandlerManager();
 
 export default assetHandlerManager;
+
+function localizeAssetConfigMap(configMap: Record<string, IAssetConfig>): Record<string, IAssetConfig> {
+    const localizedConfigMap = lodash.cloneDeep(configMap);
+    for (const config of Object.values(localizedConfigMap)) {
+        localizeAssetConfig(config);
+    }
+    return localizedConfigMap;
+}
+
+function localizeAssetConfig(config: IAssetConfig): void {
+    config.displayName = translateAssetConfigText(config.displayName);
+    config.description = translateAssetConfigText(config.description);
+
+    if (config.userDataConfig) {
+        localizeUserDataConfig(config.userDataConfig);
+    }
+}
+
+function localizeUserDataConfig(config: Record<string, IUerDataConfigItem>): void {
+    for (const item of Object.values(config)) {
+        localizeUserDataConfigItem(item);
+    }
+}
+
+function localizeUserDataConfigItem(item: IUerDataConfigItem): void {
+    item.label = translateAssetConfigText(item.label);
+    item.description = translateAssetConfigText(item.description);
+
+    if (item.render?.items) {
+        item.render.items = item.render.items.map((option) => ({
+            ...option,
+            label: translateAssetConfigText(option.label) ?? option.label,
+        }));
+    }
+
+    if (!item.itemConfigs) {
+        return;
+    }
+
+    if (Array.isArray(item.itemConfigs)) {
+        item.itemConfigs.forEach((child) => {
+            localizeUserDataConfigItem(child);
+        });
+        return;
+    }
+
+    for (const child of Object.values(item.itemConfigs)) {
+        localizeUserDataConfigItem(child);
+    }
+}
+
+function translateAssetConfigText(value: string | undefined): string | undefined {
+    if (typeof value !== 'string' || value.length === 0) {
+        return value;
+    }
+
+    const i18nPrefix = 'i18n:';
+    if (!value.startsWith(i18nPrefix)) {
+        return value;
+    }
+
+    const key = value.slice(i18nPrefix.length);
+    if (!key) {
+        return value;
+    }
+
+    const translated = i18n.transI18nName(value);
+    if (translated && translated !== value) {
+        return translated;
+    }
+
+    return key;
+}
 
 function patchHandler(info: ICreateMenuInfo, handler: string, extensions: string[]) {
     // 避免污染原始 info 数据

--- a/src/core/assets/test/asset-config-map-i18n.test.ts
+++ b/src/core/assets/test/asset-config-map-i18n.test.ts
@@ -1,0 +1,188 @@
+import i18n from '../../base/i18n';
+import { assetManager } from '..';
+import assetHandlerManager from '../manager/asset-handler';
+import type { AssetHandler, IUerDataConfigItem } from '../@types/protected/asset-handler';
+
+describe('asset config map i18n', () => {
+    beforeAll(() => {
+        i18n.registerLanguagePatch('en', 'assets.assetConfigMapTest', {
+            asset: 'Localized Asset',
+            description: 'Localized Description',
+            mode: 'Import Mode',
+            modeHelp: 'Mode Help',
+            fast: 'Fast Mode',
+            nested: 'Nested Setting',
+            nestedHelp: 'Nested Help',
+            lazyAsset: 'Lazy Asset',
+        });
+        i18n.registerLanguagePatch('zh', 'assets.assetConfigMapTest', {
+            asset: 'ZH Asset',
+            description: 'ZH Description',
+            mode: 'ZH Mode',
+            modeHelp: 'ZH Mode Help',
+            fast: 'ZH Fast',
+            nested: 'ZH Nested',
+            nestedHelp: 'ZH Nested Help',
+            lazyAsset: 'ZH Lazy Asset',
+        });
+    });
+
+    beforeEach(async () => {
+        resetAssetHandlerManager();
+        await i18n.setLanguage('en');
+    });
+
+    afterEach(async () => {
+        resetAssetHandlerManager();
+        await i18n.setLanguage('en');
+    });
+
+    it('localizes asset display fields and nested userDataConfig without mutating raw handler config', async () => {
+        const rawUserDataConfig = createUserDataConfig();
+        addAssetHandler(createAssetHandler('localized-asset', {
+            displayName: 'i18n:assets.assetConfigMapTest.asset',
+            description: 'i18n:assets.assetConfigMapTest.description',
+            userDataConfig: {
+                default: rawUserDataConfig,
+            },
+        }));
+
+        const configMap = await assetManager.queryAssetConfigMap();
+        const config = configMap['localized-asset'];
+        const modeConfig = config.userDataConfig?.mode;
+        const arrayChild = (modeConfig?.itemConfigs as IUerDataConfigItem[])[0];
+        const objectChild = (config.userDataConfig?.texture.itemConfigs as Record<string, IUerDataConfigItem>).wrapMode;
+
+        expect(config.displayName).toBe('Localized Asset');
+        expect(config.description).toBe('Localized Description');
+        expect(modeConfig?.label).toBe('Import Mode');
+        expect(modeConfig?.description).toBe('Mode Help');
+        expect(modeConfig?.render?.items?.[0].label).toBe('Fast Mode');
+        expect(arrayChild.label).toBe('Nested Setting');
+        expect(arrayChild.description).toBe('Nested Help');
+        expect(objectChild.label).toBe('Nested Setting');
+        expect(config.userDataConfig?.unknown.label).toBe('assets.assetConfigMapTest.missing');
+
+        expect(config.userDataConfig).not.toBe(rawUserDataConfig);
+        expect(rawUserDataConfig.mode.label).toBe('i18n:assets.assetConfigMapTest.mode');
+        expect(rawUserDataConfig.mode.render?.items?.[0].label).toBe('i18n:assets.assetConfigMapTest.fast');
+        expect((rawUserDataConfig.mode.itemConfigs as IUerDataConfigItem[])[0].label).toBe('i18n:assets.assetConfigMapTest.nested');
+    });
+
+    it('returns language-specific labels from the existing queryAssetConfigMap path', async () => {
+        addAssetHandler(createAssetHandler('localized-asset', {
+            displayName: 'i18n:assets.assetConfigMapTest.asset',
+            userDataConfig: {
+                default: createUserDataConfig(),
+            },
+        }));
+
+        await i18n.setLanguage('zh');
+        const configMap = await assetManager.queryAssetConfigMap();
+
+        expect(configMap['localized-asset'].displayName).toBe('ZH Asset');
+        expect(configMap['localized-asset'].userDataConfig?.mode.label).toBe('ZH Mode');
+        expect(configMap['localized-asset'].userDataConfig?.mode.render?.items?.[0].label).toBe('ZH Fast');
+    });
+
+    it('keeps raw i18n keys available through queryRawAssetConfigMap', async () => {
+        const rawUserDataConfig = createUserDataConfig();
+        addAssetHandler(createAssetHandler('localized-asset', {
+            displayName: 'i18n:assets.assetConfigMapTest.asset',
+            description: 'i18n:assets.assetConfigMapTest.description',
+            userDataConfig: {
+                default: rawUserDataConfig,
+            },
+        }));
+
+        const rawConfigMap = await assetHandlerManager.queryRawAssetConfigMap();
+
+        expect(rawConfigMap['localized-asset'].displayName).toBe('i18n:assets.assetConfigMapTest.asset');
+        expect(rawConfigMap['localized-asset'].description).toBe('i18n:assets.assetConfigMapTest.description');
+        expect(rawConfigMap['localized-asset'].userDataConfig).toBe(rawUserDataConfig);
+        expect(rawConfigMap['localized-asset'].userDataConfig?.mode.label).toBe('i18n:assets.assetConfigMapTest.mode');
+    });
+
+    it('activates lazy asset handlers before building the config map', async () => {
+        assetHandlerManager.register('asset-config-map-test', [{
+            name: 'lazy-asset',
+            extensions: ['.lazy'],
+            load: async () => createAssetHandler('lazy-asset', {
+                displayName: 'i18n:assets.assetConfigMapTest.lazyAsset',
+            }),
+        }] as any, true);
+
+        const configMap = await assetManager.queryAssetConfigMap();
+
+        expect(configMap['lazy-asset'].displayName).toBe('Lazy Asset');
+        expect(assetHandlerManager.name2handler['lazy-asset']).toBeDefined();
+    });
+});
+
+function resetAssetHandlerManager(): void {
+    const manager = assetHandlerManager as any;
+    assetHandlerManager.clear();
+    manager.type2handler = {};
+    manager.name2importer = {};
+    manager._userDataCache = {};
+    manager._defaultUserData = {};
+}
+
+function addAssetHandler(handler: AssetHandler): void {
+    assetHandlerManager.name2handler[handler.name] = handler;
+}
+
+function createAssetHandler(
+    name: string,
+    overrides: Partial<AssetHandler> = {}
+): AssetHandler {
+    return {
+        name,
+        importer: {
+            version: '1.0.0',
+            import: async () => true,
+        },
+        ...overrides,
+    } as AssetHandler;
+}
+
+function createUserDataConfig(): Record<string, IUerDataConfigItem> {
+    return {
+        mode: {
+            label: 'i18n:assets.assetConfigMapTest.mode',
+            description: 'i18n:assets.assetConfigMapTest.modeHelp',
+            default: 'fast',
+            render: {
+                ui: 'ui-select',
+                items: [
+                    { label: 'i18n:assets.assetConfigMapTest.fast', value: 'fast' },
+                ],
+            },
+            itemConfigs: [
+                {
+                    key: 'nested',
+                    label: 'i18n:assets.assetConfigMapTest.nested',
+                    description: 'i18n:assets.assetConfigMapTest.nestedHelp',
+                    default: true,
+                    render: { ui: 'ui-checkbox' },
+                },
+            ],
+        },
+        texture: {
+            label: 'Texture',
+            default: {},
+            itemConfigs: {
+                wrapMode: {
+                    label: 'i18n:assets.assetConfigMapTest.nested',
+                    default: 'repeat',
+                    render: { ui: 'ui-input' },
+                },
+            },
+        },
+        unknown: {
+            label: 'i18n:assets.assetConfigMapTest.missing',
+            default: '',
+            render: { ui: 'ui-input' },
+        },
+    };
+}


### PR DESCRIPTION
## 变更说明

本次修复 `queryAssetConfigMap()` 返回给 PinK 的资源配置文案未做 i18n 的问题。

### 核心改动

- `assetHandlerManager.queryAssetConfigMap()` 现在返回已本地化的配置数据。
- 查询配置 map 前会先激活全部懒加载 asset handler，保证默认 meta 配置覆盖完整。
- 新增 `queryRawAssetConfigMap()` 保留原始 `i18n:` key 能力，供 core 内部兼容/测试使用。
- 本地化过程基于深拷贝，不会污染 handler 原始 `userDataConfig.default`。
- 递归翻译字段：
  - `displayName`
  - `description`
  - `userDataConfig.*.label`
  - `userDataConfig.*.description`
  - `render.items[].label`
  - 嵌套 `itemConfigs` 内的同类字段

### 兼容性说明

PinK 不需要改调用链，继续通过现有 `pink.assets.queryAssetConfigMap()` 即可拿到已翻译文本。

对外接口名称和返回结构保持不变；变化点是展示文案从 raw `i18n:` key 变为当前语言下的翻译结果。找不到翻译时会回退为去掉 `i18n:` 前缀后的 key，避免 UI 直接显示 `i18n:`。