### PR TITLE
feat(i18n): add lib entry for host-driven language switching

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -44,9 +44,10 @@ function loadLanguageResources(language: string): Record<string, any> {
     return resources;
 }
 
-// 纯 Node.js 初始化 
+// 纯 Node.js 初始化
 i18n.init({
     // 基础配置
+    // 默认英文;目标语言由宿主 (如 PinK) 通过 lib/i18n 入口调用 setLanguage 驱动。
     lng: 'en',
     fallbackLng: 'en',
 

--- a/src/lib/i18n/i18n.ts
+++ b/src/lib/i18n/i18n.ts
@@ -1,0 +1,18 @@
+/**
+ * i18n lib 入口
+ *
+ * 供外部宿主 (如 PinK) 在启动时设置当前语言。
+ * 设置后,所有走 i18n.transI18nName / i18n.t 的输出会以目标语言返回。
+ * 语言码只支持 'zh' / 'en';宿主侧需自行把 zh-cn 等 BCP-47 变体归一化后传入。
+ */
+
+export async function setLanguage(language: string): Promise<void> {
+    const { default: i18n } = await import('../../core/base/i18n');
+    await i18n.setLanguage(language);
+}
+
+/** 获取当前语言,便于宿主诊断 */
+export async function getLanguage(): Promise<string> {
+    const { default: i18n } = await import('../../core/base/i18n');
+    return i18n._lang;
+}


### PR DESCRIPTION
## Summary
- Add `src/lib/i18n/i18n.ts` with `setLanguage` / `getLanguage` exports, allowing external hosts (e.g. PinK) to drive the active language at startup.
- Clarify the default language comment in `src/i18n/index.ts` init config.

## Motivation
The i18n module currently initializes with English as default but provides no public API for external hosts to switch the language. This PR exposes a clean entry point so hosts can set the language via `lib/i18n` without reaching into internal modules.
