### PR TITLE
Fix preview build option state leakage

### DIFF
--- a/src/core/builder/index.ts
+++ b/src/core/builder/index.ts
@@ -273,7 +273,8 @@ function readBuildTaskOptions(root: string): IBuildTaskOption<any> {
 }
 
 export async function getPreviewSettings<P extends Platform>(options?: IBuildTaskOption<P>): Promise<IPreviewSettingsResult> {
-    const buildOptions = options || (await pluginManager.getOptionsByPlatform('web-desktop'));
+    const temp = options || (await pluginManager.getOptionsByPlatform('web-desktop'));
+    const buildOptions = JSON.parse(JSON.stringify(temp));
     buildOptions.preview = true;
     // TODO 预览 settings 的排队之类的
     const { BuildTask } = await import('./worker/builder/index');


### PR DESCRIPTION
Clone build options inside preview settings generation before setting preview=true.
Keep the original build options object unchanged when preview settings are requested.