### PR TITLE
fix: support deleted scene source recovery

### DIFF
--- a/src/core/scene/common/editor/options.ts
+++ b/src/core/scene/common/editor/options.ts
@@ -42,4 +42,8 @@ export interface ICloseOptions {
     urlOrUUID?: string;
     /** Whether to save before closing. Defaults to true for backward compatibility. */
     save?: boolean;
+    /** Allows closing the current editor when the requested source asset was deleted. */
+    allowDeletedSourceFallback?: boolean;
+    /** The source editor UUID expected before applying a deleted-source fallback. */
+    expectedCurrentUuid?: string;
 }

--- a/src/core/scene/scene-process/service/editor.ts
+++ b/src/core/scene/scene-process/service/editor.ts
@@ -179,33 +179,39 @@ export class EditorService extends BaseService<IEditorEvents> implements IEditor
     async close(params: ICloseOptions): Promise<boolean> {
         const urlOrUUID = params.urlOrUUID ?? this.currentEditorUuid;
         try {
-            if (!urlOrUUID) return true;
+            const currentEditorUuid = this.currentEditorUuid;
+            if (!urlOrUUID || !currentEditorUuid) return true;
 
             const assetInfo = await Rpc.getInstance().request('assetManager', 'queryAssetInfo', [urlOrUUID]);
-            if (!assetInfo) {
-                throw new Error(`通过 ${urlOrUUID} 请求资源失败`);
+            const editor = assetInfo
+                ? this.editorMap.get(assetInfo.uuid)
+                : params.allowDeletedSourceFallback && params.expectedCurrentUuid === currentEditorUuid
+                    ? this.editorMap.get(currentEditorUuid)
+                    : undefined;
+            if (!editor) {
+                if (!assetInfo) {
+                    throw new Error(`通过 ${urlOrUUID} 请求资源失败`);
+                }
+                return true;
             }
-
-            const uuid = assetInfo.uuid;
-            const editor = this.editorMap.get(uuid);
-            if (!editor) return true;
 
             const result = await editor.close({ save: params.save ?? true });
 
-            // 如果关闭的是当前打开的编辑器，清除当前状态
-            if (uuid === this.currentEditorUuid) {
+            if (editor === this.editorMap.get(currentEditorUuid)) {
                 this._clearUndoHistory();
                 this.currentEditorUuid = null;
             }
-
-            // 移除编辑器实例以释放内存
-            this.editorMap.delete(uuid);
+            for (const [uuid, candidate] of this.editorMap) {
+                if (candidate === editor) {
+                    this.editorMap.delete(uuid);
+                }
+            }
 
             this.emit('editor:close');
             // 真正关闭编辑器时的会话清理边界；重载只复用内容卸载/挂载边界。
             this.emitInternal(InternalServiceEvents.EditorDisposed);
             this.isOpen = false;
-            console.log(`关闭 ${assetInfo.url}`);
+            console.log(`关闭 ${assetInfo?.url ?? urlOrUUID}`);
             return result;
         } catch (error) {
             console.error(`关闭失败: [${urlOrUUID}]`, error);
@@ -216,7 +222,8 @@ export class EditorService extends BaseService<IEditorEvents> implements IEditor
     async save(params: ISaveOptions): Promise<IAssetInfo> {
         const urlOrUUID = params.urlOrUUID ?? this.currentEditorUuid;
         try {
-            if (!urlOrUUID) {
+            const currentEditorUuid = this.currentEditorUuid;
+            if (!urlOrUUID || !currentEditorUuid) {
                 throw new Error('当前没有打开任何编辑器');
             }
 
@@ -225,13 +232,25 @@ export class EditorService extends BaseService<IEditorEvents> implements IEditor
                 throw new Error(`通过 ${urlOrUUID} 请求资源失败`);
             }
 
-            const uuid = assetInfo.uuid;
-            const editor = this.editorMap.get(uuid);
+            const editor = this.editorMap.get(currentEditorUuid);
             if (!editor) {
-                throw new Error(`当前没有打开任何编辑器`);
+                throw new Error('当前没有打开任何编辑器');
+            }
+            if (!this.isSaveTargetCompatible(editor, assetInfo.type)) {
+                throw new Error(`不能将 ${editor instanceof SceneEditor ? 'scene' : 'prefab'} 保存到 ${assetInfo.type} 资源`);
             }
 
-            const result = await editor.save();
+            const result = assetInfo.uuid === currentEditorUuid
+                ? await editor.save()
+                : await editor.saveTo(assetInfo);
+            if (result.uuid !== assetInfo.uuid) {
+                throw new Error(`保存目标资源标识不一致: 期望 ${assetInfo.uuid}，实际 ${result.uuid}`);
+            }
+            if (assetInfo.uuid !== currentEditorUuid) {
+                this.editorMap.delete(currentEditorUuid);
+                this.editorMap.set(result.uuid, editor);
+                this.currentEditorUuid = result.uuid;
+            }
 
             this._markUndoSaved();
 
@@ -242,6 +261,13 @@ export class EditorService extends BaseService<IEditorEvents> implements IEditor
             console.error(`保存失败: [${urlOrUUID}]`, error);
             throw error;
         }
+    }
+
+    private isSaveTargetCompatible(editor: SceneEditor | PrefabEditor, targetType: string): boolean {
+        if (editor instanceof SceneEditor) {
+            return targetType === 'scene' || targetType === 'cc.SceneAsset';
+        }
+        return targetType === 'prefab' || targetType === 'cc.Prefab';
     }
 
     async reload(params: IReloadOptions): Promise<ReloadResult> {

--- a/src/core/scene/scene-process/service/editors/base-editor.ts
+++ b/src/core/scene/scene-process/service/editors/base-editor.ts
@@ -118,6 +118,7 @@ export abstract class BaseEditor {
     protected abstract _doOpen(asset: IAssetInfo, options?: INodeDumpOptions): Promise<TEditorEntity>;
     abstract close(options?: { save?: boolean }): Promise<boolean>;
     abstract save(): Promise<IAssetInfo>;
+    abstract saveTo(asset: IAssetInfo): Promise<IAssetInfo>;
     /**
      * 执行实际的重载操作，子类需要实现具体的重载逻辑
      */

--- a/src/core/scene/scene-process/service/editors/prefab-editor.ts
+++ b/src/core/scene/scene-process/service/editors/prefab-editor.ts
@@ -62,10 +62,24 @@ export class PrefabEditor extends BaseEditor {
         if (!this.entity) {
             throw new Error('没有打开预制体');
         }
-        // 序列化预制体数据
+        return this.saveToAsset(this.entity.identifier.assetUuid);
+    }
+
+    async saveTo(asset: IAssetInfo): Promise<IAssetInfo> {
+        return this.saveToAsset(asset.uuid);
+    }
+
+    private async saveToAsset(assetUuid: string): Promise<IAssetInfo> {
+        if (!this.entity) {
+            throw new Error('没有打开预制体');
+        }
         const serializedData = editorPrefabUtils.serialize(this.entity.instance);
-        // 保存到磁盘
-        return await Rpc.getInstance().request('assetManager', 'saveAsset', [this.entity.identifier.assetUuid, serializedData]);
+        const saved = await Rpc.getInstance().request('assetManager', 'saveAsset', [assetUuid, serializedData]);
+        if (!saved || saved.uuid !== assetUuid) {
+            throw new Error(`保存目标资源标识不一致: 期望 ${assetUuid}，实际 ${saved?.uuid ?? 'undefined'}`);
+        }
+        this.entity.identifier = this.getIdentifier(saved);
+        return saved;
     }
 
     protected async _doReload(): Promise<INode> {

--- a/src/core/scene/scene-process/service/editors/scene-editor.ts
+++ b/src/core/scene/scene-process/service/editors/scene-editor.ts
@@ -1,4 +1,4 @@
-import { Scene, SceneAsset, Component, Node } from 'cc';
+import { Scene, SceneAsset } from 'cc';
 import { type IBaseIdentifier, ICreateOptions, IEditorTarget, IScene, INodeDumpOptions } from '../../../common';
 import { Rpc } from '../../rpc';
 import { sceneUtils } from '../scene/utils';
@@ -58,8 +58,24 @@ export class SceneEditor extends BaseEditor {
         if (!this.entity) {
             throw new Error('[save] 没有打开场景');
         }
+        return this.saveToAsset(this.entity.identifier.assetUuid);
+    }
+
+    async saveTo(asset: IAssetInfo): Promise<IAssetInfo> {
+        return this.saveToAsset(asset.uuid);
+    }
+
+    private async saveToAsset(assetUuid: string): Promise<IAssetInfo> {
+        if (!this.entity) {
+            throw new Error('[save] 没有打开场景');
+        }
         const serializedData = sceneUtils.serialize(this.entity.instance as Scene);
-        return await Rpc.getInstance().request('assetManager', 'saveAsset', [this.entity.identifier.assetUuid, serializedData]);
+        const saved = await Rpc.getInstance().request('assetManager', 'saveAsset', [assetUuid, serializedData]);
+        if (!saved || saved.uuid !== assetUuid) {
+            throw new Error(`保存目标资源标识不一致: 期望 ${assetUuid}，实际 ${saved?.uuid ?? 'undefined'}`);
+        }
+        this.entity.identifier = this.getIdentifier(saved);
+        return saved;
     }
 
     protected async _doReload(): Promise<IScene> {

--- a/src/core/scene/test/editor-close-options.test.ts
+++ b/src/core/scene/test/editor-close-options.test.ts
@@ -34,8 +34,15 @@ jest.mock('../scene-process/service/prefab/prefab-editor-utils', () => ({
     },
 }));
 
+const mockRpcRequest = jest.fn();
+jest.mock('../scene-process/rpc', () => ({
+    Rpc: { getInstance: () => ({ request: mockRpcRequest }) },
+}));
+
 import { SceneEditor } from '../scene-process/service/editors/scene-editor';
 import { PrefabEditor } from '../scene-process/service/editors/prefab-editor';
+import { sceneUtils } from '../scene-process/service/scene/utils';
+import { editorPrefabUtils } from '../scene-process/service/prefab/prefab-editor-utils';
 
 type CloseableEditor = SceneEditor | PrefabEditor;
 
@@ -61,6 +68,10 @@ async function expectCloseSaveCalls(editor: CloseableEditor, options: { save?: b
 }
 
 describe('Editor close options', () => {
+    beforeEach(() => {
+        mockRpcRequest.mockReset();
+    });
+
     it('scene close saves by default and can skip save', async () => {
         await expectCloseSaveCalls(new SceneEditor(), undefined, 1);
         await expectCloseSaveCalls(new SceneEditor(), { save: false }, 0);
@@ -69,5 +80,36 @@ describe('Editor close options', () => {
     it('prefab close saves by default and can skip save', async () => {
         await expectCloseSaveCalls(new PrefabEditor(), undefined, 1);
         await expectCloseSaveCalls(new PrefabEditor(), { save: false }, 0);
+    });
+
+    it('scene and prefab saveTo write serialized content to the target asset', async () => {
+        const targetScene = { uuid: 'target-scene-uuid', url: 'db://assets/recovered.scene', type: 'scene', name: 'recovered' };
+        const targetPrefab = { uuid: 'target-prefab-uuid', url: 'db://assets/recovered.prefab', type: 'prefab', name: 'recovered' };
+        const sceneEditor = new SceneEditor();
+        const prefabEditor = new PrefabEditor();
+        setOpen(sceneEditor);
+        setOpen(prefabEditor);
+        (sceneUtils.serialize as jest.Mock).mockReturnValue('serialized-scene');
+        (editorPrefabUtils.serialize as jest.Mock).mockReturnValue('serialized-prefab');
+        mockRpcRequest.mockResolvedValueOnce(targetScene).mockResolvedValueOnce(targetPrefab);
+
+        await sceneEditor.saveTo(targetScene as never);
+        await prefabEditor.saveTo(targetPrefab as never);
+
+        expect(mockRpcRequest).toHaveBeenNthCalledWith(1, 'assetManager', 'saveAsset', [targetScene.uuid, 'serialized-scene']);
+        expect(mockRpcRequest).toHaveBeenNthCalledWith(2, 'assetManager', 'saveAsset', [targetPrefab.uuid, 'serialized-prefab']);
+        expect((sceneEditor as any).entity.identifier.assetUuid).toBe(targetScene.uuid);
+        expect((prefabEditor as any).entity.identifier.assetUuid).toBe(targetPrefab.uuid);
+    });
+
+    it('saveTo rejects an unexpected saved UUID without changing the editor identifier', async () => {
+        const editor = new SceneEditor();
+        setOpen(editor);
+        (sceneUtils.serialize as jest.Mock).mockReturnValue('serialized-scene');
+        mockRpcRequest.mockResolvedValueOnce({ uuid: 'unexpected-uuid', url: 'db://assets/unexpected.scene', type: 'scene', name: 'unexpected' });
+
+        await expect(editor.saveTo({ uuid: 'target-scene-uuid' } as never)).rejects.toThrow('保存目标资源标识不一致');
+
+        expect((editor as any).entity.identifier.assetUuid).toBe('asset-uuid');
     });
 });

--- a/src/core/scene/test/service-core/message-callsite.test.ts
+++ b/src/core/scene/test/service-core/message-callsite.test.ts
@@ -361,6 +361,13 @@ describe('ServiceEvents 事件发射集成测试', () => {
             editorService = new EditorService();
         });
 
+        beforeEach(() => {
+            editorService.editorMap.clear();
+            editorService.currentEditorUuid = null;
+            mockRpcRequest.mockReset();
+            mockRpcRequest.mockResolvedValue({});
+        });
+
         it('open 应 emit editor:open 到 ServiceEvents', async () => {
             const listener = jest.fn();
             globalEventEmitter.on('editor:open', listener);
@@ -392,16 +399,115 @@ describe('ServiceEvents 事件发射集成测试', () => {
             expect(listener).toHaveBeenCalledTimes(1);
         });
 
+        it('close 在源资源已删除时仍可丢弃当前编辑器会话', async () => {
+            const uuid = 'deleted-source-uuid';
+            const mockEditor = { close: jest.fn().mockResolvedValue(true) };
+            editorService.editorMap.set(uuid, mockEditor);
+            editorService.currentEditorUuid = uuid;
+
+            mockRpcRequest.mockResolvedValueOnce(null);
+
+            await editorService.close({
+                urlOrUUID: 'db://assets/deleted.scene',
+                save: false,
+                allowDeletedSourceFallback: true,
+                expectedCurrentUuid: uuid,
+            });
+
+            expect(mockEditor.close).toHaveBeenCalledWith({ save: false });
+            expect(editorService.currentEditorUuid).toBeNull();
+            expect(editorService.editorMap.get(uuid)).toBeUndefined();
+        });
+
+        it('save 到新资源应使用当前编辑器内容并更新当前资源标识', async () => {
+            const { SceneEditor } = require('../../scene-process/service/editors');
+            const sourceUuid = 'source-uuid';
+            const target = { uuid: 'target-uuid', url: 'db://assets/recovered.scene', type: 'scene' };
+            const mockEditor = Object.assign(Object.create(SceneEditor.prototype), {
+                saveTo: jest.fn().mockResolvedValue(target),
+            });
+            editorService.editorMap.set(sourceUuid, mockEditor);
+            editorService.currentEditorUuid = sourceUuid;
+
+            mockRpcRequest.mockResolvedValueOnce(target);
+
+            await editorService.save({ urlOrUUID: target.url });
+
+            expect(mockEditor.saveTo).toHaveBeenCalledWith(target);
+            expect(editorService.currentEditorUuid).toBe(target.uuid);
+            expect(editorService.editorMap.get(sourceUuid)).toBeUndefined();
+            expect(editorService.editorMap.get(target.uuid)).toBe(mockEditor);
+        });
+
+        it('deleted-source fallback 不会关闭 Save As 后已重绑的目标编辑器', async () => {
+            const sourceUuid = 'source-uuid';
+            const targetUuid = 'target-uuid';
+            const mockEditor = { close: jest.fn().mockResolvedValue(true) };
+            editorService.editorMap.set(targetUuid, mockEditor);
+            editorService.currentEditorUuid = targetUuid;
+            mockRpcRequest.mockResolvedValueOnce(null);
+
+            await expect(editorService.close({
+                urlOrUUID: 'db://assets/deleted.scene',
+                save: false,
+                allowDeletedSourceFallback: true,
+                expectedCurrentUuid: sourceUuid,
+            })).rejects.toThrow('请求资源失败');
+
+            expect(mockEditor.close).not.toHaveBeenCalled();
+            expect(editorService.currentEditorUuid).toBe(targetUuid);
+            expect(editorService.editorMap.get(targetUuid)).toBe(mockEditor);
+        });
+
+        it('save 到不同类型的资源时保持当前编辑器状态不变', async () => {
+            const { SceneEditor } = require('../../scene-process/service/editors');
+            const sourceUuid = 'source-uuid';
+            const target = { uuid: 'target-prefab-uuid', url: 'db://assets/recovered.prefab', type: 'prefab' };
+            const mockEditor = Object.assign(Object.create(SceneEditor.prototype), {
+                saveTo: jest.fn(),
+            });
+            editorService.editorMap.set(sourceUuid, mockEditor);
+            editorService.currentEditorUuid = sourceUuid;
+            mockRpcRequest.mockResolvedValueOnce(target);
+
+            await expect(editorService.save({ urlOrUUID: target.url })).rejects.toThrow('不能将 scene 保存到 prefab 资源');
+
+            expect(mockEditor.saveTo).not.toHaveBeenCalled();
+            expect(editorService.currentEditorUuid).toBe(sourceUuid);
+            expect(editorService.editorMap.get(sourceUuid)).toBe(mockEditor);
+        });
+
+        it('saveTo 返回非目标 UUID 时保持当前编辑器映射不变', async () => {
+            const { SceneEditor } = require('../../scene-process/service/editors');
+            const sourceUuid = 'source-uuid';
+            const target = { uuid: 'target-uuid', url: 'db://assets/recovered.scene', type: 'scene' };
+            const mockEditor = Object.assign(Object.create(SceneEditor.prototype), {
+                saveTo: jest.fn().mockResolvedValue({ ...target, uuid: 'unexpected-uuid' }),
+            });
+            editorService.editorMap.set(sourceUuid, mockEditor);
+            editorService.currentEditorUuid = sourceUuid;
+            mockRpcRequest.mockResolvedValueOnce(target);
+
+            await expect(editorService.save({ urlOrUUID: target.url })).rejects.toThrow('保存目标资源标识不一致');
+
+            expect(editorService.currentEditorUuid).toBe(sourceUuid);
+            expect(editorService.editorMap.get(sourceUuid)).toBe(mockEditor);
+            expect(editorService.editorMap.get(target.uuid)).toBeUndefined();
+        });
+
         it('save 应 emit editor:save 到 ServiceEvents', async () => {
+            const { PrefabEditor } = require('../../scene-process/service/editors');
             const listener = jest.fn();
             globalEventEmitter.on('editor:save', listener);
 
-            const mockEditor = { save: jest.fn().mockResolvedValue({ uuid: 'save-uuid' }) };
+            const mockEditor = Object.assign(Object.create(PrefabEditor.prototype), {
+                save: jest.fn().mockResolvedValue({ uuid: 'save-uuid' }),
+            });
             const uuid = 'save-uuid';
             editorService.editorMap.set(uuid, mockEditor);
             editorService.currentEditorUuid = uuid;
 
-            mockRpcRequest.mockResolvedValueOnce({ uuid, url: 'test.scene' });
+            mockRpcRequest.mockResolvedValueOnce({ uuid, url: 'test.prefab', type: 'prefab' });
 
             await editorService.save({ urlOrUUID: uuid });
 


### PR DESCRIPTION
## 变更说明
- 支持在源场景或预制体资源已删除后，将当前内存编辑器内容保存到新创建的目标资源，并安全重绑当前 editor UUID。
- 删除源资源的关闭回退改为显式标记且校验预期 UUID，避免 Save As 后迟到的旧 close 请求误关新目标场景。
- 校验 scene/prefab 的 Save As 目标类型及 saveAsset 返回 UUID；失败时不迁移 editorMap/currentEditorUuid。
- SceneEditor 与 PrefabEditor 的 Save As 均直接写入 target UUID，并补充目标写入、UUID 异常、类型不匹配与迟到 close 的回归覆盖。