### PR TITLE
fix(scene): assign path for _globals sub-properties in scene dump

### DIFF
--- a/src/core/scene/scene-process/service/dump/encode.ts
+++ b/src/core/scene/scene-process/service/dump/encode.ts
@@ -267,7 +267,15 @@ export function encodeScene(scene: any): IScene {
     }
     for (const [key, val] of Object.entries(data._globals)) {
         if (val && typeof val === 'object' && 'type' in val && 'value' in val) {
-            (val as IProperty).path = `_globals.${key}`;
+            const prop = val as IProperty;
+            prop.path = `_globals.${key}`;
+            if (prop.value && typeof prop.value === 'object' && !Array.isArray(prop.value)) {
+                for (const [subKey, subProp] of Object.entries(prop.value as Record<string, unknown>)) {
+                    if (subProp && typeof subProp === 'object' && !Array.isArray(subProp) && 'type' in subProp && 'value' in subProp) {
+                        (subProp as IProperty).path = `_globals.${key}.${subKey}`;
+                    }
+                }
+            }
         }
     }
 

--- a/src/core/scene/test/node-for-editor.testcase.ts
+++ b/src/core/scene/test/node-for-editor.testcase.ts
@@ -763,5 +763,27 @@ describe('Node ForEditor 接口测试', () => {
                 }
             }
         });
+
+        it('场景 _globals 子属性的 path 格式为 _globals.{key}.{subKey}', async () => {
+            const dump = await rpcRequest('query', []) as IScene;
+
+            let count = 0;
+            if (dump._globals && typeof dump._globals === 'object') {
+                for (const [key, val] of Object.entries(dump._globals)) {
+                    if (val && typeof val === 'object' && 'type' in val && 'value' in val) {
+                        const value = (val as any).value;
+                        if (value && typeof value === 'object' && !Array.isArray(value)) {
+                            for (const [subKey, subVal] of Object.entries(value)) {
+                                if (subVal && typeof subVal === 'object' && 'type' in subVal && 'value' in subVal) {
+                                    expect((subVal as any).path).toBe(`_globals.${key}.${subKey}`);
+                                    count++;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            expect(count).toBeGreaterThan(0);
+        });
     });
 });


### PR DESCRIPTION
## Summary

- 为 `encodeScene` 中 `_globals` 的子属性递归赋值 `path`，格式为 `_globals.{key}.{subKey}`，供 inspector setProperty 使用
- 补充对应测试用例，并确保断言实际被执行（添加 count 计数验证）

## Changes

- `encode.ts`: 遍历 `_globals` 每个属性的 `value`，为符合 `IProperty` 结构的子属性赋值 `path`
- `node-for-editor.testcase.ts`: 新增测试验证子属性 path 格式正确，使用 `expect(count).toBeGreaterThan(0)` 防止静默通过

## Test plan

- [ ] 现有测试通过
- [ ] 新增测试覆盖 `_globals` 子属性 path 赋值逻辑