### PR TITLE
fix(scene): reset animation state before clip edits

### DIFF
--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -445,9 +445,10 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
         const rootNode = this._getSessionRootNode();
         const state = await this._getAnimationState(session.clipUuid);
+        const clip = state.clip;
         const propertyMetadataContext = createAnimationPropertyCurveMetadataContext(rootNode);
         const shouldRecordUndo = options.recordUndo !== false;
-        const before = captureAnimationClipSnapshot(state.clip, propertyMetadataContext);
+        const before = captureAnimationClipSnapshot(clip, propertyMetadataContext);
         const appliedOperations: IAnimationOperation[] = [];
         let shouldSyncDuration = false;
         let shouldRestoreOnFailure = false;
@@ -455,7 +456,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             const inputFailure = validateAnimationOperation(inputOperation, session.clipUuid);
             if (inputFailure) {
                 if (shouldRestoreOnFailure) {
-                    await this._restoreFailedOperationSnapshot(state.clip, before, rootNode);
+                    await this._restoreFailedOperationSnapshot(clip, before, rootNode);
                 }
                 return inputFailure;
             }
@@ -466,7 +467,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
                     reason: `Method '${inputOperation.type}' is not allowed in skeleton animation.`,
                 } as IAnimationOperationResult;
                 if (shouldRestoreOnFailure) {
-                    await this._restoreFailedOperationSnapshot(state.clip, before, rootNode);
+                    await this._restoreFailedOperationSnapshot(clip, before, rootNode);
                 }
                 return skeletonFailure;
             }
@@ -479,7 +480,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             });
             if (isAnimationOperationResult(normalized)) {
                 if (shouldRestoreOnFailure) {
-                    await this._restoreFailedOperationSnapshot(state.clip, before, rootNode);
+                    await this._restoreFailedOperationSnapshot(clip, before, rootNode);
                 }
                 return normalized;
             }
@@ -488,7 +489,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             const failure = validateAnimationOperation(operation, session.clipUuid);
             if (failure) {
                 if (shouldRestoreOnFailure) {
-                    await this._restoreFailedOperationSnapshot(state.clip, before, rootNode);
+                    await this._restoreFailedOperationSnapshot(clip, before, rootNode);
                 }
                 return failure;
             }
@@ -496,14 +497,15 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             let result = false;
             shouldRestoreOnFailure = true;
             try {
-                result = await applyClipOperation(state, operation, {
+                await this._resetAnimationStatePreservingClip(session.clipUuid, clip, propertyMetadataContext);
+                result = await applyClipOperation(clip, operation, {
                     rootNode,
                     rootPath: session.rootPath,
                     queryPropertyMetadata: propertyMetadataContext.queryPropertyMetadata,
                 });
             } catch (error) {
                 const normalizedError = error instanceof Error ? error : new Error(String(error));
-                await this._restoreFailedOperationSnapshot(state.clip, before, rootNode);
+                await this._restoreFailedOperationSnapshot(clip, before, rootNode);
                 return {
                     state: 'failure',
                     result: false,
@@ -516,7 +518,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
                     result: false,
                     reason: `call method ${operation.type} failed`,
                 } as IAnimationOperationResult;
-                await this._restoreFailedOperationSnapshot(state.clip, before, rootNode);
+                await this._restoreFailedOperationSnapshot(clip, before, rootNode);
                 return failureResult;
             }
             appliedOperations.push(operation);
@@ -524,12 +526,12 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         }
 
         if (shouldSyncDuration) {
-            syncAnimationClipDuration(state.clip);
+            syncAnimationClipDuration(clip);
         }
-        this._animationStates.reset(session.clipUuid);
-        this._animationStates.create(session.clipUuid, state.clip);
+        await this._resetAnimationStatePreservingClip(session.clipUuid, clip, propertyMetadataContext);
+        this._animationStates.create(session.clipUuid, clip);
         await this.setTime({ time: this._curEditTime });
-        const after = shouldRecordUndo ? captureAnimationClipSnapshot(state.clip, propertyMetadataContext) : null;
+        const after = shouldRecordUndo ? captureAnimationClipSnapshot(clip, propertyMetadataContext) : null;
         if (before && after && !animationClipSnapshotsEqual(before, after)) {
             const undoCommand = new AnimationClipSnapshotCommand({
                 clipUuid: session.clipUuid,
@@ -644,6 +646,23 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
     private async _stopCurrent(): Promise<void> {
         await this._playback.stopCurrent();
+    }
+
+    private async _resetAnimationStatePreservingClip(
+        uuid: string,
+        clip: AnimationClip,
+        options = createAnimationPropertyCurveMetadataContext(this._getSessionRootNode()),
+    ): Promise<void> {
+        if (!this._animationStates.get(uuid)) {
+            return;
+        }
+
+        // AnimationState.destroy() may touch curves it initialized. Preserve the
+        // current clip data around reset so state cleanup cannot wipe existing or
+        // newly edited keyframes.
+        const snapshot = captureAnimationClipSnapshot(clip, options);
+        this._animationStates.reset(uuid);
+        await restoreAnimationClipSnapshot(clip, snapshot);
     }
 
     private async _restoreFailedOperationSnapshot(clip: AnimationClip, snapshot: IAnimationClipSnapshot, _rootNode: Node): Promise<void> {

--- a/src/core/scene/scene-process/service/animation/clip-operations.ts
+++ b/src/core/scene/scene-process/service/animation/clip-operations.ts
@@ -1,4 +1,4 @@
-import type { AnimationClip, AnimationState } from 'cc';
+import type { AnimationClip } from 'cc';
 import type {
     IAnimationEventDump,
     IAnimationOperation,
@@ -112,8 +112,7 @@ export function isSupportedClipOperation(funcName: string): boolean {
     return SUPPORTED_CLIP_OPERATIONS.includes(funcName);
 }
 
-export async function applyClipOperation(state: AnimationState, operation: IAnimationOperation, context: IPropertyCurveOperationContext): Promise<boolean> {
-    const clip = state.clip;
+export async function applyClipOperation(clip: AnimationClip, operation: IAnimationOperation, context: IPropertyCurveOperationContext): Promise<boolean> {
     switch (operation.type) {
         case 'changeSample':
             return changeClipSample(clip, operation.sample);

--- a/src/core/scene/test/animation-clip-operations.test.ts
+++ b/src/core/scene/test/animation-clip-operations.test.ts
@@ -41,7 +41,7 @@ describe('animation clip operations', () => {
             updateEventDatas: jest.fn(),
         };
 
-        const result = await applyClipOperation({ clip }, {
+        const result = await applyClipOperation(clip, {
             type: 'changeSample',
             clipUuid: 'clip-uuid',
             sample: 60,


### PR DESCRIPTION
## 变更说明

- 修复动画服务在 `applyOperations` 修改 `AnimationClip` 曲线后才销毁旧 `AnimationState`，偶发导致刚写入的 keyframes 被 state cleanup 清掉的问题。
- 将 clip mutation 改为先 reset 当前 `AnimationState`，再执行 clip 操作，最后基于修改后的 clip 重建 state。
- 同步更新 `applyClipOperation` 的单测调用方式。
