### PR TITLE
Fix resource preview view switching

### DIFF
--- a/src/core/scene/scene-process/service/preview/index.ts
+++ b/src/core/scene/scene-process/service/preview/index.ts
@@ -7,6 +7,7 @@ import { MeshPreview } from './mesh-preview';
 import { SkeletonPreview } from './skeleton-preview';
 import { PrefabPreview } from './prefab-preview';
 import { SpinePreview } from './spine-preview';
+import { Camera, gfx } from 'cc';
 import { BaseService, register, Service } from '../core';
 import { Rpc } from '../../rpc';
 import type { InteractivePreview } from './interactive-preview';
@@ -149,8 +150,28 @@ export class PreviewService extends BaseService<IPreviewEvents> implements IPrev
         const camera = inst.cameraComp.camera || inst.camera;
         if (!camera || !mainWindow) return;
 
+        const cameraService = Service.Camera as any;
+        const editorCamera = cameraService?.getCamera?.() ?? cameraService?.camera;
+        if (editorCamera) {
+            editorCamera.enabled = false;
+        }
+        const sceneGizmoCamera = (Service.Gizmo as any)?.sceneGizmoCamera;
+        if (sceneGizmoCamera) {
+            sceneGizmoCamera.enabled = false;
+        }
+
+        const skybox = inst.scene?.globals?.skybox;
+        if (skybox?.enabled) {
+            skybox.enabled = false;
+            inst.scene.globals.activate(inst.scene);
+        }
+
         camera.changeTargetWindow(mainWindow);
         camera.isWindowSize = true;
+        camera.priority = -1;
+        inst.cameraComp.clearFlags = Camera.ClearFlag.SOLID_COLOR;
+        camera.clearColor = inst.cameraComp.clearColor;
+        camera.clearFlag = gfx.ClearFlagBit.COLOR | gfx.ClearFlagBit.DEPTH_STENCIL;
         camera.enabled = true;
         inst.cameraComp.enabled = true;
 

--- a/src/core/scene/scene-process/service/preview/interactive-preview.ts
+++ b/src/core/scene/scene-process/service/preview/interactive-preview.ts
@@ -1,4 +1,4 @@
-import { Camera, Color, geometry, Node, Quat, renderer, Scene, Layers, Vec3, EventMouse, SkyboxInfo, UITransform } from 'cc';
+import { Camera, Color, geometry, gfx, Node, Quat, renderer, Scene, Layers, Vec3, EventMouse, SkyboxInfo, UITransform } from 'cc';
 import PreviewBuffer from './buffer';
 import { PreviewBase } from './preview-base';
 import { PreviewWorldAxis } from './preview-axis';
