### PR TITLE
[break] fix(builder): accept platform arrays in init

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -3141,7 +3141,7 @@ export declare class InfoManager {
     compare(path: string, mtimeMs: number): boolean;
     forEach(handler: Function): Promise<void>;
 }
-export declare function init(platform?: string): Promise<void>;
+export declare function init(platform?: string[]): Promise<void>;
 export declare type InputOption = string | string[] | { [entryAlias: string]: string };
 export declare interface InputOptions {
     	acorn?: Record<string, unknown>;

--- a/src/core/builder/index.ts
+++ b/src/core/builder/index.ts
@@ -16,12 +16,14 @@ import { BuildGlobalInfo } from './share/global';
 export { clearCache } from './cache';
 export type { BuildCacheScope, ClearCacheResult } from './cache';
 
-export async function init(platform?: string) {
+export async function init(platform?: string[]) {
     await builderConfig.init();
     await pluginManager.init();
     middlewareService.register('Build', BuildMiddleware);
-    if (platform) {
-        await pluginManager.register(platform);
+    if (platform?.length) {
+        for (const platformName of platform) {
+            await pluginManager.register(platformName);
+        }
     } else {
         await pluginManager.registerAllPlatform();
     }

--- a/src/core/builder/test/builder-init.spec.ts
+++ b/src/core/builder/test/builder-init.spec.ts
@@ -1,0 +1,78 @@
+const mockBuilderConfigInit = jest.fn(async () => undefined);
+const mockPluginManagerInit = jest.fn(async () => undefined);
+const mockRegister = jest.fn(async () => undefined);
+const mockRegisterAllPlatform = jest.fn(async () => undefined);
+const mockMiddlewareRegister = jest.fn();
+const mockBuildMiddleware = {};
+
+jest.mock('../share/builder-config', () => ({
+    __esModule: true,
+    default: {
+        init: mockBuilderConfigInit,
+    },
+}));
+
+jest.mock('../manager/plugin', () => ({
+    pluginManager: {
+        init: mockPluginManagerInit,
+        register: mockRegister,
+        registerAllPlatform: mockRegisterAllPlatform,
+    },
+}));
+
+jest.mock('../../../server/middleware/core', () => ({
+    middlewareService: {
+        register: mockMiddlewareRegister,
+    },
+}));
+
+jest.mock('../build.middleware', () => ({
+    __esModule: true,
+    default: mockBuildMiddleware,
+}));
+
+jest.mock('../../base/i18n', () => ({
+    __esModule: true,
+    default: {
+        t: (key: string) => key,
+    },
+}));
+
+jest.mock('../../base/console', () => ({
+    newConsole: {
+        record: jest.fn(),
+        createLogSinkRestorer: jest.fn(() => jest.fn()),
+    },
+}));
+
+jest.mock('../../assets/manager/asset', () => ({
+    __esModule: true,
+    default: {},
+}));
+
+import { init } from '../index';
+
+describe('builder init', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('registers every requested platform', async () => {
+        await init(['web-desktop', 'android']);
+
+        expect(mockBuilderConfigInit).toHaveBeenCalledTimes(1);
+        expect(mockPluginManagerInit).toHaveBeenCalledTimes(1);
+        expect(mockMiddlewareRegister).toHaveBeenCalledWith('Build', mockBuildMiddleware);
+        expect(mockRegister).toHaveBeenNthCalledWith(1, 'web-desktop');
+        expect(mockRegister).toHaveBeenNthCalledWith(2, 'android');
+        expect(mockRegister).toHaveBeenCalledTimes(2);
+        expect(mockRegisterAllPlatform).not.toHaveBeenCalled();
+    });
+
+    it.each<[string[] | undefined]>([[undefined], [[]]])('registers all platforms when platform list is %p', async (platforms) => {
+        await init(platforms);
+
+        expect(mockRegister).not.toHaveBeenCalled();
+        expect(mockRegisterAllPlatform).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/core/launcher.ts
+++ b/src/core/launcher.ts
@@ -103,7 +103,7 @@ export default class Launcher {
         await startServer(previewOptions.port);
 
         const { init, build } = await import('./builder');
-        await init(platform);
+        await init([platform]);
 
         const buildOptions: Partial<IBuildCommandOption> = {
             ...previewOptions.buildOptions,
@@ -228,14 +228,14 @@ export default class Launcher {
         await this.import();
         // 执行构建流程
         const { init, build } = await import('./builder');
-        await init(platform);
+        await init([platform]);
         return await build(platform, options);
     }
 
     static async make(platform: Platform, dest: string) {
         GlobalConfig.mode = 'simple';
         const { init, executeBuildStageTask } = await import('./builder');
-        await init(platform);
+        await init([platform]);
         return await executeBuildStageTask('command make', 'make', {
             platform,
             dest,
@@ -248,7 +248,7 @@ export default class Launcher {
         if (platform.startsWith('web')) {
             await startServer();
         }
-        await init(platform);
+        await init([platform]);
         return await executeBuildStageTask('command run', 'run', {
             platform,
             dest,
@@ -258,7 +258,7 @@ export default class Launcher {
     static async upload(platform: Platform, dest: string, accessToken?: string) {
         GlobalConfig.mode = 'simple';
         const { init, executeBuildStageTask } = await import('./builder');
-        await init(platform);
+        await init([platform]);
         return await executeBuildStageTask('command upload', 'upload', {
             platform,
             dest,

--- a/src/lib/builder/builder.ts
+++ b/src/lib/builder/builder.ts
@@ -7,7 +7,7 @@ export type * from '../../core/builder/@types/private';
 export type * from '../../core/builder/@types/config-export';
 export type { BuildCacheScope, ClearCacheResult };
 
-export async function init(platform?: string): Promise<void> {
+export async function init(platform?: string[]): Promise<void> {
     const builder = await import('../../core/builder');
     return builder.init(platform);
 }


### PR DESCRIPTION
Update builder init to register each requested platform from an array, adapt launcher call sites, and refresh DTS snapshot coverage.

Add unit tests for multi-platform init registration and default all-platform registration.