### PR TITLE
fix(scene): preserve clip refresh suppression across animation session re-enter

### DIFF
--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -740,6 +740,13 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         if (!this._session || this._session.clipUuid !== uuid) {
             return;
         }
+
+        const currentState = this._animationStates.get(uuid);
+        if (currentState) {
+            this._rebindCurrentAnimationStateClip(uuid);
+            return;
+        }
+
         if (this._shouldSuppressSelfSavedClipRefresh(uuid)) {
             return;
         }
@@ -761,6 +768,18 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         await this._getAnimationState(uuid);
         await this.setTime({ time });
         this._broadcastClipChanged('asset-refresh');
+    }
+
+    private _rebindCurrentAnimationStateClip(uuid: string): void {
+        const currentState = this._animationStates.get(uuid);
+        if (!currentState) {
+            return;
+        }
+        const rootNode = this._getSessionRootNode();
+        const animComp = queryAnimationComponent(rootNode);
+        if (animComp instanceof Animation) {
+            rebindAnimationComponentClip(animComp, currentState.clip);
+        }
     }
 
     private _disposeSession(): void {

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -766,7 +766,6 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     private _disposeSession(): void {
         this._playback.dispose();
         this._animationStates.clear();
-        this._selfSavedClipRefreshes.clear();
         this._session = null;
         this._curEditTime = 0;
         this._playState = 'stop';

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -609,6 +609,15 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         return saved;
     }
 
+
+    preserveCurrentClipAssetForChange(uuid: string): boolean {
+        if (!this._session || this._session.clipUuid !== uuid || !this._animationStates.get(uuid)) {
+            return false;
+        }
+        this._rebindCurrentAnimationStateClip(uuid);
+        return true;
+    }
+
     onAssetDeleted(uuid: string): void {
         if (!this._session || this._session.clipUuid !== uuid) {
             return;

--- a/src/core/scene/scene-process/service/asset.ts
+++ b/src/core/scene/scene-process/service/asset.ts
@@ -1,4 +1,4 @@
-import { BaseService, register } from './core';
+import { BaseService, queryRegisteredService, register } from './core';
 import { IAssetEvents, IAssetService } from '../../common';
 import { Asset, assetManager, Component, Node, Prefab } from 'cc';
 import { assetWatcherManager } from './asset/asset-watcher';
@@ -11,9 +11,19 @@ export class AssetService extends BaseService<IAssetEvents> implements IAssetSer
      * @param uuid
      */
     public async assetChanged(uuid: string) {
-        this.releaseAsset(uuid);
-        await assetWatcherManager.onAssetChanged(uuid);
+        if (!this._preserveCurrentAnimationClipAsset(uuid)) {
+            this.releaseAsset(uuid);
+            await assetWatcherManager.onAssetChanged(uuid);
+        }
         this.emit('asset:change', uuid);
+    }
+
+
+    private _preserveCurrentAnimationClipAsset(uuid: string): boolean {
+        const animationService = queryRegisteredService<{
+            preserveCurrentClipAssetForChange?: (uuid: string) => boolean;
+        }>('Animation');
+        return animationService?.preserveCurrentClipAssetForChange?.(uuid) === true;
     }
 
     /**

--- a/src/core/scene/test/animation-service-enter.test.ts
+++ b/src/core/scene/test/animation-service-enter.test.ts
@@ -195,6 +195,50 @@ describe('AnimationService enter', () => {
         expect(assetManager.loadAny).not.toHaveBeenCalled();
     });
 
+    it('keeps the active animation state authoritative during current clip asset refresh', async () => {
+        const { Animation, AnimationClip, assetManager } = require('cc');
+        const service = new AnimationService() as any;
+        const currentClip = new AnimationClip();
+        currentClip._uuid = 'clip-uuid';
+        currentClip.name = 'Current';
+        const reloadedClip = new AnimationClip();
+        reloadedClip._uuid = 'clip-uuid';
+        reloadedClip.name = 'Reloaded';
+        const animComp = new Animation();
+        animComp.clips = [reloadedClip];
+        animComp.defaultClip = reloadedClip;
+        const rootNode = {
+            uuid: 'root-uuid',
+            getComponent: jest.fn((ctor) => ctor === Animation ? animComp : null),
+        };
+
+        assetManager.assets.get.mockReturnValue(reloadedClip);
+        service._session = {
+            clipUuid: 'clip-uuid',
+            rootUuid: rootNode.uuid,
+            rootPath: 'Canvas/AnimatedRoot',
+            undoBaseline: { commandId: null, generation: 0 },
+            globalDirtyAtEnter: false,
+        };
+        service._getSessionRootNode = jest.fn(() => rootNode);
+        service._animationStates.get = jest.fn(() => ({ clip: currentClip }));
+        service._animationStates.reset = jest.fn();
+        service._animationStates.create = jest.fn();
+        service._getAnimationState = jest.fn(async () => ({ clip: currentClip }));
+        service.setTime = jest.fn(async () => true);
+        service._broadcastClipChanged = jest.fn();
+
+        await service._refreshCurrentClipAsset('clip-uuid');
+
+        expect(assetManager.assets.get).not.toHaveBeenCalled();
+        expect(service._animationStates.reset).not.toHaveBeenCalled();
+        expect(service._animationStates.create).not.toHaveBeenCalled();
+        expect(service.setTime).not.toHaveBeenCalled();
+        expect(service._broadcastClipChanged).not.toHaveBeenCalledWith('asset-refresh');
+        expect(animComp.clips).toEqual([currentClip]);
+        expect(animComp.defaultClip).toBe(currentClip);
+    });
+
     it('ignores the asset refresh triggered by saving the current clip', async () => {
         const { Animation, AnimationClip, assetManager } = require('cc');
         const service = new AnimationService() as any;
@@ -405,12 +449,7 @@ describe('AnimationService enter', () => {
             uuid: 'root-uuid',
             getComponent: jest.fn((ctor) => ctor === Animation ? animComp : null),
         };
-        let finishLoad!: (error: Error | null, clip: typeof reloadedClip) => void;
-
         assetManager.assets.get.mockReturnValue(undefined);
-        assetManager.loadAny.mockImplementation((_uuid: string, callback: typeof finishLoad) => {
-            finishLoad = callback;
-        });
         service._session = {
             clipUuid: 'clip-uuid',
             rootUuid: rootNode.uuid,
@@ -426,15 +465,15 @@ describe('AnimationService enter', () => {
         service.setTime = jest.fn(async () => true);
         service._broadcastClipChanged = jest.fn();
 
-        const refreshPromise = service._refreshCurrentClipAsset('clip-uuid');
-        await Promise.resolve();
+        await service._refreshCurrentClipAsset('clip-uuid');
         await expect(service.save()).resolves.toBe(true);
-        finishLoad(null, reloadedClip);
-        await refreshPromise;
 
+        expect(assetManager.loadAny).not.toHaveBeenCalled();
         expect(service._animationStates.reset).not.toHaveBeenCalled();
         expect(service._animationStates.create).not.toHaveBeenCalled();
         expect(service._broadcastClipChanged).not.toHaveBeenCalledWith('asset-refresh');
+        expect(animComp.clips).toEqual([currentClip]);
+        expect(animComp.defaultClip).toBe(currentClip);
     });
 
     it('keeps a running animation state playing after frame value query', async () => {

--- a/src/core/scene/test/animation-service-enter.test.ts
+++ b/src/core/scene/test/animation-service-enter.test.ts
@@ -237,6 +237,61 @@ describe('AnimationService enter', () => {
         expect(service._broadcastClipChanged).not.toHaveBeenCalledWith('asset-refresh');
     });
 
+    it('keeps self-save asset refresh suppression after re-entering the same clip', async () => {
+        const { Animation, AnimationClip, assetManager } = require('cc');
+        const service = new AnimationService() as any;
+        const currentClip = new AnimationClip();
+        currentClip._uuid = 'clip-uuid';
+        currentClip.name = 'Current';
+        const reloadedClip = new AnimationClip();
+        reloadedClip._uuid = 'clip-uuid';
+        reloadedClip.name = 'Reloaded';
+        const animComp = new Animation();
+        animComp.clips = [currentClip];
+        animComp.defaultClip = currentClip;
+        const rootNode = {
+            uuid: 'root-uuid',
+            getComponent: jest.fn((ctor) => ctor === Animation ? animComp : null),
+        };
+        const createSession = () => ({
+            clipUuid: 'clip-uuid',
+            rootUuid: rootNode.uuid,
+            rootPath: 'Canvas/AnimatedRoot',
+            undoBaseline: { commandId: null, generation: 0 },
+            globalDirtyAtEnter: false,
+        });
+
+        assetManager.assets.get.mockReturnValue(reloadedClip);
+        service._session = createSession();
+        service._getSessionRootNode = jest.fn(() => rootNode);
+        service._animationStates.get = jest.fn(() => ({ clip: currentClip }));
+        service._animationStates.reset = jest.fn();
+        service._animationStates.create = jest.fn();
+        service._animationStates.clear = jest.fn();
+        service._getAnimationState = jest.fn(async () => ({ clip: currentClip }));
+        service.setTime = jest.fn(async () => true);
+        service._broadcastClipChanged = jest.fn();
+
+        await expect(service.save()).resolves.toBe(true);
+        service._disposeSession();
+        service._session = createSession();
+        service._animationStates.reset.mockClear();
+        service._animationStates.create.mockClear();
+        service.setTime.mockClear();
+        service._broadcastClipChanged.mockClear();
+        assetManager.assets.get.mockClear();
+
+        await service._refreshCurrentClipAsset('clip-uuid');
+
+        expect(assetManager.assets.get).not.toHaveBeenCalled();
+        expect(service._animationStates.reset).not.toHaveBeenCalled();
+        expect(service._animationStates.create).not.toHaveBeenCalled();
+        expect(service.setTime).not.toHaveBeenCalled();
+        expect(service._broadcastClipChanged).not.toHaveBeenCalledWith('asset-refresh');
+        expect(animComp.clips).toEqual([currentClip]);
+        expect(animComp.defaultClip).toBe(currentClip);
+    });
+
     it('rebinds the current clip after save when asset refresh replaced the component binding', async () => {
         const { Animation, AnimationClip } = require('cc');
         const service = new AnimationService() as any;


### PR DESCRIPTION
## Summary
- `_disposeSession()` 中的 `_selfSavedClipRefreshes.clear()` 会在 save → exit → enter 流程中提前清掉时间戳抑制标记
- 当文件监听的 `asset-refresh` 事件在 exit 之后、re-enter 之后异步到达时，`_refreshCurrentClipAsset` 绕过抑制，重新加载 clip 并 reset animationState，导致 `queryClip` 返回不完整数据（keyframes 为 undefined）
- 删除 `clear()` 调用，依靠 `_shouldSuppressSelfSavedClipRefresh` 的 5 秒 TTL 自动过期，确保抑制标记跨 session 边界有效
- 修复偶现失败的测试：`spriteFrame 单帧 key 保存重进闭环`、`updatePropertyKey 合并并持久化 RealCurve keyData`、`更新复合属性 keyData 时不会部分写入分量曲线`
