### PR TITLE
Add gizmo icons for probe components

### DIFF
--- a/src/core/scene/scene-process/service/gizmo/components/light-probe-group/index.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/light-probe-group/index.ts
@@ -2,6 +2,7 @@
 
 import { Color, js, LightProbeGroup, Node, Quat, Vec3 } from 'cc';
 import GizmoBase from '../../base/gizmo-base';
+import IconGizmoBase from '../../base/gizmo-icon';
 import BoxController from '../../controller/box';
 import ControllerUtils from '../../utils/controller-utils';
 import { addMeshToNode, create3DNode, getModel, setMeshColor } from '../../utils/engine-utils';
@@ -312,10 +313,19 @@ class LightProbeGroupComponentGizmo extends GizmoBase<LightProbeGroup> {
     }
 }
 
+class LightProbeGroupIconGizmo extends IconGizmoBase<LightProbeGroup> {
+    public disableOnSelected = true;
+
+    createController() {
+        super.createController();
+        this._controller.setTextureByUUID('9e0cc8d3-a76b-4bee-b53e-f3abab91c4b8@6c48a');
+    }
+}
+
 export const name = js.getClassName(LightProbeGroup);
 // 仅选中 LightProbeGroup 节点时显示；选中“使用探针的物体”时的四面体见 utils/light-probe-tetra。
 export const SelectGizmo = LightProbeGroupComponentGizmo;
-export const IconGizmo = null;
+export const IconGizmo = LightProbeGroupIconGizmo;
 export const PersistentGizmo = null;
 
-registerGizmo(name, { SelectGizmo });
+registerGizmo(name, { SelectGizmo, IconGizmo });

--- a/src/core/scene/scene-process/service/gizmo/components/reflection-probe/index.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/reflection-probe/index.ts
@@ -2,6 +2,7 @@
 
 import { Color, js, Quat, ReflectionProbe, Vec3 } from 'cc';
 import GizmoBase from '../../base/gizmo-base';
+import IconGizmoBase from '../../base/gizmo-icon';
 import BoxController from '../../controller/box';
 import { registerGizmo } from '../../gizmo-defines';
 
@@ -110,10 +111,19 @@ class ReflectionProbeComponentGizmo extends GizmoBase<ReflectionProbe> {
     }
 }
 
+class ReflectionProbeIconGizmo extends IconGizmoBase<ReflectionProbe> {
+    public disableOnSelected = true;
+
+    createController() {
+        super.createController();
+        this._controller.setTextureByUUID('dee6f7cc-ba21-4091-948f-4f508495f260@6c48a');
+    }
+}
+
 export const name = js.getClassName(ReflectionProbe);
 // 仅选中 ReflectionProbe 节点时显示影响盒（对齐 Creator 的选中态；图标/预览球后续再加）。
 export const SelectGizmo = ReflectionProbeComponentGizmo;
-export const IconGizmo = null;
+export const IconGizmo = ReflectionProbeIconGizmo;
 export const PersistentGizmo = null;
 
-registerGizmo(name, { SelectGizmo });
+registerGizmo(name, { SelectGizmo, IconGizmo });


### PR DESCRIPTION
Related issue: https://zentao.sud.center/index.php?m=bug&f=view&bugID=321

## Summary
- Add icon gizmos for LightProbeGroup and ReflectionProbe components.
- Use the same editor icon assets as Creator for the probe scene markers.
- Keep the icons hidden while the node is selected so the existing selection gizmos remain visible.

## Testing
- npx tsc -b --pretty false