### PR TITLE
fix: serve browser asset requests as bytes

### DIFF
--- a/src/core/scene/scene.middleware.ts
+++ b/src/core/scene/scene.middleware.ts
@@ -4,11 +4,14 @@ import path from 'path';
 import fse from 'fs-extra';
 
 function isBrowserRequest(req: Request): boolean {
+    if (req.query.isBrowser === 'true') {
+        return true;
+    }
+
     const userAgent = req.headers['user-agent'];
-    return req.query.isBrowser === 'true'
-        || !!req.headers['sec-ch-ua']
+    return !!req.headers['sec-ch-ua']
         || req.headers['accept']?.includes('text/html') === true
-        || (typeof userAgent === 'string' && userAgent.includes('Mozilla/'));
+        || (typeof userAgent === 'string' && userAgent.includes('Mozilla/') && !userAgent.includes('node.js/'));
 }
 
 export default {

--- a/src/core/scene/scene.middleware.ts
+++ b/src/core/scene/scene.middleware.ts
@@ -3,6 +3,14 @@ import { Request, Response, NextFunction } from 'express';
 import path from 'path';
 import fse from 'fs-extra';
 
+function isBrowserRequest(req: Request): boolean {
+    const userAgent = req.headers['user-agent'];
+    return req.query.isBrowser === 'true'
+        || !!req.headers['sec-ch-ua']
+        || req.headers['accept']?.includes('text/html') === true
+        || (typeof userAgent === 'string' && userAgent.includes('Mozilla/'));
+}
+
 export default {
     get: [
         {
@@ -121,9 +129,7 @@ export default {
                     });
                 }
 
-                const isBrowser = !!(req.headers['accept']?.includes('text/html') || 
-                                   req.headers['sec-ch-ua'] || 
-                                   req.query.isBrowser === 'true');
+                const isBrowser = isBrowserRequest(req);
 
                 if (isBrowser) {
                     const content = await fse.readFile(filePath);
@@ -160,9 +166,7 @@ export default {
                     });
                 }
 
-                const isBrowser = !!(req.headers['accept']?.includes('text/html') || 
-                                   req.headers['sec-ch-ua'] || 
-                                   req.query.isBrowser === 'true');
+                const isBrowser = isBrowserRequest(req);
 
                 if (isBrowser) {
                     const content = await fse.readFile(filePath);

--- a/src/core/scene/test/scene.middleware.test.ts
+++ b/src/core/scene/test/scene.middleware.test.ts
@@ -1,0 +1,73 @@
+const mockQueryAssetInfo = jest.fn();
+const mockReadFile = jest.fn();
+
+jest.mock('../../assets', () => ({
+    assetManager: {
+        queryAssetInfo: (...args: unknown[]) => mockQueryAssetInfo(...args),
+    },
+}));
+
+jest.mock('fs-extra', () => ({
+    readFile: (...args: unknown[]) => mockReadFile(...args),
+}));
+
+import sceneMiddleware from '../scene.middleware';
+
+const uuid = '04796f71-2f24-4b07-81d2-01f528b45157';
+const filePath = '/tmp/04796f71-2f24-4b07-81d2-01f528b45157.json';
+const fileContent = Buffer.from('{"name":"effect"}');
+
+function createResponse() {
+    const response = {
+        setHeader: jest.fn(),
+        status: jest.fn(),
+        send: jest.fn(),
+    };
+    response.status.mockReturnValue(response);
+    return response;
+}
+
+function createRequest(userAgent: string): any {
+    return {
+        params: { dir: uuid.slice(0, 2), uuid, ext: 'json' },
+        query: {},
+        headers: { 'user-agent': userAgent },
+    };
+}
+
+describe('scene asset middleware', () => {
+    const route = sceneMiddleware.get!.find((item) => item.url === '/:dir/:uuid.:ext');
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockQueryAssetInfo.mockReturnValue({ library: { '.json': filePath } });
+        mockReadFile.mockResolvedValue(fileContent);
+    });
+
+    it('serves asset bytes to the PinK browser renderer', async () => {
+        const response = createResponse();
+
+        await route!.handler(
+            createRequest('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/138.0.0.0 Safari/537.36'),
+            response as any,
+        );
+
+        expect(mockReadFile).toHaveBeenCalledWith(filePath);
+        expect(response.setHeader).toHaveBeenCalledWith('Content-Type', 'application/json');
+        expect(response.status).toHaveBeenCalledWith(200);
+        expect(response.send).toHaveBeenCalledWith(fileContent);
+    });
+
+    it('returns the asset path to the Node scene engine xhr2 client', async () => {
+        const response = createResponse();
+
+        await route!.handler(
+            createRequest('Mozilla/5.0 (darwin arm64) node.js/22.22.0 v8/12.4.254.21-node.24'),
+            response as any,
+        );
+
+        expect(mockReadFile).not.toHaveBeenCalled();
+        expect(response.status).toHaveBeenCalledWith(200);
+        expect(response.send).toHaveBeenCalledWith(filePath);
+    });
+});


### PR DESCRIPTION
## 变更说明

- 修正场景资源路由对浏览器 XHR 的识别：除了 `Sec-CH-UA` 和显式 `isBrowser=true` 外，也识别浏览器 `Mozilla/` User-Agent。
- 浏览器 scene-bundle 请求 `/xx/<uuid>.json` 时返回 JSON 内容，不再返回本机文件路径字符串。
- Node 场景/MCP 请求仍保持返回本机文件路径的既有行为。
