### PR TITLE
fix(android): fill toolchain paths before build

### DIFF
--- a/src/core/builder/platforms/android/scripts/build-view.js
+++ b/src/core/builder/platforms/android/scripts/build-view.js
@@ -29,7 +29,7 @@ const hostOptions = {
     format: 'cjs',
     platform: 'node',
     target: 'node18',
-    external: ['vscode'],
+    external: ['vscode', 'pink'],
     logLevel: 'info',
 };
 

--- a/src/core/builder/platforms/android/src/view/build-config-host.ts
+++ b/src/core/builder/platforms/android/src/view/build-config-host.ts
@@ -1,7 +1,12 @@
 import * as fs from 'node:fs';
+import * as pink from 'pink';
 import * as path from 'node:path';
 
 type Bundle = Record<string, unknown>;
+
+type PreBuildHookFn = (
+    options: Record<string, unknown>,
+) => Promise<Record<string, unknown> | void>;
 
 interface NativeEngineInfo {
     type?: string;
@@ -10,6 +15,25 @@ interface NativeEngineInfo {
 
 interface HostContext {
     registerMethod(name: string, handler: (...args: any[]) => unknown | Promise<unknown>): void;
+    registerPreBuildHook?(fn: PreBuildHookFn): void;
+}
+
+const PLATFORM = 'android';
+const ANDROID_SDK_CONFIG_KEY = 'programManager.androidSDK';
+const ANDROID_NDK_CONFIG_KEY = 'programManager.androidNDK';
+const JAVA_HOME_CONFIG_KEY = 'programManager.javaHome';
+
+interface AndroidPackage {
+    sdkPath?: string;
+    ndkPath?: string;
+    javaHome?: string;
+    javaPath?: string;
+}
+
+interface AndroidBuildOptions {
+    packages?: {
+        [PLATFORM]?: AndroidPackage;
+    };
 }
 
 function currentLang(): 'zh' | 'en' {
@@ -72,25 +96,79 @@ function existsDir(filePath: string): boolean {
     }
 }
 
-function findSdkPath(): string {
-    const envSdk = process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT;
-    if (envSdk && existsDir(envSdk)) {
-        return envSdk;
+async function findSdkPath(): Promise<string> {
+    return getConfigurationString(ANDROID_SDK_CONFIG_KEY);
+}
+
+async function getConfigurationString(key: string): Promise<string> {
+    const value = await pink.configuration.get(key);
+    return typeof value === 'string' ? value : '';
+}
+
+function resolveJavaPaths(javaHome: string): { javaHome: string; javaPath: string } {
+    if (!javaHome) {
+        return { javaHome: '', javaPath: '' };
     }
 
-    if (process.platform === 'win32' && process.env.LOCALAPPDATA) {
-        const defaultSdkPath = path.join(process.env.LOCALAPPDATA, 'Android', 'Sdk');
-        if (existsDir(defaultSdkPath)) {
-            return defaultSdkPath;
+    try {
+        const st = fs.statSync(javaHome);
+        if (st.isFile()) {
+            return {
+                javaHome: path.normalize(path.join(path.dirname(javaHome), '..')),
+                javaPath: javaHome,
+            };
+        }
+
+        if (st.isDirectory()) {
+            const javaFileName = process.platform === 'win32' ? 'java.exe' : 'java';
+            const javaPath = path.join(javaHome, 'bin', javaFileName);
+            if (fs.existsSync(javaPath)) {
+                return { javaHome, javaPath };
+            }
+            console.error(`Java executable not found at ${javaHome}/bin`);
+        }
+    } catch (error) {
+        console.error(error);
+    }
+
+    return { javaHome, javaPath: '' };
+}
+
+async function createProgramPathPatch(pkg?: AndroidPackage): Promise<AndroidPackage> {
+    const patch: AndroidPackage = {};
+
+    if (!pkg?.sdkPath) {
+        const sdkPath = await getConfigurationString(ANDROID_SDK_CONFIG_KEY);
+        if (sdkPath) {
+            patch.sdkPath = sdkPath;
         }
     }
-    if (process.platform === 'darwin' && process.env.HOME) {
-        const defaultSdkPath = path.join(process.env.HOME, 'Library', 'Android', 'sdk');
-        if (existsDir(defaultSdkPath)) {
-            return defaultSdkPath;
+
+    if (!pkg?.ndkPath) {
+        const ndkPath = await getConfigurationString(ANDROID_NDK_CONFIG_KEY);
+        if (ndkPath) {
+            patch.ndkPath = ndkPath;
         }
     }
-    return '';
+
+    const javaHomeSource = pkg?.javaHome || (await getConfigurationString(JAVA_HOME_CONFIG_KEY));
+    if (!pkg?.javaHome && javaHomeSource) {
+        patch.javaHome = javaHomeSource;
+    }
+
+    if (!pkg?.javaPath && javaHomeSource) {
+        const javaPaths = resolveJavaPaths(javaHomeSource);
+        if (!pkg?.javaHome && javaPaths.javaHome) {
+            patch.javaHome = javaPaths.javaHome;
+        } else if (pkg?.javaHome && javaPaths.javaHome !== pkg.javaHome) {
+            patch.javaHome = javaPaths.javaHome;
+        }
+        if (javaPaths.javaPath) {
+            patch.javaPath = javaPaths.javaPath;
+        }
+    }
+
+    return patch;
 }
 
 function getAPILevel(apiLevelStr: string): number {
@@ -98,8 +176,8 @@ function getAPILevel(apiLevelStr: string): number {
     return match ? Number.parseInt(match[1], 10) : -1;
 }
 
-function getAndroidAPILevels(): number[] {
-    const sdkPath = findSdkPath();
+async function getAndroidAPILevels(): Promise<number[]> {
+    const sdkPath = await findSdkPath();
     if (!sdkPath) {
         return [];
     }
@@ -153,5 +231,20 @@ export function activate(context: HostContext): void {
         } catch {
             return false;
         }
+    });
+
+    context.registerPreBuildHook?.(async (options) => {
+        const buildOptions = options as AndroidBuildOptions;
+        const pkg = buildOptions.packages?.[PLATFORM];
+        const patch = await createProgramPathPatch(pkg);
+
+        if (Object.keys(patch).length) {
+            return {
+                packages: {
+                    [PLATFORM]: patch,
+                },
+            };
+        }
+        return;
     });
 }

--- a/src/core/builder/platforms/native-common/pack-tool/platforms/android.ts
+++ b/src/core/builder/platforms/native-common/pack-tool/platforms/android.ts
@@ -340,6 +340,7 @@ export default class AndroidPackTool extends NativePackTool {
         try {
             process.chdir(nativePrjDir);
             await cchelper.runCmd(gradlew, [buildMode], false, nativePrjDir);
+        // eslint-disable-next-line no-useless-catch
         } catch (e) {
             throw e;
         } finally {


### PR DESCRIPTION
Read Android SDK, NDK, and Java settings from pink configuration in the Android build config host.

Patch missing Android toolchain paths through the pre-build hook and keep pink external in the host bundle.