### PR TITLE
fix(web): improve preview URL handling

### DIFF
--- a/src/core/builder/platforms/web-common/utils.ts
+++ b/src/core/builder/platforms/web-common/utils.ts
@@ -2,8 +2,12 @@ import { existsSync } from 'fs';
 import { join, relative, basename } from 'path';
 import utils from '../../../base/utils';
 import builderConfig from '../../share/builder-config';
-import { getBuildUrlPath, registerBuildPath } from '../../build.middleware';
-import { exec } from 'child_process';
+import { getBuildPath, getBuildUrlPath, registerBuildPath } from '../../build.middleware';
+import { execFile } from 'child_process';
+
+export async function getBuidPath(platform: string, name: string) {
+    return getBuildPath(platform, name);
+}
 
 export async function getPreviewUrl(dest: string, platform?: string) {
     const rawPath = utils.Path.resolveToRaw(dest);
@@ -12,6 +16,7 @@ export async function getPreviewUrl(dest: string, platform?: string) {
     }
     const serverService = (await import('../../../../server/server')).serverService;
     const buildKey = getBuildUrlPath(rawPath);
+    console.log(`getPreviewUrl: rawPath=${rawPath}, buildKey=${buildKey}, platform=${platform}`);
     if (buildKey) {
         return `${serverService.url}/build/${buildKey}/index.html`;
     }
@@ -36,15 +41,19 @@ function openBrowser(url: string, completedCallback?: () => void): void {
     const currentPlatform = process.platform;
 
     let command: string | undefined;
+    let args: string[] = [];
     switch (currentPlatform) {
         case 'win32':
-            command = `start ${url}`;
+            command = 'rundll32.exe';
+            args = ['url.dll,FileProtocolHandler', url];
             break;
         case 'darwin':
-            command = `open ${url}`;
+            command = 'open';
+            args = [url];
             break;
         case 'linux':
-            command = `xdg-open ${url}`;
+            command = 'xdg-open';
+            args = [url];
             break;
         default:
             console.log(`请手动打开浏览器访问: ${url}`);
@@ -54,19 +63,8 @@ function openBrowser(url: string, completedCallback?: () => void): void {
             return;
     }
 
-    //@ts-expect-error
-    //hack: when run on pink use simple browser instead of default browser
-    if (process && process.addGlobalOpenUrl) {
-        //@ts-expect-error
-        process.addGlobalOpenUrl(url);
-        if (completedCallback) {
-            completedCallback();
-        }
-        return;
-    }
-
     if (command) {
-        exec(command, (error: any) => {
+        execFile(command, args, { windowsHide: true }, (error: any) => {
             if (error) {
                 console.error('打开浏览器失败:', error.message);
                 console.log(`请手动打开浏览器访问: ${url}`);

--- a/src/core/builder/platforms/web-desktop/src/hooks.ts
+++ b/src/core/builder/platforms/web-desktop/src/hooks.ts
@@ -93,10 +93,6 @@ export async function onAfterBuild(this: IBuilder, options:ITaskOption, result: 
         result.settings.plugins.jsList[i] = url.split('/').map(encodeURIComponent).join('/');
     });
     outputFileSync(result.paths.settings, JSON.stringify(result.settings, null, options.debug ? 4 : 0));
-    const previewUrl = await commonUtils.getPreviewUrl(result.paths.dir, options.platform);
-    this.buildExitRes.custom = {
-        previewUrl,
-    };
 }
 
 export async function run(this: IBuildStageTask, root: string, options: ITaskOption) {

--- a/src/core/builder/platforms/web-mobile/src/hooks.ts
+++ b/src/core/builder/platforms/web-mobile/src/hooks.ts
@@ -114,10 +114,7 @@ export async function onAfterBuild(this: IBuilder, options: IInterBuildTaskOptio
         result.settings.plugins.jsList[i] = url.split('/').map(encodeURIComponent).join('/');
     });
     outputFileSync(result.paths.settings, JSON.stringify(result.settings, null, options.debug ? 4 : 0));
-    const previewUrl = await commonUtils.getPreviewUrl(result.paths.dir, options.platform);
-    this.buildExitRes.custom = {
-        previewUrl,
-    };
+
 }
 
 export async function run(this: IBuildStageTask, root: string) {

--- a/src/core/builder/platforms/web-mobile/src/view/build-config-host.ts
+++ b/src/core/builder/platforms/web-mobile/src/view/build-config-host.ts
@@ -105,7 +105,7 @@ async function getPreviewInfo(request: PreviewRequest = {}): Promise<PreviewInfo
     const buildPath = request.buildPath || 'project://build';
     const outputName = request.outputName || 'web-mobile';
     const platform = 'web-mobile';
-    const previewUrl = await pink.builder.getPreviewUrl(path.join(buildPath, outputName), platform) || '';
+    const previewUrl = await pink.builder.getPreviewUrl(buildPath + "/" + outputName, platform) || '';
     const webGPUTips = request.useWebGPU && previewUrl && !previewUrl.startsWith('https')
         ? lookup(loadBundle(), 'tips.webGPUServer') || ''
         : '';

--- a/src/core/builder/platforms/web-mobile/src/view/build-config.tsx
+++ b/src/core/builder/platforms/web-mobile/src/view/build-config.tsx
@@ -165,7 +165,7 @@ export default function WebMobileBuildView({ value, onChange, bridge, commonValu
                         ) : previewInfo.qrcodeSrc ? (
                             <img alt="" src={previewInfo.qrcodeSrc} style={QR_CODE} />
                         ) : (
-                            <div style={INFO}>{loadingPreview ? 'Loading...' : 'Preview server is not available.'}</div>
+                            <div style={INFO}>{loadingPreview ? 'Loading...' : 'Preview server is not available. Please build first.'}</div>
                         )}
                     </div>
                 </TypedField>
@@ -186,7 +186,7 @@ export default function WebMobileBuildView({ value, onChange, bridge, commonValu
                                 {previewInfo.previewUrl}
                             </a>
                         ) : (
-                            <span style={INFO}>{loadingPreview ? 'Loading...' : 'Preview server is not available.'}</span>
+                            <span style={INFO}>{loadingPreview ? 'Loading...' : 'Preview server is not available. Please build first.'}</span>
                         )}
                     </div>
                 </TypedField>


### PR DESCRIPTION
Use platform URL handlers for preview launching, keep web preview URL assignment outside after-build hooks, and update DTS snapshots for the builder init platform array API.