@@ -148,12 +148,12 @@ class InteractivePreview extends PreviewBase implements IPreviewInstance {
         this.is2D = !this.is2D;
         this.switchViewModeState();
         this.initCamera();
-        this.initSceneCamera();
         this.initGrid();
-        this.initPreviewWorldAxis();
+        this.updatePreviewWorldAxisVisibility();
         if (this._modelNode) {
             this.autoPerfectCameraViewOnModel(this._modelNode);
         }
+        Service.Engine.repaintInEditMode();
     }
 
     public initScene(registerName: string, queryName: string) {
@@ -176,15 +176,14 @@ class InteractivePreview extends PreviewBase implements IPreviewInstance {
     public initCamera() {
         if (this.is2D) {
             this.cameraComp.node.setPosition(0, 0, 1000);
-            this.cameraComp.orthoHeight = 0;
-            this.cameraComp.node.setRotation(0, 0, 0, 0);
+            this.cameraComp.orthoHeight = 1;
+            this.cameraComp.node.setRotationFromEuler(0, 0, 0);
             this.cameraComp.projection = Camera.ProjectionType.ORTHO;
             this.cameraComp.clearFlags = Camera.ClearFlag.SOLID_COLOR;
         } else {
             this.cameraComp.node.setPosition(0, 1, 2.5);
             this.cameraComp.node.lookAt(Vec3.ZERO);
             this.cameraComp.projection = Camera.ProjectionType.PERSPECTIVE;
-            this.cameraComp.clearFlags = Camera.ClearFlag.SKYBOX;
         }
         this.cameraComp.clearColor = new Color(76, 76, 76, 255);
         this.cameraComp.near = 0.01;
@@ -200,6 +199,9 @@ class InteractivePreview extends PreviewBase implements IPreviewInstance {
             this.camera = this.cameraComp.camera;
         }
         this.camera.isWindowSize = false;
+        if (this.cameraComp.projection === Camera.ProjectionType.PERSPECTIVE) {
+            this.camera.clearFlag = (gfx.ClearFlagBit.STENCIL << 1) | gfx.ClearFlagBit.DEPTH_STENCIL;
+        }
         this.camera.cameraUsage = renderer.scene.CameraUsage.EDITOR;
         // Disable until a preview window is available — scene._activate() already
         // enabled the camera targeting mainWindow, which causes framebuffer errors.
@@ -224,47 +226,6 @@ class InteractivePreview extends PreviewBase implements IPreviewInstance {
         // @ts-ignore
         this.scene._activate();
 
-        if (this.enableSkybox) {
-            this.ensureSkyboxMaterial();
-            this.loadDefaultEnvmap();
-        }
-    }
-
-    private loadDefaultEnvmap() {
-        const skyboxInfo = this.scene.globals.skybox;
-        if (!skyboxInfo) return;
-        const envmapUuid = 'd032ac98-05e1-4090-88bb-eb640dcb5fc1@b47c0';
-        cc.assetManager.loadAny(envmapUuid, (err: any, asset: any) => {
-            if (err || !asset) return;
-            skyboxInfo.envmap = asset;
-        });
-    }
-
-    private ensureSkyboxMaterial() {
-        const skyboxInfo = this.scene.globals.skybox;
-        const resource = (skyboxInfo as any)?._resource;
-        if (!resource) {
-            console.warn(`[InteractivePreview] ensureSkyboxMaterial: no skybox resource`);
-            return;
-        }
-
-        const model = resource.model;
-        const subModels = model?.subModels;
-        const passes = subModels?.[0]?.passes;
-        const passCount = passes?.length ?? 0;
-
-        if (model && subModels?.length > 0 && passCount === 0) {
-            const skyboxEffect = cc.EffectAsset?.get?.('pipeline/skybox');
-            if (skyboxEffect) {
-                const isRGBE = resource._default?.isRGBE ?? false;
-                const mat = new cc.Material();
-                mat.initialize({ effectName: 'pipeline/skybox', defines: { USE_RGBE_CUBEMAP: isRGBE } });
-                if (mat.passes?.length > 0) {
-                    resource._editableMaterial = mat;
-                    resource._updatePipeline();
-                }
-            }
-        }
     }
 
     protected switchViewModeState() {
@@ -302,11 +263,18 @@ class InteractivePreview extends PreviewBase implements IPreviewInstance {
         }
         if (this.previewBuffer?.window) {
             this.worldAxis._sceneGizmoCamera.camera.changeTargetWindow(this.previewBuffer.window);
-            if (this.enableAxis) {
-                this.worldAxis.show();
-            } else {
-                this.worldAxis.hide();
-            }
+            this.updatePreviewWorldAxisVisibility();
+        } else {
+            this.worldAxis.hide();
+        }
+    }
+
+    protected updatePreviewWorldAxisVisibility() {
+        if (!this.worldAxis) {
+            this.worldAxis = new PreviewWorldAxis(this.scene, this.cameraComp);
+        }
+        if (this.enableAxis) {
+            this.worldAxis.show();
         } else {
             this.worldAxis.hide();
         }
@@ -325,12 +293,16 @@ class InteractivePreview extends PreviewBase implements IPreviewInstance {
 
     resetCamera(modelNode: Node) {
         if (this.isOrtho) {
-            tempVec3A.set(0, 0, 0);
+            tempVec3A.set(0, 0, 1000);
         } else {
             tempVec3A.set(0, 1, 2.5);
         }
         this.cameraComp.node.setPosition(tempVec3A);
-        this.cameraComp.node.lookAt(Vec3.ZERO);
+        if (this.isOrtho) {
+            this.cameraComp.node.setRotationFromEuler(0, 0, 0);
+        } else {
+            this.cameraComp.node.lookAt(Vec3.ZERO);
+        }
         modelNode.getWorldPosition(tempVec3B);
         Vec3.set(this.viewCenter, 0, 0, 0);
         this.viewDist = Vec3.distance(tempVec3A, tempVec3B);
@@ -356,20 +328,25 @@ class InteractivePreview extends PreviewBase implements IPreviewInstance {
     private _forward = cc.v3(Vec3.UNIT_Z);
 
     protected perfectCameraView(boundary: geometry.AABB | null | undefined) {
+        let orthoHeight = 1;
         if (boundary) {
             const radius = Math.max(boundary.halfExtents.x, boundary.halfExtents.y, boundary.halfExtents.z);
             const fov = this.cameraComp.fov * Math.PI / 180;
             const requiredDist = radius / Math.tan(fov / 2);
             const dist = Vec3.distance(this.cameraComp.node.worldPosition, boundary.center);
             this.viewDist = Math.max(dist, requiredDist);
+            Vec3.set(this.viewCenter, boundary.center.x, boundary.center.y, boundary.center.z);
+            orthoHeight = Math.max(1, radius * 1.2);
         } else if (this._modelNode) {
             const uiTransform = this._modelNode.getComponent(UITransform);
             if (uiTransform) {
                 const bbox = uiTransform.getBoundingBoxToWorld();
                 Vec3.set(this.viewCenter, bbox.x + bbox.width / 2, bbox.y + bbox.height / 2, 0);
+                orthoHeight = Math.max(1, bbox.height / 2);
             } else {
                 const pos = this._modelNode.worldPosition;
                 Vec3.set(this.viewCenter, pos.x, pos.y, pos.z);
+                orthoHeight = Math.max(1, Math.abs(this.viewCenter.y));
             }
         }
 
@@ -384,7 +361,7 @@ class InteractivePreview extends PreviewBase implements IPreviewInstance {
                 const bbox = uiTransform.getBoundingBoxToWorld();
                 this.cameraComp.orthoHeight = Math.max(1, bbox.height / 2);
             } else {
-                this.cameraComp.orthoHeight = Math.max(1, this.viewCenter.y);
+                this.cameraComp.orthoHeight = orthoHeight;
             }
         } else {
             this.cameraComp.node.getWorldRotation(this._curRot);

--- a/static/web/preview-app.js
+++ b/static/web/preview-app.js
@@ -46,6 +46,7 @@ async function doPreview() {
             return null;
         }
         status.textContent = 'ok';
+        refreshViewModeControls();
         return instance;
     } catch (e) {
         log('Preview error: ' + e.message, 'err');
@@ -74,13 +75,44 @@ function toggleLight() {
     log('Light: ' + (on ? 'ON' : 'OFF'));
 }
 
-function toggle2D3D() {
+function refreshViewModeControls() {
     var active = getActive();
-    if (active && active.viewToggle) {
-        active.viewToggle();
-        window.cli.Scene.Engine.repaintInEditMode();
-        log('Toggled 2D/3D view');
+    var is2D = false;
+    if (active && active.is2DView) {
+        try {
+            is2D = !!active.is2DView();
+        } catch (e) {
+            is2D = false;
+        }
     }
+
+    var btn2D = document.getElementById('pvBtn2D');
+    var btn3D = document.getElementById('pvBtn3D');
+    if (btn2D) btn2D.classList.toggle('active', is2D);
+    if (btn3D) btn3D.classList.toggle('active', !is2D);
+}
+
+function switch2D3D(targetIs2D) {
+    var active = getActive();
+    if (!active) {
+        log('No active preview', 'warn');
+        refreshViewModeControls();
+        return;
+    }
+
+    var currentIs2D = !!(active.is2DView && active.is2DView());
+    var nextIs2D = typeof targetIs2D === 'boolean' ? targetIs2D : !currentIs2D;
+    if (active.viewToggle && currentIs2D !== nextIs2D) {
+        active.viewToggle();
+    }
+
+    window.cli.Scene.Engine.repaintInEditMode();
+    refreshViewModeControls();
+    log('View mode: ' + (nextIs2D ? '2D' : '3D'));
+}
+
+function toggle2D3D(targetIs2D) {
+    switch2D3D(targetIs2D);
 }
 
 // ── Mouse event forwarding to InteractivePreview ──
@@ -145,6 +177,7 @@ export default function initPreviewApp() {
     }
 
     status.textContent = 'Ready';
+    refreshViewModeControls();
     log('Preview service ready');
 
     // Parse URL params for auto-preview

--- a/static/web/preview.ejs
+++ b/static/web/preview.ejs
@@ -62,6 +62,10 @@
         #toolbar button:hover { background: #4a8ec5; }
         #toolbar button.secondary { background: #555; }
         #toolbar button.secondary:hover { background: #666; }
+        #toolbar button.secondary.active {
+            background: #2a6da8;
+            box-shadow: inset 0 0 0 1px #6bb6ff;
+        }
         #toolbar .separator { width: 1px; height: 20px; background: #555; }
         #toolbar .status { color: #8cf; font-size: 11px; }
     </style>
@@ -94,7 +98,8 @@
         </select>
 
         <button class="secondary" onclick="window.previewAPI?.toggleLight()">Light</button>
-        <button class="secondary" onclick="window.previewAPI?.toggle2D3D()">2D/3D</button>
+        <button class="secondary" id="pvBtn2D" onclick="window.previewAPI?.toggle2D3D(true)">2D</button>
+        <button class="secondary active" id="pvBtn3D" onclick="window.previewAPI?.toggle2D3D(false)">3D</button>
 
         <span class="status" id="pvStatus">Initializing...</span>
     </div>


### PR DESCRIPTION
## Summary
- Keep the resource preview 2D and 3D toolbar buttons in sync with the active preview mode.
- Preserve the preview camera target when switching modes so direct rendering to the main window keeps working.
- Reset preview clear state and disable the preview skybox when rendering to the main window to avoid mixed editor and preview backgrounds.

## Testing
- npx tsc -b --pretty false