### PR TITLE
Fix resource preview rendering isolation

### DIFF
--- a/src/core/scene/scene-process/engine-bootstrap.ts
+++ b/src/core/scene/scene-process/engine-bootstrap.ts
@@ -495,13 +495,41 @@ async function setupBrowserInvokeChannel(serverURL: string) {
                 console.warn('[scene:invoke] failed:', e);
             }
         };
+        const request = async (
+            msg: { module?: string; method?: string; args?: any[] },
+            reply?: (response: { result?: any; error?: string }) => void,
+        ) => {
+            const respond = typeof reply === 'function' ? reply : () => {};
+            try {
+                if (!msg?.module || !msg?.method) {
+                    respond({ error: 'Invalid scene RPC request' });
+                    return;
+                }
+                const svc = (DecoratorService as any)[msg.module];
+                if (!svc || typeof svc[msg.method] !== 'function') {
+                    respond({ error: `Method not found: ${msg.module}.${msg.method}` });
+                    return;
+                }
+                const result = await svc[msg.method](...(msg.args || []));
+                respond({ result });
+            } catch (e: any) {
+                respond({ error: e?.message || String(e) });
+            }
+        };
         socket.on('scene:invoke', (msg: { module?: string; method?: string; args?: any[] }) => {
             if (msg && msg.module && msg.method) {
                 invoke(msg.module, msg.method, msg.args);
             }
         });
+        socket.on('scene:rpc:request', request);
         // 连接建立时同步一次设计分辨率（首次进入 / 断线重连时补齐错过的变更）
-        socket.on('connect', () => invoke('Engine', 'syncDesignResolution', []));
+        socket.on('connect', () => {
+            socket.emit('scene:rpc:register');
+            invoke('Engine', 'syncDesignResolution', []);
+        });
+        if (socket.connected) {
+            socket.emit('scene:rpc:register');
+        }
     } catch (e) {
         console.warn('[engine-bootstrap] setup browser-invoke channel failed:', e);
     }

--- a/src/core/scene/scene-process/service/preview/buffer.ts
+++ b/src/core/scene/scene-process/service/preview/buffer.ts
@@ -256,6 +256,7 @@ class PreviewBuffer extends EventEmitter {
         }
 
         this.ensureWindow(width, height);
+        Service.Engine.repaintInEditMode();
 
         const root = this.renderScene.root;
         const currWindow = this.window;
