### PR TITLE
feat(builder): expose preview URL API

### DIFF
--- a/src/core/builder/test/lib-get-preview-url.spec.ts
+++ b/src/core/builder/test/lib-get-preview-url.spec.ts
@@ -1,0 +1,39 @@
+const getPreviewUrlMock = jest.fn(async (dest: string, platform?: string) => {
+    const outputName = dest.replace(/\\/g, '/').split('/').pop();
+    return `http://localhost:9527/build/${platform}/${outputName}/index.html`;
+});
+
+jest.mock('../platforms/web-common/utils', () => ({
+    getPreviewUrl: getPreviewUrlMock,
+}));
+
+jest.mock('../manager/plugin', () => ({
+    pluginManager: {},
+}));
+
+describe('lib/builder getPreviewUrl API', () => {
+    beforeEach(() => {
+        getPreviewUrlMock.mockClear();
+    });
+
+    async function getBuilderLib() {
+        return import('../../../lib/builder/builder');
+    }
+
+    it('delegates preview URL resolution to web common utilities', async () => {
+        const builderLib = await getBuilderLib();
+
+        const result = await builderLib.getPreviewUrl('project://build/web-mobile', 'web-mobile');
+
+        expect(getPreviewUrlMock).toHaveBeenCalledTimes(1);
+        expect(getPreviewUrlMock).toHaveBeenCalledWith('project://build/web-mobile', 'web-mobile');
+        expect(result).toBe('http://localhost:9527/build/web-mobile/web-mobile/index.html');
+    });
+
+    it('propagates preview URL resolution errors', async () => {
+        getPreviewUrlMock.mockRejectedValueOnce(new Error('Build path not found'));
+        const builderLib = await getBuilderLib();
+
+        await expect(builderLib.getPreviewUrl('project://missing', 'web-mobile')).rejects.toThrow('Build path not found');
+    });
+});

--- a/src/lib/builder/builder.ts
+++ b/src/lib/builder/builder.ts
@@ -52,6 +52,11 @@ export async function run(platform: Platform, dest: string) {
     return Launcher.run(platform, dest);
 }
 
+export async function getPreviewUrl(dest: string, platform?: string): Promise<string> {
+    const commonUtils = await import('../../core/builder/platforms/web-common/utils');
+    return commonUtils.getPreviewUrl(dest, platform);
+}
+
 export async function upload(platform: Platform, dest: string, accessToken?: string) {
     const { default: Launcher } = await import('../../core/launcher');
     return Launcher.upload(platform, dest, accessToken);


### PR DESCRIPTION
Expose Builder.getPreviewUrl through the public library API.

Add unit coverage for URL resolution delegation and error propagation.