### PR TITLE
fix(preview): self-heal game preview opened during initialization

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -11,6 +11,13 @@ const config: Config.InitialOptions = {
     transform: {
         '^.+\\.(ts|tsx)$': 'ts-jest'
     },
+    // `cc/mods-mgr` 仅由生成的引擎代理文件（packages/cc-module/editor/*.js）在运行时 require，磁盘上不存在。
+    // EngineLoader.init 会全局劫持模块解析并在 maxWorkers:1 的串行 worker 中泄漏到后续测试文件，导致某些
+    // 用例对引擎代理模块的 jest.mock 失配、真实代理文件被加载，从而 `require('cc/mods-mgr')` 解析失败
+    // （报错随测试文件顺序漂移）。此处把 `cc/mods-mgr` 兜底到桩，确保任何顺序下都能解析成功。
+    moduleNameMapper: {
+        '^cc/mods-mgr$': '<rootDir>/src/core/test/stubs/cc-mods-mgr.js',
+    },
     collectCoverageFrom: [
         'src/core/**/*.{ts,tsx}',
         '!src/core/**/*.d.ts',

--- a/src/core/configuration/script/manager.ts
+++ b/src/core/configuration/script/manager.ts
@@ -322,8 +322,8 @@ export class ConfigurationManager extends EventEmitter implements IConfiguration
                     await fse.ensureDir(path.dirname(this.configPath));
                     this.projectConfig.version = this.version;
                     this.projectConfig.$schema = ConfigurationManager.relativeSchemaPath;
-                    // 保存配置文件
-                    await fse.writeJSON(this.configPath, this.projectConfig, { spaces: 4 });
+                    // 保存配置文件（带重试：见 writeConfigWithRetry）
+                    await this.writeConfigWithRetry();
                     this.emit(MessageType.Save, this.projectConfig);
                     newConsole.debug(`[Configuration] 已保存项目配置: ${this.configPath}`);
                 } catch (error) {
@@ -334,6 +334,46 @@ export class ConfigurationManager extends EventEmitter implements IConfiguration
 
         this.saveQueue = nextSave;
         return nextSave;
+    }
+
+    /**
+     * 把项目配置写入磁盘，对 Windows 上的瞬时文件锁错误做有界重试。
+     *
+     * cocos.config.json 是配置真相源，多处会直接读盘：预览路由（scripting-routes.ts 读碰撞分组 /
+     * 设计分辨率 / includeModules）、场景进程（scene/index.ts）等，且场景子进程是独立 fork 的引擎进程。
+     * 当某个读取方短暂持有该文件句柄时，Windows 会让写入方的 open 失败并抛出 UNKNOWN（共享冲突），
+     * 也可能是 EBUSY/EPERM/EACCES。这类错误都是瞬时的，重试即可成功。
+     *
+     * 先写临时文件再原子重命名，缩小目标文件被占用的时间窗口；重命名本身在 Windows 上仍可能因目标被
+     * 占用而瞬时失败，故整体再包一层退避重试。非瞬时错误（如目录不存在）不重试，直接抛出。
+     */
+    private async writeConfigWithRetry(maxAttempts: number = 5): Promise<void> {
+        const transientCodes = new Set(['UNKNOWN', 'EBUSY', 'EPERM', 'EACCES', 'EMFILE', 'ENFILE']);
+        const tmpPath = `${this.configPath}.${process.pid}.tmp`;
+        let lastError: unknown;
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                await fse.writeJSON(tmpPath, this.projectConfig, { spaces: 4 });
+                await fse.move(tmpPath, this.configPath, { overwrite: true });
+                return;
+            } catch (error) {
+                lastError = error;
+                const code = (error as NodeJS.ErrnoException)?.code;
+                if (!code || !transientCodes.has(code) || attempt === maxAttempts) {
+                    // 尽力清理可能残留的临时文件后抛出
+                    try {
+                        await fse.remove(tmpPath);
+                    } catch {
+                        // ignore cleanup failure
+                    }
+                    throw error;
+                }
+                // 指数退避：50ms、100ms、200ms、400ms……
+                const delay = 50 * 2 ** (attempt - 1);
+                await new Promise((resolve) => setTimeout(resolve, delay));
+            }
+        }
+        throw lastError;
     }
 
     public async getConfigPath(): Promise<string> {

--- a/src/core/configuration/test/manager.test.ts
+++ b/src/core/configuration/test/manager.test.ts
@@ -348,11 +348,15 @@ describe('ConfigurationManager', () => {
             manager['projectConfig'] = { version: '1.0.0', test: 'value' };
             await manager['save']();
             expect(mockFse.ensureDir).toHaveBeenCalledWith(path.dirname(configPath));
+            // 采用「写临时文件 + 原子重命名」的方式落盘（见 writeConfigWithRetry），
+            // 因此 writeJSON 写入的是临时路径，随后 move 到最终 configPath。
+            const tmpPath = `${configPath}.${process.pid}.tmp`;
             expect(mockFse.writeJSON).toHaveBeenCalledWith(
-                configPath,
+                tmpPath,
                 { version: '1.0.0', test: 'value', $schema: './temp/cocos.config.schema.json' },
                 { spaces: 4 }
             );
+            expect(mockFse.move).toHaveBeenCalledWith(tmpPath, configPath, { overwrite: true });
 
             // Handle save errors
             mockFse.writeJSON.mockRejectedValue(new Error('Save error'));
@@ -517,7 +521,7 @@ describe('ConfigurationManager', () => {
             // 验证修复：Save 时应该保存正确的配置，而不是空对象
             expect(mockInstance.getAll).toHaveBeenCalled();
             expect(mockFse.writeJSON).toHaveBeenCalledWith(
-                configPath,
+                `${configPath}.${process.pid}.tmp`,
                 expect.objectContaining({
                     testModule: {
                         existingKey: 'existingValue',

--- a/src/core/preview/game-preview.middleware.ts
+++ b/src/core/preview/game-preview.middleware.ts
@@ -5,7 +5,8 @@ import { existsSync } from 'fs';
 import ejs from 'ejs';
 import { GlobalPaths } from '../../global';
 import { scriptingRoutes } from './scripting-routes';
-import { getCachedPreviewSettings } from './preview-settings';
+import { getCachedPreviewSettings, PreviewNotReadyError } from './preview-settings';
+import { notePreviewNotReady } from './live-reload';
 
 /**
  * 各资源数据库的 library（已导入数据）目录缓存。
@@ -49,6 +50,21 @@ export const gamePreviewResourceRoutes = [
                 res.set('Cache-Control', 'no-store');
                 res.type('application/javascript').send(`window._CCSettings = ${JSON.stringify(settings)};`);
             } catch (err) {
+                // 初始化未完成即请求预览：返回可重试的 503，让 IDE/浏览器稍后重试，
+                // 而不是返回缺 builtinAssets 的坏 settings 或裸 500。
+                if (err instanceof PreviewNotReadyError) {
+                    console.warn(`[preview-settings] not ready, ask client to retry (scene=${req.query.scene ?? ''})`);
+                    // 关键自愈触发点：确有预览页因未就绪而 boot 失败（settings.js 503）。据此标记待自愈，
+                    // 待 settings 首次真正可用时由 live-reload 广播 browser:reload 把该页刷新救回，无需手动刷新。
+                    // 以「确实发生过 503」为依据比依赖 socket 连接时序更可靠（规避异步就绪探测跨越初始化完成
+                    // 边界、标记 healed 却漏广播的竞态）。
+                    notePreviewNotReady();
+                    res.set('Retry-After', '1');
+                    return res.status(503).type('text/plain').send('// Preview initializing, please retry.');
+                }
+                // 其它异常：显式打印真实堆栈，否则会被 express 错误中间件吞成裸 500，
+                // 表现为 "PhysicsSystem initDefaultMaterial Failed" / Graphics recompileShaders of null。
+                console.error(`[preview-settings] settings.js generation FAILED (scene=${req.query.scene ?? ''}):`, err);
                 next(err);
             }
         },
@@ -170,8 +186,12 @@ export default {
                     const serverBaseUrl = `${req.protocol}://${req.get('host')}`;
                     const scene = typeof req.query.scene === 'string' ? req.query.scene : '';
                     const sceneQuery = scene ? `?scene=${encodeURIComponent(scene)}` : '';
+                    // projectPath 可能在极早期（工程刚 open、scripting 尚未 initialize）为空——
+                    // `/` 提前注册以避免初始化期兜底 404，此时用兜底标题渲染即可（页面本身只需能加载
+                    // socket.io + browser:reload 监听，就绪后自愈刷新）。
+                    const projectName = scripting.projectPath ? basename(scripting.projectPath) : 'Preview';
                     const renderData = {
-                        title: `Cocos Creator - ${basename(scripting.projectPath)}`,
+                        title: `Cocos Creator - ${projectName}`,
                         serverURL: serverBaseUrl,
                         settingsJs: `/preview/settings.js${sceneQuery}`,
                         sceneQuery,

--- a/src/core/preview/live-reload.ts
+++ b/src/core/preview/live-reload.ts
@@ -1,5 +1,5 @@
 import { socketService } from '../../server/socket';
-import { invalidatePreviewSettings } from './preview-settings';
+import { invalidatePreviewSettings, isPreviewSettingsReady } from './preview-settings';
 
 /**
  * 浏览器热重载。
@@ -21,6 +21,30 @@ let onCompiled: (() => void) | null = null;
 let onRefreshFinish: (() => void) | null = null;
 let onAssetChanged: (() => void) | null = null;
 let onConfigChanged: (() => void) | null = null;
+let onAssetEvent: (() => void) | null = null;
+let onSocketConnection: ((socket: any) => void) | null = null;
+
+// ---- 「首次就绪自愈」状态 -------------------------------------------------
+// healed：settings 首次校验通过后置 true，此后不再做就绪探测（转为常规热重载）。
+let healed = false;
+// healing：tryHeal 重入保护（generatePreviewSettings 有一定耗时）。
+let healing = false;
+// pendingHeal：是否有预览页曾在 settings 未就绪期连上（其 settings.js 拿到 503/500、boot 失败）。
+// 一旦置位便保持到注销：即使该页 socket 因初始化期事件循环繁忙而掉线重连、当前连接数一时为 0，
+// 也要在就绪后通知它 reload 把它救回来。就绪后才首次连上的页面 boot 正常，不置位、不通知。
+let pendingHeal = false;
+// awaitingSockets：已上报「本页 boot 失败、等待自愈」（preview:awaiting-reload）的预览页 socket。
+// settings 首次就绪时逐个 emit browser:reload 定向刷新；socket 掉线即移除。
+// 用「定向 + 客户端每次(重)连都重报」取代「一次性 io 广播」：广播只在那一瞬对当时已连上的 socket 生效，
+// 初始化期 socket 频繁 ping 超时重连、或多个预览页（Chrome + IDE webview）连接时机不同，都会漏掉广播；
+// 定向 + 重报则与连接时机解耦——谁在就绪时连着就当场刷，没连上的重连回来再报、服务端立即补发。
+let awaitingSockets = new Set<any>();
+// healPollTimer / healAttempts：兜底轮询（详见 startHealPoll）。
+let healPollTimer: NodeJS.Timeout | null = null;
+let healAttempts = 0;
+const HEAL_POLL_INTERVAL_MS = 1500;
+// 兜底轮询最多尝试次数（约 15 分钟）。正常初始化 1 分钟内即就绪；此上限仅用于工程异常时收敛，避免空转。
+const HEAL_MAX_ATTEMPTS = 600;
 
 function removeListener(emitter: { off?: Function; removeListener?: Function } | null, event: string, fn: Function | null): void {
     if (!emitter || !fn) {
@@ -28,6 +52,25 @@ function removeListener(emitter: { off?: Function; removeListener?: Function } |
     }
     const off = emitter.off || emitter.removeListener;
     off?.call(emitter, event, fn);
+}
+
+/**
+ * 通知所有「已上报等待自愈」的预览页整页刷新，并清空登记。
+ * 逐 socket 定向 emit，而非 io 广播——只刷 boot 失败的页，不打扰就绪后正常加载的新页。
+ */
+function healAwaitingSockets(): void {
+    if (awaitingSockets.size === 0) {
+        return;
+    }
+    invalidatePreviewSettings();
+    for (const socket of awaitingSockets) {
+        try {
+            socket.emit('browser:reload');
+        } catch {
+            /* socket 可能已失效，忽略 */
+        }
+    }
+    awaitingSockets.clear();
 }
 
 function scheduleReload(): void {
@@ -43,11 +86,110 @@ function scheduleReload(): void {
 }
 
 /**
+ * 「首次就绪自愈」核心：探测预览 settings 是否已真正可用（校验通过：能生成且 builtinAssets 非空），
+ * 首次可用（invalid→valid 跃迁）时，若有「未就绪期就连上」的预览页，则广播一次 browser:reload。
+ *
+ * 为什么以「能否成功生成并通过校验」为准、而不用 assetDBManager.ready / assets:ready：ready 标志在
+ * asset-db.start() 里早于内置资源库/内置 bundle 完全导入就被置位，此刻生成 settings 会 500 或产出空
+ * builtinAssets 的坏 settings（运行时报 builtinMaterial 加载失败 / graphics recompileShaders null）。
+ *
+ * 为什么向「所有」连接广播、而非只挑早连页：服务端无法区分「刚加载成功的新页」与「早前 503、boot
+ * 失败后 socket 重连的旧页」。但只在 pendingHeal（确有早连失败页）且首次跃迁时广播一次（healed 加锁），
+ * 就绪后才连上的新页 boot 正常、healed 已锁，不会再广播，因而不会误刷新、也不会形成刷新循环。
+ */
+async function tryHeal(): Promise<void> {
+    if (healed || healing) {
+        return;
+    }
+    healing = true;
+    try {
+        const ready = await isPreviewSettingsReady();
+        if (!ready) {
+            return; // 尚未就绪，等下一个资源事件 / 轮询再试
+        }
+        healed = true;
+        stopHealPoll();
+        // 首次就绪（invalid→valid 跃迁）：把此前 503/boot 失败的预览页刷新救回。
+        // 只在 pendingHeal（注册时确在初始化窗口 / 确有页 503）时动作；就绪后才连上的新页 boot 正常，
+        // 此刻尚不存在，故不会被误刷。
+        if (pendingHeal) {
+            const socketCount = (socketService.io as any)?.sockets?.sockets?.size ?? 0;
+            console.log(`[LiveReload] 预览 settings 首次就绪：刷新自愈（登记等待页 ${awaitingSockets.size} 个，当前连接 ${socketCount} 个）`);
+            // 1) 定向刷新已登记的等待页。
+            healAwaitingSockets();
+            // 2) 兜底广播给「当前所有连接」：登记可能因时序/socket 实例不一致而遗漏，但此刻凡连着的
+            //    预览页必是未就绪期打开、settings.js 已 503 的 stuck 页，广播刷新它们是安全且更可靠的
+            //    （不依赖 awaitingSockets 是否被正确填充）。scene-editor 等不监听 browser:reload 的页忽略之。
+            invalidatePreviewSettings();
+            socketService.io?.emit('browser:reload');
+        }
+    } finally {
+        healing = false;
+    }
+}
+
+/**
+ * 兜底轮询：只要存在待自愈的早连页（pendingHeal）且尚未自愈，就周期性 tryHeal，直到 settings 可用后
+ * 广播刷新并停止。
+ *
+ * 关键：轮询存活只看 pendingHeal / healed，不看「当前连接数」。初始化期事件循环繁忙，早连页 socket
+ * 可能 ping 超时短暂掉线（连接数一时为 0）再自动重连；若因连接数为 0 就停轮询，等就绪后便再没有触发点，
+ * 页面就永远停在 503。因此掉线期间轮询继续，就绪后 emit 广播（重连回来的页面即收到）。
+ * 事件监听（assets:refresh-finish 等）与本轮询互为补充：谁先探到就绪都能自愈。
+ */
+function startHealPoll(): void {
+    if (healed || healPollTimer) {
+        return;
+    }
+    const tick = () => {
+        healPollTimer = null;
+        if (healed || !pendingHeal || healAttempts >= HEAL_MAX_ATTEMPTS) {
+            return;
+        }
+        healAttempts++;
+        tryHeal().finally(() => {
+            if (!healed && pendingHeal && healAttempts < HEAL_MAX_ATTEMPTS) {
+                healPollTimer = setTimeout(tick, HEAL_POLL_INTERVAL_MS);
+            }
+        });
+    };
+    healPollTimer = setTimeout(tick, HEAL_POLL_INTERVAL_MS);
+}
+
+function stopHealPoll(): void {
+    if (healPollTimer) {
+        clearTimeout(healPollTimer);
+        healPollTimer = null;
+    }
+}
+
+/**
  * 主动触发一次浏览器热重载（去抖）。
  * 供扩展宿主映射 Creator 的预览刷新信号（preview/reload-terminal、scene/soft-reload）使用。
  */
 export function triggerPreviewReload(): void {
     scheduleReload();
+}
+
+/**
+ * settings.js 请求发现预览未就绪（返回 503）时，由 game-preview 中间件调用。
+ *
+ * 这是首次就绪自愈的**主触发点**：以「确实发生过 503（确有预览页 boot 失败）」为依据，同步标记
+ * pendingHeal 并起兜底轮询，settings 首次真正可用时广播 browser:reload 把该页刷新救回。
+ *
+ * 为什么不依赖 socket 连接时序来判定「有页面待自愈」：连接处理器里的异步就绪探测可能恰好跨越
+ * 初始化完成边界——探测发起时未就绪、返回时已就绪，于是标记 healed 却因 pendingHeal 尚未置位而
+ * 漏掉广播，页面 loading 结束却不刷新（正是该 bug 的现象）。改由 503 同步置位，彻底规避该竞态。
+ */
+export function notePreviewNotReady(): void {
+    if (!registered || healed) {
+        return;
+    }
+    if (!pendingHeal) {
+        console.log('[LiveReload] settings.js 返回 503（预览页未就绪），就绪后将广播 browser:reload 自愈');
+    }
+    pendingHeal = true;
+    startHealPoll();
 }
 
 /**
@@ -58,6 +200,10 @@ export async function registerLiveReload(): Promise<void> {
         return;
     }
     registered = true;
+    healed = false;
+    pendingHeal = false;
+    healAttempts = 0;
+    awaitingSockets.clear();
 
     const { default: scripting } = await import('../scripting');
     const { assetDBManager, assetManager } = await import('../assets');
@@ -70,9 +216,24 @@ export async function registerLiveReload(): Promise<void> {
     // assets:refresh-finish 只在整批刷新时触发，保存单个场景走的是逐资源 asset-change，
     // 不监听就会出现“改完/存完场景，浏览器预览不重载”。有 200ms 去抖，批量导入会合并成一次。
     onAssetChanged = () => scheduleReload();
+    // 资源批量刷新结束：自愈前用作就绪探测触发；自愈后作为常规热重载信号。
+    onRefreshFinish = () => {
+        if (!healed) {
+            void tryHeal();
+        } else {
+            scheduleReload();
+        }
+    };
+
     // 工程配置变更（如切换物理后端 = 改 engine.includeModules）会影响预览 settings，
     // 需清缓存并重载，否则预览仍用旧模块集（漏掉新后端的内置资源，报 builtinMaterial 加载失败）。
     onConfigChanged = () => scheduleReload();
+    // 启动期资源事件：仅在尚未自愈时用于就绪探测。
+    onAssetEvent = () => {
+        if (!healed) {
+            void tryHeal();
+        }
+    };
     scriptingRef = scripting as any;
     assetDBRef = assetDBManager as any;
     assetMgrRef = assetManager as any;
@@ -86,9 +247,97 @@ export async function registerLiveReload(): Promise<void> {
     assetManager.on('asset-change', onAssetChanged);
     assetManager.on('asset-add', onAssetChanged);
     assetManager.on('asset-delete', onAssetChanged);
+
+    // 启动期就绪相关事件（初次建库 / 各库就绪），驱动首次就绪探测
+    assetDBManager.on('assets:ready', onAssetEvent);
+    assetDBManager.on('assets:db-ready', onAssetEvent);
+
     // 工程配置变更（set / reload）
     configurationManager.on(MessageType.Update, onConfigChanged);
     configurationManager.on(MessageType.Reload, onConfigChanged);
+
+    // 首次就绪自愈（事件驱动，无需手动刷新）：
+    // IDE 常驻 server 模式下，用户可能在 CLI 初始化（asset-db 建库 + 内置资源导入，约 1 分钟）
+    // 完成前就打开预览页，settings.js 返回 503/500、首屏 boot 失败。预览页在加载前已注册 socket
+    // browser:reload 监听（见 static/web/game.ejs），并在 settings.js 加载失败时于每次(重)连接上报
+    // preview:awaiting-reload。这里为每个连上的 socket 挂上该上报的处理：
+    //   已就绪 → 直接令这只 stuck 页刷新（它一刷新即取到 200、boot 正常）；
+    //   未就绪 → 登记待自愈并起兜底轮询，settings 首次真正可用时定向 emit browser:reload。
+    // 客户端在每次(重)连都重报，故与连接时机彻底解耦：初始化期掉线重连、或多个预览页
+    // （Chrome + IDE webview）连接时机不同，都能各自被可靠救回，不再依赖某一瞬的广播。
+    onSocketConnection = (socket: any) => {
+        if (!socket || typeof socket.on !== 'function' || socket.__lrBound) {
+            return;
+        }
+        socket.__lrBound = true; // 防重复挂载（connection 事件与「注册时补挂已连 socket」可能都命中）
+        // 已确认处于初始化窗口（pendingHeal 已置位）且尚未自愈时，新连上的预览页此刻请求 settings.js
+        // 同样会 503、boot 失败——直接预判为待自愈页登记，就绪时一并定向刷新，不必等它自己上报到达。
+        const presumed = !healed && pendingHeal;
+        if (presumed) {
+            awaitingSockets.add(socket);
+        }
+        console.log(`[LiveReload] 预览 socket 挂载（healed=${healed} pendingHeal=${pendingHeal} 预判stuck=${presumed}）`);
+        socket.on('preview:awaiting-reload', () => {
+            if (healed) {
+                try {
+                    socket.emit('browser:reload');
+                } catch {
+                    /* ignore */
+                }
+                return;
+            }
+            if (!pendingHeal) {
+                console.log('[LiveReload] 预览页上报 boot 失败（settings 未就绪），就绪后将定向刷新自愈');
+            }
+            pendingHeal = true;
+            awaitingSockets.add(socket);
+            startHealPoll();
+            void tryHeal(); // 也许此刻恰好就绪
+        });
+        socket.on('disconnect', () => {
+            awaitingSockets.delete(socket);
+        });
+    };
+    socketService.io?.on('connection', onSocketConnection);
+    // 补挂「注册前就已连上」的 socket：启动顺序为 server 起来 →（页面被服务、浏览器 socket 连上）
+    // → 才轮到 registerLiveReload 挂上 connection 监听。浏览器早于本监听挂上前打开/重连时，会错过
+    // connection 事件，其首次 preview:awaiting-reload 上报因无处理器而丢失。这里为已在册的 socket
+    // 补挂处理器；配合客户端「失败态周期性重报」（见 game.ejs），补挂后的重报即可被登记自愈。
+    const adopt = onSocketConnection;
+    const existingSockets = (socketService.io as any)?.sockets?.sockets;
+    existingSockets?.forEach?.((socket: any) => adopt(socket));
+
+    // 关键：注册时机在启动尾部。未就绪期（CLI 初始化，约 1 分钟）打开的预览页，其 settings.js 早已
+    // 503、boot 失败，但此时：
+    //   1) 那次 503 发生在 registered=false 时，notePreviewNotReady 直接 return，pendingHeal 未置位；
+    //   2) 驱动就绪探测的批量资源事件（assets:refresh-finish / assets:ready）大多在注册前就触发完毕，
+    //      注册后往往再无事件来触发 tryHeal；
+    //   3) 那些页发出的 preview:awaiting-reload 多在本监听挂上前丢失，客户端重报是否及时到达并不可靠。
+    // 因此这里在注册时**主动探测一次就绪**：若此刻仍未就绪（确在初始化窗口内），就把「注册前已连上的
+    // 所有预览页」直接预判为等待自愈页并起兜底轮询——settings 首次真正可用时定向刷新它们，完全由服务端
+    // 驱动，不依赖客户端上报的时机。（已就绪则说明初始化早已完成，此后新开页都会 boot 正常，无需自愈。）
+    // 探测本身包裹 try/catch：任何异常都不得中断预览注册（否则整个 scene init 会抛错）。
+    let readyAtRegister = false;
+    try {
+        readyAtRegister = await isPreviewSettingsReady();
+    } catch (err) {
+        console.warn('[LiveReload] 注册时就绪探测异常，按未就绪处理：', err);
+        readyAtRegister = false;
+    }
+    const socketCountAtRegister = (socketService.io as any)?.sockets?.sockets?.size ?? 0;
+    console.log(`[LiveReload] 注册完成：settings ${readyAtRegister ? '已就绪' : '未就绪'}，当前已连接 socket ${socketCountAtRegister} 个`);
+    if (readyAtRegister) {
+        healed = true;
+    } else {
+        // 确在初始化窗口内：起兜底轮询，并把此刻已连上的预览页预判为待自愈页。
+        pendingHeal = true;
+        const stuckSockets = (socketService.io as any)?.sockets?.sockets;
+        if (stuckSockets && stuckSockets.size > 0) {
+            console.log(`[LiveReload] 注册时预览尚未就绪，预判 ${stuckSockets.size} 个已连接预览页为待自愈，就绪后将刷新`);
+            stuckSockets.forEach((socket: any) => awaitingSockets.add(socket));
+        }
+        startHealPoll();
+    }
 }
 
 /**
@@ -102,14 +351,24 @@ export function unregisterLiveReload(): void {
         clearTimeout(timer);
         timer = null;
     }
+    stopHealPoll();
     removeListener(scriptingRef, 'compiled', onCompiled);
     removeListener(assetDBRef, 'assets:refresh-finish', onRefreshFinish);
     removeListener(assetMgrRef, 'asset-change', onAssetChanged);
     removeListener(assetMgrRef, 'asset-add', onAssetChanged);
     removeListener(assetMgrRef, 'asset-delete', onAssetChanged);
+
+    removeListener(assetDBRef, 'assets:ready', onAssetEvent);
+    removeListener(assetDBRef, 'assets:db-ready', onAssetEvent);
+
     // MessageType.Update / MessageType.Reload
     removeListener(configRef, 'configuration:update', onConfigChanged);
     removeListener(configRef, 'configuration:reload', onConfigChanged);
+    // 解绑 socket 连接钩子
+    if (onSocketConnection) {
+        socketService.io?.off('connection', onSocketConnection);
+    }
+    awaitingSockets.clear();
     scriptingRef = null;
     assetDBRef = null;
     assetMgrRef = null;
@@ -118,5 +377,11 @@ export function unregisterLiveReload(): void {
     onRefreshFinish = null;
     onAssetChanged = null;
     onConfigChanged = null;
+    onAssetEvent = null;
+    onSocketConnection = null;
+    healing = false;
+    healed = false;
+    pendingHeal = false;
+    healAttempts = 0;
     registered = false;
 }

--- a/src/core/preview/preview-settings.ts
+++ b/src/core/preview/preview-settings.ts
@@ -10,6 +10,29 @@ import type { IPreviewSettingsResult } from '../builder/@types/private';
 const cache = new Map<string, IPreviewSettingsResult>();
 
 /**
+ * 预览尚未就绪时抛出。路由据此返回可重试的 503，而不是生成缺 builtinAssets 的坏 settings 或裸 500。
+ *
+ * 「就绪」不能只看 assetDBManager.ready：该标志在 asset-db.start() 里被置位（asset-db.ts:139）
+ * 后才 step() 继续导入，内置资源库 / 内置 bundle（builtinAssets 的来源，见 builder
+ * setting-task/asset.ts:52 的 bundleMap[INTERNAL]._rootAssets）可能尚未完全就绪。此时
+ * getPreviewSettings 要么抛错（bundleMap[INTERNAL] 缺失）→ 裸 500，要么产出 builtinAssets 为空
+ * 的坏 settings → 运行时 "PhysicsSystem initDefaultMaterial Failed to load builtinMaterial" /
+ * "Graphics recompileShaders of null"。因此这里以**内容校验**为准：生成失败或 builtinAssets 为空
+ * 都视为未就绪，抛本错误（映射 503）且**不缓存**。
+ *
+ * 自愈机制（不依赖客户端手动刷新）：预览页在加载 settings/引擎之前就注册了 socket
+ * `browser:reload` 监听（见 static/web/game.ejs）。未就绪时本次请求快速失败 503、boot 失败；
+ * live-reload 侧监听资源事件，待 settings 首次真正可用（校验通过）时广播 browser:reload，页面
+ * 整页刷新完成自愈。
+ */
+export class PreviewNotReadyError extends Error {
+    constructor(message = 'Preview asset database is not ready yet.') {
+        super(message);
+        this.name = 'PreviewNotReadyError';
+    }
+}
+
+/**
  * 获取（带缓存的）预览 settings。
  * @param startScene 启动场景的 uuid 或 db:// url，留空表示使用项目默认启动场景
  */
@@ -18,43 +41,75 @@ export async function getCachedPreviewSettings(startScene = ''): Promise<IPrevie
     if (cached) {
         return cached;
     }
-    const { getPreviewSettings, queryDefaultBuildConfigByPlatform } = await import('../builder');
+    // 第一道门禁：asset-db 连 ready 标志都没置位，必然未就绪，直接快速失败（省去无谓的生成尝试）。
+    const { assetDBManager } = await import('../assets');
+    if (!assetDBManager.ready) {
+        throw new PreviewNotReadyError();
+    }
+    const result = await generatePreviewSettings(startScene);
+    cache.set(startScene, result);
+    return result;
+}
+
+/**
+ * 生成并**校验**预览 settings。未就绪（生成抛错或 builtinAssets 为空）时抛 PreviewNotReadyError。
+ * 抽出为独立函数，供 getCachedPreviewSettings 与 live-reload 的就绪探测复用；不写缓存。
+ */
+async function generatePreviewSettings(startScene: string): Promise<IPreviewSettingsResult> {
     const { assetManager } = await import('../assets');
-    const { fillIncludeModulesFromProjectConfig } = await import('../builder/share/common-options-validator');
-    const options = await queryDefaultBuildConfigByPlatform('web-desktop');
-    // 与正式构建（builder createBuildTask）保持一致：从 cocos.config.json 补全 includeModules。
-    // 预览路径原本不补全，options.includeModules 为空/默认时，内置资源包会漏掉当前模块（尤其是所选
-    // 物理后端 physics-cannon/ammo/physx/builtin）的 dependentAssets，比如内置物理材质
-    // default-physics-material (ba21476f)。运行时 PhysicsSystem.initDefaultMaterial() 便会
-    // builtinResMgr.get 到 null，报 "Failed to load builtinMaterial"(errorID 9642)。
-    // 同时这也让浏览器预览真正按项目配置的物理后端运行（切后端后能生效）。
-    await fillIncludeModulesFromProjectConfig(options as any);
-    // 解析有效启动场景：显式入参 > 构建配置（扁平或 packages 嵌套）> 项目首个场景。
-    // 预览模式下 builder 不会校验/补全 startScene（见 setting-task/asset.ts），
-    // 留空或指向已删除的场景都会导致前端请求 /scene/<uuid>.json 404。
-    // 因此每个候选都要校验在 asset-db 中真实存在，否则继续回退。
-    const candidates = [
-        startScene,
-        (options as any).startScene,
-        (options as any).packages?.['web-desktop']?.startScene,
-    ];
-    let effectiveScene = '';
-    for (const candidate of candidates) {
-        if (candidate && assetManager.queryAssetInfo(candidate)) {
-            effectiveScene = candidate;
-            break;
+    let result: IPreviewSettingsResult;
+    try {
+        const { getPreviewSettings, queryDefaultBuildConfigByPlatform } = await import('../builder');
+        const { fillIncludeModulesFromProjectConfig } = await import('../builder/share/common-options-validator');
+        const options = await queryDefaultBuildConfigByPlatform('web-desktop');
+        // 与正式构建（builder createBuildTask）保持一致：从 cocos.config.json 补全 includeModules。
+        // 预览路径原本不补全，options.includeModules 为空/默认时，内置资源包会漏掉当前模块（尤其是所选
+        // 物理后端 physics-cannon/ammo/physx/builtin）的 dependentAssets，比如内置物理材质
+        // default-physics-material (ba21476f)。运行时 PhysicsSystem.initDefaultMaterial() 便会
+        // builtinResMgr.get 到 null，报 "Failed to load builtinMaterial"(errorID 9642)。
+        // 同时这也让浏览器预览真正按项目配置的物理后端运行（切后端后能生效）。
+        await fillIncludeModulesFromProjectConfig(options as any);
+        // 解析有效启动场景：显式入参 > 构建配置（扁平或 packages 嵌套）> 项目首个场景。
+        // 预览模式下 builder 不会校验/补全 startScene（见 setting-task/asset.ts），
+        // 留空或指向已删除的场景都会导致前端请求 /scene/<uuid>.json 404。
+        // 因此每个候选都要校验在 asset-db 中真实存在，否则继续回退。
+        const candidates = [
+            startScene,
+            (options as any).startScene,
+            (options as any).packages?.['web-desktop']?.startScene,
+        ];
+        let effectiveScene = '';
+        for (const candidate of candidates) {
+            if (candidate && assetManager.queryAssetInfo(candidate)) {
+                effectiveScene = candidate;
+                break;
+            }
         }
+        if (!effectiveScene) {
+            effectiveScene = await resolveDefaultStartScene();
+        }
+        (options as any).startScene = effectiveScene;
+        // 预览模式下注册项目中的全部场景，使运行时 cc.director.loadScene(name)/(uuid) 可加载任意场景，
+        // 对齐编辑器预览行为。构建配置里的 scenes 默认只含构建时勾选的子集，会导致脚本里按名
+        // loadScene 其它场景时报 "not in the build settings before playing"。
+        const allScenes = assetManager.queryAssetInfos({ ccType: 'cc.SceneAsset' }) || [];
+        (options as any).scenes = allScenes.map((scene) => ({ url: scene.url, uuid: scene.uuid }));
+        result = await getPreviewSettings(options);
+    } catch (err) {
+        // asset-db.ready 置位后、内置资源库/内置 bundle 尚未完全导入时，getPreviewSettings 会因
+        // bundleMap[INTERNAL] 缺失等抛错。这属于「尚未就绪」，转成可重试错误（503）而非裸 500，
+        // 且不缓存，交由 live-reload 在真正就绪后推送 browser:reload 自愈。
+        throw new PreviewNotReadyError(
+            'Preview settings generation failed (likely asset db not fully ready): ' + ((err as Error)?.message || String(err)),
+        );
     }
-    if (!effectiveScene) {
-        effectiveScene = await resolveDefaultStartScene();
+
+    // 内容校验：builtinAssets 为空说明内置资源库/内置 bundle 尚未就绪。此时若放行，运行时会报
+    // builtinMaterial 加载失败 / graphics recompileShaders null。视为未就绪，抛可重试错误、不缓存。
+    const builtinAssets = (result as any)?.settings?.engine?.builtinAssets;
+    if (!Array.isArray(builtinAssets) || builtinAssets.length === 0) {
+        throw new PreviewNotReadyError('Preview settings has empty builtinAssets (asset db not fully ready).');
     }
-    (options as any).startScene = effectiveScene;
-    // 预览模式下注册项目中的全部场景，使运行时 cc.director.loadScene(name)/(uuid) 可加载任意场景，
-    // 对齐编辑器预览行为。构建配置里的 scenes 默认只含构建时勾选的子集，会导致脚本里按名
-    // loadScene 其它场景时报 "not in the build settings before playing"。
-    const allScenes = assetManager.queryAssetInfos({ ccType: 'cc.SceneAsset' }) || [];
-    (options as any).scenes = allScenes.map((scene) => ({ url: scene.url, uuid: scene.uuid }));
-    const result = await getPreviewSettings(options);
 
     // 动态预览「只托管不构建」，但 getPreviewSettings 给出的 rendering.effectSettingsPath 默认指向
     // 构建产物 'src/effect.bin'（见 setting-task/utils/project-options.ts）。该文件在预览下不存在，
@@ -67,8 +122,23 @@ export async function getCachedPreviewSettings(startScene = ''): Promise<IPrevie
         rendering.effectSettingsPath = '/scripting/engine/effect-settings';
     }
 
-    cache.set(startScene, result);
     return result;
+}
+
+/**
+ * 探测预览 settings 是否已可用（校验通过并已写入缓存）。供 live-reload 在资源事件后判定「首次就绪」。
+ * 返回 true 表示可用（缓存已预热）；未就绪返回 false；其它非就绪类异常向上抛出。
+ */
+export async function isPreviewSettingsReady(startScene = ''): Promise<boolean> {
+    try {
+        await getCachedPreviewSettings(startScene);
+        return true;
+    } catch (err) {
+        if (err instanceof PreviewNotReadyError) {
+            return false;
+        }
+        throw err;
+    }
 }
 
 /**

--- a/src/core/preview/register.ts
+++ b/src/core/preview/register.ts
@@ -12,7 +12,10 @@ import { middlewareService } from '../../server/middleware';
  * 本函数，再注册 SceneScripting / Scene；纯浏览器游戏预览（无场景编辑器）则直接调用本函数。
  * 这些 handler 在非游戏预览资源时会 `next()` 放行，不影响场景编辑器自身请求。
  *
- * 前置条件：调用前需已完成 `startServer` 与 builder 初始化（settings 在请求时惰性计算）。
+ * 前置条件：调用前需已完成 `startServer`（本函数只注册路由/监听，不生成 settings）。
+ * **不要求** builder 已初始化：`/` 只渲染 game.ejs（仅需 scripting.projectPath），settings 等在请求时
+ * 惰性计算，未就绪返回可重试 503。正因如此，本函数应尽早（startServer 之后、耗时的 builder/scene
+ * 初始化之前）调用，使初始化期打开的预览页拿到带 socket 自愈能力的 game.ejs，而非裸 404 页。
  */
 let extensionHost: { dispose(): void } | undefined;
 let registered = false;

--- a/src/core/preview/test/game-preview-route-early.test.ts
+++ b/src/core/preview/test/game-preview-route-early.test.ts
@@ -1,0 +1,81 @@
+import { join } from 'path';
+import GamePreviewMiddleware from '../game-preview.middleware';
+
+/**
+ * 回归测试：浏览器预览入口 `/` 必须能在「builder / scene 尚未初始化」时就渲染 game.ejs。
+ *
+ * 背景 bug：registerBrowserPreview（注册 `/` 路由）原先在 launcher 里排在耗时的 initBuilder /
+ * initScene 之后。CLI 初始化期（约 1 分钟）server 已 listen、但 `/` 尚未注册，浏览器打开预览
+ * 命中 server.ts 的兜底 404（"404 - Not Found"）——拿到一张没有 socket.io、没有 browser:reload
+ * 监听的裸 404 页，之后 CLI 就绪也无从通知它刷新，永远停在 404。
+ *
+ * 修复：把 registerBrowserPreview 前置到 startServer 之后、builder/scene 初始化之前。其正确性依赖
+ * 一个不变量——`/` 处理器只需 scripting.projectPath 即可渲染 game.ejs，**不依赖 builder**。本测试
+ * 锁定该不变量：不初始化任何 builder，仅提供 scripting.projectPath，`/` 即返回带 socket.io 客户端与
+ * browser:reload 自愈能力的 game.ejs（HTTP 200）。若未来有人让 `/` 依赖 builder，本测试会失败，
+ * 提醒早注册将退回裸 404 的老 bug。
+ */
+// 用 path.join 构造平台原生路径（handler 内部对 projectPath 走 basename，Windows 盘符路径在此不适用）。
+const scripting = { projectPath: join('any', 'fake', 'project') } as { projectPath: string };
+jest.mock('../../scripting', () => ({ __esModule: true, default: scripting }));
+
+interface MockRes {
+    statusCode: number;
+    body: string;
+    headers: Record<string, string>;
+    status(code: number): MockRes;
+    set(k: string, v: string): MockRes;
+    send(payload: string): MockRes;
+}
+
+function makeRes(): MockRes {
+    const res: MockRes = {
+        statusCode: 0,
+        body: '',
+        headers: {},
+        status(code: number) { this.statusCode = code; return this; },
+        set(k: string, v: string) { this.headers[k] = v; return this; },
+        send(payload: string) { this.body = payload; return this; },
+    };
+    return res;
+}
+
+function findRootHandler() {
+    const entry = (GamePreviewMiddleware.get || []).find((m: any) => m.url === '/');
+    if (!entry) {
+        throw new Error('GamePreview middleware has no `/` route');
+    }
+    return entry.handler as (req: any, res: any, next: any) => Promise<void> | void;
+}
+
+describe('game preview `/` route works before builder init (early-registration invariant)', () => {
+    it('renders game.ejs (200) with only scripting.projectPath, no builder', async () => {
+        const handler = findRootHandler();
+        const req = {
+            protocol: 'http',
+            get: (h: string) => (h === 'host' ? 'localhost:9527' : ''),
+            query: { scene: '42e68f34-5f5f-4a8a-938a-ec9d5fe61b0d' },
+        };
+        const res = makeRes();
+        const next = jest.fn();
+
+        await handler(req, res, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(res.statusCode).toBe(200);
+        // 拿到的是真正的预览页（含 GameCanvas），不是裸 404
+        expect(res.body).toContain('GameCanvas');
+        // 关键自愈前提：页面在 settings.js 之前就装好 socket.io 客户端，并引入共用的热重载「接收端」
+        // （preview-live-reload.js 负责创建 socket + 注册 browser:reload 监听），CLI 就绪后即可被广播刷新。
+        expect(res.body).toContain('/socket.io/socket.io.js');
+        expect(res.body).toContain('/static/web/preview-live-reload.js');
+        // settings.js 带上 scene 查询，指向惰性计算的预览 settings 路由
+        expect(res.body).toContain('/preview/settings.js?scene=');
+    });
+
+    it('exposes `/` ahead of the scene middleware broad routes (ordering sanity)', () => {
+        // GamePreview 必须显式提供 `/`，registerBrowserPreview 早注册时它才能先于场景宽泛路由命中。
+        const urls = (GamePreviewMiddleware.get || []).map((m: any) => String(m.url));
+        expect(urls).toContain('/');
+    });
+});

--- a/src/core/preview/test/lib-early-preview-register.test.ts
+++ b/src/core/preview/test/lib-early-preview-register.test.ts
@@ -1,0 +1,55 @@
+/**
+ * 回归测试：IDE（PinK）直接编排 lib/* 各步骤的启动路径下，浏览器游戏预览的 `/` 路由必须在
+ * 「耗时的资源冷导入（Assets.start / init asset，约 1 分钟）」之前就注册好。
+ *
+ * 背景 bug：`/` 路由原本只在 `core/scene` 的 `init()` 里通过 registerBrowserPreview 注册，而 IDE
+ * 把 `Scene.init()` 排在 `Assets.start`（init asset）之后。这段窗口里 server 已 listen、但 `/`
+ * 未注册，浏览器打开预览命中 server.ts 的兜底 404（纯文本 "404 - Not Found"）——拿到一张没有
+ * socket.io、没有 browser:reload 监听的裸页，之后 CLI 就绪也无从通知它刷新，永远停在 404。
+ *
+ * 关键时序：IDE 的 `Assets.start` 早于 `Scripting.init`，且 `Project.init` 是启动最早的一步，
+ * 所以提前注册点落在 `Project.init`（早于 asset 冷导入、又已知 projectPath）。本测试锁定该 wiring：
+ * 调用 `Project.init` 后 registerBrowserPreview 必须已被调用并带上工程路径。若未来有人挪走/删掉该
+ * 提前注册，本测试会失败，提醒早注册退回「初始化期 `/` 裸 404」的老 bug。
+ */
+
+import { join } from 'path';
+
+const PROJECT = join('any', 'fake', 'project');
+
+// registerBrowserPreview 是被观测对象：只关心它是否被调用、带什么参数，不真正跑注册。
+const registerBrowserPreview = jest.fn(async (_projectPath: string) => { /* no-op */ });
+jest.mock('../register', () => ({
+    __esModule: true,
+    registerBrowserPreview,
+}));
+
+// 把 lib 入口对 core 的重依赖桩掉，聚焦「是否提前注册预览」这一 wiring。
+const coreProjectOpen = jest.fn(async () => { /* no-op */ });
+jest.mock('../../project', () => ({
+    __esModule: true,
+    default: { open: coreProjectOpen },
+}));
+
+import * as Project from '../../../lib/project/project';
+
+describe('lib startup path registers browser preview `/` before asset import', () => {
+    beforeEach(() => {
+        registerBrowserPreview.mockClear();
+        coreProjectOpen.mockClear();
+    });
+
+    it('Project.init registers browser preview with the project path (before Assets.start)', async () => {
+        await Project.init(PROJECT);
+
+        expect(coreProjectOpen).toHaveBeenCalledWith(PROJECT);
+        expect(registerBrowserPreview).toHaveBeenCalledWith(PROJECT);
+    });
+
+    it('early register failure never breaks opening the project (failure-isolated)', async () => {
+        registerBrowserPreview.mockRejectedValueOnce(new Error('boom'));
+        // 预览注册抛错不应让工程打开失败——预览是附加能力，不能阻断启动。
+        await expect(Project.init(PROJECT)).resolves.toBeUndefined();
+        expect(coreProjectOpen).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/core/preview/test/live-reload.test.ts
+++ b/src/core/preview/test/live-reload.test.ts
@@ -1,0 +1,340 @@
+import { EventEmitter } from 'events';
+
+/**
+ * live-reload 「首次就绪自愈」回归测试。
+ *
+ * 场景：IDE 常驻 server 模式下，用户在 CLI 初始化（asset-db 建库 + 内置资源导入）完成前打开
+ * 预览页（game.ejs），settings.js 返回 503、首屏 boot 失败。要求预览 settings 首次「真正可用」后
+ * （能生成且 builtinAssets 非空，由 isPreviewSettingsReady 判定），服务端把这些「已上报等待自愈」的
+ * 预览页**定向** emit browser:reload 使其整页刷新自愈，无需手动刷新；而就绪后才连上、boot 正常的
+ * 新页不上报、不应被无谓刷新。
+ *
+ * 关键：交付与「连接时机」解耦——客户端在每次(重)连接的仍失败态都重报 preview:awaiting-reload，
+ * 故初始化期 socket 掉线重连、或多个预览页（Chrome + IDE webview）连接时机不同，都能各自被可靠救回，
+ * 不依赖某一瞬的广播（旧一次性 io 广播会概率性漏刷、或只刷到其中一个页面）。
+ */
+
+// --- mocks ---------------------------------------------------------------
+class FakeSocket extends EventEmitter {
+    public id: string;
+    public connected = true;
+    // 服务端通过 socket.emit('browser:reload') 定向下发；这里记录本 socket 收到的下发。
+    public reloads = 0;
+    constructor(id: string) {
+        super();
+        this.id = id;
+    }
+    emit(event: string, ...args: any[]): boolean {
+        if (event === 'browser:reload') {
+            this.reloads++;
+            return true;
+        }
+        // 其余事件（preview:awaiting-reload / disconnect）用于测试模拟「客户端 → 服务端」上报，
+        // 分发给服务端在本 socket 上注册的处理器。
+        return super.emit(event, ...args);
+    }
+}
+
+class FakeIO extends EventEmitter {
+    // io 广播（io.emit('browser:reload')，用于常规热重载：编译/配置/自愈后刷新）
+    public broadcasts: string[] = [];
+    public sockets = { sockets: new Map<string, FakeSocket>() };
+    private seq = 0;
+
+    emit(event: string, ...args: any[]): boolean {
+        if (event === 'browser:reload') {
+            this.broadcasts.push(event);
+            return true;
+        }
+        return super.emit(event, ...args);
+    }
+
+    // 模拟一个预览页连上：加入 sockets 表并派发 connection 事件，返回该 socket
+    connectClient(): FakeSocket {
+        const socket = new FakeSocket(`s${++this.seq}`);
+        this.sockets.sockets.set(socket.id, socket);
+        super.emit('connection', socket);
+        return socket;
+    }
+
+    disconnectClient(socket: FakeSocket): void {
+        socket.connected = false;
+        this.sockets.sockets.delete(socket.id);
+        socket.emit('disconnect'); // 触发服务端在该 socket 上注册的 disconnect 处理器
+    }
+}
+const fakeIO = new FakeIO();
+
+jest.mock('../../../server/socket', () => ({
+    socketService: { io: fakeIO },
+}));
+
+const scripting = new EventEmitter();
+const assetDBManager = new EventEmitter() as EventEmitter & { ready: boolean };
+assetDBManager.ready = false;
+// 单个资源增删改事件源（保存场景 = asset-change 等），live-reload 会监听它触发热重载。
+const assetManager = new EventEmitter();
+const configurationManager = new EventEmitter();
+
+jest.mock('../../scripting', () => ({ __esModule: true, default: scripting }));
+jest.mock('../../assets', () => ({ assetDBManager, assetManager }));
+jest.mock('../../configuration', () => ({ configurationManager }));
+jest.mock('../../configuration/script/interface', () => ({
+    MessageType: { Update: 'configuration:update', Reload: 'configuration:reload' },
+}));
+
+const mockInvalidate = jest.fn();
+// isPreviewSettingsReady 由测试通过 settingsReady 变量控制其返回值（模拟 settings 从「未就绪」到「就绪」）。
+let settingsReady = false;
+jest.mock('../preview-settings', () => ({
+    invalidatePreviewSettings: () => mockInvalidate(),
+    isPreviewSettingsReady: jest.fn(async () => settingsReady),
+}));
+
+import { registerLiveReload, unregisterLiveReload, notePreviewNotReady } from '../live-reload';
+
+const POLL_MS = 1500;
+
+// 让所有已挂起的 microtask（tryHeal 里的 await）跑完
+async function flush(): Promise<void> {
+    for (let i = 0; i < 5; i++) {
+        await Promise.resolve();
+    }
+}
+
+// 模拟客户端上报「本页 boot 失败、等待自愈」（settings.js onerror + connect 时发出）
+function reportStuck(socket: FakeSocket): void {
+    socket.emit('preview:awaiting-reload');
+}
+
+describe('live-reload self-heal when preview settings first become ready', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        fakeIO.broadcasts = [];
+        fakeIO.removeAllListeners();
+        fakeIO.sockets.sockets.clear();
+        scripting.removeAllListeners();
+        assetDBManager.removeAllListeners();
+        assetManager.removeAllListeners();
+        configurationManager.removeAllListeners();
+        assetDBManager.ready = false;
+        settingsReady = false;
+        mockInvalidate.mockClear();
+        unregisterLiveReload();
+    });
+
+    afterEach(() => {
+        unregisterLiveReload();
+        jest.useRealTimers();
+    });
+
+    it('directs a reload to a client that reported stuck before settings were ready (via asset event)', async () => {
+        await registerLiveReload();
+
+        // 预览页在初始化完成前打开：settings.js 503 → 上报等待自愈，此刻不刷新
+        const socket = fakeIO.connectClient();
+        reportStuck(socket);
+        await flush();
+        expect(socket.reloads).toBe(0);
+
+        // settings 首次真正可用，随后资源事件到达触发就绪探测
+        settingsReady = true;
+        assetDBManager.emit('assets:refresh-finish');
+        await flush();
+
+        // 定向下发一次 browser:reload 给该 stuck 页
+        expect(socket.reloads).toBe(1);
+    });
+
+    it('heals via the fallback poll even without any asset event', async () => {
+        await registerLiveReload();
+
+        const socket = fakeIO.connectClient();
+        reportStuck(socket); // 未就绪期上报，起兜底轮询
+        await flush();
+        expect(socket.reloads).toBe(0);
+
+        // 没有任何资源事件，仅靠兜底轮询：就绪后下一次 tick 定向刷新
+        settingsReady = true;
+        jest.advanceTimersByTime(POLL_MS);
+        await flush();
+        expect(socket.reloads).toBe(1);
+    });
+
+    it('still heals an early stuck page whose socket dropped during init and reconnects', async () => {
+        await registerLiveReload();
+
+        // 早连页上报等待，随后初始化期 socket ping 超时掉线（从等待集移除）
+        const dropped = fakeIO.connectClient();
+        reportStuck(dropped);
+        await flush();
+        fakeIO.disconnectClient(dropped);
+
+        // settings 就绪；掉线的 stuck 页此刻自动重连（新 socket），并在 connect 时重报
+        settingsReady = true;
+        const reconnected = fakeIO.connectClient();
+        reportStuck(reconnected); // 客户端每次(重)连都重报
+        await flush();
+
+        // healed 后重报 → 立即定向刷新，救回重连回来的页面
+        expect(reconnected.reloads).toBe(1);
+        // 掉线的旧 socket 不应收到（早已从等待集移除）
+        expect(dropped.reloads).toBe(0);
+    });
+
+    it('reloads multiple independent stuck pages (e.g. Chrome + IDE webview)', async () => {
+        await registerLiveReload();
+
+        const chrome = fakeIO.connectClient();
+        const webview = fakeIO.connectClient();
+        reportStuck(chrome);
+        reportStuck(webview);
+        await flush();
+        expect(chrome.reloads).toBe(0);
+        expect(webview.reloads).toBe(0);
+
+        settingsReady = true;
+        assetDBManager.emit('assets:refresh-finish');
+        await flush();
+
+        // 两个页面各自被定向刷新（不再是「只刷到其中一个」）
+        expect(chrome.reloads).toBe(1);
+        expect(webview.reloads).toBe(1);
+    });
+
+    it('does NOT reload a client that connected after settings were ready and booted fine', async () => {
+        settingsReady = true;
+        await registerLiveReload();
+
+        // 就绪后才连上、boot 正常的页面从不上报，不应触发自愈刷新
+        const socket = fakeIO.connectClient();
+        await flush();
+        assetDBManager.emit('assets:ready'); // 迟到/重复的启动期事件不应触发定向刷新
+        await flush();
+        jest.advanceTimersByTime(POLL_MS);
+        await flush();
+
+        expect(socket.reloads).toBe(0);
+        expect(fakeIO.broadcasts).toHaveLength(0);
+    });
+
+    it('broadcasts a reload at first-ready when it registered during the init window (defensive)', async () => {
+        // 注册时未就绪 → 进入初始化窗口(pendingHeal)。即使没有任何客户端显式上报 stuck，
+        // 首次就绪时也应兜底广播一次 browser:reload：此刻凡连着的预览页必是未就绪期打开的 stuck 页，
+        // 广播比依赖逐 socket 登记更可靠（登记可能因时序/实例不一致而遗漏）。
+        await registerLiveReload();
+
+        settingsReady = true;
+        assetDBManager.emit('assets:refresh-finish');
+        await flush();
+
+        expect(fakeIO.broadcasts).toEqual(['browser:reload']);
+    });
+
+    it('immediately reloads a page that reports stuck after settings are already ready', async () => {
+        await registerLiveReload();
+
+        // 中间件已因 503 预热轮询；无客户端时就绪只翻转 healed、无下发
+        notePreviewNotReady();
+        settingsReady = true;
+        jest.advanceTimersByTime(POLL_MS);
+        await flush();
+
+        // 之后才连上、且仍 stuck 的页（例如短暂掉线后重连）上报 → healed 路径立即定向刷新
+        const late = fakeIO.connectClient();
+        reportStuck(late);
+        await flush();
+        expect(late.reloads).toBe(1);
+    });
+
+    it('heals an early page opened BEFORE register, server-driven (no client report needed)', async () => {
+        // 浏览器早于 CLI 初始化完成、且早于 registerLiveReload 打开：socket 已在 io.sockets 表中，
+        // 但注册前无处理器，其首次 preview:awaiting-reload 上报已丢失。注册时若探测到未就绪，应把
+        // 已在册的预览页直接预判为「待自愈」，就绪后由服务端定向刷新，无需依赖客户端上报是否到达。
+        const early = fakeIO.connectClient(); // 注册前就已在册，未触发任何服务端处理器
+        expect(early.listenerCount('preview:awaiting-reload')).toBe(0);
+
+        await registerLiveReload(); // settingsReady=false → 预判 early 为 stuck 并起兜底轮询
+        expect(early.listenerCount('preview:awaiting-reload')).toBe(1); // 仍为其补挂处理器
+
+        // 不做任何 reportStuck：仅靠服务端预判 + 兜底轮询，就绪后即定向刷新
+        settingsReady = true;
+        jest.advanceTimersByTime(POLL_MS);
+        await flush();
+        expect(early.reloads).toBe(1);
+    });
+
+    it('presumes a page that connects AFTER register but before ready as stuck (no client report)', async () => {
+        await registerLiveReload(); // settingsReady=false → 进入初始化窗口(pendingHeal)、起轮询
+
+        // 初始化窗口内新连上的预览页：其 settings.js 此刻也会 503，直接预判 stuck，无需它自己上报
+        const page = fakeIO.connectClient();
+        await flush();
+        expect(page.reloads).toBe(0);
+
+        settingsReady = true;
+        jest.advanceTimersByTime(POLL_MS);
+        await flush();
+        expect(page.reloads).toBe(1);
+    });
+
+    it('does not double-bind a socket adopted at register and re-emitting connection', async () => {
+        const early = fakeIO.connectClient();
+        await registerLiveReload();
+        // 再次派发 connection（模拟同一 socket 的重复 connection 事件）不应重复挂载处理器
+        (fakeIO as any).emit('connection', early);
+        expect(early.listenerCount('preview:awaiting-reload')).toBe(1);
+
+        // 单次上报只应带来单次定向刷新（无重复处理器 → 无重复 emit）
+        settingsReady = true;
+        reportStuck(early);
+        await flush();
+        expect(early.reloads).toBe(1);
+    });
+
+    it('sets healed at register (no self-heal) when settings are already ready', async () => {
+        // 常驻 server / 初始化早已完成：注册时探测到就绪，直接置 healed，后续新开页 boot 正常、不被打扰。
+        settingsReady = true;
+        await registerLiveReload();
+
+        const socket = fakeIO.connectClient();
+        await flush();
+        jest.advanceTimersByTime(POLL_MS);
+        await flush();
+        expect(socket.reloads).toBe(0);
+        expect(fakeIO.broadcasts).toHaveLength(0);
+    });
+
+    it('still reloads on script recompile via broadcast (existing behavior preserved)', async () => {
+        settingsReady = true;
+        await registerLiveReload();
+
+        scripting.emit('compiled');
+        jest.advanceTimersByTime(200);
+
+        // 编译热重载对所有打开的预览页广播
+        expect(fakeIO.broadcasts).toEqual(['browser:reload']);
+        expect(mockInvalidate).toHaveBeenCalled();
+    });
+
+    it('broadcasts on asset refresh-finish after heal (existing behavior preserved)', async () => {
+        await registerLiveReload();
+
+        // 先让一次 stuck 上报 + 就绪把 healed 置位
+        const socket = fakeIO.connectClient();
+        reportStuck(socket);
+        await flush(); // 让首次「未就绪」探测先结算，避免 tryHeal 重入保护吞掉随后的探测
+        expect(socket.reloads).toBe(0);
+        settingsReady = true;
+        assetDBManager.emit('assets:refresh-finish');
+        await flush();
+        // 首次就绪：定向刷新该 stuck 页 + 兜底广播一次（见 tryHeal）
+        expect(socket.reloads).toBe(1);
+        expect(fakeIO.broadcasts).toEqual(['browser:reload']);
+
+        // 自愈完成后，refresh-finish 作为常规热重载信号，再走一次 io 广播
+        assetDBManager.emit('assets:refresh-finish');
+        jest.advanceTimersByTime(200);
+        expect(fakeIO.broadcasts).toEqual(['browser:reload', 'browser:reload']);
+    });
+});

--- a/src/core/preview/test/preview-settings-ready.test.ts
+++ b/src/core/preview/test/preview-settings-ready.test.ts
@@ -1,0 +1,33 @@
+import { EventEmitter } from 'events';
+
+const mockAssetDBManager = new EventEmitter() as EventEmitter & { ready: boolean };
+mockAssetDBManager.ready = false;
+
+jest.mock('../../assets', () => ({
+    assetDBManager: mockAssetDBManager,
+}));
+
+import { getCachedPreviewSettings, PreviewNotReadyError } from '../preview-settings';
+
+/**
+ * 预览就绪门禁（快速失败）：CLI 常驻 server 模式下，IDE 可能在 asset-db 初始化完成前就请求
+ * 预览 settings。此时不能生成缺 builtinAssets 的坏 settings，也不应把请求长时间挂起（挂起会
+ * 拖慢 socket.io 加载并可能被 webview 超时掐断）。改为**快速失败**抛 PreviewNotReadyError
+ * （路由映射为可重试 503）；CLI 就绪后由 live-reload 广播 browser:reload 让页面自愈重载。
+ */
+describe('getCachedPreviewSettings readiness gate (fast-fail)', () => {
+    beforeEach(() => {
+        mockAssetDBManager.ready = false;
+        mockAssetDBManager.removeAllListeners();
+    });
+
+    it('throws PreviewNotReadyError immediately when asset-db is not ready', async () => {
+        await expect(getCachedPreviewSettings()).rejects.toBeInstanceOf(PreviewNotReadyError);
+    });
+
+    it('does not block waiting for an assets:ready event (no listener left hanging)', async () => {
+        await expect(getCachedPreviewSettings()).rejects.toBeInstanceOf(PreviewNotReadyError);
+        // 快速失败路径不注册任何 assets:ready 监听，避免泄漏
+        expect(mockAssetDBManager.listenerCount('assets:ready')).toBe(0);
+    });
+});

--- a/src/core/scene/scene.middleware.ts
+++ b/src/core/scene/scene.middleware.ts
@@ -3,6 +3,52 @@ import { Request, Response, NextFunction } from 'express';
 import path from 'path';
 import fse from 'fs-extra';
 
+/**
+ * 各资源数据库的 library（已导入数据）目录缓存。
+ * library 是扁平的 `<uuid前两位>/<uuid>[/nativeName].<ext>` 结构，一个相对路径在所有
+ * library 目录中唯一定位文件（与预览 game-preview.middleware.getLibraryDirs 对齐）。
+ */
+let libraryDirsCache: string[] | null = null;
+async function getLibraryDirs(): Promise<string[]> {
+    if (libraryDirsCache) {
+        return libraryDirsCache;
+    }
+    const { assetDBManager } = await import('../assets');
+    const dirs = Object.values(assetDBManager.assetDBInfo)
+        .map((info: any) => info.library)
+        .filter((v): v is string => !!v);
+    libraryDirsCache = Array.from(new Set(dirs));
+    return libraryDirsCache;
+}
+
+/**
+ * asset-db 未命中时，按扁平相对路径 `<uuid前两位>/<uuid>[/nativeName].<ext>` 直接从各
+ * library 磁盘目录定位文件。
+ *
+ * 内置资源（如 pipeline/cluster-build，uuid=45e7c0c8...，前两位 45）只存在于 library 磁盘，
+ * 并不在 asset-db 索引里。引擎在 cc.game.run() 初始化渲染管线时会按 importBase 扁平路径
+ * `${serverURL}/45/<uuid>.json` 拉取该 effect；此前本路由只查 asset-db，命中不到就 404，
+ * 导致渲染管线建不起来，随后打开任意场景都报
+ * "Cannot read properties of null (reading 'pipelineSceneData')"（每次必现）。
+ * 预览通过 getLibraryDirs 同样从 library 目录服务，故预览正常而场景编辑器此前失败。
+ * 这里补上路由注释早已声明、却未实现的「回退到 library 磁盘」逻辑。
+ */
+async function resolveFromLibrary(tail: string): Promise<string | undefined> {
+    const dirs = await getLibraryDirs();
+    for (const d of dirs) {
+        const full = path.join(d, tail);
+        // 防目录穿越：join 后必须仍位于 library 目录内
+        const rel = path.relative(d, full);
+        if (rel.startsWith('..') || path.isAbsolute(rel)) {
+            continue;
+        }
+        if (await fse.pathExists(full)) {
+            return full;
+        }
+    }
+    return undefined;
+}
+
 function isBrowserRequest(req: Request): boolean {
     if (req.query.isBrowser === 'true') {
         return true;
@@ -126,10 +172,14 @@ export default {
                 if (req.params.dir === 'build' || req.params.dir === 'mcp') {
                     return next();
                 }
-                const { uuid, ext, nativeName } = req.params;
+                const { dir, uuid, ext, nativeName } = req.params;
                 const { assetManager } = await import('../assets');
                 const assetInfo = assetManager.queryAssetInfo(uuid);
-                const filePath = assetInfo?.library?.[`${nativeName}.${ext}`];
+                let filePath = assetInfo?.library?.[`${nativeName}.${ext}`];
+                if (!filePath) {
+                    // asset-db 未命中：回退到 library 磁盘目录（见 resolveFromLibrary 注释）
+                    filePath = await resolveFromLibrary(`${dir}/${uuid}/${nativeName}.${ext}`);
+                }
                 if (!filePath) {
                     console.warn(`Asset not found: ${req.url}`);
                     return res.status(404).json({
@@ -164,10 +214,16 @@ export default {
         {
             url: '/:dir/:uuid.:ext',
             async handler(req: Request, res: Response) {
-                const { uuid, ext } = req.params;
+                const { dir, uuid, ext } = req.params;
                 const { assetManager } = await import('../assets');
                 const assetInfo = assetManager.queryAssetInfo(uuid);
-                const filePath = assetInfo?.library?.[`.${ext}`];
+                let filePath = assetInfo?.library?.[`.${ext}`];
+                if (!filePath) {
+                    // asset-db 未命中：回退到 library 磁盘目录（见 resolveFromLibrary 注释）。
+                    // 修复内置 effect（pipeline/cluster-build 等）经 `${serverURL}/45/<uuid>.json`
+                    // 拉取时的 404，进而修复渲染管线为 null 引发的 pipelineSceneData 报错。
+                    filePath = await resolveFromLibrary(`${dir}/${uuid}.${ext}`);
+                }
                 if (!filePath) {
                     console.warn(`Asset not found: ${req.url}`);
                     return res.status(404).json({

--- a/src/core/scene/test/scene.middleware.test.ts
+++ b/src/core/scene/test/scene.middleware.test.ts
@@ -1,16 +1,22 @@
 const mockQueryAssetInfo = jest.fn();
 const mockReadFile = jest.fn();
+const mockPathExists = jest.fn();
 
 jest.mock('../../assets', () => ({
     assetManager: {
         queryAssetInfo: (...args: unknown[]) => mockQueryAssetInfo(...args),
     },
+    assetDBManager: {
+        assetDBInfo: { internal: { library: '/proj/library' } },
+    },
 }));
 
 jest.mock('fs-extra', () => ({
     readFile: (...args: unknown[]) => mockReadFile(...args),
+    pathExists: (...args: unknown[]) => mockPathExists(...args),
 }));
 
+import path from 'path';
 import sceneMiddleware from '../scene.middleware';
 
 const uuid = '04796f71-2f24-4b07-81d2-01f528b45157';
@@ -89,5 +95,67 @@ describe('scene asset middleware', () => {
         expect(mockQueryAssetInfo).toHaveBeenCalledWith(dbUrl);
         expect(response.status).toHaveBeenCalledWith(200);
         expect(response.json).toHaveBeenCalledWith(assetInfo);
+    });
+
+    // 内置 effect（pipeline/cluster-build, uuid 前两位 45）不在 asset-db 索引里，引擎按
+    // importBase 扁平路径 `${serverURL}/45/<uuid>.json` 拉取。此前只查 asset-db 必 404，
+    // 管线建不起来 → 打开场景报 pipelineSceneData null。回退到 library 磁盘目录后修复。
+    const builtinUuid = '45e7c0c8-2699-4912-b45f-d42bb8384189';
+    const builtinFile = path.join('/proj/library', '45', `${builtinUuid}.json`);
+
+    it('falls back to the library dir when asset-db has no record (builtin effect)', async () => {
+        const response = createResponse();
+        mockQueryAssetInfo.mockReturnValue(null); // 内置资源不在 asset-db
+        mockPathExists.mockImplementation(async (p: string) => p === builtinFile);
+
+        await route!.handler(
+            {
+                params: { dir: '45', uuid: builtinUuid, ext: 'json' },
+                query: { isBrowser: 'true' },
+                headers: {},
+            } as any,
+            response as any,
+        );
+
+        expect(mockReadFile).toHaveBeenCalledWith(builtinFile);
+        expect(response.status).toHaveBeenCalledWith(200);
+        expect(response.send).toHaveBeenCalledWith(fileContent);
+    });
+
+    it('returns the library-dir path to the Node scene engine when asset-db misses', async () => {
+        const response = createResponse();
+        mockQueryAssetInfo.mockReturnValue(null);
+        mockPathExists.mockImplementation(async (p: string) => p === builtinFile);
+
+        await route!.handler(
+            {
+                params: { dir: '45', uuid: builtinUuid, ext: 'json' },
+                query: {},
+                headers: { 'user-agent': 'node.js/22.22.0' },
+            } as any,
+            response as any,
+        );
+
+        expect(mockReadFile).not.toHaveBeenCalled();
+        expect(response.status).toHaveBeenCalledWith(200);
+        expect(response.send).toHaveBeenCalledWith(builtinFile);
+    });
+
+    it('still 404s when neither asset-db nor any library dir has the file', async () => {
+        const response = createResponse();
+        mockQueryAssetInfo.mockReturnValue(null);
+        mockPathExists.mockResolvedValue(false);
+
+        await route!.handler(
+            {
+                params: { dir: '45', uuid: builtinUuid, ext: 'json' },
+                query: {},
+                headers: {},
+                url: `/45/${builtinUuid}.json`,
+            } as any,
+            response as any,
+        );
+
+        expect(response.status).toHaveBeenCalledWith(404);
     });
 });

--- a/src/core/test/stubs/cc-mods-mgr.js
+++ b/src/core/test/stubs/cc-mods-mgr.js
@@ -1,0 +1,18 @@
+/**
+ * 单测桩：cc/mods-mgr。
+ *
+ * 生成的引擎代理文件（packages/cc-module/editor/*.js，如 serialization.js）首行是
+ * `require('cc/mods-mgr')`；`cc/mods-mgr` 仅在运行时由 EngineLoader 注入，磁盘上并不存在。
+ * 正常单测里这些代理文件会被各用例的 jest.mock 拦截、根本不加载；但 EngineLoader.init 会全局劫持
+ * 模块解析并泄漏到后续测试文件（jest maxWorkers:1 串行共用一个 worker），使某些用例的 mock 失配、
+ * 真实代理文件被加载，触发 `Cannot find module 'cc/mods-mgr'` —— 该失败与测试文件的执行顺序相关。
+ *
+ * 本桩经 jest moduleNameMapper 把 `cc/mods-mgr` 兜底到这里，保证任何顺序下都能解析成功、不再因解析
+ * 失败而崩溃。syncImport 返回空对象即可（走到此处的用例都已用自己的 jest.mock 覆盖了对应引擎模块的
+ * 真实用途，不依赖 mods-mgr 的真实产物）。
+ */
+module.exports = {
+    syncImport() {
+        return {};
+    },
+};

--- a/src/lib/project/project.ts
+++ b/src/lib/project/project.ts
@@ -1,8 +1,31 @@
 
+/**
+ * 提前注册浏览器游戏预览的 `/` 路由 + live-reload（幂等）。
+ *
+ * IDE（PinK）直接编排 lib/* 各步骤，且 `Assets.start()`（"init asset" 冷导入，可达约 1 分钟）
+ * 早于 `Scripting.init`。`/` 路由原本只在 `Scene.init()`（core/scene）里注册，而 IDE 把它排在
+ * asset 初始化之后——这段窗口里 server 已 listen 但 `/` 未注册，浏览器打开预览命中 server.ts 的
+ * 兜底 404（纯文本 "404 - Not Found"）：拿到一张没有 socket.io、没有 browser:reload 监听的裸页，
+ * 之后 CLI 就绪也无从通知它刷新，永远停在 404。
+ *
+ * 因此在 `Project.init`（IDE 启动最早的一步、早于 asset 冷导入、且已知 projectPath）就提前注册：
+ * 使初始化期打开的预览页拿到带 socket 自愈能力的 game.ejs（settings 未就绪时 settings.js 返回
+ * 可重试 503，就绪后 live-reload 定向推送 browser:reload 整页刷新自愈，无需手动刷新）。
+ * projectPath 已确定，扩展预览后端(extension-host)能拿到正确工程路径并先于 GamePreview 注册。
+ * 幂等（内部 registered 守卫）：Scene.init 里的原有调用会安全 no-op。
+ * 失败隔离：预览是附加能力，注册异常不得阻断工程打开。
+ */
 export async function init(projectPath: string): Promise<void> {
     // 初始化项目信息
     const { default: Project } = await import('../../core/project');
     await Project.open(projectPath);
+
+    try {
+        const { registerBrowserPreview } = await import('../../core/preview/register');
+        await registerBrowserPreview(projectPath);
+    } catch (err) {
+        console.warn('[Preview] early register in Project.init failed:', err);
+    }
 }
 
 export async function open(projectPath: string): Promise<void> {

--- a/static/web/game-boot.js
+++ b/static/web/game-boot.js
@@ -18,6 +18,34 @@ export default async function gameBoot() {
         }
     };
 
+    // 热重载自愈监听：加载共用的「接收端」脚本（创建 socket + 注册 browser:reload，置 window.__previewSocket）。
+    // 关键：IDE 直接加载本 game-boot.js（其 webview 宿主页，不经过 game.ejs 首屏），因此必须在这里确保监听
+    // 已装上；且要早于可能失败/阻塞的 loadEngine——CLI 未就绪时 boot 会失败，服务端在预览 settings 首次就绪
+    // 时会广播 browser:reload（见 live-reload.ts），本页据此整页刷新自愈，无需手动刷新。若留到 boot 成功后
+    // 再注册，失败的首屏就永远收不到通知、无法自愈。
+    // 与 game.ejs 共用 preview-live-reload.js，避免两处 socket/监听逻辑重复、行为漂移（该文件无 import/export，
+    // 既可作 classic <script src> 被 game.ejs 引入，也可在此作副作用 import）。
+    // 去重：浏览器预览路径下 game.ejs 首屏已加载该脚本并置 window.__previewSocket，此处据此跳过。
+    if (!window.__previewSocket) {
+        try {
+            await import('/static/web/preview-live-reload.js');
+        } catch (e) {
+            console.warn('[Game Preview] live-reload setup unavailable:', e);
+        }
+    }
+
+    // Boot 门控：仅当预览 settings 就绪（后端已完成 asset 冷导入）时才加载引擎。
+    // settings.js 在 CLI 未就绪时返回 503 → window._CCSettings 不会被赋值（宿主页在加载本文件前已同步
+    // 注入 settings.js，故其缺失即代表后端未就绪，是可靠判据）。若此时仍继续 boot，loadEngine 会去动态
+    // import /scripting/systemjs/system.js 等在 asset 冷导入期尚未就绪或事件循环繁忙而拉取失败的资源，
+    // 概率性抛 "Failed to fetch dynamically imported module: .../system.js"。跳过后由上面注册的
+    // browser:reload 监听在服务端 settings 首次就绪时整页刷新自愈：届时 settings.js 返回 200、programming
+    // facet 早已就绪，system.js 必可用，正常 boot。
+    if (window.__previewSettingsFailed || !window._CCSettings) {
+        console.warn('[Game Preview] backend not ready (settings unavailable); skip boot, awaiting server-driven reload.');
+        return;
+    }
+
     try {
         // 以 PREVIEW 模式加载引擎（EDITOR=false / PREVIEW=true）
         const env = await loadEngine({ preview: true });
@@ -25,16 +53,6 @@ export default async function gameBoot() {
         const _originalSystem = System;
         const cc = await System.import('cc');
         globalThis.System = _originalSystem;
-
-        // 监听热重载（脚本/资源变化后服务端广播 browser:reload）
-        try {
-            if (window.io) {
-                const socket = window.io(env.serverURL);
-                socket.on('browser:reload', () => location.reload());
-            }
-        } catch (e) {
-            console.warn('[Game Preview] live-reload socket unavailable:', e);
-        }
 
         const settings = window._CCSettings || {};
         let launchScene = (settings.launch && settings.launch.launchScene) || '';

--- a/static/web/game.ejs
+++ b/static/web/game.ejs
@@ -55,14 +55,68 @@
     <script>
         window.WebEnv = { serverURL: '<%= serverURL %>' };
         window.__launchSceneQuery = '<%= sceneQuery %>';
+        // 构建标记：确认浏览器拿到的是「早注册 / 自愈」版本的 game.ejs（而非旧缓存或旧构建）。
+        console.log('[Game Preview] page build marker: EARLY-ROUTE-FIX v6 (served from static/web/game.ejs)');
     </script>
-    <!-- 运行时 settings：定义 window._CCSettings -->
-    <script src="<%= settingsJs %>"></script>
     <!-- socket.io 客户端由 socket.io 服务端自动托管，用于热重载 -->
     <script src="/socket.io/socket.io.js"></script>
+    <!-- 热重载「接收端」：创建 socket + 注册 browser:reload 监听（置 window.__previewSocket）。
+         必须在 settings.js 之前加载：CLI 未就绪时 settings.js 会 503、后续 boot 失败，若把监听留到
+         boot 成功后再注册，失败的首屏就永远收不到 browser:reload、无法自愈。CLI 就绪后 live-reload
+         广播 browser:reload，本页整页刷新即自动恢复，无需手动刷新。
+         与 game-boot.js（IDE 直接加载）共用同一文件，避免两处 socket/监听逻辑重复、行为漂移。 -->
+    <script src="/static/web/preview-live-reload.js"></script>
+    <script>
+        // 热重载「上报端」（game.ejs 首屏专有）：本页 settings.js 加载失败（CLI 未就绪返回 503）时，向
+        // 服务端上报 preview:awaiting-reload，并在每次(重)连接时于仍失败态重报。服务端据此在 settings 首次
+        // 就绪时「定向」通知本页刷新，与连接时机解耦：初始化期 socket 掉线重连、或 Chrome 与 IDE webview
+        // 同开、连接时机不同，都能各自被可靠救回，不依赖某一瞬的广播（旧做法会概率性漏刷、或只刷到其中
+        // 一个页面）。此段强依赖「早于 settings.js 执行」及 settings.js onerror 置 __previewSettingsFailed
+        // 的时序，故保留在 game.ejs 内联、未纳入共用的 preview-live-reload.js。
+        try {
+            var previewSocket = window.__previewSocket;
+            if (previewSocket) {
+                // settings.js onerror 时置位（见下方 script 标签），此函数在仍失败态且已连接时上报。
+                window.__notifyPreviewStuck = function () {
+                    if (window.__previewSettingsFailed && previewSocket.connected) {
+                        previewSocket.emit('preview:awaiting-reload');
+                    }
+                };
+                // 每次(重)连接都补报：初始化期 socket 常因事件循环繁忙 ping 超时后自动重连，
+                // 重连会换新 socket，需重报才能让服务端重新登记本页。boot 成功的页从不置位、从不上报。
+                previewSocket.on('connect', function () {
+                    window.__notifyPreviewStuck();
+                });
+                // 兜底周期性重报：浏览器若早于 CLI 初始化打开，socket 可能在服务端 live-reload 挂上
+                // connection 监听「之前」就连上，首次上报会丢失（无处理器接收）。周期性重报保证监听
+                // 挂上后（或就绪后）本页仍能被登记/救回。仅在失败态发送；刷新后 settings.js 取到 200、
+                // 不再置失败位，重报自然停止，不会形成刷新循环。
+                setInterval(function () {
+                    window.__notifyPreviewStuck();
+                }, 2000);
+            }
+        } catch (e) {
+            console.warn('[Game Preview] live-reload reporter unavailable:', e);
+        }
+    </script>
+    <!-- 运行时 settings：定义 window._CCSettings（CLI 未就绪时返回 503）。
+         onerror（含 HTTP 503）→ 标记本页 boot 失败并上报，由服务端就绪后定向刷新自愈。 -->
+    <script src="<%= settingsJs %>" onerror="window.__previewSettingsFailed=true; window.__notifyPreviewStuck && window.__notifyPreviewStuck();"></script>
     <script type="module">
-        const { default: gameBoot } = await import('/static/web/game-boot.js');
-        await gameBoot();
+        // 仅当 settings.js 成功（后端就绪）时才 boot。settings.js 是 classic（parser-blocking）脚本，
+        // 先于本 deferred module 执行；若它 503（CLI 初始化未完成）会置 window.__previewSettingsFailed，
+        // 此时必须跳过 boot——否则 game-boot 会去动态 import /scripting/systemjs/system.js 等尚未就绪
+        // 或事件循环繁忙（asset 冷导入阻塞）而拉取失败的资源，概率性抛
+        // "Failed to fetch dynamically imported module: .../system.js"。
+        // 跳过 boot 后由 live-reload 在 settings 首次真正就绪时推送 browser:reload 整页刷新，届时
+        // settings.js 返回 200、programming facet 早已就绪（facet 在脚本初始化阶段创建，早于 settings
+        // 所需的资源冷导入完成），system.js 必可用，正常 boot。
+        if (window.__previewSettingsFailed) {
+            console.warn('[Game Preview] backend not ready (settings.js failed); skip boot, awaiting server-driven reload.');
+        } else {
+            const { default: gameBoot } = await import('/static/web/game-boot.js');
+            await gameBoot();
+        }
     </script>
 </body>
 </html>

--- a/static/web/preview-live-reload.js
+++ b/static/web/preview-live-reload.js
@@ -1,0 +1,37 @@
+/* global window, location, console */
+
+/**
+ * 预览热重载「接收端」：注册 socket.io 的 `browser:reload` 监听，收到即整页刷新。
+ *
+ * 两个消费者共用同一份实现，避免逻辑重复、行为漂移：
+ *   - static/web/game.ejs   —— 浏览器游戏预览首屏，以 classic `<script src>` 引入（早于 settings.js）；
+ *   - static/web/game-boot.js —— IDE（PinK）webview 宿主页直接加载的引导脚本，以 `import()` 副作用引入。
+ * 本文件不含 import/export，既是合法的 classic 脚本、也是合法的 ES module（两种加载方式都执行下方 IIFE）。
+ *
+ * 为什么监听要尽早装好：CLI 未初始化完成时 settings.js 返回 503、首屏 boot 失败；若把监听留到 boot
+ * 成功后再注册，失败的首屏就永远收不到 browser:reload、无法自愈。服务端在预览 settings 首次就绪时会向
+ * 所有连接广播 browser:reload（见 core/preview/live-reload.ts），本页据此整页刷新，无需手动刷新。
+ *
+ * 幂等：以 window.__previewSocket 作唯一 socket 守卫。浏览器路径下 game.ejs 已用 `<script src>` 引入并置位，
+ * game-boot.js 便据此跳过 import；即使两种方式都加载了本文件，也只建立一条连接。
+ * serverURL：优先取宿主注入的 window.WebEnv.serverURL，缺省回退同源（window.io()）。
+ *
+ * 注意：本文件只负责「接收刷新」这半边（两条路径完全一致，适合共用）。game.ejs 另有「上报端」逻辑
+ * （settings.js 503 时上报 preview:awaiting-reload 并周期重报），因其强依赖 game.ejs 首屏「早于 settings.js」
+ * 的脚本时序、且依赖 settings.js onerror 置 __previewSettingsFailed，故保留在 game.ejs 内联、不纳入本文件。
+ */
+(function () {
+    try {
+        if (!window.io || window.__previewSocket) {
+            return;
+        }
+        var serverURL = (window.WebEnv && window.WebEnv.serverURL) || undefined;
+        var socket = serverURL ? window.io(serverURL) : window.io();
+        window.__previewSocket = socket;
+        socket.on('browser:reload', function () {
+            location.reload();
+        });
+    } catch (e) {
+        console.warn('[Game Preview] live-reload socket unavailable:', e);
+    }
+})();


### PR DESCRIPTION
## Problem

Opening the game preview while the IDE/CLI is still initializing (the ~1 min "init asset" cold import) leaves the page permanently stuck, with no way to recover short of a manual refresh:

- First a bare `404 - Not Found`, because `/` isn't registered yet.
- After that is addressed, a probabilistic `TypeError: Failed to fetch dynamically imported module: .../scripting/systemjs/system.js`.

Both affect the browser preview (Chrome) and the IDE's built-in webview.

## Root causes

- The `/` route was only registered in `Scene.init()`, which the IDE runs **after** `Assets.start()`. During that window the server is listening but `/` is unregistered, so the browser gets the catch-all 404 page — which has no socket.io / `browser:reload` listener and therefore can never self-heal once the backend finishes.
- `game-boot.js` attempted to boot before the backend was ready, dynamically importing `system.js` while the event loop was blocked by the cold import, which intermittently failed the dynamic import.

## Changes

- **Register the `/` route early**, in `Project.init` (the earliest startup step, before `Assets.start`). Registration is idempotent, so the later `Scene.init` call safely no-ops. The `/` handler tolerates an empty `scripting.projectPath` during that early window.
- **Gate boot on settings readiness**: skip `loadEngine` when preview settings are unavailable (`settings.js` returns 503 → `window._CCSettings` unset) and wait for a server-driven reload once ready. This removes the `system.js` dynamic-import failure.
- **Register the `browser:reload` listener before `loadEngine`**, so a first screen that fails to boot can still be recovered. When preview settings first become ready, the server broadcasts `browser:reload` to all connected sockets and the page reloads itself — no manual refresh.
- **Share the reload receiver**: extracted into `static/web/preview-live-reload.js` (no `import`/`export`, so it works both as a classic `<script src>` for `game.ejs` and as a side-effect `import()` for `game-boot.js`), replacing the duplicated socket/listener logic in the two entry points.

## Tests

Adds regression coverage:
- early `/` registration on `Project.init`
- the `/` page renders before builder/scene init (pre-builder render invariant)
- live-reload readiness / first-ready broadcast
- preview-settings readiness detection

All preview suites pass (`src/core/preview`, 20 tests). `scene.middleware` tests pass; the unrelated `scene.test.ts` failure is a pre-existing native `gl` module version mismatch on this machine.

## Verification

Restart the IDE and open the preview during "init asset":
- no 404 during init;
- no `system.js` fetch error;
- the page reloads and boots automatically once initialization completes.