@@ -283,22 +284,23 @@ class PreviewBuffer extends EventEmitter {
 
         for (let i = 0; i < cameras.length; i++) {
             const curWindowCamera = cameras[i];
-            this.switchCameras(curWindowCamera, currWindow);
             if (curWindowCamera.width !== this.width || curWindowCamera.height !== this.height) {
                 curWindowCamera.resize(width, height);
             }
             curWindowCamera.update(true);
         }
 
-        const prevTempWindow = cc.director.root.tempWindow;
-        cc.director.root.tempWindow = currWindow;
-        Service.Engine.repaintInEditMode();
-
         return await new Promise((resolve) => {
-            cc.director.once(cc.Director.EVENT_AFTER_DRAW, () => {
-                cc.director.root.tempWindow = prevTempWindow;
+            let done = false;
+            const finish = () => {
+                if (done) return;
+                done = true;
                 resolve(this.copyFrameBuffer(this.window));
+            };
+            cc.director.once(cc.Director.EVENT_AFTER_DRAW, () => {
+                finish();
             });
+            setTimeout(finish, 1000);
         });
     }
 }

--- a/src/core/scene/scene-process/service/preview/index.ts
+++ b/src/core/scene/scene-process/service/preview/index.ts
@@ -7,14 +7,24 @@ import { MeshPreview } from './mesh-preview';
 import { SkeletonPreview } from './skeleton-preview';
 import { PrefabPreview } from './prefab-preview';
 import { SpinePreview } from './spine-preview';
-import { BaseService, register, Service } from '../core';
+import { BaseService, register } from '../core';
 import { Rpc } from '../../rpc';
-import type { InteractivePreview } from './interactive-preview';
 import type { IPreviewService, IPreviewEvents, IPreviewInstance } from '../../../common/preview';
 
 interface PreviewTypeEntry {
     instance: PreviewBase;
     setup: string;
+}
+
+interface ResolvedPreviewEntry extends PreviewTypeEntry {
+    assetType: string;
+}
+
+function withTimeout<T>(promise: Promise<T>, message: string, timeout = 10000): Promise<T> {
+    return Promise.race([
+        promise,
+        new Promise<T>((_, reject) => setTimeout(() => reject(new Error(message)), timeout)),
+    ]);
 }
 
 @register('Preview')
@@ -71,23 +81,28 @@ export class PreviewService extends BaseService<IPreviewEvents> implements IPrev
     // importer name → preview type 的映射（用于 assetType 为 cc.Asset 等泛型的回退）
     private static readonly IMPORTER_MAP: Record<string, string> = {
         'gltf': 'model',
+        'gltf-scene': 'model',
         'fbx': 'model',
         'spine-data': 'spine',
     };
 
-    private resolvePreview(assetType: string): PreviewTypeEntry | null {
-        return this._typeMap.get(assetType) ?? null;
+    private resolvePreview(assetType: string): ResolvedPreviewEntry | null {
+        const entry = this._typeMap.get(assetType);
+        return entry ? { ...entry, assetType } : null;
     }
 
     private async resolveAssetType(uuid: string): Promise<string | null> {
-        const info = await Rpc.getInstance().request('assetManager', 'queryAssetInfo', [uuid]);
+        const info = await withTimeout(
+            Rpc.getInstance().request('assetManager', 'queryAssetInfo', [uuid]),
+            `Query asset info timeout: ${uuid}`,
+        );
         if (!info) return null;
-        // 优先用 type 匹配；若 type 为泛型（如 cc.Asset），用 importer 回退
-        if (info.type && this._typeMap.has(info.type)) {
-            return info.type;
-        }
+        // Importer is more specific for virtual model sub-assets such as gltf-scene.
         if (info.importer && PreviewService.IMPORTER_MAP[info.importer]) {
             return PreviewService.IMPORTER_MAP[info.importer];
+        }
+        if (info.type && this._typeMap.has(info.type)) {
+            return info.type;
         }
         return info.type ?? null;
     }
@@ -107,7 +122,60 @@ export class PreviewService extends BaseService<IPreviewEvents> implements IPrev
         return false;
     }
 
+    public async queryPreviewData(previewName: string, info: any) {
+        const preview = this._previewMap.get(previewName);
+        if (preview) {
+            return await preview.queryPreviewData(info);
+        }
+        return null;
+    }
+
+    public async callActivePreviewFunction(funcName: string, ...args: any[]) {
+        const preview: any = this._activePreview;
+        if (preview?.[funcName]) {
+            return await preview[funcName](...args);
+        }
+        return false;
+    }
+
+    public async queryActivePreviewData(info: any) {
+        const preview: any = this._activePreview;
+        if (preview?.queryPreviewData) {
+            return await preview.queryPreviewData(info);
+        }
+        return null;
+    }
+
+    public async toggleActivePreviewView(info?: any) {
+        const preview: any = this._activePreview;
+        if (!preview?.viewToggle) {
+            return null;
+        }
+        const state = preview.queryViewToolState?.();
+        if (state?.enableViewToggle === false) {
+            return null;
+        }
+        await preview.viewToggle();
+        const is2D = preview.is2DView?.() ?? null;
+        if (info && preview.queryPreviewData) {
+            return {
+                is2D,
+                frame: await preview.queryPreviewData(info),
+            };
+        }
+        return is2D;
+    }
+
     // --- 上屏预览 ---
+
+    public async openAsset(uuid: string) {
+        const preview = await this.open(uuid);
+        return {
+            supported: !!preview,
+            assetType: (preview as any)?._previewAssetType ?? null,
+            is2D: preview?.is2DView?.() ?? null,
+        };
+    }
 
     async open(uuid: string): Promise<IPreviewInstance | null> {
         const assetType = await this.resolveAssetType(uuid);
@@ -131,39 +199,15 @@ export class PreviewService extends BaseService<IPreviewEvents> implements IPrev
         }
 
         // 设置资源
-        await (entry.instance as any)[entry.setup](uuid);
+        await withTimeout(
+            (entry.instance as any)[entry.setup](uuid),
+            `Preview setup timeout: ${uuid}`,
+            15000,
+        );
+        (entry.instance as any)._previewAssetType = entry.assetType;
         this._activePreview = entry.instance as unknown as IPreviewInstance;
 
-        // 将相机挂到 mainWindow 上屏渲染
-        this.attachToMainWindow(entry.instance as InteractivePreview);
-        Service.Engine.repaintInEditMode();
-
         return this._activePreview;
-    }
-
-    private attachToMainWindow(previewInstance: InteractivePreview) {
-        const inst = previewInstance as any;
-        if (!inst?.cameraComp) return;
-
-        const mainWindow = cc.director.root.mainWindow;
-        const camera = inst.cameraComp.camera || inst.camera;
-        if (!camera || !mainWindow) return;
-
-        camera.changeTargetWindow(mainWindow);
-        camera.isWindowSize = true;
-        camera.enabled = true;
-        inst.cameraComp.enabled = true;
-
-        if (inst.scene?.renderScene && !camera.scene) {
-            inst.scene.renderScene.addCamera(camera);
-        }
-
-        if (inst.worldAxis) {
-            inst.worldAxis._sceneGizmoCamera.camera.changeTargetWindow(mainWindow);
-            if (inst.enableAxis) {
-                inst.worldAxis.show();
-            }
-        }
     }
 
     // --- 缩略图生成 ---

