### PR TITLE
refactor(cli): extract --project path to config.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ e2e/reports/
 # auto generated files
 src/i18n/types/generated.d.ts
 CLAUDE.md
+config.local.json

--- a/config.local.example.json
+++ b/config.local.example.json
@@ -1,0 +1,3 @@
+{
+    "project": "/path/to/your/cocos/project"
+}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "pack:script": "node workflow/pack-scripts.js",
         "release": "npx --yes gulp release --gulpfile workflow/release.js",
         "start:mcp-debug": "node ./dist/cli.js start-mcp-server --project=./tests/fixtures/projects/asset-operation",
-        "start:preview": "node ./dist/cli.js preview --project=./tests/fixtures/projects/asset-operation --scene-editor",
+        "start:preview": "node ./dist/cli.js preview --scene-editor",
         "start:mcp-inspector": "npx @modelcontextprotocol/inspector",
         "cli": "node ./dist/cli.js",
         "rebuild": "node workflow/electron-rebuild.js"

--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { join, resolve } from 'path';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import chalk from 'chalk';
 
 /**
@@ -37,6 +37,18 @@ export abstract class BaseCommand {
         }
 
         return resolvedPath;
+    }
+
+    protected readLocalConfigProject(): string | undefined {
+        const configPath = resolve('config.local.json');
+        if (!existsSync(configPath)) return undefined;
+        try {
+            const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+            return config.project;
+        } catch {
+            console.warn(chalk.yellow('Warning: Failed to parse config.local.json'));
+            return undefined;
+        }
     }
 
     /**

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -11,7 +11,7 @@ export class PreviewCommand extends BaseCommand {
         this.program
             .command('preview')
             .description('Preview a Cocos project')
-            .requiredOption('-j, --project <path>', 'Path to the Cocos project (required)')
+            .option('-j, --project <path>', 'Path to the Cocos project')
             .option('-p, --port <number>', 'Port number for the preview server', '9527')
             .option('-P, --platform <platform>', 'Target web platform (web-desktop or web-mobile)')
             .option('-c, --build-config <path>', 'Specify build config file path')
@@ -21,7 +21,12 @@ export class PreviewCommand extends BaseCommand {
             .option('--scene-editor', 'Start the scene editor debug preview instead of the game preview')
             .action(async (options: any) => {
                 try {
-                    const resolvedPath = this.validateProjectPath(options.project);
+                    const projectPath = options.project ?? this.readLocalConfigProject();
+                    if (!projectPath) {
+                        console.error(chalk.red('Error: --project is required. Provide it via CLI or config.local.json'));
+                        process.exit(1);
+                    }
+                    const resolvedPath = this.validateProjectPath(projectPath);
                     const port = parseInt(options.port, 10);
 
                     // 验证端口号


### PR DESCRIPTION
## Summary

将 preview 命令中硬编码的 --project 路径提取到 config.local.json，使每个开发者可以独立配置自己的测试项目路径。

## Changes

- preview 命令的 --project 从必填改为可选，未传时自动从 config.local.json 读取
- BaseCommand 新增 readLocalConfigProject() 方法，供子命令复用
- 新增 config.local.example.json 作为配置模板
- .gitignore 添加 config.local.json
- package.json 中 start:preview 脚本移除硬编码路径