### PR TITLE
fix: add scripting plugin sorting config

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -2676,6 +2676,11 @@ export declare interface ICocosConfigurationPropertySchema {
     items?: ICocosConfigurationPropertySchema | ICocosConfigurationPropertySchema[];
     additionalProperties?: boolean | ICocosConfigurationPropertySchema;
     required?: string[];
+    ui?: 'asset-picker' | string;
+    assetType?: string;
+    valueField?: string;
+    displayFields?: string[];
+    query?: Record<string, unknown>;
 }
 export declare interface ICollisionMatrix {
     [x: string]: number;
@@ -7127,6 +7132,11 @@ export declare interface ICocosConfigurationPropertySchema {
     items?: ICocosConfigurationPropertySchema | ICocosConfigurationPropertySchema[];
     additionalProperties?: boolean | ICocosConfigurationPropertySchema;
     required?: string[];
+    ui?: 'asset-picker' | string;
+    assetType?: string;
+    valueField?: string;
+    displayFields?: string[];
+    query?: Record<string, unknown>;
 }
 export declare interface IConfiguration {
     [key: string]: any;
@@ -8141,6 +8151,11 @@ export declare interface ICocosConfigurationPropertySchema {
     items?: ICocosConfigurationPropertySchema | ICocosConfigurationPropertySchema[];
     additionalProperties?: boolean | ICocosConfigurationPropertySchema;
     required?: string[];
+    ui?: 'asset-picker' | string;
+    assetType?: string;
+    valueField?: string;
+    displayFields?: string[];
+    query?: Record<string, unknown>;
 }
 export declare interface ICollisionMatrix {
     [x: string]: number;

--- a/src/core/assets/asset-config.ts
+++ b/src/core/assets/asset-config.ts
@@ -1,7 +1,8 @@
 import { join } from 'path';
 import { existsSync, readdirSync } from 'fs';
 import { AssetDBRegisterInfo } from './@types/private';
-import { configurationRegistry, ConfigurationScope, IBaseConfiguration } from '../configuration';
+import { configurationManager, configurationRegistry, ConfigurationScope, IBaseConfiguration } from '../configuration';
+import { MessageType } from '../configuration/script/interface';
 import project from '../project';
 import { Engine } from '../engine';
 import { createImportMetadataNodes } from './metadata';
@@ -55,6 +56,7 @@ class AssetConfig {
     };
 
     private _init = false;
+    private _watchingConfiguration = false;
 
     /**
      * 持有的可双向绑定的配置管理实例
@@ -87,6 +89,7 @@ class AssetConfig {
         const enginePath = Engine.getInfo().typescript.path;
         this._assetConfig.libraryRoot = this._assetConfig.libraryRoot || join(this._assetConfig.root, 'library');
         this._assetConfig.tempRoot = join(this._assetConfig.root, 'temp/asset-db');
+        this.watchConfigurationChanges();
         await this.syncRuntimeConfigFromConfiguration();
         this._assetConfig.assetDBList = [{
             name: 'assets',
@@ -145,6 +148,22 @@ class AssetConfig {
         return this._configInstance.set(path, value, scope);
     }
 
+    setSortingPlugin(value: unknown) {
+        this._assetConfig.sortingPlugin = Array.isArray(value)
+            ? value.filter((item): item is string => typeof item === 'string')
+            : [];
+    }
+
+    async syncSortingPluginFromConfiguration() {
+        const scriptConfigInstance = configurationRegistry.getInstances().script;
+        if (!scriptConfigInstance) {
+            return;
+        }
+
+        const scriptConfig = await scriptConfigInstance.get<{ sortingPlugin?: unknown }>();
+        this.setSortingPlugin(scriptConfig?.sortingPlugin);
+    }
+
     private async syncRuntimeConfigFromConfiguration() {
         const importConfig = await this._configInstance.get<Partial<Pick<AssetDBConfig, 'restoreAssetDBFromCache' | 'globList' | 'createTemplateRoot'>>>();
         this._assetConfig.restoreAssetDBFromCache = importConfig.restoreAssetDBFromCache ?? false;
@@ -153,6 +172,36 @@ class AssetConfig {
             this._assetConfig.root,
             importConfig.createTemplateRoot ?? DEFAULT_CREATE_TEMPLATE_ROOT
         );
+        await this.syncSortingPluginFromConfiguration();
+    }
+
+    private watchConfigurationChanges() {
+        if (this._watchingConfiguration) {
+            return;
+        }
+        this._watchingConfiguration = true;
+
+        configurationRegistry.on(MessageType.Registry, (instance: IBaseConfiguration) => {
+            if (instance.moduleName === 'script') {
+                void this.syncSortingPluginFromConfiguration();
+            }
+        });
+
+        configurationManager.on(MessageType.Update, (key: string) => {
+            if (key === 'script.sortingPlugin' || key === 'script') {
+                void this.syncSortingPluginFromConfiguration();
+            }
+        });
+
+        configurationManager.on(MessageType.Remove, (key: string) => {
+            if (key === 'script.sortingPlugin' || key === 'script') {
+                this.setSortingPlugin([]);
+            }
+        });
+
+        configurationManager.on(MessageType.Reload, () => {
+            void this.syncRuntimeConfigFromConfiguration();
+        });
     }
 }
 

--- a/src/core/assets/index.ts
+++ b/src/core/assets/index.ts
@@ -12,6 +12,8 @@ import assetConfig from './asset-config';
 export async function initAssetDB() {
     // @ts-ignore HACK 目前引擎有在一些资源序列化会调用的接口里使用这个变量，没有合理的传参之前需要临时设置兼容
     globalThis.Build = true;
+    const { scriptConfig } = await import('../scripting/shared/query-shared-settings');
+    await scriptConfig.init();
     await assetConfig.init();
     newConsole.trackMemoryStart('assets:worker-init');
     await assetManager.init();

--- a/src/core/assets/test/config-sync.test.ts
+++ b/src/core/assets/test/config-sync.test.ts
@@ -8,9 +8,11 @@ interface IAssetConfigRuntime {
     configurationManager: typeof import('../../configuration').configurationManager;
     project: typeof import('../../project').default;
     Engine: typeof import('../../engine').Engine;
+    initAssetDB: typeof import('../index').initAssetDB;
     assetConfig: typeof import('../asset-config').default;
     assetDBManager: typeof import('../manager/asset-db').default;
     assetHandlerManager: typeof import('../manager/asset-handler').default;
+    scriptConfig: typeof import('../../scripting/shared/query-shared-settings').scriptConfig;
 }
 
 const configPath = join(TestGlobalEnv.projectRoot, 'cocos.config.json');
@@ -36,22 +38,39 @@ function writeProjectImportConfig(importConfig: Record<string, unknown>) {
     writeJSONSync(configPath, nextConfig, { spaces: 4 });
 }
 
+function writeProjectScriptConfig(scriptConfig: Record<string, unknown>) {
+    const nextConfig = JSON.parse(JSON.stringify(originalConfig));
+    nextConfig.script = {
+        ...nextConfig.script,
+        ...scriptConfig,
+    };
+    writeJSONSync(configPath, nextConfig, { spaces: 4 });
+}
+
+function waitForAsyncListeners(): Promise<void> {
+    return new Promise((resolve) => setImmediate(resolve));
+}
+
 async function loadFreshRuntime(): Promise<IAssetConfigRuntime> {
     jest.resetModules();
     const { configurationManager } = require('../../configuration') as typeof import('../../configuration');
     const project = (require('../../project') as typeof import('../../project')).default;
     const { Engine } = require('../../engine') as typeof import('../../engine');
+    const { initAssetDB } = require('../index') as typeof import('../index');
     const assetConfig = (require('../asset-config') as typeof import('../asset-config')).default;
     const assetDBManager = (require('../manager/asset-db') as typeof import('../manager/asset-db')).default;
     const assetHandlerManager = (require('../manager/asset-handler') as typeof import('../manager/asset-handler')).default;
+    const { scriptConfig } = require('../../scripting/shared/query-shared-settings') as typeof import('../../scripting/shared/query-shared-settings');
 
     return {
         configurationManager,
         project,
         Engine,
+        initAssetDB,
         assetConfig,
         assetDBManager,
         assetHandlerManager,
+        scriptConfig,
     };
 }
 
@@ -112,5 +131,60 @@ describe('asset import config sync', () => {
 
         expect(existsSync(configuredGuideFile)).toBe(true);
         expect(existsSync(legacyGuideFile)).toBe(false);
+    });
+
+    it('should sync project script sortingPlugin after script config registers', async () => {
+        const sortingPlugin = ['plugin-uuid-a', 'plugin-uuid-b'];
+        writeProjectScriptConfig({ sortingPlugin });
+
+        const runtime = await loadFreshRuntime();
+        await runtime.configurationManager.initialize(TestGlobalEnv.projectRoot);
+        await runtime.project.open(TestGlobalEnv.projectRoot);
+        await runtime.Engine.init(TestGlobalEnv.engineRoot);
+        await runtime.assetConfig.init();
+
+        expect(runtime.assetConfig.data.sortingPlugin).toEqual([]);
+
+        await runtime.scriptConfig.init();
+        await waitForAsyncListeners();
+
+        expect(runtime.assetConfig.data.sortingPlugin).toEqual(sortingPlugin);
+    });
+
+    it('should load script sortingPlugin when initializing asset-db without explicit scripting init', async () => {
+        const sortingPlugin = ['plugin-uuid-a', 'plugin-uuid-b'];
+        writeProjectScriptConfig({ sortingPlugin });
+
+        const runtime = await loadFreshRuntime();
+        await runtime.configurationManager.initialize(TestGlobalEnv.projectRoot);
+        await runtime.project.open(TestGlobalEnv.projectRoot);
+        await runtime.Engine.init(TestGlobalEnv.engineRoot);
+        await ensureDir(join(TestGlobalEnv.projectRoot, 'library'));
+        await runtime.initAssetDB();
+
+        expect(runtime.assetConfig.data.sortingPlugin).toEqual(sortingPlugin);
+    });
+
+    it('should keep runtime sortingPlugin in sync when configuration changes', async () => {
+        const runtime = await loadFreshRuntime();
+        await runtime.configurationManager.initialize(TestGlobalEnv.projectRoot);
+        await runtime.project.open(TestGlobalEnv.projectRoot);
+        await runtime.Engine.init(TestGlobalEnv.engineRoot);
+        await runtime.assetConfig.init();
+        await runtime.scriptConfig.init();
+
+        await runtime.configurationManager.set('script.sortingPlugin', ['plugin-uuid-c']);
+        await waitForAsyncListeners();
+
+        expect(runtime.assetConfig.data.sortingPlugin).toEqual(['plugin-uuid-c']);
+
+        await runtime.scriptConfig.setProject('sortingPlugin', ['plugin-uuid-d']);
+        await runtime.configurationManager.save(true);
+
+        expect(runtime.assetConfig.data.sortingPlugin).toEqual(['plugin-uuid-d']);
+
+        await runtime.configurationManager.remove('script.sortingPlugin');
+
+        expect(runtime.assetConfig.data.sortingPlugin).toEqual([]);
     });
 });

--- a/src/core/configuration/script/metadata.ts
+++ b/src/core/configuration/script/metadata.ts
@@ -17,6 +17,11 @@ export interface ICocosConfigurationPropertySchema {
     items?: ICocosConfigurationPropertySchema | ICocosConfigurationPropertySchema[];
     additionalProperties?: boolean | ICocosConfigurationPropertySchema;
     required?: string[];
+    ui?: 'asset-picker' | string;
+    assetType?: string;
+    valueField?: string;
+    displayFields?: string[];
+    query?: Record<string, unknown>;
 }
 
 export interface ICocosConfigurationNode {

--- a/src/core/configuration/test/cocos-config-schema.test.ts
+++ b/src/core/configuration/test/cocos-config-schema.test.ts
@@ -43,4 +43,13 @@ describe('cocos config schema', () => {
 
         expect(overwriteSettings.additionalProperties?.$ref).toBe('#/definitions/BundleConfigItem');
     });
+
+    it('allows script sortingPlugin as a UUID string array', () => {
+        const schema = generateSchema();
+        const scriptConfigRef = schema.properties.script.$ref;
+        const scriptConfig = resolveDefinition(schema, scriptConfigRef);
+
+        expect(scriptConfig.properties.sortingPlugin.type).toBe('array');
+        expect(scriptConfig.properties.sortingPlugin.items.type).toBe('string');
+    });
 });

--- a/src/core/configuration/test/cocos-migration.test.ts
+++ b/src/core/configuration/test/cocos-migration.test.ts
@@ -1,5 +1,6 @@
 import { CocosMigrationManager, CocosMigration } from '../migration';
 import type { IMigrationTarget } from '../migration';
+import { getMigrationList } from '../migration/register-migration';
 
 jest.mock('../migration/cocos-migration', () => ({
     CocosMigration: {
@@ -128,5 +129,26 @@ describe('CocosMigrationManager', () => {
                 .mockRejectedValueOnce(new Error('单个迁移器失败直接抛异常'));
             await expect(CocosMigrationManager.migrate('/proj')).rejects.toThrow('[Migration] 迁移失败, 详情请查看日志');
         });
+    });
+});
+
+describe('registered cocos migrations', () => {
+    it('应从 Creator project script 配置迁移 sortingPlugin 到新 script 域', async () => {
+        const projectMigration = getMigrationList().find((target) => (
+            target.sourceScope === 'project'
+            && target.pluginName === 'project'
+            && !target.targetPath
+        ));
+
+        expect(projectMigration).toBeDefined();
+
+        const result = await projectMigration!.migrate({
+            script: {
+                exportsConditions: ['browser'],
+                sortingPlugin: ['plugin-uuid-a', 'plugin-uuid-b'],
+            },
+        });
+
+        expect(result.script.sortingPlugin).toEqual(['plugin-uuid-a', 'plugin-uuid-b']);
     });
 });

--- a/src/core/configuration/test/metadata.test.ts
+++ b/src/core/configuration/test/metadata.test.ts
@@ -197,11 +197,29 @@ describe('configuration metadata', () => {
         const afterRegister = await runtime.getMetadata();
         const importNode = findNode(afterRegister, 'import');
         const scriptNode = findNode(afterRegister, 'script');
+        const sortingPluginProperty = findProperty(scriptNode, 'script.sortingPlugin');
+        const sortingPluginItemSchema = Array.isArray(sortingPluginProperty.items)
+            ? sortingPluginProperty.items[0]
+            : sortingPluginProperty.items;
 
         expect(findProperty(importNode, 'import.restoreAssetDBFromCache').type).toBe('boolean');
         expect(findProperty(importNode, 'import.fbx.material.smart').type).toBe('boolean');
         expect(importNode.properties['import.fbx']).toBeUndefined();
         expect(findProperty(scriptNode, 'script.useDefineForClassFields').type).toBe('boolean');
+        expect(sortingPluginProperty.type).toBe('array');
+        expect(sortingPluginProperty.default).toEqual([]);
+        expect(sortingPluginItemSchema).toMatchObject({
+            type: 'string',
+            ui: 'asset-picker',
+            assetType: 'cc.Script',
+            valueField: 'uuid',
+            displayFields: ['url', 'name'],
+            query: {
+                userData: {
+                    isPlugin: true,
+                },
+            },
+        });
     });
 
     it('should expose scene metadata only after the scene module registers itself', async () => {
@@ -272,6 +290,8 @@ describe('configuration metadata', () => {
         expect(findProperty(importNode, 'import.globList').description).toBe('资源导入 glob 匹配规则');
         expect(scriptNode.title).toBe('脚本');
         expect(findProperty(scriptNode, 'script.useDefineForClassFields').title).toBe('使用 defineProperty 定义类字段');
+        expect(findProperty(scriptNode, 'script.sortingPlugin').title).toBe('插件脚本排序配置');
+        expect(findProperty(scriptNode, 'script.sortingPlugin').description).toBe('插件脚本加载顺序配置，使用资源选择器选择插件脚本，配置文件中保存插件脚本 UUID。');
         expect(sceneTickNode.title).toBe('启用 Tick');
         expect(findProperty(sceneTickNode, 'scene.tick').title).toBe('启用 Tick');
         expect(findProperty(sceneTickNode, 'scene.tick').description).toBe('保持场景主循环运行');
@@ -295,6 +315,8 @@ describe('configuration metadata', () => {
 
         expect(findNode(zhNodes, 'script').title).toBe('脚本');
         expect(findNode(enNodes, 'script').title).toBe('Script');
+        expect(findProperty(findNode(zhNodes, 'script'), 'script.sortingPlugin').title).toBe('插件脚本排序配置');
+        expect(findProperty(findNode(enNodes, 'script'), 'script.sortingPlugin').title).toBe('Plugin Scripts Sorting Config');
         expect(findProperty(findNode(zhNodes, 'builder.common'), 'builder.common.platform').title).toBe('平台');
         expect(findProperty(findNode(enNodes, 'builder.common'), 'builder.common.platform').title).toBe('Platform');
         expect(findProperty(findNode(zhNodes, 'import'), 'import.globList').description).toBe('资源导入 glob 匹配规则');

--- a/src/core/scripting/@types/config-export.ts
+++ b/src/core/scripting/@types/config-export.ts
@@ -4,6 +4,7 @@ export interface ScriptProjectConfig {
     loose: boolean;
     guessCommonJsExports: boolean;
     exportsConditions: string[];
+    sortingPlugin: string[];
     preserveSymlinks: boolean;
 
     importMap: string;

--- a/src/core/scripting/shared/metadata.ts
+++ b/src/core/scripting/shared/metadata.ts
@@ -30,6 +30,25 @@ export function createScriptMetadataNodes(): ICocosConfigurationNode[] {
                 default: [],
                 title: 'i18n:configuration.script.exportsConditions.title',
             },
+            'script.sortingPlugin': {
+                type: 'array',
+                default: [],
+                title: 'i18n:configuration.script.sortingPlugin.title',
+                description: 'i18n:configuration.script.sortingPlugin.description',
+                items: {
+                    type: 'string',
+                    title: 'i18n:configuration.script.sortingPlugin.itemTitle',
+                    ui: 'asset-picker',
+                    assetType: 'cc.Script',
+                    valueField: 'uuid',
+                    displayFields: ['url', 'name'],
+                    query: {
+                        userData: {
+                            isPlugin: true,
+                        },
+                    },
+                },
+            },
             'script.preserveSymlinks': {
                 type: 'boolean',
                 default: false,

--- a/src/core/scripting/shared/query-shared-settings.ts
+++ b/src/core/scripting/shared/query-shared-settings.ts
@@ -30,6 +30,7 @@ export function getDefaultSharedSettings(): ScriptProjectConfig {
         loose: false,
         guessCommonJsExports: false,
         exportsConditions: [],
+        sortingPlugin: [],
         preserveSymlinks: false,
         importMap: '',
         previewBrowserslistConfigFile: '',
@@ -62,8 +63,13 @@ class ScriptConfig {
         return this._configInstance.get<T>(path, scope);
     }
 
-    setProject(path: string, value: any, scope?: ConfigurationScope) {
-        return this._configInstance.set(path, value, scope);
+    async setProject(path: string, value: any, scope?: ConfigurationScope) {
+        const result = await this._configInstance.set(path, value, scope);
+        if (path === 'sortingPlugin') {
+            const { default: assetConfig } = await import('../../assets/asset-config');
+            assetConfig.setSortingPlugin(value);
+        }
+        return result;
     }
 }
 

--- a/static/i18n/en/configuration.json
+++ b/static/i18n/en/configuration.json
@@ -94,6 +94,11 @@
     "exportsConditions": {
       "title": "Export Conditions"
     },
+    "sortingPlugin": {
+      "title": "Plugin Scripts Sorting Config",
+      "description": "Plugin script load order. Select plugin scripts with the asset picker; the configuration stores plugin script UUIDs.",
+      "itemTitle": "Plugin Script"
+    },
     "preserveSymlinks": {
       "title": "Preserve Symlinks"
     },

--- a/static/i18n/zh/configuration.json
+++ b/static/i18n/zh/configuration.json
@@ -94,6 +94,11 @@
     "exportsConditions": {
       "title": "导出条件"
     },
+    "sortingPlugin": {
+      "title": "插件脚本排序配置",
+      "description": "插件脚本加载顺序配置，使用资源选择器选择插件脚本，配置文件中保存插件脚本 UUID。",
+      "itemTitle": "插件脚本"
+    },
     "preserveSymlinks": {
       "title": "保留符号链接"
     },


### PR DESCRIPTION
## 变更摘要

- 新增 Scripting 配置项 `script.sortingPlugin`，默认值为空数组。
- 配置面板元数据支持插件脚本资产选择器，展示 `url/name`，写入值为 `uuid`。
- 将 `script.sortingPlugin` 同步到 AssetDB runtime `sortingPlugin`，覆盖注册、更新、重载、删除场景。