### PR TITLE
[break] feat(server): support custom ip/port and use absolute URLs in browser fetch

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -9071,10 +9071,7 @@ export declare interface SpriteFrameVertices {
     maxPos: number[];
 }
 export declare function start(): Promise<void>;
-export declare function start_2(options?: {
-    ip?: string;
-    port?: number;
-}): Promise<string>;
+export declare function start_2(port?: number, host?: string): Promise<string>;
 export declare function startCompileScript(assetChanges?: AssetChangeInfo[]): Promise<void>;
 export declare function startEngineCompilation(force?: boolean): Promise<void>;
 export declare function startupWorker(projectPath: string): Promise<void>;

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -9071,7 +9071,10 @@ export declare interface SpriteFrameVertices {
     maxPos: number[];
 }
 export declare function start(): Promise<void>;
-export declare function start_2(port?: number): Promise<string>;
+export declare function start_2(options?: {
+    ip?: string;
+    port?: number;
+}): Promise<string>;
 export declare function startCompileScript(assetChanges?: AssetChangeInfo[]): Promise<void>;
 export declare function startEngineCompilation(force?: boolean): Promise<void>;
 export declare function startupWorker(projectPath: string): Promise<void>;

--- a/src/core/scene/scene-process/engine-bootstrap.ts
+++ b/src/core/scene/scene-process/engine-bootstrap.ts
@@ -24,11 +24,11 @@ declare const cc: any;
 export async function startup(options: {
     serverURL: string;
 }) {
-    const defaultConfig = await fetch('/scripting/engine/game-config');
-    const config = await defaultConfig.json();
-    const modules = await fetch('/scripting/engine/modules');
-    const features = (await modules.json()) as string[];
     const { serverURL } = options;
+    const defaultConfig = await fetch(`${serverURL}/scripting/engine/game-config`);
+    const config = await defaultConfig.json();
+    const modules = await fetch(`${serverURL}/scripting/engine/modules`);
+    const features = (await modules.json()) as string[];
 
     serviceManager.initialize(serverURL);
 
@@ -153,7 +153,7 @@ export async function startup(options: {
     // are available before preview services initialize.
     await (async () => {
         try {
-            const res = await fetch('/query-asset-infos/cc.EffectAsset');
+            const res = await fetch(`${serverURL}/query-asset-infos/cc.EffectAsset`);
             if (!res.ok) return;
             const effectInfos: any[] = await res.json();
             if (!effectInfos.length) return;
@@ -168,7 +168,7 @@ export async function startup(options: {
                     const encodedUuid = encodeURIComponent(uuid);
                     const ext = (lib['.bin'] && !lib['.json']) ? 'bin' : 'json';
 
-                    const r = await fetch(`/import/${encodedUuid}.${ext}?isBrowser=true`);
+                    const r = await fetch(`${serverURL}/import/${encodedUuid}.${ext}?isBrowser=true`);
                     if (!r.ok) return;
 
                     const isBinary = ext === 'bin';
@@ -275,7 +275,7 @@ export async function startup(options: {
         // reports width 0, and every SpriteFrame on it fails checkRect and gets
         // its rect reset (e.g. sprite frames from a plist atlas in a prefab).
         try {
-            const res = await fetch(`/query-asset-info/${encodeURIComponent(uuid)}`);
+            const res = await fetch(`${serverURL}/query-asset-info/${encodeURIComponent(uuid)}`);
             if (!res.ok) return '';
             const info: any = await res.json();
             const lib = info?.library;
@@ -306,8 +306,8 @@ export async function startup(options: {
         const encodedUuid = encodeURIComponent(uuid);
         const isSubAsset = nativeExt.length > 0 && nativeExt[0] !== '.';
         const nativeUrl = isSubAsset
-            ? `/native/${encodedUuid}/${nativeExt}?isBrowser=true`
-            : `/native/${encodedUuid}${nativeExt}?isBrowser=true`;
+            ? `${serverURL}/native/${encodedUuid}/${nativeExt}?isBrowser=true`
+            : `${serverURL}/native/${encodedUuid}${nativeExt}?isBrowser=true`;
 
         try {
             const res = await fetch(nativeUrl);
@@ -340,12 +340,12 @@ export async function startup(options: {
             // binary (.bin/cconb) instead of .json.
             let ext = 'json';
             try {
-                const extRes = await fetch(`/query-extname/${encodedUuid}`);
+                const extRes = await fetch(`${serverURL}/query-extname/${encodedUuid}`);
                 const queryExt = (await extRes.text()).trim();
                 if (queryExt === '.cconb') ext = 'bin';
             } catch { /* default to json */ }
 
-            const res = await fetch(`/import/${encodedUuid}.${ext}?isBrowser=true`);
+            const res = await fetch(`${serverURL}/import/${encodedUuid}.${ext}?isBrowser=true`);
             if (!res.ok) throw new Error(`Asset fetch failed (${res.status}): ${uuid}`);
 
             const isBinary = ext === 'bin';

--- a/src/core/scene/scene-process/service/engine.ts
+++ b/src/core/scene/scene-process/service/engine.ts
@@ -8,6 +8,7 @@ import { Service } from './core/decorator';
 import type { ICustomLayerConfig, IEngineEvents, IEngineService } from '../../common';
 import { NodeEventType } from '../../common';
 import { Rpc } from '../rpc';
+import { serviceManager } from './service-manager';
 import { TimerUtil } from './utils/timer-util';
 
 const tickTime = 1000 / 60;
@@ -149,7 +150,8 @@ export class EngineService extends BaseService<IEngineEvents> implements IEngine
             if (!view || typeof fetch !== 'function') {
                 return;
             }
-            const res = await fetch('/scripting/engine/design-resolution');
+            const serverURL = serviceManager.getServerUrl();
+            const res = await fetch(`${serverURL}/scripting/engine/design-resolution`);
             const dr = await res.json();
             const width = Number(dr?.width);
             const height = Number(dr?.height);

--- a/src/lib/server/server.ts
+++ b/src/lib/server/server.ts
@@ -11,16 +11,19 @@ let isRunning = false;
 /**
  * Initialize and start the Express HTTP server.
  *
- * @param port Optional port number; auto-selected if omitted
- * @returns The server base URL (e.g. http://localhost:9527)
+ * @param options Optional `{ ip, port }`. `port` is auto-selected if omitted (and
+ *                retried on conflict); `ip` sets the bind/base-URL host (defaults
+ *                to localhost). More parameters can be added here later.
+ * @returns The server base URL (e.g. http://localhost:9527), reflecting the
+ *          actual bound port and the configured ip.
  */
-export async function start(port?: number): Promise<string> {
+export async function start(options?: { ip?: string; port?: number }): Promise<string> {
     if (isRunning && serverUrl) {
         return serverUrl;
     }
 
     const { serverService } = await import('../../server/server');
-    await serverService.start(port);
+    await serverService.start(options?.port, options?.ip);
 
     serverUrl = serverService.url;
     isRunning = true;

--- a/src/lib/server/server.ts
+++ b/src/lib/server/server.ts
@@ -11,19 +11,18 @@ let isRunning = false;
 /**
  * Initialize and start the Express HTTP server.
  *
- * @param options Optional `{ ip, port }`. `port` is auto-selected if omitted (and
- *                retried on conflict); `ip` sets the bind/base-URL host (defaults
- *                to localhost). More parameters can be added here later.
+ * @param port  Preferred port number. Auto-selected if omitted (retried on conflict).
+ * @param host  Bind address / base-URL host. Defaults to localhost.
  * @returns The server base URL (e.g. http://localhost:9527), reflecting the
- *          actual bound port and the configured ip.
+ *          actual bound port and the configured host.
  */
-export async function start(options?: { ip?: string; port?: number }): Promise<string> {
+export async function start(port?: number, host?: string): Promise<string> {
     if (isRunning && serverUrl) {
         return serverUrl;
     }
 
     const { serverService } = await import('../../server/server');
-    await serverService.start(options?.port, options?.ip);
+    await serverService.start(port, host);
 
     serverUrl = serverService.url;
     isRunning = true;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4,10 +4,10 @@ import { IMiddlewareContribution } from './interfaces';
 /**
  * 启动服务器
  */
-export async function startServer(port?: number): Promise<void> {
+export async function startServer(port?: number, host?: string): Promise<void> {
     try {
         serverService.init();
-        await serverService.start(port);
+        await serverService.start(port, host);
     } catch (error) {
         console.error(error);
     }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -14,6 +14,7 @@ import { IMiddlewareContribution } from './interfaces';
 
 interface ServerOptions {
     port: number,// 端口
+    host?: string,// 绑定/对外地址(ip 或 host);省略则绑定所有网卡
     useHttps: boolean;// 是否启动 HTTPS
     keyFile?: string; // HTTPS 私钥文件路径
     certFile?: string;// HTTPS 证书文件路径
@@ -24,6 +25,7 @@ export class ServerService {
     private app: Express = express();
     private server: HTTPServer | HTTPSServer | undefined;
     private _port = 9527;
+    private _host = 'localhost';// 对外 url 使用的 host/ip
     private useHttps = false;
     private httpsConfig = {
         key: '',// HTTPS 私钥文件路径
@@ -34,20 +36,27 @@ export class ServerService {
     public get url() {
         if (this.server && this.server.listening) {
             const httpRoot = this.useHttps ? 'https' : 'http';
-            return `${httpRoot}://localhost:${this._port}`;
+            return `${httpRoot}://${this._host}:${this._port}`;
         }
         return '服务器未启动';
+    }
+
+    public get host() {
+        return this._host;
     }
 
     public get port() {
         return this._port;
     }
 
-    async start(port?: number) {
+    async start(port?: number, host?: string) {
         console.log('🚀 开始启动服务器...');
         this.init();
+        if (host) {
+            this._host = host;
+        }
         const preferredPort = await getAvailablePort(port || this._port);
-        const { server, port: actualPort } = await this.createServerWithRetry(preferredPort);
+        const { server, port: actualPort } = await this.createServerWithRetry(preferredPort, host);
         this._port = actualPort;
         this.server = server;
         socketService.startup(this.server);
@@ -78,7 +87,7 @@ export class ServerService {
      * @returns Promise<http.Server | https.Server>
      */
     async createServer(options: ServerOptions, requestHandler: Express): Promise<HTTPServer | HTTPSServer> {
-        const { port, useHttps, keyFile, certFile, caFile } = options;
+        const { port, host, useHttps, keyFile, certFile, caFile } = options;
 
         let server: HTTPServer | HTTPSServer;
 
@@ -119,14 +128,20 @@ export class ServerService {
                 reject(err);
             });
 
-            server.listen(port);
+            // host 省略时 listen(port, undefined) 等价于绑定所有网卡(保持原行为)。
+            if (host) {
+                server.listen(port, host);
+            } else {
+                server.listen(port);
+            }
         });
     }
 
-    private async createServerWithRetry(port: number): Promise<{ server: HTTPServer | HTTPSServer; port: number }> {
+    private async createServerWithRetry(port: number, host?: string): Promise<{ server: HTTPServer | HTTPSServer; port: number }> {
         try {
             const server = await this.createServer({
                 port,
+                host,
                 useHttps: this.useHttps,
                 keyFile: this.httpsConfig.key,
                 certFile: this.httpsConfig.cert,
@@ -135,7 +150,7 @@ export class ServerService {
             return { server, port };
         } catch (err: any) {
             if (err.code === 'EADDRINUSE') {
-                return this.createServerWithRetry(port + 1);
+                return this.createServerWithRetry(port + 1, host);
             }
             throw err;
         }


### PR DESCRIPTION
## Summary
- Add optional `host` parameter to `ServerService.start()` so the server can bind to a specific IP/host instead of all interfaces
- Change `lib/server/start(port?)` to `start({ ip?, port? })` for cleaner extensibility
- `ServerService.url` now reflects the configured host instead of hardcoded `localhost`
- Replace all relative fetch URLs (`/path`) with absolute URLs (`${serverURL}/path`) in browser-side scene-process code, ensuring correct requests when the server binds to a custom ip/port

## Changes
- `src/server/server.ts`: Add `host` to `ServerOptions`, `_host` field, pass through `createServer`/`createServerWithRetry`, conditional `server.listen(port, host)`
- `src/server/index.ts`: Forward `host` parameter in `startServer()`
- `src/lib/server/server.ts`: Change `start(port?)` to `start({ ip?, port? })` options object
- `src/core/scene/scene-process/engine-bootstrap.ts`: Use `${serverURL}` for all fetch calls
- `src/core/scene/scene-process/service/engine.ts`: Use `${serverURL}` in `syncDesignResolution()`