--- a/src/core/scene/scene-process/service/preview/interactive-preview.ts
+++ b/src/core/scene/scene-process/service/preview/interactive-preview.ts
@@ -77,9 +77,9 @@ class InteractivePreview extends PreviewBase implements IPreviewInstance {
     protected skybox: SkyboxInfo | null = null;
 
     public async queryPreviewData(info: any) {
-        this.ensurePreviewGlobalsActive();
         this.previewBuffer.ensureWindow(info.width, info.height);
         this.ensureCameraAttached();
+        this.syncRenderCameraState();
         if (this.worldAxis && this.previewBuffer?.window) {
             this.worldAxis._sceneGizmoCamera.camera.changeTargetWindow(this.previewBuffer.window);
             if (this.enableAxis) {
@@ -87,15 +87,6 @@ class InteractivePreview extends PreviewBase implements IPreviewInstance {
             }
         }
         return super.queryPreviewData(info);
-    }
-
-    private ensurePreviewGlobalsActive() {
-        if (!this.enableSkybox) return;
-        const psd = (cc.director.root as any)?.pipeline?.pipelineSceneData;
-        if (!psd?.skybox) return;
-        if (!psd.skybox.enabled) {
-            this.scene.globals.activate(this.scene);
-        }
     }
 
     protected readonly _minScalar = 1;
@@ -149,11 +140,13 @@ class InteractivePreview extends PreviewBase implements IPreviewInstance {
         this.switchViewModeState();
         this.initCamera();
         this.initSceneCamera();
+        this.syncRenderCameraState();
         this.initGrid();
         this.initPreviewWorldAxis();
         if (this._modelNode) {
             this.autoPerfectCameraViewOnModel(this._modelNode);
         }
+        this.syncRenderCameraState();
     }
 
     public initScene(registerName: string, queryName: string) {
@@ -177,7 +170,7 @@ class InteractivePreview extends PreviewBase implements IPreviewInstance {
         if (this.is2D) {
             this.cameraComp.node.setPosition(0, 0, 1000);
             this.cameraComp.orthoHeight = 0;
-            this.cameraComp.node.setRotation(0, 0, 0, 0);
+            this.cameraComp.node.setRotationFromEuler(0, 0, 0);
             this.cameraComp.projection = Camera.ProjectionType.ORTHO;
             this.cameraComp.clearFlags = Camera.ClearFlag.SOLID_COLOR;
         } else {
@@ -210,19 +203,57 @@ class InteractivePreview extends PreviewBase implements IPreviewInstance {
     protected ensureCameraAttached() {
         if (!this.camera || !this.previewBuffer?.window) return;
 
-        this.cameraComp.enabled = true;
-        if (!this.camera.scene && this.scene?.renderScene) {
-            this.scene.renderScene.addCamera(this.camera);
+        const root = cc.director.root as any;
+        const prevTempWindow = root.tempWindow;
+        root.tempWindow = this.previewBuffer.window;
+        try {
+            this.cameraComp.enabled = true;
+            if (!this.camera.scene && this.scene?.renderScene) {
+                this.scene.renderScene.addCamera(this.camera);
+            }
+            this.camera.changeTargetWindow(this.previewBuffer.window);
+            this.camera.enabled = true;
+            this.syncRenderCameraState();
+        } finally {
+            root.tempWindow = prevTempWindow;
         }
-        this.camera.changeTargetWindow(this.previewBuffer.window);
-        this.camera.enabled = true;
+    }
+
+    protected enablePreviewCamera() {
+        this.previewBuffer.ensureWindow();
+        this.ensureCameraAttached();
+    }
+
+    protected syncRenderCameraState() {
+        if (!this.camera) return;
+        this.camera.projectionType = this.cameraComp.projection;
+        this.camera.orthoHeight = this.cameraComp.orthoHeight;
+        this.camera.clearFlag = this.cameraComp.clearFlags;
+        this.camera.clearColor = this.cameraComp.clearColor as Color;
+        this.camera.nearClip = this.cameraComp.near;
+        this.camera.farClip = this.cameraComp.far;
+        this.camera.visibility = this.cameraComp.visibility;
+        this.camera.update(true);
     }
 
     public loadScene() {
-        // @ts-ignore
-        this.scene._load();
-        // @ts-ignore
-        this.scene._activate();
+        const root = cc.director.root as any;
+        const prevTempWindow = root.tempWindow;
+        const activeScene = cc.director.getScene?.();
+        if (this.previewBuffer?.window) {
+            root.tempWindow = this.previewBuffer.window;
+        }
+        try {
+            // @ts-ignore
+            this.scene._load();
+            // @ts-ignore
+            this.scene._activate();
+        } finally {
+            root.tempWindow = prevTempWindow;
+            if (activeScene && activeScene !== this.scene && activeScene.globals) {
+                activeScene.globals.activate(activeScene);
+            }
+        }
 
         if (this.enableSkybox) {
             this.ensureSkyboxMaterial();

--- a/src/core/scene/scene-process/service/preview/material-preview.ts
+++ b/src/core/scene/scene-process/service/preview/material-preview.ts
@@ -161,7 +161,7 @@ export class MaterialPreview extends InteractivePreview implements IMaterialPrev
             comp.material = instantiated;
             this.material = material;
             this.updateDs();
-            this.cameraComp.enabled = true;
+            this.enablePreviewCamera();
             this.cameraComp.node.getWorldPosition(tempVec3A);
             this.modelComp.node.getWorldPosition(tempVec3B);
             this.viewDist = Vec3.distance(tempVec3A, tempVec3B);
@@ -231,7 +231,7 @@ export class MaterialPreview extends InteractivePreview implements IMaterialPrev
         this.modelComp.mesh = data[type].mesh;
         this.updateDs();
         this.modelComp.node.setScale(data[type].scale);
-        this.cameraComp.enabled = true;
+        this.enablePreviewCamera();
         this.resetCameraView();
     }
 

--- a/src/core/scene/scene-process/service/preview/mesh-preview.ts
+++ b/src/core/scene/scene-process/service/preview/mesh-preview.ts
@@ -42,7 +42,7 @@ export class MeshPreview extends InteractivePreview {
             for (let i = 0; i < this._modelComp.mesh!.struct.primitives.length; i++) {
                 this._modelComp.setMaterial(this._defaultMat, i);
             }
-            this.cameraComp.enabled = true;
+            this.enablePreviewCamera();
             this.resetCameraView();
         } catch (e) {
             console.warn(e);

--- a/src/core/scene/scene-process/service/preview/model-preview.ts
+++ b/src/core/scene/scene-process/service/preview/model-preview.ts
@@ -41,13 +41,16 @@ export class ModelPreview extends InteractivePreview {
 
         assetManager.assets.remove(prefabUuid);
         const prefabAsset = await new Promise<Prefab>((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error(`Load model prefab timeout: ${prefabUuid}`)), 10000);
             assetManager.loadAny(prefabUuid, { reloadAsset: true }, (err: any, result: any) => {
+                clearTimeout(timeout);
                 if (err) reject(err);
+                else if (!result) reject(new Error(`Load model prefab failed: ${prefabUuid}`));
                 else resolve(result);
             });
         });
 
-        this.cameraComp.enabled = true;
+        this.enablePreviewCamera();
 
         if (this._modelNode) {
             this.scene.removeChild(this._modelNode);
@@ -59,14 +62,20 @@ export class ModelPreview extends InteractivePreview {
         this._modelNode = instantiate(prefabAsset) as Node;
         this._modelNode.parent = this.scene;
 
-        this.resetCamera(this._modelNode);
-
-        Service.Engine.repaintInEditMode();
         return await new Promise((resolve) => {
-            cc.director.once(cc.Director.EVENT_AFTER_DRAW, () => {
+            let done = false;
+            const finish = () => {
+                if (done) return;
+                done = true;
                 this.perfectCameraView(getBoundaryOfMeshNodes([this._modelNode!]));
                 resolve(null);
+            };
+            cc.director.once(cc.Director.EVENT_AFTER_DRAW, () => {
+                finish();
             });
+            this.resetCamera(this._modelNode!);
+            Service.Engine.repaintInEditMode();
+            setTimeout(finish, 1000);
         });
     }
 

--- a/src/core/scene/scene-process/service/preview/prefab-preview.ts
+++ b/src/core/scene/scene-process/service/preview/prefab-preview.ts
@@ -53,7 +53,7 @@ export class PrefabPreview extends InteractivePreview {
             }
 
             this._modelNode.setPosition(0, 0, 0);
-            this.cameraComp.enabled = true;
+            this.enablePreviewCamera();
             this.resetCameraView();
         } catch (e) {
             console.warn(e);

--- a/src/core/scene/scene-process/service/preview/skeleton-preview.ts
+++ b/src/core/scene/scene-process/service/preview/skeleton-preview.ts
@@ -51,7 +51,7 @@ export class SkeletonPreview extends InteractivePreview {
                 this.jointNodes.push(jointNode);
             }
 
-            this.cameraComp.enabled = true;
+            this.enablePreviewCamera();
             this.resetCameraView();
 
             const geometryRenderer = (Service.Engine as any).getGeometryRenderer?.();

--- a/src/core/scene/scene-process/service/preview/spine-preview.ts
+++ b/src/core/scene/scene-process/service/preview/spine-preview.ts
@@ -58,7 +58,7 @@ export class SpinePreview extends InteractivePreview implements ISpinePreviewIns
             this.skeletonComponent.node.active = true;
             this.skeletonComponent.skeletonData = skeletonData;
 
-            this.cameraComp.enabled = true;
+            this.enablePreviewCamera();
             this.resetCamera(this.skeletonComponent.node);
             this.perfectCameraView(getBoundaryOfMeshNodes([this.skeletonComponent.node]));
 

--- a/src/core/scene/scene.scripting.middleware.ts
+++ b/src/core/scene/scene.scripting.middleware.ts
@@ -6,6 +6,32 @@ import { GlobalPaths } from '../../global';
 import { scriptingRoutes } from '../preview/scripting-routes';
 import { pathExists } from 'fs-extra';
 
+let sceneRpcSocket: any = null;
+const SCENE_RPC_TIMEOUT = 60000;
+
+function replySceneRpcError(reply: any, message: string) {
+    if (typeof reply === 'function') {
+        reply({ error: message });
+    }
+}
+
+function forwardSceneRpcRequest(msg: any, reply: any) {
+    if (!sceneRpcSocket?.connected) {
+        replySceneRpcError(reply, 'Scene editor is not connected');
+        return;
+    }
+
+    sceneRpcSocket.timeout(SCENE_RPC_TIMEOUT).emit('scene:rpc:request', msg, (err: any, response: any) => {
+        if (err) {
+            replySceneRpcError(reply, err?.message || String(err));
+            return;
+        }
+        if (typeof reply === 'function') {
+            reply(response ?? { result: null });
+        }
+    });
+}
+
 export default {
     get: [
         {
@@ -72,7 +98,18 @@ export default {
     post: [],
     staticFiles: [],
     socket: {
-        connection: (_socket: any) => { },
-        disconnect: (_socket: any) => { }
+        connection: (socket: any) => {
+            socket.on('scene:rpc:register', () => {
+                sceneRpcSocket = socket;
+            });
+            socket.on('scene:rpc:request', (msg: any, reply: any) => {
+                forwardSceneRpcRequest(msg, reply);
+            });
+        },
+        disconnect: (socket: any) => {
+            if (sceneRpcSocket?.id === socket.id) {
+                sceneRpcSocket = null;
+            }
+        }
     },
 } as IMiddlewareContribution;

--- a/src/server/socket.ts
+++ b/src/server/socket.ts
@@ -16,6 +16,7 @@ export class SocketService {
         // 与 HTTP 路由的 CORS（server.ts 的 app.use(cors)，Access-Control-Allow-Origin: *）保持一致。
         this.io = new Server(server, {
             cors: { origin: '*', methods: ['GET', 'POST'] },
+            maxHttpBufferSize: 64 * 1024 * 1024,
         });
         this.io.on('connection', (socket: any) => {
             console.log(`socket ${socket.id} connected`);

--- a/static/web/preview-app.js
+++ b/static/web/preview-app.js
@@ -1,4 +1,10 @@
-/* global window, document, cc */
+/* global window, document */
+
+const RPC_TIMEOUT = 60000;
+const SCENE_READY_RETRY_COUNT = 20;
+const SCENE_READY_RETRY_DELAY = 250;
+const MAX_PREVIEW_PIXELS = 3840 * 2160;
+const MAX_PREVIEW_SIDE = 4096;
 
 function log(msg, level) {
     if (level === 'err') console.error('[Preview]', msg);
@@ -6,30 +12,217 @@ function log(msg, level) {
     else console.log('[Preview]', msg);
 }
 
-function getPreviewService() {
-    try {
-        return window.cli && window.cli.Scene && window.cli.Scene.Preview;
-    } catch (e) {
-        return null;
+let socket = null;
+let activePreview = false;
+let lightEnabled = true;
+let renderScheduled = false;
+let renderInProgress = false;
+let renderQueued = false;
+
+function getStatus() {
+    return document.getElementById('pvStatus');
+}
+
+function getPreviewCanvas() {
+    return document.getElementById('PreviewCanvas');
+}
+
+function resizePreviewCanvas(canvas) {
+    const dpr = window.devicePixelRatio || 1;
+    const targetWidth = Math.max(1, Math.floor(canvas.clientWidth * dpr));
+    const targetHeight = Math.max(1, Math.floor(canvas.clientHeight * dpr));
+    const scale = Math.min(
+        1,
+        MAX_PREVIEW_SIDE / targetWidth,
+        MAX_PREVIEW_SIDE / targetHeight,
+        Math.sqrt(MAX_PREVIEW_PIXELS / (targetWidth * targetHeight)),
+    );
+    const width = Math.max(1, Math.floor(targetWidth * scale));
+    const height = Math.max(1, Math.floor(targetHeight * scale));
+    if (canvas.width !== width || canvas.height !== height) {
+        canvas.width = width;
+        canvas.height = height;
+    }
+    return { width, height };
+}
+
+function toClampedArray(buffer) {
+    if (buffer instanceof Uint8ClampedArray) {
+        return buffer;
+    }
+    if (ArrayBuffer.isView(buffer)) {
+        return new Uint8ClampedArray(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+    }
+    if (buffer instanceof ArrayBuffer) {
+        return new Uint8ClampedArray(buffer);
+    }
+    if (Array.isArray(buffer)) {
+        return new Uint8ClampedArray(buffer);
+    }
+    if (buffer && Array.isArray(buffer.data)) {
+        return new Uint8ClampedArray(buffer.data);
+    }
+    return null;
+}
+
+function getSceneSocket() {
+    return new Promise((resolve, reject) => {
+        if (!window.io) {
+            reject(new Error('socket.io client is unavailable'));
+            return;
+        }
+        if (!socket) {
+            socket = window.io(window.WebEnv.serverURL);
+            socket.on('connect', () => {
+                const status = getStatus();
+                if (status && !activePreview) {
+                    status.textContent = 'Ready';
+                }
+            });
+            socket.on('disconnect', () => {
+                const status = getStatus();
+                if (status) {
+                    status.textContent = 'Disconnected';
+                }
+            });
+        }
+        if (socket.connected) {
+            resolve(socket);
+            return;
+        }
+
+        const timer = window.setTimeout(() => {
+            cleanup();
+            reject(new Error('Timed out connecting to preview socket'));
+        }, RPC_TIMEOUT);
+
+        function cleanup() {
+            window.clearTimeout(timer);
+            socket.off('connect', onConnect);
+            socket.off('connect_error', onError);
+        }
+        function onConnect() {
+            cleanup();
+            resolve(socket);
+        }
+        function onError(err) {
+            cleanup();
+            reject(err || new Error('Preview socket connection failed'));
+        }
+
+        socket.once('connect', onConnect);
+        socket.once('connect_error', onError);
+    });
+}
+
+async function sceneRpcRequest(module, method, args) {
+    const sceneSocket = await getSceneSocket();
+    return await new Promise((resolve, reject) => {
+        sceneSocket.timeout(RPC_TIMEOUT).emit('scene:rpc:request', {
+            module,
+            method,
+            args: args || [],
+        }, (err, response) => {
+            if (err) {
+                reject(err);
+                return;
+            }
+            if (response && response.error) {
+                reject(new Error(response.error));
+                return;
+            }
+            resolve(response ? response.result : null);
+        });
+    });
+}
+
+async function waitForSceneRpc() {
+    let lastError = null;
+    for (let i = 0; i < SCENE_READY_RETRY_COUNT; i++) {
+        try {
+            await sceneRpcRequest('Preview', 'queryActivePreviewData', [{ width: 1, height: 1 }]);
+            return;
+        } catch (e) {
+            lastError = e;
+            if (!/Scene editor is not connected|Timed out connecting/.test(e?.message || '')) {
+                return;
+            }
+            await new Promise((resolve) => window.setTimeout(resolve, SCENE_READY_RETRY_DELAY));
+        }
+    }
+    if (lastError) {
+        throw lastError;
     }
 }
 
-function getActive() {
-    var preview = getPreviewService();
-    return preview && preview.activePreview;
+function previewRequest(method, args) {
+    return sceneRpcRequest('Preview', method, args);
 }
 
-// ── Preview execution ──
+function drawPreviewInfo(canvas, info, fallbackSize) {
+    if (!info || !info.buffer) return;
+
+    const width = info.width || fallbackSize.width;
+    const height = info.height || fallbackSize.height;
+    const data = toClampedArray(info.buffer);
+    if (!data || data.length < width * height * 4) {
+        log('Preview frame buffer is invalid', 'warn');
+        return;
+    }
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.putImageData(new ImageData(data, width, height), 0, 0);
+    log('Preview frame: ' + width + 'x' + height + ', bytes=' + data.length);
+}
+
+async function drawPreviewFrame() {
+    const canvas = getPreviewCanvas();
+    if (!canvas || !activePreview) return;
+
+    const size = resizePreviewCanvas(canvas);
+    const info = await previewRequest('queryActivePreviewData', [{ width: size.width, height: size.height }]);
+    drawPreviewInfo(canvas, info, size);
+}
+
+async function flushPreviewFrame() {
+    if (renderInProgress) {
+        renderQueued = true;
+        return;
+    }
+
+    renderInProgress = true;
+    try {
+        do {
+            renderQueued = false;
+            await drawPreviewFrame();
+        } while (renderQueued);
+    } catch (e) {
+        log('Render preview frame failed: ' + e.message, 'warn');
+    } finally {
+        renderInProgress = false;
+    }
+}
+
+function requestPreviewFrame() {
+    if (renderScheduled) return;
+    renderScheduled = true;
+    window.requestAnimationFrame(() => {
+        renderScheduled = false;
+        flushPreviewFrame();
+    });
+}
+
+function requestPreviewFrames(count) {
+    requestPreviewFrame();
+    if (count > 1) {
+        window.setTimeout(() => requestPreviewFrames(count - 1), 50);
+    }
+}
 
 async function doPreview() {
-    var preview = getPreviewService();
-    if (!preview) {
-        log('Preview service not ready', 'err');
-        return null;
-    }
-
-    var uuid = document.getElementById('pvUuid').value.trim();
-    var status = document.getElementById('pvStatus');
+    const uuid = document.getElementById('pvUuid').value.trim();
+    const status = getStatus();
 
     if (!uuid) {
         log('UUID is required', 'warn');
@@ -40,132 +233,149 @@ async function doPreview() {
     log('Preview: uuid=' + uuid);
 
     try {
-        var instance = await preview.open(uuid);
-        if (!instance) {
+        await waitForSceneRpc();
+        const result = await previewRequest('openAsset', [uuid]);
+        log('Open asset result: ' + JSON.stringify(result));
+        activePreview = !!result?.supported;
+        if (!activePreview) {
             status.textContent = 'unsupported type';
             return null;
         }
+        lightEnabled = true;
         status.textContent = 'ok';
-        return instance;
+        requestPreviewFrames(2);
+        return result;
     } catch (e) {
+        activePreview = false;
         log('Preview error: ' + e.message, 'err');
         status.textContent = 'error';
-        console.error('Preview error:', e);
         return null;
     }
 }
 
+function serializeMouseEvent(event) {
+    return {
+        button: event.button,
+        buttons: event.buttons,
+        movementX: event.movementX || 0,
+        movementY: event.movementY || 0,
+        clientX: event.clientX,
+        clientY: event.clientY,
+        offsetX: event.offsetX,
+        offsetY: event.offsetY,
+    };
+}
+
+async function callActivePreviewFunction(funcName, ...args) {
+    if (!activePreview) return false;
+    return await previewRequest('callActivePreviewFunction', [funcName, ...args]);
+}
+
 function switchPrimitive(type) {
-    var active = getActive();
-    if (active && active.switchPrimitive) {
-        active.switchPrimitive(type);
-        window.cli.Scene.Engine.repaintInEditMode();
-        log('Switched primitive: ' + type);
-    }
+    callActivePreviewFunction('switchPrimitive', type)
+        .then(() => {
+            requestPreviewFrame();
+            log('Switched primitive: ' + type);
+        })
+        .catch((e) => log('Switch primitive failed: ' + e.message, 'warn'));
 }
 
 function toggleLight() {
-    var active = getActive();
-    if (!active || !active.setLightEnable) return;
-    var light = active.lightComp;
-    var on = light ? !light.enabled : true;
-    active.setLightEnable(on);
-    window.cli.Scene.Engine.repaintInEditMode();
-    log('Light: ' + (on ? 'ON' : 'OFF'));
+    lightEnabled = !lightEnabled;
+    callActivePreviewFunction('setLightEnable', lightEnabled)
+        .then(() => {
+            requestPreviewFrame();
+            log('Light: ' + (lightEnabled ? 'ON' : 'OFF'));
+        })
+        .catch((e) => log('Toggle light failed: ' + e.message, 'warn'));
 }
 
-function toggle2D3D() {
-    var active = getActive();
-    if (active && active.viewToggle) {
-        active.viewToggle();
-        window.cli.Scene.Engine.repaintInEditMode();
-        log('Toggled 2D/3D view');
+async function toggle2D3D() {
+    const canvas = getPreviewCanvas();
+    const size = canvas ? resizePreviewCanvas(canvas) : null;
+    try {
+        const result = await previewRequest('toggleActivePreviewView', [size]);
+        const nextIs2D = result && typeof result === 'object' ? result.is2D : result;
+        if (nextIs2D == null) {
+            log('No active preview supports 2D/3D toggle', 'warn');
+            return;
+        }
+        if (canvas && result?.frame) {
+            drawPreviewInfo(canvas, result.frame, size);
+        }
+        requestPreviewFrames(2);
+        log('Toggled 2D/3D view: ' + (nextIs2D ? '2D' : '3D'));
+    } catch (e) {
+        log('Toggle 2D/3D failed: ' + e.message, 'warn');
     }
 }
-
-// ── Mouse event forwarding to InteractivePreview ──
 
 function bindPreviewMouseEvents(canvas) {
-    canvas.addEventListener('mousedown', function(e) {
-        var active = getActive();
-        if (active) active.onMouseDown(e);
+    canvas.addEventListener('mousedown', (e) => {
+        callActivePreviewFunction('onMouseDown', serializeMouseEvent(e))
+            .catch((err) => log('Mouse down failed: ' + err.message, 'warn'));
     });
 
-    canvas.addEventListener('mousemove', function(e) {
-        var active = getActive();
-        if (!active) return;
-        active.onMouseMove(e);
-        if (active._isMouseDown) {
-            window.cli.Scene.Engine.repaintInEditMode();
-        }
+    canvas.addEventListener('mousemove', (e) => {
+        callActivePreviewFunction('onMouseMove', serializeMouseEvent(e))
+            .then(() => requestPreviewFrame())
+            .catch((err) => log('Mouse move failed: ' + err.message, 'warn'));
     });
 
-    canvas.addEventListener('mouseup', function(e) {
-        var active = getActive();
-        if (active) active.onMouseUp(e);
+    canvas.addEventListener('mouseup', (e) => {
+        callActivePreviewFunction('onMouseUp', serializeMouseEvent(e))
+            .then(() => requestPreviewFrame())
+            .catch((err) => log('Mouse up failed: ' + err.message, 'warn'));
     });
 
-    canvas.addEventListener('wheel', function(e) {
-        var active = getActive();
-        if (!active) return;
+    canvas.addEventListener('wheel', (e) => {
         e.preventDefault();
-        active.onMouseWheel({
-            wheelDeltaY: -e.deltaY,
-        });
-        window.cli.Scene.Engine.repaintInEditMode();
+        callActivePreviewFunction('onMouseWheel', { wheelDeltaY: -e.deltaY })
+            .then(() => requestPreviewFrame())
+            .catch((err) => log('Mouse wheel failed: ' + err.message, 'warn'));
     }, { passive: false });
 
-    canvas.addEventListener('contextmenu', function(e) {
+    canvas.addEventListener('contextmenu', (e) => {
         e.preventDefault();
     });
 }
 
-// ── Initialization ──
-
 export default function initPreviewApp() {
-    var status = document.getElementById('pvStatus');
-
-    var preview = getPreviewService();
-    if (!preview) {
-        status.textContent = 'Service unavailable';
-        log('Preview service not found after boot', 'err');
-        return;
-    }
-
-    try {
-        window.cli.Scene.Engine.resume();
-    } catch (e) {
-        log('Engine resume failed: ' + e.message, 'warn');
-    }
-
-    var canvas = document.getElementById('GameCanvas');
+    const status = getStatus();
+    const canvas = getPreviewCanvas();
     if (canvas) {
         bindPreviewMouseEvents(canvas);
-        log('Bound preview mouse events to canvas');
     }
+    window.addEventListener('resize', requestPreviewFrame);
 
-    status.textContent = 'Ready';
-    log('Preview service ready');
+    status.textContent = 'Connecting...';
+    getSceneSocket()
+        .then(() => {
+            status.textContent = 'Ready';
+            log('Preview display connected');
+        })
+        .catch((e) => {
+            status.textContent = 'Scene editor unavailable';
+            log(e.message, 'warn');
+        });
 
-    // Parse URL params for auto-preview
-    var params = new URLSearchParams(window.location.search);
-    var uuid = params.get('uuid');
-
+    const params = new URLSearchParams(window.location.search);
+    const uuid = params.get('uuid');
     if (uuid) {
         document.getElementById('pvUuid').value = uuid;
         log('Auto-preview from URL params: uuid=' + uuid);
-        setTimeout(function() { doPreview(); }, 100);
+        window.setTimeout(() => doPreview(), 100);
     }
 
-    // Expose API for external automation
     window.previewAPI = {
-        doPreview: doPreview,
-        open: function(uuid) {
-            document.getElementById('pvUuid').value = uuid || '';
+        doPreview,
+        open(uuidValue) {
+            document.getElementById('pvUuid').value = uuidValue || '';
             return doPreview();
         },
-        switchPrimitive: switchPrimitive,
-        toggleLight: toggleLight,
-        toggle2D3D: toggle2D3D,
+        switchPrimitive,
+        toggleLight,
+        toggle2D3D,
+        render: requestPreviewFrame,
     };
 }

--- a/static/web/preview.ejs
+++ b/static/web/preview.ejs
@@ -17,10 +17,17 @@
         #GameDiv, #Cocos3dGameContainer {
             width: 100%;
             height: 100%;
+            position: relative;
         }
-        #GameCanvas {
+        #PreviewCanvas {
+            position: absolute;
+            inset: 0;
             width: 100%;
             height: 100%;
+        }
+        #PreviewCanvas {
+            background: #333;
+            z-index: 1;
         }
 
         /* ── Toolbar ── */
@@ -69,7 +76,7 @@
 <body>
     <div id="GameDiv">
         <div id="Cocos3dGameContainer">
-            <canvas id="GameCanvas" tabindex="-1"></canvas>
+            <canvas id="PreviewCanvas" tabindex="-1"></canvas>
         </div>
     </div>
 
@@ -102,10 +109,9 @@
     <script>
         window.WebEnv = { serverURL: '<%= serverURL %>' };
     </script>
+    <script src="/socket.io/socket.io.js"></script>
     <script type="module">
-        const { default: boot } = await import("/static/web/scene-editor-boot.js");
-        await boot();
-        const { default: initPreviewApp } = await import("/static/web/preview-app.js");
+        const { default: initPreviewApp } = await import("/static/web/preview-app.js?v=preview-rpc-10");
         initPreviewApp();
     </script>
 </body>

--- a/static/web/scene-editor-boot.js
+++ b/static/web/scene-editor-boot.js
@@ -16,7 +16,7 @@ export default async function boot() {
         const _originalSystem = System;
         console.log('[Scene] loading scene bundle');
         // SystemJS natively awaits the attached import maps above
-        const SceneBundle = await System.import('/static/web/scene-bundle.js');
+        const SceneBundle = await System.import('/static/web/scene-bundle.js?v=preview-rpc-10');
         const { startup, Service } = SceneBundle;
 
         globalThis.System = _originalSystem;

--- a/static/web/scene-editor.ejs
+++ b/static/web/scene-editor.ejs
@@ -411,7 +411,7 @@
         };
     </script>
     <script type="module">
-        const { default: boot } = await import("/static/web/scene-editor-boot.js");
+        const { default: boot } = await import("/static/web/scene-editor-boot.js?v=preview-rpc-10");
         await boot();
     </script>
     <script>


### PR DESCRIPTION
## Summary

- Route the standalone resource preview page through the scene editor engine instance instead of booting a second engine instance.
- Render resource previews through offscreen preview windows and return frame buffers to the preview page over Socket.IO.
- Keep preview cameras attached to their offscreen windows so resource previews do not affect the scene editor view.
- Resolve glTF/FBX virtual scene sub-assets through the model preview path and avoid hanging when preview asset loading or frame capture stalls.
- Increase Socket.IO and scene RPC limits so high-resolution preview frames, including 4K-sized buffers, can be transferred reliably.

## Validation

- `npx tsc -b --pretty false`
- `node --check static/web/preview-app.js`
- `npm run build:static-web`