### PR TITLE
fix(scene): fix vertex snap not cancelling on V key release

### DIFF
--- a/static/web/input-bridge.js
+++ b/static/web/input-bridge.js
@@ -212,7 +212,10 @@ function setupInputBridge(options) {
     canvas.addEventListener('wheel', onWheel, { passive: false });
     canvas.addEventListener('contextmenu', onContextMenu);
     canvas.addEventListener('keydown', onKeyDown);
-    canvas.addEventListener('keyup', onKeyUp);
+    // keyup uses capture phase on document: the engine's KeyboardInputSource calls
+    // stopPropagation() on canvas keyup, so a normal document listener never fires.
+    // Capture runs top-down before the event reaches the canvas, bypassing that.
+    document.addEventListener('keyup', onKeyUp, true);
     document.addEventListener('pointerlockchange', onPointerLockChange);
 
     return function cleanup() {
@@ -232,7 +235,7 @@ function setupInputBridge(options) {
         canvas.removeEventListener('wheel', onWheel);
         canvas.removeEventListener('contextmenu', onContextMenu);
         canvas.removeEventListener('keydown', onKeyDown);
-        canvas.removeEventListener('keyup', onKeyUp);
+        document.removeEventListener('keyup', onKeyUp, true);
         document.removeEventListener('pointerlockchange', onPointerLockChange);
         if (pointerLocked) {
             document.exitPointerLock();


### PR DESCRIPTION
Related issue:  https://zentao.sud.center/index.php?m=bug&f=view&bugID=414


## Summary

Vertex snapping (hold V) could not be cancelled by releasing the V key — the snap gizmo stayed active after key release.

### Root cause

The engine's `KeyboardInputSource._handleKeyboardUp` calls `event.stopPropagation()` on every canvas `keyup` event. Since `input-bridge.js` registered its `keyup` listener on `document` (bubble phase), the stopped propagation meant the listener never fired.

In Creator this is not an issue because the engine runs inside a separate iframe/webview, so its `stopPropagation()` on the inner canvas does not affect the outer document's listeners. In the CLI, the engine and `input-bridge.js` share the same document context.

### Fix

Switch the `keyup` listener from a normal `document` listener to **capture phase** (`addEventListener('keyup', handler, true)`). Capture runs top-down (window → document → ... → canvas) before the event reaches the canvas target, so it fires before the engine can stop propagation.

## Test plan

- Open scene editor, select a node with a mesh
- Hold V → vertex snap activates (floating gizmo appears at nearest vertex)
- Release V → vertex snap cancels (gizmo returns to node center, snap drag plane hides)
- Repeat while moving mouse outside the canvas area during V hold — keyup should still be captured