### PR TITLE
fix(animation): smooth playback time sync

### DIFF
--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -313,6 +313,11 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             throw new Error(`current edit clip: '${session.clipUuid}' but you want to operate: '${uuid}'`);
         }
 
+        if (this._playState === 'playing') {
+            const node = resolveAnimationFrameQueryNode(options, session);
+            return serializeAnimationPropertyValue(readPropertyValue(node, options.propKey));
+        }
+
         const state = await this._getAnimationState(uuid);
         const previousTime = this._curEditTime;
         const previousStateTime = typeof state.current === 'number' && Number.isFinite(state.current)

--- a/src/core/scene/scene-process/service/animation/service-playback.ts
+++ b/src/core/scene/scene-process/service/animation/service-playback.ts
@@ -1,6 +1,9 @@
 import type { AnimationState } from 'cc';
 import type { AnimationEventReason, AnimationPlayState } from '../../../common';
 
+const PLAYBACK_TIME_BROADCAST_INTERVAL_MS = 1000 / 60;
+const PLAYBACK_TIME_BROADCAST_EPSILON = 0.001;
+
 export interface IAnimationServicePlaybackContext {
     getCurrentState(): AnimationState | undefined;
     getEditTime(): number;
@@ -78,7 +81,8 @@ export class AnimationServicePlayback {
         this._lastPlaybackBroadcastTime = Number.NaN;
         this._playbackTimeBroadcastTimer = setInterval(() => {
             this._broadcastPlaybackTimeTick();
-        }, 100);
+        }, PLAYBACK_TIME_BROADCAST_INTERVAL_MS);
+        this._broadcastPlaybackTimeTick();
     }
 
     private _stopPlaybackTimeBroadcast(): void {
@@ -120,7 +124,11 @@ export class AnimationServicePlayback {
         if (typeof time !== 'number' || !Number.isFinite(time)) {
             return;
         }
-        if (Math.abs(time - this._lastPlaybackBroadcastTime) < 0.001) {
+        if (Number.isNaN(this._lastPlaybackBroadcastTime) && time <= PLAYBACK_TIME_BROADCAST_EPSILON) {
+            this._lastPlaybackBroadcastTime = time;
+            return;
+        }
+        if (Math.abs(time - this._lastPlaybackBroadcastTime) < PLAYBACK_TIME_BROADCAST_EPSILON) {
             return;
         }
         this._context.setEditTime(time);

--- a/src/core/scene/test/animation-service-playback.test.ts
+++ b/src/core/scene/test/animation-service-playback.test.ts
@@ -1,6 +1,47 @@
 const { AnimationServicePlayback } = require('../scene-process/service/animation/service-playback');
 
 describe('AnimationServicePlayback', () => {
+    it('does not broadcast an initial zero playback time before the state advances', () => {
+        jest.useFakeTimers();
+
+        const state = {
+            current: 0,
+            duration: 1,
+            isPaused: false,
+            isPlaying: false,
+            weight: 0,
+            play: jest.fn(() => {
+                state.isPlaying = true;
+            }),
+            setTime: jest.fn(),
+            sample: jest.fn(),
+        };
+        const broadcastTimeChanged = jest.fn();
+        const playback = new AnimationServicePlayback({
+            getCurrentState: () => state,
+            getEditTime: () => 0,
+            getPlayState: () => 'playing',
+            setEditTime: jest.fn(),
+            setPlayState: jest.fn(),
+            enterAnimationMode: jest.fn(),
+            exitAnimationMode: jest.fn(),
+            repaintInEditMode: jest.fn(async () => undefined),
+            broadcastTimeChanged,
+            broadcastStateChanged: jest.fn(async () => undefined),
+        });
+
+        playback.play(state as any);
+
+        expect(broadcastTimeChanged).not.toHaveBeenCalled();
+
+        state.current = 0.02;
+        jest.advanceTimersByTime(17);
+
+        expect(broadcastTimeChanged).toHaveBeenCalledTimes(1);
+        playback.dispose();
+        jest.useRealTimers();
+    });
+
     it('keeps the playback timer alive when the state is only transiently paused', () => {
         const state = {
             current: 0.5,


### PR DESCRIPTION
## 变更说明
- 播放期间查询当前属性值时直接读取场景当前值，不再临时改写同一个 AnimationState 的时间并 sample，避免播放被高频查询打断。
- 将播放时间同步广播从 100ms 调整为接近帧级间隔；播放起点仍为 0 时跳过首个 0 时间广播，避免 UI 把起点事件当作运行态进度。
- 保留暂停、停止、自然结束和重复时间去重逻辑不变。
