### PR TITLE
Fix builtin effect loading for scene previews

### DIFF
--- a/src/core/preview/scripting-routes.ts
+++ b/src/core/preview/scripting-routes.ts
@@ -16,6 +16,14 @@ function sendQuickPackChunk(res: Response, filePath: string): void {
     res.sendFile(filePath, { dotfiles: 'allow' });
 }
 
+function decodePathParam(value: string): string {
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return value;
+    }
+}
+
 /**
  * 动态预览的共享资源路由。
  *
@@ -141,7 +149,7 @@ export const scriptingRoutes = [
         url: /^\/query-asset-info\/(.+)$/,
         async handler(req: Request, res: Response, next: NextFunction) {
             try {
-                const uuid = req.params[0];
+                const uuid = decodePathParam(req.params[0]);
                 const { assetManager } = await import('../assets');
                 const assetInfo = assetManager.queryAssetInfo(uuid);
                 if (assetInfo) {
@@ -175,7 +183,7 @@ export const scriptingRoutes = [
         url: /^\/query-extname\/(.+)$/,
         async handler(req: Request, res: Response, next: NextFunction) {
             try {
-                const uuid = req.params[0];
+                const uuid = decodePathParam(req.params[0]);
                 const { assetManager } = await import('../assets');
                 const assetInfo = assetManager.queryAssetInfo(uuid);
                 if (assetInfo?.library?.['.bin'] && Object.keys(assetInfo.library).length === 1) {

--- a/src/core/scene/scene-process/engine-bootstrap.ts
+++ b/src/core/scene/scene-process/engine-bootstrap.ts
@@ -149,48 +149,95 @@ export async function startup(options: {
     // Our own edit-mode tick loop (Engine.startTick) takes over later.
     cc.game.pause();
 
-    // Load and register all effect assets so materials (e.g. builtin-standard)
+    function hasUsableEffect(name: string): boolean {
+        const effect = cc.EffectAsset?.get?.(name);
+        return !!effect
+            && Array.isArray(effect.shaders)
+            && effect.shaders.length > 0
+            && Array.isArray(effect.techniques)
+            && effect.techniques.some((tech: any) => Array.isArray(tech?.passes) && tech.passes.length > 0);
+    }
+
+    async function queryAssetInfo(urlOrUuid: string): Promise<any | null> {
+        try {
+            const res = await fetch(`${serverURL}/query-asset-info/${encodeURIComponent(urlOrUuid)}`);
+            if (!res.ok) return null;
+            return await res.json();
+        } catch {
+            return null;
+        }
+    }
+
+    async function loadAndRegisterEffect(info: any, required = false): Promise<boolean> {
+        const uuid: string = info?.uuid;
+        const label = info?.url || info?.name || uuid || '<unknown>';
+        try {
+            if (!uuid) return false;
+            const lib = info.library;
+            if (!lib || (!lib['.json'] && !lib['.bin'])) {
+                if (required) console.warn(`[Effects] Missing library data for required effect: ${label}`);
+                return false;
+            }
+
+            const encodedUuid = encodeURIComponent(uuid);
+            const ext = (lib['.bin'] && !lib['.json']) ? 'bin' : 'json';
+            const r = await fetch(`${serverURL}/import/${encodedUuid}.${ext}?isBrowser=true`);
+            if (!r.ok) {
+                if (required) console.warn(`[Effects] Failed to fetch required effect ${label}: ${r.status}`);
+                return false;
+            }
+
+            const isBinary = ext === 'bin';
+            const decode = isBinary ? await getDecodeCCONBinary() : null;
+            if (isBinary && !decode) {
+                if (required) console.warn(`[Effects] decodeCCONBinary is not available for required effect: ${label}`);
+                return false;
+            }
+            const deserializeData = isBinary
+                ? decode!(new Uint8Array(await r.arrayBuffer()))
+                : await r.json();
+
+            const classFinder = (id: string): any => cc.js?.getClassById?.(id) ?? null;
+            const asset = cc.deserialize(deserializeData, undefined, { classFinder });
+            asset._uuid = uuid;
+            cc.assetManager.assets.add(uuid, asset);
+            try {
+                if (asset.onLoaded) asset.onLoaded();
+            } catch (e) {
+                console.warn(`[Effects] onLoaded failed for ${asset._name || label}:`, e);
+                try { cc.EffectAsset.register(asset); } catch {}
+            }
+            return hasUsableEffect(asset.name);
+        } catch (e) {
+            if (required) console.warn(`[Effects] Failed to load required effect ${label}:`, e);
+            return false;
+        }
+    }
+
+    // Load and register effect assets so materials (e.g. builtin-standard)
     // are available before preview services initialize.
     await (async () => {
         try {
             const res = await fetch(`${serverURL}/query-asset-infos/cc.EffectAsset`);
-            if (!res.ok) return;
-            const effectInfos: any[] = await res.json();
-            if (!effectInfos.length) return;
-            const classFinder = (id: string): any => cc.js?.getClassById?.(id) ?? null;
-            await Promise.all(effectInfos.map(async (info: any) => {
-                try {
-                    const uuid: string = info.uuid;
-                    if (!uuid) return;
-                    const lib = info.library;
-                    if (!lib || (!lib['.json'] && !lib['.bin'])) return;
-
-                    const encodedUuid = encodeURIComponent(uuid);
-                    const ext = (lib['.bin'] && !lib['.json']) ? 'bin' : 'json';
-
-                    const r = await fetch(`${serverURL}/import/${encodedUuid}.${ext}?isBrowser=true`);
-                    if (!r.ok) return;
-
-                    const isBinary = ext === 'bin';
-                    let deserializeData: any;
-                    const decode = isBinary ? await getDecodeCCONBinary() : null;
-                    if (isBinary && decode) {
-                        deserializeData = decode(new Uint8Array(await r.arrayBuffer()));
-                    } else {
-                        deserializeData = await r.json();
+            const effectInfos: any[] = res.ok ? await res.json() : [];
+            if (effectInfos.length) {
+                await Promise.all(effectInfos.map((info: any) => loadAndRegisterEffect(info)));
+            }
+            const requiredEffects = [
+                { name: 'builtin-standard', url: 'db://internal/effects/builtin-standard.effect' },
+                { name: 'builtin-unlit', url: 'db://internal/effects/builtin-unlit.effect' },
+            ];
+            for (const effect of requiredEffects) {
+                if (!hasUsableEffect(effect.name)) {
+                    const info = await queryAssetInfo(effect.url);
+                    if (info) {
+                        await loadAndRegisterEffect(info, true);
                     }
-
-                    const asset = cc.deserialize(deserializeData, undefined, { classFinder });
-                    asset._uuid = uuid;
-                    cc.assetManager.assets.add(uuid, asset);
-                    try {
-                        if (asset.onLoaded) asset.onLoaded();
-                    } catch (e) {
-                        console.warn(`[Effects] onLoaded failed for ${asset._name || uuid}:`, e);
-                        try { cc.EffectAsset.register(asset); } catch {}
-                    }
-                } catch { /* skip individual effect */ }
-            }));
+                }
+                if (!hasUsableEffect(effect.name)) {
+                    console.warn(`[Effects] Required effect is not available: ${effect.name}`);
+                }
+            }
             const count = Object.keys(cc.EffectAsset.getAll()).length;
             console.log(`[Effects] Registered ${count} effects`);
         } catch (e: any) {

--- a/src/core/scene/scene-process/service/preview/grid.ts
+++ b/src/core/scene/scene-process/service/preview/grid.ts
@@ -1,9 +1,28 @@
-import { Camera, Color, Node, Vec3, gfx, MeshRenderer, Layers, utils } from 'cc';
+import { Camera, Color, EffectAsset, Material, Node, Vec3, gfx, MeshRenderer, Layers, utils } from 'cc';
 import { CameraUtils } from '../camera/utils';
 import LinearTicks from '../camera/grid/linear-ticks';
 
 const _lineEnd = 1000000;
 const tempV3 = new Vec3();
+
+function createGridMaterial(): Material | null {
+    const effectName = 'builtin-unlit';
+    if (!EffectAsset.get(effectName)) {
+        console.warn(`[Grid] Effect is not registered: ${effectName}`);
+        return null;
+    }
+    const material = new Material();
+    material.initialize({
+        effectName,
+        states: { primitive: gfx.PrimitiveMode.LINE_LIST },
+    });
+    if (!material.passes.length) {
+        console.warn(`[Grid] Effect has no usable passes: ${effectName}`);
+        return null;
+    }
+    try { material.setProperty('mainColor', new Color(166, 166, 166, 120)); } catch { /* ignore */ }
+    return material;
+}
 
 export class Grid {
     private _gridMeshComp: MeshRenderer;
@@ -33,6 +52,13 @@ export class Grid {
     }
 
     private createFallbackGrid(rootNode: Node) {
+        const material = createGridMaterial();
+        if (!material) {
+            this._gridMeshComp.enabled = false;
+            this._gridMeshComp.node.active = false;
+            return;
+        }
+
         this._gridMeshComp.node.destroy();
 
         const node = new Node('Fallback Grid');
@@ -54,19 +80,12 @@ export class Grid {
             indices.push(idx++, idx++);
         }
 
+        comp.material = material;
         comp.mesh = utils.createMesh({
             positions,
             indices,
             primitiveMode: gfx.PrimitiveMode.LINE_LIST,
         });
-
-        const mtl = new cc.Material();
-        mtl.initialize({
-            effectName: 'builtin-unlit',
-            states: { primitive: gfx.PrimitiveMode.LINE_LIST },
-        });
-        try { mtl.setProperty('mainColor', new Color(166, 166, 166, 120)); } catch { /* ignore */ }
-        comp.material = mtl;
 
         this._gridMeshComp = comp;
     }

--- a/src/core/scene/scene-process/service/preview/material-preview.ts
+++ b/src/core/scene/scene-process/service/preview/material-preview.ts
@@ -13,6 +13,7 @@ import {
     Node,
     renderer,
     director,
+    EffectAsset,
 } from 'cc';
 
 const regions = [new gfx.BufferTextureCopy()];
@@ -77,6 +78,21 @@ function getPrimitiveData(): Record<string, IPrimitiveInfo> {
     return primitiveData;
 }
 
+function createPreviewMaterial(effectName: string): Material | null {
+    const effect = EffectAsset.get(effectName);
+    if (!effect) {
+        console.warn(`[MaterialPreview] Effect is not registered: ${effectName}`);
+        return null;
+    }
+    const material = new Material();
+    material.initialize({ effectName });
+    if (!material.passes.length) {
+        console.warn(`[MaterialPreview] Effect has no usable passes: ${effectName}`);
+        return null;
+    }
+    return material;
+}
+
 const tempVec3A = new Vec3();
 const tempVec3B = new Vec3();
 
@@ -139,11 +155,14 @@ export class MaterialPreview extends InteractivePreview implements IMaterialPrev
         this.lightComp.node.setParent(scene);
 
         this.modelComp = new Node('Material Preview Model').addComponent(MeshRenderer);
-        this.modelComp.mesh = getPrimitiveData().sphere.mesh;
-        const material = new Material();
-        material.initialize({ effectName: 'builtin-standard' });
-        this.modelComp.material = material;
-        this.setMaterial(material);
+        const material = createPreviewMaterial('builtin-standard');
+        if (material) {
+            this.modelComp.mesh = getPrimitiveData().sphere.mesh;
+            this.modelComp.material = material;
+            this.setMaterial(material);
+        } else {
+            this.modelComp.enabled = false;
+        }
 
         this.modelComp.node.setParent(this.scene);
         this._modelNode = this.modelComp.node;
@@ -151,7 +170,15 @@ export class MaterialPreview extends InteractivePreview implements IMaterialPrev
 
     public setMaterial(material: Material | null) {
         if (material && material !== this.material) {
+            if (!material.passes.length) {
+                console.warn(`[MaterialPreview] Material has no usable passes: ${material.name || material.effectName || (material as any)._uuid}`);
+                return;
+            }
             const comp = this.modelComp;
+            if (!comp.mesh) {
+                comp.mesh = getPrimitiveData()[this.currentPrimitive].mesh;
+            }
+            comp.enabled = true;
             const _matInsInfo = {
                 parent: material,
                 owner: comp as any,
@@ -227,6 +254,10 @@ export class MaterialPreview extends InteractivePreview implements IMaterialPrev
     public switchPrimitive(type: string) {
         const data = getPrimitiveData();
         if (!data[type]) return;
+        if (!this.material || !this.material.passes.length) {
+            console.warn('[MaterialPreview] Cannot switch primitive before a valid material is available.');
+            return;
+        }
         this.currentPrimitive = type;
         this.modelComp.mesh = data[type].mesh;
         this.updateDs();

--- a/src/core/scene/scene-process/service/preview/mesh-preview.ts
+++ b/src/core/scene/scene-process/service/preview/mesh-preview.ts
@@ -1,10 +1,25 @@
 import { InteractivePreview, getBoundaryOfMeshNodes } from './interactive-preview';
-import { DirectionalLight, Material, Mesh, MeshRenderer, Scene, Node, assetManager } from 'cc';
+import { DirectionalLight, EffectAsset, Material, Mesh, MeshRenderer, Scene, Node, assetManager } from 'cc';
+
+function createPreviewMaterial(effectName: string): Material | null {
+    const effect = EffectAsset.get(effectName);
+    if (!effect) {
+        console.warn(`[MeshPreview] Effect is not registered: ${effectName}`);
+        return null;
+    }
+    const material = new Material();
+    material.initialize({ effectName });
+    if (!material.passes.length) {
+        console.warn(`[MeshPreview] Effect has no usable passes: ${effectName}`);
+        return null;
+    }
+    return material;
+}
 
 export class MeshPreview extends InteractivePreview {
     private lightComp: DirectionalLight | any;
     private _modelComp!: MeshRenderer;
-    private _defaultMat!: Material;
+    private _defaultMat: Material | null = null;
 
     public createNodes(scene: Scene) {
         this.lightComp = new Node('Mesh Preview Light').addComponent(DirectionalLight);
@@ -14,9 +29,12 @@ export class MeshPreview extends InteractivePreview {
         this._modelNode = new Node('Mesh Preview Mesh');
         this._modelNode.parent = scene;
         this._modelComp = this._modelNode.addComponent(MeshRenderer);
-        this._defaultMat = new Material();
-        this._defaultMat.initialize({ effectName: 'builtin-standard' });
-        this._modelComp.material = this._defaultMat;
+        this._defaultMat = createPreviewMaterial('builtin-standard');
+        if (this._defaultMat) {
+            this._modelComp.material = this._defaultMat;
+        } else {
+            this._modelComp.enabled = false;
+        }
     }
 
     public async setMesh(uuid: string) {
@@ -36,6 +54,14 @@ export class MeshPreview extends InteractivePreview {
                 });
             });
 
+            if (!this._defaultMat || !this._defaultMat.passes.length) {
+                this._defaultMat = createPreviewMaterial('builtin-standard');
+            }
+            if (!this._defaultMat || !this._defaultMat.passes.length) {
+                console.warn('[MeshPreview] Cannot preview mesh before builtin-standard is available.');
+                return null;
+            }
+            this._modelComp.enabled = true;
             this._modelComp.mesh = meshAsset;
             this._modelNode!.parent = this.scene;
 

--- a/src/core/scene/scene-process/service/service-manager.ts
+++ b/src/core/scene/scene-process/service/service-manager.ts
@@ -115,10 +115,24 @@ export class ServiceManager {
         '084eba38-5336-4444-8c8c-aebb75d5c627', // internal/editor/box-height-light
     ];
 
+    private static readonly BUILTIN_PREVIEW_EFFECTS = [
+        {
+            name: 'builtin-standard',
+            url: 'db://internal/effects/builtin-standard.effect',
+            fallbackUuid: 'c8f66d17-351a-48da-a12c-0212d28575c4',
+        },
+        {
+            name: 'builtin-unlit',
+            url: 'db://internal/effects/builtin-unlit.effect',
+            fallbackUuid: 'a3cd009f-0ab0-420d-9278-b9fdab939bbc',
+        },
+    ];
+
     /**
      * 遍历所有已注册的 Service，依次调用 init()（跳过 Engine，它需要单独初始化）
      */
     async initAllServices() {
+        await this.loadBuiltinPreviewEffects();
         await this.loadEditorEffects();
         for (const service of getServiceAll()) {
             const name = service.constructor.name;
@@ -129,6 +143,86 @@ export class ServiceManager {
                 } catch (e) {
                     console.warn(`[ServiceManager] init failed on ${name}:`, e);
                 }
+            }
+        }
+    }
+
+    private hasUsableEffect(name: string): boolean {
+        const effect = cc.EffectAsset?.get?.(name);
+        return !!effect
+            && Array.isArray(effect.shaders)
+            && effect.shaders.length > 0
+            && Array.isArray(effect.techniques)
+            && effect.techniques.some((tech: any) => Array.isArray(tech?.passes) && tech.passes.length > 0);
+    }
+
+    private async queryAssetUuid(url: string): Promise<string | null> {
+        if (!this.serverUrl) {
+            return null;
+        }
+
+        try {
+            const res = await fetch(`${this.serverUrl}/query-asset-info/${encodeURIComponent(url)}`);
+            if (!res.ok) {
+                return null;
+            }
+            const info = await res.json();
+            return typeof info?.uuid === 'string' ? info.uuid : null;
+        } catch {
+            return null;
+        }
+    }
+
+    private loadAssetByUuid(uuid: string): Promise<any> {
+        return new Promise((resolve) => {
+            try {
+                cc.assetManager.loadAny(uuid, (err: any, asset: any) => {
+                    if (err) {
+                        console.warn(`[ServiceManager] Failed to load asset ${uuid}:`, err);
+                        resolve(null);
+                    } else {
+                        resolve(asset);
+                    }
+                });
+            } catch (e) {
+                console.warn(`[ServiceManager] loadAny error for ${uuid}:`, e);
+                resolve(null);
+            }
+        });
+    }
+
+    private registerLoadedEffect(asset: any, name: string) {
+        if (!asset || this.hasUsableEffect(name)) {
+            return;
+        }
+
+        try {
+            asset.onLoaded?.();
+        } catch (e) {
+            console.warn(`[ServiceManager] onLoaded failed for ${name}:`, e);
+        }
+
+        if (!this.hasUsableEffect(name)) {
+            try {
+                cc.EffectAsset?.register?.(asset);
+            } catch (e) {
+                console.warn(`[ServiceManager] register failed for ${name}:`, e);
+            }
+        }
+    }
+
+    private async loadBuiltinPreviewEffects(): Promise<void> {
+        for (const effect of ServiceManager.BUILTIN_PREVIEW_EFFECTS) {
+            if (this.hasUsableEffect(effect.name)) {
+                continue;
+            }
+
+            const uuid = await this.queryAssetUuid(effect.url) || effect.fallbackUuid;
+            const asset = await this.loadAssetByUuid(uuid);
+            this.registerLoadedEffect(asset, effect.name);
+
+            if (!this.hasUsableEffect(effect.name)) {
+                console.warn(`[ServiceManager] Builtin preview effect is not available: ${effect.name}`);
             }
         }
     }

--- a/src/core/scene/scene.middleware.ts
+++ b/src/core/scene/scene.middleware.ts
@@ -14,6 +14,14 @@ function isBrowserRequest(req: Request): boolean {
         || (typeof userAgent === 'string' && userAgent.includes('Mozilla/') && !userAgent.includes('node.js/'));
 }
 
+function decodePathParam(value: string): string {
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return value;
+    }
+}
+
 export default {
     get: [
         {
@@ -74,7 +82,7 @@ export default {
         {
             url: /^\/query-extname\/(.+)$/,
             async handler(req: Request, res: Response) {
-                const uuid = req.params[0];
+                const uuid = decodePathParam(req.params[0]);
                 const { assetManager } = await import('../assets');
                 const assetInfo = assetManager.queryAssetInfo(uuid);
                 if (assetInfo?.library?.['.bin'] && Object.keys(assetInfo.library).length === 1) {
@@ -87,7 +95,7 @@ export default {
         {
             url: /^\/query-asset-info\/(.+)$/,
             async handler(req: Request, res: Response) {
-                const uuid = req.params[0];
+                const uuid = decodePathParam(req.params[0]);
                 const { assetManager } = await import('../assets');
                 const assetInfo = assetManager.queryAssetInfo(uuid);
                 if (assetInfo) {

--- a/src/core/scene/test/scene.middleware.test.ts
+++ b/src/core/scene/test/scene.middleware.test.ts
@@ -22,6 +22,7 @@ function createResponse() {
         setHeader: jest.fn(),
         status: jest.fn(),
         send: jest.fn(),
+        json: jest.fn(),
     };
     response.status.mockReturnValue(response);
     return response;
@@ -37,6 +38,9 @@ function createRequest(userAgent: string): any {
 
 describe('scene asset middleware', () => {
     const route = sceneMiddleware.get!.find((item) => item.url === '/:dir/:uuid.:ext');
+    const queryAssetInfoRoute = sceneMiddleware.get!.find((item) => (
+        item.url instanceof RegExp && item.url.source === '^\\/query-asset-info\\/(.+)$'
+    ));
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -69,5 +73,21 @@ describe('scene asset middleware', () => {
         expect(mockReadFile).not.toHaveBeenCalled();
         expect(response.status).toHaveBeenCalledWith(200);
         expect(response.send).toHaveBeenCalledWith(filePath);
+    });
+
+    it('decodes asset URLs before querying asset info', async () => {
+        const response = createResponse();
+        const dbUrl = 'db://internal/effects/builtin-standard.effect';
+        const assetInfo = { uuid: 'builtin-standard-uuid', url: dbUrl };
+        mockQueryAssetInfo.mockReturnValueOnce(assetInfo);
+
+        await queryAssetInfoRoute!.handler(
+            { params: { 0: encodeURIComponent(dbUrl) } } as any,
+            response as any,
+        );
+
+        expect(mockQueryAssetInfo).toHaveBeenCalledWith(dbUrl);
+        expect(response.status).toHaveBeenCalledWith(200);
+        expect(response.json).toHaveBeenCalledWith(assetInfo);
     });
 });


### PR DESCRIPTION
## Summary
- Load required builtin preview effects before scene services initialize.
- Avoid assigning preview materials with missing or empty passes to MeshRenderer components.
- Decode asset URL route parameters so internal effect assets can be queried by db URL.

## Testing
- `git diff --check cli/main...HEAD`
- `npx jest src/core/scene/test/scene.middleware.test.ts --runInBand`
