### PR TITLE
fix(physics): live-update collision groups without restarting IDE

### DIFF
--- a/src/core/preview/live-reload.ts
+++ b/src/core/preview/live-reload.ts
@@ -15,9 +15,11 @@ let registered = false;
 // 保存已注册的监听源与回调，供 unregisterLiveReload 精确解绑，避免预览重启后监听泄漏。
 let scriptingRef: { off?: Function; removeListener?: Function } | null = null;
 let assetDBRef: { off?: Function; removeListener?: Function } | null = null;
+let assetMgrRef: { off?: Function; removeListener?: Function } | null = null;
 let configRef: { off?: Function; removeListener?: Function } | null = null;
 let onCompiled: (() => void) | null = null;
 let onRefreshFinish: (() => void) | null = null;
+let onAssetChanged: (() => void) | null = null;
 let onConfigChanged: (() => void) | null = null;
 
 function removeListener(emitter: { off?: Function; removeListener?: Function } | null, event: string, fn: Function | null): void {
@@ -58,23 +60,32 @@ export async function registerLiveReload(): Promise<void> {
     registered = true;
 
     const { default: scripting } = await import('../scripting');
-    const { assetDBManager } = await import('../assets');
+    const { assetDBManager, assetManager } = await import('../assets');
     const { configurationManager } = await import('../configuration');
     const { MessageType } = await import('../configuration/script/interface');
 
     onCompiled = () => scheduleReload();
     onRefreshFinish = () => scheduleReload();
+    // 单个资源变更（如保存场景 = .scene asset-change、编辑材质/预制体等）。
+    // assets:refresh-finish 只在整批刷新时触发，保存单个场景走的是逐资源 asset-change，
+    // 不监听就会出现“改完/存完场景，浏览器预览不重载”。有 200ms 去抖，批量导入会合并成一次。
+    onAssetChanged = () => scheduleReload();
     // 工程配置变更（如切换物理后端 = 改 engine.includeModules）会影响预览 settings，
     // 需清缓存并重载，否则预览仍用旧模块集（漏掉新后端的内置资源，报 builtinMaterial 加载失败）。
     onConfigChanged = () => scheduleReload();
     scriptingRef = scripting as any;
     assetDBRef = assetDBManager as any;
+    assetMgrRef = assetManager as any;
     configRef = configurationManager as any;
 
     // 脚本重编译成功
     scripting.on('compiled', onCompiled);
     // 资源批量刷新结束
     assetDBManager.on('assets:refresh-finish', onRefreshFinish);
+    // 单个资源增删改（含保存场景）
+    assetManager.on('asset-change', onAssetChanged);
+    assetManager.on('asset-add', onAssetChanged);
+    assetManager.on('asset-delete', onAssetChanged);
     // 工程配置变更（set / reload）
     configurationManager.on(MessageType.Update, onConfigChanged);
     configurationManager.on(MessageType.Reload, onConfigChanged);
@@ -93,14 +104,19 @@ export function unregisterLiveReload(): void {
     }
     removeListener(scriptingRef, 'compiled', onCompiled);
     removeListener(assetDBRef, 'assets:refresh-finish', onRefreshFinish);
+    removeListener(assetMgrRef, 'asset-change', onAssetChanged);
+    removeListener(assetMgrRef, 'asset-add', onAssetChanged);
+    removeListener(assetMgrRef, 'asset-delete', onAssetChanged);
     // MessageType.Update / MessageType.Reload
     removeListener(configRef, 'configuration:update', onConfigChanged);
     removeListener(configRef, 'configuration:reload', onConfigChanged);
     scriptingRef = null;
     assetDBRef = null;
+    assetMgrRef = null;
     configRef = null;
     onCompiled = null;
     onRefreshFinish = null;
+    onAssetChanged = null;
     onConfigChanged = null;
     registered = false;
 }

--- a/src/core/preview/live-reload.ts
+++ b/src/core/preview/live-reload.ts
@@ -1,5 +1,6 @@
 import { socketService } from '../../server/socket';
 import { invalidatePreviewSettings } from './preview-settings';
+import type { IAsset } from '../assets/@types/protected/asset';
 
 /**
  * 浏览器热重载。
@@ -15,9 +16,11 @@ let registered = false;
 // 保存已注册的监听源与回调，供 unregisterLiveReload 精确解绑，避免预览重启后监听泄漏。
 let scriptingRef: { off?: Function; removeListener?: Function } | null = null;
 let assetDBRef: { off?: Function; removeListener?: Function } | null = null;
+let assetMgrRef: { off?: Function; removeListener?: Function } | null = null;
 let configRef: { off?: Function; removeListener?: Function } | null = null;
 let onCompiled: (() => void) | null = null;
 let onRefreshFinish: (() => void) | null = null;
+let onAssetChanged: ((asset: IAsset) => void) | null = null;
 let onConfigChanged: (() => void) | null = null;
 
 function removeListener(emitter: { off?: Function; removeListener?: Function } | null, event: string, fn: Function | null): void {
@@ -58,23 +61,42 @@ export async function registerLiveReload(): Promise<void> {
     registered = true;
 
     const { default: scripting } = await import('../scripting');
-    const { assetDBManager } = await import('../assets');
+    const { assetDBManager, assetManager } = await import('../assets');
     const { configurationManager } = await import('../configuration');
     const { MessageType } = await import('../configuration/script/interface');
 
     onCompiled = () => scheduleReload();
     onRefreshFinish = () => scheduleReload();
+    // 仅在「场景 / 预制体」资源增删改时重载（= 用户保存场景/预制体）。
+    // 不监听全部 asset-change：预览启动/构建会导入大量贴图、材质等资源并触发 asset-change，
+    // 若都重载，会在引擎初始化 / 场景激活途中整页刷新，概率性报错
+    // （initDefaultMaterial 失败、recompileShaders 读 null、asset destroyed 等）。
+    // 有 200ms 去抖，保存时的连带变更会合并成一次。
+    const shouldReloadForAsset = (asset: IAsset): boolean => {
+        const importer = asset?.meta?.importer;
+        return importer === 'scene' || importer === 'prefab';
+    };
+    onAssetChanged = (asset: IAsset) => {
+        if (shouldReloadForAsset(asset)) {
+            scheduleReload();
+        }
+    };
     // 工程配置变更（如切换物理后端 = 改 engine.includeModules）会影响预览 settings，
     // 需清缓存并重载，否则预览仍用旧模块集（漏掉新后端的内置资源，报 builtinMaterial 加载失败）。
     onConfigChanged = () => scheduleReload();
     scriptingRef = scripting as any;
     assetDBRef = assetDBManager as any;
+    assetMgrRef = assetManager as any;
     configRef = configurationManager as any;
 
     // 脚本重编译成功
     scripting.on('compiled', onCompiled);
     // 资源批量刷新结束
     assetDBManager.on('assets:refresh-finish', onRefreshFinish);
+    // 场景 / 预制体保存（逐资源变更）
+    assetManager.on('asset-change', onAssetChanged);
+    assetManager.on('asset-add', onAssetChanged);
+    assetManager.on('asset-delete', onAssetChanged);
     // 工程配置变更（set / reload）
     configurationManager.on(MessageType.Update, onConfigChanged);
     configurationManager.on(MessageType.Reload, onConfigChanged);
@@ -93,14 +115,19 @@ export function unregisterLiveReload(): void {
     }
     removeListener(scriptingRef, 'compiled', onCompiled);
     removeListener(assetDBRef, 'assets:refresh-finish', onRefreshFinish);
+    removeListener(assetMgrRef, 'asset-change', onAssetChanged);
+    removeListener(assetMgrRef, 'asset-add', onAssetChanged);
+    removeListener(assetMgrRef, 'asset-delete', onAssetChanged);
     // MessageType.Update / MessageType.Reload
     removeListener(configRef, 'configuration:update', onConfigChanged);
     removeListener(configRef, 'configuration:reload', onConfigChanged);
     scriptingRef = null;
     assetDBRef = null;
+    assetMgrRef = null;
     configRef = null;
     onCompiled = null;
     onRefreshFinish = null;
+    onAssetChanged = null;
     onConfigChanged = null;
     registered = false;
 }

--- a/src/core/preview/live-reload.ts
+++ b/src/core/preview/live-reload.ts
@@ -1,6 +1,5 @@
 import { socketService } from '../../server/socket';
 import { invalidatePreviewSettings } from './preview-settings';
-import type { IAsset } from '../assets/@types/protected/asset';
 
 /**
  * 浏览器热重载。
@@ -20,7 +19,7 @@ let assetMgrRef: { off?: Function; removeListener?: Function } | null = null;
 let configRef: { off?: Function; removeListener?: Function } | null = null;
 let onCompiled: (() => void) | null = null;
 let onRefreshFinish: (() => void) | null = null;
-let onAssetChanged: ((asset: IAsset) => void) | null = null;
+let onAssetChanged: (() => void) | null = null;
 let onConfigChanged: (() => void) | null = null;
 
 function removeListener(emitter: { off?: Function; removeListener?: Function } | null, event: string, fn: Function | null): void {
@@ -67,20 +66,10 @@ export async function registerLiveReload(): Promise<void> {
 
     onCompiled = () => scheduleReload();
     onRefreshFinish = () => scheduleReload();
-    // 仅在「场景 / 预制体」资源增删改时重载（= 用户保存场景/预制体）。
-    // 不监听全部 asset-change：预览启动/构建会导入大量贴图、材质等资源并触发 asset-change，
-    // 若都重载，会在引擎初始化 / 场景激活途中整页刷新，概率性报错
-    // （initDefaultMaterial 失败、recompileShaders 读 null、asset destroyed 等）。
-    // 有 200ms 去抖，保存时的连带变更会合并成一次。
-    const shouldReloadForAsset = (asset: IAsset): boolean => {
-        const importer = asset?.meta?.importer;
-        return importer === 'scene' || importer === 'prefab';
-    };
-    onAssetChanged = (asset: IAsset) => {
-        if (shouldReloadForAsset(asset)) {
-            scheduleReload();
-        }
-    };
+    // 单个资源变更（如保存场景 = .scene asset-change、编辑材质/预制体等）。
+    // assets:refresh-finish 只在整批刷新时触发，保存单个场景走的是逐资源 asset-change，
+    // 不监听就会出现“改完/存完场景，浏览器预览不重载”。有 200ms 去抖，批量导入会合并成一次。
+    onAssetChanged = () => scheduleReload();
     // 工程配置变更（如切换物理后端 = 改 engine.includeModules）会影响预览 settings，
     // 需清缓存并重载，否则预览仍用旧模块集（漏掉新后端的内置资源，报 builtinMaterial 加载失败）。
     onConfigChanged = () => scheduleReload();
@@ -93,7 +82,7 @@ export async function registerLiveReload(): Promise<void> {
     scripting.on('compiled', onCompiled);
     // 资源批量刷新结束
     assetDBManager.on('assets:refresh-finish', onRefreshFinish);
-    // 场景 / 预制体保存（逐资源变更）
+    // 单个资源增删改（含保存场景）
     assetManager.on('asset-change', onAssetChanged);
     assetManager.on('asset-add', onAssetChanged);
     assetManager.on('asset-delete', onAssetChanged);

--- a/src/core/preview/live-reload.ts
+++ b/src/core/preview/live-reload.ts
@@ -1,5 +1,6 @@
 import { socketService } from '../../server/socket';
 import { invalidatePreviewSettings } from './preview-settings';
+import type { IAsset } from '../assets/@types/protected/asset';
 
 /**
  * 浏览器热重载。
@@ -19,7 +20,7 @@ let assetMgrRef: { off?: Function; removeListener?: Function } | null = null;
 let configRef: { off?: Function; removeListener?: Function } | null = null;
 let onCompiled: (() => void) | null = null;
 let onRefreshFinish: (() => void) | null = null;
-let onAssetChanged: (() => void) | null = null;
+let onAssetChanged: ((asset: IAsset) => void) | null = null;
 let onConfigChanged: (() => void) | null = null;
 
 function removeListener(emitter: { off?: Function; removeListener?: Function } | null, event: string, fn: Function | null): void {
@@ -66,10 +67,20 @@ export async function registerLiveReload(): Promise<void> {
 
     onCompiled = () => scheduleReload();
     onRefreshFinish = () => scheduleReload();
-    // 单个资源变更（如保存场景 = .scene asset-change、编辑材质/预制体等）。
-    // assets:refresh-finish 只在整批刷新时触发，保存单个场景走的是逐资源 asset-change，
-    // 不监听就会出现“改完/存完场景，浏览器预览不重载”。有 200ms 去抖，批量导入会合并成一次。
-    onAssetChanged = () => scheduleReload();
+    // 仅在「场景 / 预制体」资源增删改时重载（= 用户保存场景/预制体）。
+    // 不监听全部 asset-change：预览启动/构建会导入大量贴图、材质等资源并触发 asset-change，
+    // 若都重载，会在引擎初始化 / 场景激活途中整页刷新，概率性报错
+    // （initDefaultMaterial 失败、recompileShaders 读 null、asset destroyed 等）。
+    // 有 200ms 去抖，保存时的连带变更会合并成一次。
+    const shouldReloadForAsset = (asset: IAsset): boolean => {
+        const importer = asset?.meta?.importer;
+        return importer === 'scene' || importer === 'prefab';
+    };
+    onAssetChanged = (asset: IAsset) => {
+        if (shouldReloadForAsset(asset)) {
+            scheduleReload();
+        }
+    };
     // 工程配置变更（如切换物理后端 = 改 engine.includeModules）会影响预览 settings，
     // 需清缓存并重载，否则预览仍用旧模块集（漏掉新后端的内置资源，报 builtinMaterial 加载失败）。
     onConfigChanged = () => scheduleReload();
@@ -82,7 +93,7 @@ export async function registerLiveReload(): Promise<void> {
     scripting.on('compiled', onCompiled);
     // 资源批量刷新结束
     assetDBManager.on('assets:refresh-finish', onRefreshFinish);
-    // 单个资源增删改（含保存场景）
+    // 场景 / 预制体保存（逐资源变更）
     assetManager.on('asset-change', onAssetChanged);
     assetManager.on('asset-add', onAssetChanged);
     assetManager.on('asset-delete', onAssetChanged);

--- a/src/core/preview/live-reload.ts
+++ b/src/core/preview/live-reload.ts
@@ -1,6 +1,5 @@
 import { socketService } from '../../server/socket';
 import { invalidatePreviewSettings } from './preview-settings';
-import type { IAsset } from '../assets/@types/protected/asset';
 
 /**
  * 浏览器热重载。
@@ -16,11 +15,9 @@ let registered = false;
 // 保存已注册的监听源与回调，供 unregisterLiveReload 精确解绑，避免预览重启后监听泄漏。
 let scriptingRef: { off?: Function; removeListener?: Function } | null = null;
 let assetDBRef: { off?: Function; removeListener?: Function } | null = null;
-let assetMgrRef: { off?: Function; removeListener?: Function } | null = null;
 let configRef: { off?: Function; removeListener?: Function } | null = null;
 let onCompiled: (() => void) | null = null;
 let onRefreshFinish: (() => void) | null = null;
-let onAssetChanged: ((asset: IAsset) => void) | null = null;
 let onConfigChanged: (() => void) | null = null;
 
 function removeListener(emitter: { off?: Function; removeListener?: Function } | null, event: string, fn: Function | null): void {
@@ -61,42 +58,23 @@ export async function registerLiveReload(): Promise<void> {
     registered = true;
 
     const { default: scripting } = await import('../scripting');
-    const { assetDBManager, assetManager } = await import('../assets');
+    const { assetDBManager } = await import('../assets');
     const { configurationManager } = await import('../configuration');
     const { MessageType } = await import('../configuration/script/interface');
 
     onCompiled = () => scheduleReload();
     onRefreshFinish = () => scheduleReload();
-    // 仅在「场景 / 预制体」资源增删改时重载（= 用户保存场景/预制体）。
-    // 不监听全部 asset-change：预览启动/构建会导入大量贴图、材质等资源并触发 asset-change，
-    // 若都重载，会在引擎初始化 / 场景激活途中整页刷新，概率性报错
-    // （initDefaultMaterial 失败、recompileShaders 读 null、asset destroyed 等）。
-    // 有 200ms 去抖，保存时的连带变更会合并成一次。
-    const shouldReloadForAsset = (asset: IAsset): boolean => {
-        const importer = asset?.meta?.importer;
-        return importer === 'scene' || importer === 'prefab';
-    };
-    onAssetChanged = (asset: IAsset) => {
-        if (shouldReloadForAsset(asset)) {
-            scheduleReload();
-        }
-    };
     // 工程配置变更（如切换物理后端 = 改 engine.includeModules）会影响预览 settings，
     // 需清缓存并重载，否则预览仍用旧模块集（漏掉新后端的内置资源，报 builtinMaterial 加载失败）。
     onConfigChanged = () => scheduleReload();
     scriptingRef = scripting as any;
     assetDBRef = assetDBManager as any;
-    assetMgrRef = assetManager as any;
     configRef = configurationManager as any;
 
     // 脚本重编译成功
     scripting.on('compiled', onCompiled);
     // 资源批量刷新结束
     assetDBManager.on('assets:refresh-finish', onRefreshFinish);
-    // 场景 / 预制体保存（逐资源变更）
-    assetManager.on('asset-change', onAssetChanged);
-    assetManager.on('asset-add', onAssetChanged);
-    assetManager.on('asset-delete', onAssetChanged);
     // 工程配置变更（set / reload）
     configurationManager.on(MessageType.Update, onConfigChanged);
     configurationManager.on(MessageType.Reload, onConfigChanged);
@@ -115,19 +93,14 @@ export function unregisterLiveReload(): void {
     }
     removeListener(scriptingRef, 'compiled', onCompiled);
     removeListener(assetDBRef, 'assets:refresh-finish', onRefreshFinish);
-    removeListener(assetMgrRef, 'asset-change', onAssetChanged);
-    removeListener(assetMgrRef, 'asset-add', onAssetChanged);
-    removeListener(assetMgrRef, 'asset-delete', onAssetChanged);
     // MessageType.Update / MessageType.Reload
     removeListener(configRef, 'configuration:update', onConfigChanged);
     removeListener(configRef, 'configuration:reload', onConfigChanged);
     scriptingRef = null;
     assetDBRef = null;
-    assetMgrRef = null;
     configRef = null;
     onCompiled = null;
     onRefreshFinish = null;
-    onAssetChanged = null;
     onConfigChanged = null;
     registered = false;
 }

--- a/src/core/preview/scripting-routes.ts
+++ b/src/core/preview/scripting-routes.ts
@@ -249,6 +249,26 @@ export const scriptingRoutes = [
             const { Engine } = await import('../engine');
             const serverBaseUrl = `${req.protocol}://${req.get('host')}`;
             const config = await Engine.getGameConfig(serverBaseUrl, serverBaseUrl, serverBaseUrl);
+            // 直接读磁盘上的 cocos.config.json（配置真相源），以最新物理碰撞分组覆盖缓存值。
+            // 原因同 design-resolution / modules 路由：Engine._config 只在 configuration:save 时刷新，
+            // 改分组后不读盘兜底，预览重载仍会按旧枚举构建 cc.PhysicsGroup，导致新分组在预览里不生效。
+            try {
+                const { configurationManager } = await import('../configuration');
+                const fse = await import('fs-extra');
+                const configPath = await configurationManager.getConfigPath();
+                if (await fse.pathExists(configPath)) {
+                    const json = await fse.readJSON(configPath);
+                    const diskGroups = json?.engine?.physicsConfig?.collisionGroups;
+                    if (Array.isArray(diskGroups)) {
+                        const cfg = config as any;
+                        cfg.overrideSettings = cfg.overrideSettings || {};
+                        cfg.overrideSettings.physics = cfg.overrideSettings.physics || {};
+                        cfg.overrideSettings.physics.collisionGroups = diskGroups;
+                    }
+                }
+            } catch (error) {
+                console.debug('[game-config] read cocos.config.json collisionGroups failed, fallback to cached:', error);
+            }
             res.json(config);
         },
     },

--- a/src/core/scene/index.ts
+++ b/src/core/scene/index.ts
@@ -41,6 +41,7 @@ export async function init() {
     middlewareService.register('Scene', SceneMiddleware);
     await sceneConfigInstance.init();
     await watchDesignResolutionChange();
+    await watchCollisionGroupsChange();
 }
 
 let _designResolutionWatched = false;
@@ -70,6 +71,103 @@ async function watchDesignResolutionChange() {
         }
     });
     configurationManager.on(MessageType.Reload, () => push());
+}
+
+let _collisionGroupsWatched = false;
+/**
+ * 监听工程物理碰撞分组变更，运行时重建引擎 PhysicsGroup 枚举并刷新属性面板。
+ *
+ * 分组只在引擎初始化时读取一次生成枚举，改配置后不重建就要重启 IDE（属性面板 Group 下拉的 enumList
+ * 来自该枚举）。这里对齐 cocos-editor 的 project:update-physics-group：把最新分组通过 socket.io
+ * scene:invoke 通道推给场景 webview 的 Engine.updatePhysicsGroup（属性面板的 node:change 来自该 webview，
+ * 与设计分辨率同款通道），无需经主进程 / 子进程 RPC，也不对外暴露到 MCP。
+ */
+async function watchCollisionGroupsChange() {
+    if (_collisionGroupsWatched) {
+        return;
+    }
+    _collisionGroupsWatched = true;
+    const { configurationManager } = await import('../configuration');
+    const { MessageType } = await import('../configuration/script/interface');
+    const { socketService } = await import('../../server/socket');
+    const fse = await import('fs-extra');
+    // 读磁盘 cocos.config.json（配置真相源）取最新分组。返回 null 表示磁盘上没有该配置/读失败，
+    // 以便与「真的空数组（分组被全部删除）」区分。
+    // 不用 configurationManager.get：reload() 的 load() 不会把新值同步回已注册的配置实例，get() 会拿到旧值。
+    const readGroupsFromDisk = async (): Promise<{ index: number; name: string }[] | null> => {
+        try {
+            const configPath = await configurationManager.getConfigPath();
+            if (await fse.pathExists(configPath)) {
+                const json = await fse.readJSON(configPath);
+                const disk = json?.engine?.physicsConfig?.collisionGroups;
+                if (Array.isArray(disk)) {
+                    return disk;
+                }
+            }
+        } catch (error) {
+            console.debug('[Scene] read collisionGroups from disk failed:', error);
+        }
+        return null;
+    };
+    const push = (groups: { index: number; name: string }[], source: string) => {
+        console.log(`[Scene] physics collisionGroups changed, updating engine enum (${groups.length} groups, source=${source})`);
+        // 通过 socket.io 通知浏览器场景页（scene webview）重建 PhysicsGroup 枚举并刷新属性面板。
+        // 属性面板的 node:change 来自场景 webview，故只需推给 webview，无需经主进程/子进程 RPC。
+        socketService.io?.emit('scene:invoke', { module: 'Engine', method: 'updatePhysicsGroup', args: [groups] });
+    };
+
+    // 从事件 payload 中提取分组数组，兼容多种保存粒度：
+    //   - 精确子键：value 直接是数组
+    //   - 整体保存 physicsConfig：value.collisionGroups
+    //   - 整体保存 engine / Reload 的 projectConfig：value.(engine.)physicsConfig.collisionGroups
+    const extractGroups = (raw: any): { index: number; name: string }[] | undefined => {
+        if (Array.isArray(raw)) {
+            return raw;
+        }
+        if (raw && typeof raw === 'object') {
+            if (Array.isArray(raw.collisionGroups)) {
+                return raw.collisionGroups;
+            }
+            if (Array.isArray(raw.physicsConfig?.collisionGroups)) {
+                return raw.physicsConfig.collisionGroups;
+            }
+            if (Array.isArray(raw.engine?.physicsConfig?.collisionGroups)) {
+                return raw.engine.physicsConfig.collisionGroups;
+            }
+        }
+        return undefined;
+    };
+
+    // 防抖合并：连续增删多个分组时，只在操作停止 400ms 后统一处理一次，读取「最终」分组状态并刷新一次，
+    // 从根上消除逐次事件因数据/刷新时序错位造成的“差一步”（连加只更新一个 / 删除残留一个）。
+    let debounceTimer: NodeJS.Timeout | null = null;
+    let latestPayload: { index: number; name: string }[] | undefined;
+    const flush = async () => {
+        debounceTimer = null;
+        const payload = latestPayload;
+        latestPayload = undefined;
+        // 优先用已落定的磁盘真相（能表达“全部删除=空数组”）；磁盘无此配置时退回最近一次事件 payload
+        const disk = await readGroupsFromDisk();
+        const groups = disk ?? payload ?? [];
+        push(groups, disk ? 'disk' : (payload ? 'payload' : 'empty'));
+    };
+    const schedule = (payloadGroups?: { index: number; name: string }[]) => {
+        if (payloadGroups) {
+            latestPayload = payloadGroups;
+        }
+        if (debounceTimer) {
+            clearTimeout(debounceTimer);
+        }
+        debounceTimer = setTimeout(() => void flush(), 400);
+    };
+
+    configurationManager.on(MessageType.Update, (key: string, value: any) => {
+        // 兼容精确子键（engine.physicsConfig.collisionGroups）与整体保存（engine.physicsConfig / engine）
+        if (typeof key === 'string' && (key.startsWith('engine.physicsConfig') || key === 'engine')) {
+            schedule(extractGroups(value));
+        }
+    });
+    configurationManager.on(MessageType.Reload, (projectConfig: any) => schedule(extractGroups(projectConfig)));
 }
 
 /**

--- a/src/core/scene/scene-process/service/engine.ts
+++ b/src/core/scene/scene-process/service/engine.ts
@@ -4,7 +4,8 @@ import Time from './engine/time';
 import { Component, director, GeometryRenderer as CCGeometryRenderer, Node } from 'cc';
 import { GeometryRenderer, methods as GeometryMethods } from './engine/geometry_renderer';
 import { BaseService, register } from './core';
-import { Service } from './core/decorator';
+import { ServiceEvents } from './core/global-events';
+import { Service, queryRegisteredService } from './core/decorator';
 import type { ICustomLayerConfig, IEngineEvents, IEngineService } from '../../common';
 import { NodeEventType } from '../../common';
 import { Rpc } from '../rpc';
@@ -200,6 +201,92 @@ export class EngineService extends BaseService<IEngineEvents> implements IEngine
                 cc.Layers.addLayer(layer.name, index);
             }
         });
+    }
+
+    /**
+     * 运行时重建物理碰撞分组枚举（cc.internal.PhysicsGroup / PhysicsGroup2D）。
+     *
+     * 分组只在 cc.game.init 时从 physics.collisionGroups 读一次并生成枚举，改配置后不重建就要重启 IDE
+     * （属性面板 Group 下拉的 enumList 直接来自该枚举）。这里对齐 cocos-editor 的 updatePhysicsGroup：
+     * 用 cc.Enum.update 就地更新枚举，再对当前选中节点广播 node:change，让属性面板重新 dump 拿到新分组。
+     *
+     * 与 cocos-editor 不同点：这里按「内置 DEFAULT + 当前分组」完整重建，先清掉所有旧的用户分组条目，
+     * 以支持分组的删除 / 重命名（editor 只做覆盖，删除后残留旧项）。
+     */
+    public updatePhysicsGroup(groups: { index: number; name: string }[] = []) {
+        const internal = (cc as any).internal;
+        const enums = [internal?.PhysicsGroup, internal?.PhysicsGroup2D].filter(Boolean);
+        if (!enums.length) {
+            return;
+        }
+
+        // 引擎内置 DEFAULT 分组（PhysicsGroup / PhysicsGroup2D 均为 1<<0），恒定保留
+        const DEFAULT_VALUE = 1 << 0;
+
+        // 目标用户分组（name→value）
+        const desired: Record<string, number> = {};
+        (groups || []).forEach((group) => {
+            if (!group || typeof group.index !== 'number' || !group.name) {
+                return;
+            }
+            desired[group.name] = 1 << group.index;
+        });
+
+        enums.forEach((e: any) => {
+            // 先移除所有非内置（DEFAULT）的旧用户分组条目，含 name→value 与 value→name 反向映射，
+            // 这样删除 / 重命名的分组不会残留。__enums__ 必须保留，否则 Enum.isEnum 失败、Enum.update 抛错。
+            for (const key of Object.keys(e)) {
+                if (key === '__enums__') {
+                    continue;
+                }
+                const v = e[key];
+                if (typeof v === 'number') {
+                    // name → value 条目
+                    if (v !== DEFAULT_VALUE) {
+                        delete e[key];
+                    }
+                } else if (typeof v === 'string') {
+                    // value → name 反向映射
+                    if (Number(key) !== DEFAULT_VALUE) {
+                        delete e[key];
+                    }
+                }
+            }
+            Object.assign(e, desired);
+            cc.Enum.update(e);
+        });
+
+        // 通知属性面板重新 dump，刷新 Group 下拉。
+        // 关键：仅「路径级」node:change 只刷新属性“值”，不会重取 enumList（元数据）；必须像 setProperty
+        // 那样带上具体属性的 propPath（node.components 里碰撞体的 group），面板才会重 dump 该属性、更新下拉
+        // 选项。这与用户“切换 group 后才出现新分组”走的是同一条通道。
+        const NodeMgr = ((cc as any).EditorExtends || (globalThis as any).EditorExtends)?.Node;
+        const selection = queryRegisteredService<{ query?: () => string[] }>('Selection');
+        const paths: string[] = selection?.query?.() ?? [];
+        for (const path of paths) {
+            if (!path) {
+                continue;
+            }
+            const node: any = NodeMgr?.getNodeByPath?.(path);
+            if (!node) {
+                // 定位不到节点时，退回路径级 node:change
+                ServiceEvents.broadcast('node:change', path);
+                continue;
+            }
+            const comps: any[] = node.components || [];
+            let matched = false;
+            comps.forEach((comp, index) => {
+                // 碰撞体（Collider / Collider2D）用 group 属性引用 PhysicsGroup 枚举
+                if (comp && typeof comp.group === 'number') {
+                    matched = true;
+                    ServiceEvents.emit('node:change', node, { type: NodeEventType.SET_PROPERTY, propPath: `_components.${index}.group` });
+                }
+            });
+            if (!matched) {
+                // 选中节点上没有碰撞体：仍发一次路径级 node:change 兜底
+                ServiceEvents.broadcast('node:change', path);
+            }
+        }
     }
 
     public setFrameRate(fps: number) {

--- a/src/core/scene/test/engine-physics-group.test.ts
+++ b/src/core/scene/test/engine-physics-group.test.ts
@@ -1,0 +1,156 @@
+jest.mock('cc', () => ({
+    Component: class Component {},
+    Node: class Node {},
+    GeometryRenderer: class GeometryRenderer {},
+    director: {
+        getTotalFrames: jest.fn(() => 0),
+        tick: jest.fn(),
+    },
+}));
+
+jest.mock('../scene-process/service/core/decorator', () => {
+    const actual = jest.requireActual('../scene-process/service/core/decorator');
+    return {
+        ...actual,
+        queryRegisteredService: jest.fn(() => null),
+    };
+});
+
+import { EngineService } from '../scene-process/service/engine';
+import { ServiceEvents } from '../scene-process/service/core/global-events';
+import { queryRegisteredService } from '../scene-process/service/core/decorator';
+
+type Group = { index: number; name: string };
+
+function makeService() {
+    return new EngineService() as unknown as {
+        updatePhysicsGroup(groups?: Group[]): void;
+    };
+}
+
+describe('Engine updatePhysicsGroup', () => {
+    let enumUpdate: jest.Mock;
+
+    beforeEach(() => {
+        enumUpdate = jest.fn();
+        (globalThis as any).cc = {
+            // cc.Enum 枚举里同时存在 name→value 与 value→name 的反向映射（与引擎一致）
+            internal: {
+                PhysicsGroup: { DEFAULT: 1, '1': 'DEFAULT' },
+                PhysicsGroup2D: { DEFAULT: 1, '1': 'DEFAULT' },
+            },
+            Enum: { update: enumUpdate },
+            EditorExtends: {
+                Node: {
+                    getNode: jest.fn(),
+                    getNodePath: jest.fn(),
+                },
+            },
+        };
+        // 默认无选中，避免触发广播
+        (queryRegisteredService as jest.Mock).mockReturnValue({ query: jest.fn(() => []) });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        (queryRegisteredService as jest.Mock).mockReset();
+    });
+
+    it('新增分组按 1<<index 写入 3D/2D 枚举并调用 cc.Enum.update', () => {
+        const service = makeService();
+
+        service.updatePhysicsGroup([{ index: 2, name: 'BIT_1' }]);
+
+        const { PhysicsGroup, PhysicsGroup2D } = (globalThis as any).cc.internal;
+        expect(PhysicsGroup.BIT_1).toBe(1 << 2);
+        expect(PhysicsGroup2D.BIT_1).toBe(1 << 2);
+        // 原有 DEFAULT 保留
+        expect(PhysicsGroup.DEFAULT).toBe(1);
+        // 两个枚举各更新一次
+        expect(enumUpdate).toHaveBeenCalledTimes(2);
+    });
+
+    it('删除引擎中相同 value / name 的旧项后再写入新名', () => {
+        (globalThis as any).cc.internal.PhysicsGroup = { DEFAULT: 1, '1': 'DEFAULT', OLD: 4, '4': 'OLD' };
+        const service = makeService();
+
+        service.updatePhysicsGroup([{ index: 2, name: 'NEW' }]);
+
+        const g = (globalThis as any).cc.internal.PhysicsGroup;
+        expect(g.NEW).toBe(4);
+        // 旧的正/反向映射都被清掉
+        expect(g.OLD).toBeUndefined();
+        expect(g['4']).toBeUndefined();
+        expect(g.DEFAULT).toBe(1);
+    });
+
+    it('跳过非法分组项（缺 name / index 非数字）', () => {
+        const service = makeService();
+
+        service.updatePhysicsGroup([
+            { index: 3, name: '' } as Group,
+            { name: 'NoIndex' } as unknown as Group,
+            { index: 5, name: 'OK' },
+        ]);
+
+        const g = (globalThis as any).cc.internal.PhysicsGroup;
+        expect(g.OK).toBe(1 << 5);
+        expect(Object.prototype.hasOwnProperty.call(g, 'NoIndex')).toBe(false);
+        expect(g['8']).toBeUndefined(); // 1<<3，空 name 未写入
+    });
+
+    it('物理枚举不存在时安全跳过', () => {
+        (globalThis as any).cc.internal = {};
+        const service = makeService();
+        const broadcast = jest.spyOn(ServiceEvents, 'broadcast').mockImplementation(() => {});
+
+        expect(() => service.updatePhysicsGroup([{ index: 2, name: 'BIT_1' }])).not.toThrow();
+        expect(enumUpdate).not.toHaveBeenCalled();
+        expect(broadcast).not.toHaveBeenCalled();
+    });
+
+    it('删除的分组从枚举中移除（重建为内置 + 当前分组）', () => {
+        (globalThis as any).cc.internal.PhysicsGroup = { DEFAULT: 1, '1': 'DEFAULT', BIT_1: 4, '4': 'BIT_1' };
+        (globalThis as any).cc.internal.PhysicsGroup2D = { DEFAULT: 1, '1': 'DEFAULT', BIT_1: 4, '4': 'BIT_1' };
+        const service = makeService();
+
+        // 传入空列表：等价于用户删除了所有自定义分组
+        service.updatePhysicsGroup([]);
+
+        const g = (globalThis as any).cc.internal.PhysicsGroup;
+        expect(g.BIT_1).toBeUndefined();
+        expect(g['4']).toBeUndefined();
+        expect(g.DEFAULT).toBe(1);
+        expect(enumUpdate).toHaveBeenCalledTimes(2);
+    });
+
+    it('对选中节点上碰撞体的 group 属性发带 propPath 的 node:change（刷新下拉）', () => {
+        // 选中节点上有一个碰撞体（group 为数字），期望以 setProperty 同款方式发 node:change
+        const collider = { group: 1 };
+        const node = { components: [collider] };
+        (queryRegisteredService as jest.Mock).mockReturnValue({ query: jest.fn(() => ['root/child']) });
+        (globalThis as any).cc.EditorExtends.Node.getNodeByPath = jest.fn(() => node);
+        const emit = jest.spyOn(ServiceEvents, 'emit').mockImplementation(() => {});
+
+        const service = makeService();
+        service.updatePhysicsGroup([{ index: 2, name: 'BIT_1' }]);
+
+        expect(emit).toHaveBeenCalledWith(
+            'node:change',
+            node,
+            expect.objectContaining({ propPath: '_components.0.group' }),
+        );
+    });
+
+    it('选中节点无碰撞体时退回路径级 node:change', () => {
+        const node = { components: [{ /* 非碰撞体，无 group */ }] };
+        (queryRegisteredService as jest.Mock).mockReturnValue({ query: jest.fn(() => ['root/only']) });
+        (globalThis as any).cc.EditorExtends.Node.getNodeByPath = jest.fn(() => node);
+        const broadcast = jest.spyOn(ServiceEvents, 'broadcast').mockImplementation(() => {});
+
+        const service = makeService();
+        service.updatePhysicsGroup([{ index: 2, name: 'BIT_1' }]);
+
+        expect(broadcast).toHaveBeenCalledWith('node:change', 'root/only');
+    });
+});


### PR DESCRIPTION
## Problem

Physics collision groups configured in Project Settings are only read once when the engine initializes. As a result, adding, renaming or removing a group did not appear in a collider's **Group** dropdown, and did not take effect in the browser preview, until the whole IDE was restarted.

## Changes

- **Runtime rebuild of the group enum.** `Engine.updatePhysicsGroup` rebuilds `cc.internal.PhysicsGroup` / `PhysicsGroup2D` from the default group plus the current `collisionGroups`, then refreshes the inspector by broadcasting `node:change` (with the property path) for the selected colliders' `group` property. Rebuilding from scratch means deleted and renamed groups are reflected, not just additions.
- **Config watcher.** The scene backend watches `engine.physicsConfig.collisionGroups`, debounces bursts and reads the settled state (so consecutive add/remove operations all land), then pushes the latest groups to the scene webview via the existing `scene:invoke` socket channel. This is intentionally not exposed through the main-process proxy or MCP.
- **Preview game-config.** The `game-config` route now serves the latest `collisionGroups` read from disk, so a reloaded preview builds `PhysicsGroup` from the current configuration instead of a stale cache.
- **Preview live-reload.** The browser preview now reloads on single-asset changes (e.g. saving a scene), not only on batch asset refresh, so saving a scene after editing a collider's group is reflected in the preview.
- **Tests.** Added unit tests covering the runtime `PhysicsGroup` rebuild (add / delete / rename, 2D + 3D, invalid entries, and the inspector refresh broadcast).

## Testing

- `npx tsc -b` passes.
- `npx jest engine-physics-group engine-service-interface scripting-routes` passes.
- Manual: with the `cocos-example-physics/3d` group-mask case, adding/removing a group in Project Settings updates the collider Group dropdown without a restart; saving the scene reloads the `cocos preview` browser preview and the new group takes effect at runtime.
