### PR TITLE
fix(scene): stabilize prefab editor opening

### DIFF
--- a/src/core/scene/scene-process/service/camera.ts
+++ b/src/core/scene/scene-process/service/camera.ts
@@ -105,28 +105,56 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
 
             this.refresh();
 
-            const scene = (cc as any).director?.getScene();
-            const uuid = scene?.uuid || '';
+            const uuid = this._getCurrentViewUuid();
             if (this._currentUuid !== uuid) {
                 this._currentUuid = uuid;
                 this._controllerFirstChange = false;
             }
 
             this._detachSceneCameras();
+            void this._restoreCameraView();
 
-            setTimeout(async () => {
-                try {
-                    // 每次打开场景都重新加载相机视角记忆，避免复用 CameraService 时取到上一个场景的数据
-                    await this.loadCameraInfos();
-                    this._controller.updateGrid();
-                    this.defaultFocus(this._currentUuid);
-                    Service.Engine.repaintInEditMode();
-                } catch (e) {
-                    console.warn('[Camera] deferred grid update failed:', e);
-                }
-            }, 200);
         } catch (e) {
             console.warn('[Camera] onEditorOpened failed:', e);
+        }
+    }
+
+    private async _restoreCameraView(): Promise<void> {
+        const uuid = this._currentUuid;
+        try {
+            await this.loadCameraInfos();
+            if (uuid !== this._currentUuid) {
+                return;
+            }
+            this._controller.updateGrid();
+            this.defaultFocus(uuid);
+            this._refreshSelectedGizmos();
+            Service.Engine.repaintInEditMode();
+        } catch (e) {
+            console.warn('[Camera] restore camera view failed:', e);
+        }
+    }
+
+    private _getCurrentViewUuid(): string {
+        try {
+            const editorUuid = (Service.Editor as unknown as { getCurrentEditorUuid?: () => string | null })
+                .getCurrentEditorUuid?.();
+            if (editorUuid) {
+                return editorUuid;
+            }
+        } catch {
+            // Editor service may not be registered in early init or isolated tests.
+        }
+        const scene = (cc as any).director?.getScene?.();
+        return scene?.uuid || '';
+    }
+
+    private _refreshSelectedGizmos(): void {
+        try {
+            (Service.Gizmo as unknown as { refreshSelectedGizmos?: () => void })
+                .refreshSelectedGizmos?.();
+        } catch {
+            // Selection/Gizmo may not be registered while opening isolated editor views.
         }
     }
 

--- a/src/core/scene/scene-process/service/editors/prefab-editor.ts
+++ b/src/core/scene/scene-process/service/editors/prefab-editor.ts
@@ -28,14 +28,14 @@ export class PrefabEditor extends BaseEditor {
         // 获取预制体标识符
         const identifier = this.getIdentifier(asset);
         // 加载预制体资源
-        this.virtualScene = await sceneUtils.runScene(new Scene(`virtual-scene-${asset.uuid}`));
+        const virtualScene = new Scene(`virtual-scene-${asset.uuid}`);
         const prefabAsset = await sceneUtils.loadAny<Prefab>(identifier.assetUuid);
 
         // 实例化预制体
         const instance = instantiate(prefabAsset);
         editorPrefabUtils.preparePrefabRootForEditing(instance);
-        this.virtualScene.addChild(instance);
-        await this.ensurePreviewCanvasForUI(instance);
+        await this.mountPrefabInstanceForPreview(virtualScene, instance);
+        this.virtualScene = await sceneUtils.runScene(virtualScene);
 
         // 设置当前打开的预制体
         this.setCurrentOpen({
@@ -104,6 +104,16 @@ export class PrefabEditor extends BaseEditor {
         Prefab._utils.applyTargetOverrides(this.entity.instance);
         await this.ensurePreviewCanvasForUI(this.entity.instance);
         return this.encode(undefined, this._lastOpenOptions);
+    }
+
+    private async mountPrefabInstanceForPreview(scene: Scene, instance: Node): Promise<void> {
+        if (!this.shouldUsePreviewCanvas(instance)) {
+            scene.addChild(instance);
+            return;
+        }
+
+        const canvasNode = await createShouldHideInHierarchyCanvasNode(scene);
+        instance.parent = canvasNode;
     }
 
     private async ensurePreviewCanvasForUI(instance: Node): Promise<void> {

--- a/src/core/scene/scene-process/service/gizmo.ts
+++ b/src/core/scene/scene-process/service/gizmo.ts
@@ -8,6 +8,7 @@ import { TransformToolData, ISnapConfigData } from './gizmo/transform-tool';
 import GizmoDefines from './gizmo/gizmo-defines';
 import GizmoBase from './gizmo/base/gizmo-base';
 import GizmoOperation from './gizmo/gizmo-operation';
+import { getEditorNodeByPath, getEditorNodeByUuid, getEditorNodePath } from './gizmo/utils/editor-node';
 import { create3DNode } from './gizmo/utils/engine-utils';
 import { rectTransformSnapping } from './gizmo/utils/rect-transform-snapping';
 import WorldAxisController from './gizmo/controller/world-axis';
@@ -132,18 +133,15 @@ function walkNodeComponent(node: Node, callback: (comp: Component) => void): voi
 }
 
 function getNodeByPath(path: string): Node | null {
-    const EditorExtends = (cc as any).EditorExtends || (globalThis as any).EditorExtends;
-    return EditorExtends?.Node?.getNodeByPath?.(path) ?? null;
+    return getEditorNodeByPath(path);
 }
 
 function getNodeByUuid(uuid: string): Node | null {
-    const EditorExtends = (cc as any).EditorExtends || (globalThis as any).EditorExtends;
-    return EditorExtends?.Node?.getNode?.(uuid) ?? null;
+    return getEditorNodeByUuid(uuid);
 }
 
 function getNodePath(node: Node): string {
-    const EditorExtends = (cc as any).EditorExtends || (globalThis as any).EditorExtends;
-    return EditorExtends?.Node?.getNodePath?.(node) ?? '';
+    return getEditorNodePath(node);
 }
 const SceneGizmoLayer = Layers.Enum.SCENE_GIZMO;
 
@@ -161,6 +159,7 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
     private _gizmoOperation!: GizmoOperation;
     private _iconVisible = false;
     private _selection: string[] = [];
+    private _hasEditorOpened = false;
 
     // Pool: Map<className, GizmoBase[]> — 与 cocos-editor GizmoPool 一致
     private _componentPool: Map<string, GizmoBase[]> = new Map();
@@ -359,6 +358,10 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
         // 与 cocos-editor TransformGizmoManager.__listenEvents 一致：snap 配置变更持久化
         this._listenSnapEvents();
 
+        // 与 cocos-editor GizmoManager.init 一致：gizmo 配置只在服务初始化时恢复。
+        // 打开/重载场景时会强制切回 position，避免异步配置读取覆盖场景打开流程。
+        void this.initFromConfig();
+
         // 与 cocos-editor GizmoManager.init 一致：监听相机投影变化
         try {
             (Service as any).Camera?.controller?.on?.('projection-changed', (projection: number) => {
@@ -399,8 +402,10 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
                 if (config.is2D !== undefined) this.is2D = config.is2D;
                 if (config.is3DIcon !== undefined) this.setIconGizmo3D(config.is3DIcon);
                 if (config.iconSize !== undefined) this.setIconGizmoSize(config.iconSize);
-                if (config.transformToolName !== undefined) this.transformToolName = config.transformToolName;
-                if (config.viewMode !== undefined) this.viewMode = config.viewMode;
+                if (!this._hasEditorOpened) {
+                    if (config.transformToolName !== undefined) this.transformToolName = config.transformToolName;
+                    if (config.viewMode !== undefined) this.viewMode = config.viewMode;
+                }
                 if (config.pivot !== undefined) this.setPivot(config.pivot);
                 if (config.coordinate !== undefined) this.setCoordinate(config.coordinate);
                 if (config.toolsVisibility3d !== undefined) {
@@ -877,23 +882,44 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
         });
     }
 
-    private _rebindSelectedGizmos(): void {
-        const selectedPaths = Service.Selection?.query?.() ?? [];
+    private _reselectCurrentSelection(): void {
+        const selectedPaths = Array.from(new Set(Service.Selection?.query?.() ?? []));
         this._selection.length = 0;
+        Service.Selection?.clear?.();
         for (const path of selectedPaths) {
-            this.onSelectionSelect(path);
+            if (!getNodeByPath(path)) {
+                continue;
+            }
+            Service.Selection?.select?.(path);
         }
     }
 
     // ── 编辑器生命周期（由 BaseService 事件钩子调用）───────────────────────────
 
+    refreshSelectedGizmos(): void {
+        const selectedPaths = Service.Selection?.query?.() ?? [];
+        let refreshed = false;
+        for (const path of selectedPaths) {
+            const node = getNodeByPath(path);
+            if (node) {
+                this.onNodeChanged(node);
+                refreshed = true;
+            }
+        }
+        if (refreshed) {
+            Service.Engine?.repaintInEditMode?.();
+        }
+    }
+
     onEditorOpened(): void {
+        this._hasEditorOpened = true;
         this.clearAllGizmos();
+        // 与 Creator onSceneOpened 一致：场景加载后 active 才可靠，每次打开都回到移动工具。
+        this.transformToolName = 'position';
         this._showIconGizmosForScene();
-        this.initFromConfig();
         // 编辑器打开/重载后节点和组件对象可能已重建，保留选择路径并重新挂到新组件上。
-        this._rebindSelectedGizmos();
-        // Camera.onEditorOpened 有 200ms 延迟的 defaultFocus，需要等它完成后再显示世界坐标轴
+        this._reselectCurrentSelection();
+        // Camera.onEditorOpened 会异步恢复视图；延后一帧再补注册并刷新世界坐标轴。
         setTimeout(() => {
             // init 阶段编辑器相机还不存在，registerCameraMovedEvent 静默失败，此处补注册
             this._worldAxisController?.registerCameraMovedEvent();

--- a/src/core/scene/scene-process/service/gizmo/gizmo-operation.ts
+++ b/src/core/scene/scene-process/service/gizmo/gizmo-operation.ts
@@ -7,6 +7,7 @@ import { GizmoMouseEvent } from './utils/defines';
 import { getRaycastResults, raycast, RaycastResults } from './utils/engine-utils';
 import { getRaycastResultNodes, getRegionNodes } from './utils/node-utils';
 import { getSelectNode } from './utils/selection-utils';
+import { getEditorNodeByPath, getEditorNodePath } from './utils/editor-node';
 
 function getService(): any {
     try {
@@ -26,13 +27,11 @@ function getServiceProp(name: string): any {
 }
 
 function getNodeByPath(path: string): Node | null {
-    const EditorExtends = (cc as any).EditorExtends || (globalThis as any).EditorExtends;
-    return EditorExtends?.Node?.getNodeByPath?.(path) ?? null;
+    return getEditorNodeByPath(path);
 }
 
 function getNodePath(node: Node): string {
-    const EditorExtends = (cc as any).EditorExtends || (globalThis as any).EditorExtends;
-    return EditorExtends?.Node?.getNodePath?.(node) ?? '';
+    return getEditorNodePath(node);
 }
 
 /**

--- a/src/core/scene/scene-process/service/gizmo/node/transform-base.ts
+++ b/src/core/scene/scene-process/service/gizmo/node/transform-base.ts
@@ -3,6 +3,7 @@ import ControllerBase from '../controller/base';
 import { Node, Component, Scene } from 'cc';
 import type { GizmoMouseEvent } from '../utils/defines';
 import { ServiceEvents } from '../../core/global-events';
+import { getEditorNodeByPath } from '../utils/editor-node';
 
 /**
  * 获取 Service（惰性访问，避免循环依赖）
@@ -28,8 +29,7 @@ class TransformBaseGizmo extends GizmoBase<Component> {
         const svc = getService();
         const paths: string[] = svc?.Selection?.query?.() ?? [];
         const nodes = paths.map((path: string) => {
-            const EditorExtends = (cc as any).EditorExtends || (globalThis as any).EditorExtends;
-            return EditorExtends?.Node?.getNodeByPath?.(path) ?? null;
+            return getEditorNodeByPath(path);
         });
         return nodes.filter((node: Node | null) => {
             if (node === null || !node.isValid || this.isNodeLocked(node)) {
@@ -86,6 +86,7 @@ class TransformBaseGizmo extends GizmoBase<Component> {
     onNodeChanged(_event?: any) {
         if (this._controller && this.updateControllerTransform) {
             this.updateControllerTransform();
+            this._controller.adjustControllerSize?.();
         }
     }
 

--- a/src/core/scene/scene-process/service/gizmo/utils/editor-node.ts
+++ b/src/core/scene/scene-process/service/gizmo/utils/editor-node.ts
@@ -51,7 +51,7 @@ function getPrefabNodeByRelativePath(path: string): Node | null {
 
 function findNodeFromPrefabRoot(root: Node, path: string): Node | null {
     const normalized = path.replace(/\\/g, '/').replace(/^\/+/, '');
-    const segments = normalizePrefabPathSegments(normalized.split('/').filter(Boolean), root.name);
+    const segments = normalizePrefabPathSegments(normalized.split('/').filter(Boolean), root.name, getCurrentSceneName());
     if (!segments) {
         return null;
     }
@@ -65,14 +65,18 @@ function findNodeFromPrefabRoot(root: Node, path: string): Node | null {
     return node;
 }
 
-function normalizePrefabPathSegments(segments: string[], rootName: string): string[] | null {
+function getCurrentSceneName(): string {
+    return (cc as any).director?.getScene?.()?.name ?? '';
+}
+
+function normalizePrefabPathSegments(segments: string[], rootName: string, currentSceneName: string): string[] | null {
     if (segments[0] === rootName) {
         return segments.slice(1);
     }
     if (segments[0] === 'should_hide_in_hierarchy' && segments[1] === rootName) {
         return segments.slice(2);
     }
-    if (segments[1] === 'should_hide_in_hierarchy' && segments[2] === rootName) {
+    if (segments[0] === currentSceneName && segments[1] === 'should_hide_in_hierarchy' && segments[2] === rootName) {
         return segments.slice(3);
     }
     return null;

--- a/src/core/scene/scene-process/service/gizmo/utils/editor-node.ts
+++ b/src/core/scene/scene-process/service/gizmo/utils/editor-node.ts
@@ -1,0 +1,79 @@
+import cc, { type Node } from 'cc';
+
+function getEditorNodeApi(): any {
+    const ccGlobal = (globalThis as any).cc;
+    return (cc as any)?.EditorExtends?.Node
+        || ccGlobal?.EditorExtends?.Node
+        || (globalThis as any).EditorExtends?.Node;
+}
+
+export function getEditorNodeByPath(path: string): Node | null {
+    if (!path) {
+        return null;
+    }
+    return getEditorNodeApi()?.getNodeByPath?.(path) ?? getPrefabNodeByRelativePath(path);
+}
+
+export function getEditorNodeByUuid(uuid: string): Node | null {
+    if (!uuid) {
+        return null;
+    }
+    return getEditorNodeApi()?.getNode?.(uuid) ?? null;
+}
+
+export function getEditorNodeUuidByPath(path: string): string {
+    if (!path) {
+        return '';
+    }
+    const nodeApi = getEditorNodeApi();
+    return nodeApi?.getNodeUuidByPath?.(path) || getPrefabNodeByRelativePath(path)?.uuid || '';
+}
+
+export function getEditorNodePath(node: Node): string {
+    return getEditorNodeApi()?.getNodePath?.(node) ?? '';
+}
+
+function getPrefabNodeByRelativePath(path: string): Node | null {
+    try {
+        const { Service } = require('../../core/decorator');
+        if (Service.Editor?.getCurrentEditorType?.() !== 'prefab') {
+            return null;
+        }
+        const root = Service.Editor?.getRootNode?.() as Node | null;
+        if (!root) {
+            return null;
+        }
+        return findNodeFromPrefabRoot(root, path);
+    } catch {
+        return null;
+    }
+}
+
+function findNodeFromPrefabRoot(root: Node, path: string): Node | null {
+    const normalized = path.replace(/\\/g, '/').replace(/^\/+/, '');
+    const segments = normalizePrefabPathSegments(normalized.split('/').filter(Boolean), root.name);
+    if (!segments) {
+        return null;
+    }
+    let node: Node | null = root;
+    for (const segment of segments) {
+        node = node.children?.find((child) => child.name === segment) ?? null;
+        if (!node) {
+            return null;
+        }
+    }
+    return node;
+}
+
+function normalizePrefabPathSegments(segments: string[], rootName: string): string[] | null {
+    if (segments[0] === rootName) {
+        return segments.slice(1);
+    }
+    if (segments[0] === 'should_hide_in_hierarchy' && segments[1] === rootName) {
+        return segments.slice(2);
+    }
+    if (segments[1] === 'should_hide_in_hierarchy' && segments[2] === rootName) {
+        return segments.slice(3);
+    }
+    return null;
+}

--- a/src/core/scene/scene-process/service/selection.ts
+++ b/src/core/scene/scene-process/service/selection.ts
@@ -4,23 +4,16 @@ import { ServiceEvents } from './core/global-events';
 import type { ISelectionService, ISelectionEvents, IChangeNodeOptions } from '../../common';
 import { NodeEventType } from '../../common';
 import type { Node } from 'cc';
-
-function getNodeMgr() {
-    return ((cc as any).EditorExtends || (globalThis as any).EditorExtends)?.Node;
-}
+import { getEditorNodeByUuid, getEditorNodePath, getEditorNodeUuidByPath } from './gizmo/utils/editor-node';
 
 function pathToUuid(path: string): string {
-    const NodeMgr = getNodeMgr();
-    if (!NodeMgr) return '';
-    return NodeMgr.getNodeUuidByPath?.(path) ?? '';
+    return getEditorNodeUuidByPath(path);
 }
 
 function uuidToPath(uuid: string): string {
-    const NodeMgr = getNodeMgr();
-    if (!NodeMgr) return '';
-    const node = NodeMgr.getNode?.(uuid);
+    const node = getEditorNodeByUuid(uuid);
     if (!node) return '';
-    return NodeMgr.getNodePath(node) ?? '';
+    return getEditorNodePath(node);
 }
 
 interface SelectionEntry {
@@ -116,9 +109,7 @@ export class SelectionService extends BaseService<ISelectionEvents> implements I
 
     private _callFocusInEditor(uuid: string): void {
         try {
-            const NodeMgr = getNodeMgr();
-            if (!NodeMgr) return;
-            const node = NodeMgr.getNode(uuid);
+            const node = getEditorNodeByUuid(uuid) as any;
             if (!node?._components) return;
             for (const comp of node.components) {
                 if (comp?.onFocusInEditor) {
@@ -132,9 +123,7 @@ export class SelectionService extends BaseService<ISelectionEvents> implements I
 
     private _callLostFocusInEditor(uuid: string): void {
         try {
-            const NodeMgr = getNodeMgr();
-            if (!NodeMgr) return;
-            const node = NodeMgr.getNode(uuid);
+            const node = getEditorNodeByUuid(uuid) as any;
             if (!node?._components) return;
             for (const comp of node.components) {
                 if (comp?.onLostFocusInEditor) {

--- a/src/core/scene/test/camera-current-view-uuid.test.ts
+++ b/src/core/scene/test/camera-current-view-uuid.test.ts
@@ -1,0 +1,99 @@
+const mockService = {
+    Editor: {
+        getCurrentEditorUuid: jest.fn(),
+    },
+};
+
+const mockGetScene = jest.fn();
+
+jest.mock('cc', () => ({
+    Camera: class {},
+    Canvas: class {},
+    Color: class {},
+    Layers: {
+        Enum: {
+            GIZMOS: 1 << 1,
+            SCENE_GIZMO: 1 << 2,
+            EDITOR: 1 << 3,
+        },
+        makeMaskInclude: jest.fn(() => 0),
+    },
+    Vec3: class {},
+    gfx: {
+        AccessFlagBit: {},
+        ColorAttachment: class {},
+        DepthStencilAttachment: class {},
+        GeneralBarrierInfo: class {},
+        RenderPassInfo: class {
+            colorAttachments = [{ barrier: null }];
+        },
+    },
+}));
+
+jest.mock('../scene-process/service/core/decorator', () => ({
+    register: () => () => undefined,
+    Service: mockService,
+}));
+
+jest.mock('../scene-process/service/camera/camera-controller-2d', () => ({
+    CameraController2D: class {},
+}));
+
+jest.mock('../scene-process/service/camera/camera-controller-3d', () => ({
+    CameraController3D: class {},
+}));
+
+jest.mock('../scene-process/service/camera/camera-controller-base', () => ({
+    __esModule: true,
+    default: class {},
+}));
+
+jest.mock('../scene-process/service/camera/editor-camera-component', () => ({
+    __esModule: true,
+    default: class {},
+}));
+
+jest.mock('../scene-process/service/camera/utils', () => ({
+    CameraMoveMode: {},
+    CameraUtils: {
+        createCamera: jest.fn(),
+    },
+}));
+
+jest.mock('../scene-process/rpc', () => ({
+    Rpc: {
+        getInstance: jest.fn(),
+    },
+}));
+
+describe('CameraService current view uuid', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        jest.clearAllMocks();
+        mockService.Editor.getCurrentEditorUuid.mockReturnValue(null);
+        mockGetScene.mockReturnValue({ uuid: 'virtual-scene-uuid' });
+        (global as any).cc = {
+            director: {
+                getScene: mockGetScene,
+            },
+        };
+    });
+
+    it('uses current editor asset uuid before scene uuid', () => {
+        mockService.Editor.getCurrentEditorUuid.mockReturnValue('prefab-asset-uuid');
+        const { CameraService } = require('../scene-process/service/camera');
+        const service = new CameraService();
+
+        expect((service as any)._getCurrentViewUuid()).toBe('prefab-asset-uuid');
+        expect(mockGetScene).not.toHaveBeenCalled();
+    });
+
+    it('falls back to director scene uuid when editor uuid is unavailable', () => {
+        const { CameraService } = require('../scene-process/service/camera');
+        const service = new CameraService();
+
+        expect((service as any)._getCurrentViewUuid()).toBe('virtual-scene-uuid');
+    });
+});
+
+export {};

--- a/src/core/scene/test/gizmo-reload-events.test.ts
+++ b/src/core/scene/test/gizmo-reload-events.test.ts
@@ -3,9 +3,15 @@ import { EventEmitter } from 'events';
 const mockService = {
     Selection: {
         query: jest.fn(),
+        clear: jest.fn(),
+        select: jest.fn(),
     },
     Engine: {
         repaintInEditMode: jest.fn(),
+    },
+    Editor: {
+        getCurrentEditorType: jest.fn(),
+        getRootNode: jest.fn(),
     },
 };
 const mockGetClassName = jest.fn((obj: any) => obj?.__className ?? obj?.constructor?.name ?? '');
@@ -22,6 +28,7 @@ jest.mock('cc', () => {
     class MockCamera { }
     class MockColor { }
     class MockRect { }
+    class MockScene { }
     class MockVec3 { }
 
     return {
@@ -47,6 +54,7 @@ jest.mock('cc', () => {
         },
         Node: MockNode,
         Rect: MockRect,
+        Scene: MockScene,
         Vec3: MockVec3,
         director: {
             getScene: jest.fn(() => null),
@@ -139,12 +147,17 @@ describe('Gizmo editor lifecycle', () => {
         mockGizmoDefines.iconGizmo.clear();
         mockGizmoDefines.persistentGizmo.clear();
         mockGizmoDefines.methods.clear();
+        mockService.Editor.getCurrentEditorType.mockReturnValue('unknown');
+        mockService.Editor.getRootNode.mockReturnValue(null);
+        delete (globalThis as any).EditorExtends;
+        delete (globalThis as any).cc;
     });
 
-    it('initializes gizmos from editor open lifecycle', () => {
+    it('resets gizmos from editor open lifecycle without reloading config', () => {
         jest.useFakeTimers();
         const { GizmoService } = require('../scene-process/service/gizmo');
         const gizmo = new GizmoService();
+        gizmo.transformToolName = 'rotate';
 
         const clearAllGizmos = jest.spyOn(gizmo, 'clearAllGizmos').mockImplementation(() => {});
         const showIconGizmos = jest.spyOn(gizmo as any, '_showIconGizmosForScene').mockImplementation(() => {});
@@ -154,8 +167,34 @@ describe('Gizmo editor lifecycle', () => {
 
         expect(clearAllGizmos).toHaveBeenCalledTimes(1);
         expect(showIconGizmos).toHaveBeenCalledTimes(1);
-        expect(initFromConfig).toHaveBeenCalledTimes(1);
+        expect(gizmo.transformToolName).toBe('position');
+        expect(initFromConfig).not.toHaveBeenCalled();
         jest.runOnlyPendingTimers();
+    });
+
+    it('does not let late config restore override the editor-open position tool', async () => {
+        let resolveConfig!: (value: unknown) => void;
+        const configPromise = new Promise((resolve) => { resolveConfig = resolve; });
+        const request = jest.fn(() => configPromise);
+        const { Rpc } = require('../scene-process/rpc');
+        Rpc.getInstance.mockReturnValue({ request });
+
+        const { GizmoService } = require('../scene-process/service/gizmo');
+        const gizmo = new GizmoService();
+        gizmo.transformToolName = 'position';
+        gizmo.viewMode = 'select';
+        (gizmo as any)._hasEditorOpened = true;
+
+        const restorePromise = gizmo.initFromConfig();
+        resolveConfig({
+            transformToolName: 'rotate',
+            viewMode: 'view',
+            toolsVisibility3d: true,
+        });
+        await restorePromise;
+
+        expect(gizmo.transformToolName).toBe('position');
+        expect(gizmo.viewMode).toBe('select');
     });
 
     it('rebuilds selected gizmos from editor open lifecycle', () => {
@@ -167,17 +206,100 @@ describe('Gizmo editor lifecycle', () => {
 
         const clearAllGizmos = jest.spyOn(gizmo, 'clearAllGizmos').mockImplementation(() => {});
         const showIconGizmos = jest.spyOn(gizmo as any, '_showIconGizmosForScene').mockImplementation(() => {});
-        jest.spyOn(gizmo, 'initFromConfig').mockImplementation(() => undefined as any);
-        const onSelectionSelect = jest.spyOn(gizmo, 'onSelectionSelect').mockImplementation(() => {});
+        (globalThis as any).EditorExtends = {
+            Node: {
+                getNodeByPath: jest.fn(() => ({ uuid: 'button-uuid' })),
+            },
+        };
 
         gizmo.onEditorOpened();
 
         expect(clearAllGizmos).toHaveBeenCalledTimes(1);
         expect(showIconGizmos).toHaveBeenCalledTimes(1);
         expect((gizmo as any)._selection).toEqual([]);
-        expect(onSelectionSelect).toHaveBeenCalledWith('/Canvas/button');
+        expect(mockService.Selection.clear).toHaveBeenCalledTimes(1);
+        expect(mockService.Selection.select).toHaveBeenCalledWith('/Canvas/button');
         jest.runOnlyPendingTimers();
         expect(mockService.Engine.repaintInEditMode).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips reselecting paths that are not in the opened editor scene', () => {
+        jest.useFakeTimers();
+        (globalThis as any).EditorExtends = {
+            Node: {
+                getNodeByPath: jest.fn(() => null),
+            },
+        };
+        mockService.Selection.query.mockReturnValue(['/Missing']);
+
+        const { GizmoService } = require('../scene-process/service/gizmo');
+        const gizmo = new GizmoService();
+        jest.spyOn(gizmo, 'clearAllGizmos').mockImplementation(() => {});
+        jest.spyOn(gizmo as any, '_showIconGizmosForScene').mockImplementation(() => {});
+
+        gizmo.onEditorOpened();
+
+        expect(mockService.Selection.clear).toHaveBeenCalledTimes(1);
+        expect(mockService.Selection.select).not.toHaveBeenCalled();
+        jest.runOnlyPendingTimers();
+    });
+
+    it('reselects prefab nodes by path relative to the prefab root when hidden Canvas is not in hierarchy', () => {
+        jest.useFakeTimers();
+        const child = { name: 'Child', uuid: 'child-uuid', children: [] };
+        const root = { name: 'Node', uuid: 'root-uuid', children: [child] };
+        (globalThis as any).EditorExtends = {
+            Node: {
+                getNodeByPath: jest.fn(() => null),
+            },
+        };
+        mockService.Editor.getCurrentEditorType.mockReturnValue('prefab');
+        mockService.Editor.getRootNode.mockReturnValue(root);
+        mockService.Selection.query.mockReturnValue(['Node/Child']);
+
+        const { GizmoService } = require('../scene-process/service/gizmo');
+        const gizmo = new GizmoService();
+        jest.spyOn(gizmo, 'clearAllGizmos').mockImplementation(() => {});
+        jest.spyOn(gizmo as any, '_showIconGizmosForScene').mockImplementation(() => {});
+
+        gizmo.onEditorOpened();
+
+        expect(mockService.Selection.select).toHaveBeenCalledWith('Node/Child');
+        jest.runOnlyPendingTimers();
+    });
+
+    it('resolves transform gizmo nodes with the same prefab relative path fallback', () => {
+        const child = { name: 'Child', uuid: 'child-uuid', children: [], isValid: true, parent: null };
+        const root = { name: 'Node', uuid: 'root-uuid', children: [child], isValid: true, parent: null };
+        (globalThis as any).cc = {
+            EditorExtends: {
+                Node: {
+                    getNodeByPath: jest.fn(() => null),
+                },
+            },
+        };
+        mockService.Editor.getCurrentEditorType.mockReturnValue('prefab');
+        mockService.Editor.getRootNode.mockReturnValue(root);
+        mockService.Selection.query.mockReturnValue(['Node/Child']);
+
+        const TransformBaseGizmo = require('../scene-process/service/gizmo/node/transform-base').default;
+        const gizmo = new TransformBaseGizmo(null);
+
+        expect(gizmo.nodes).toEqual([child]);
+    });
+
+    it('refreshes transform controller size when selected gizmos are updated after camera restore', () => {
+        const TransformBaseGizmo = require('../scene-process/service/gizmo/node/transform-base').default;
+        const gizmo = new TransformBaseGizmo(null);
+        const updateControllerTransform = jest.fn();
+        const adjustControllerSize = jest.fn();
+        (gizmo as any).updateControllerTransform = updateControllerTransform;
+        (gizmo as any)._controller = { adjustControllerSize };
+
+        gizmo.onNodeChanged();
+
+        expect(updateControllerTransform).toHaveBeenCalledTimes(1);
+        expect(adjustControllerSize).toHaveBeenCalledTimes(1);
     });
 
     it('does not reuse destroyed gizmos after clearing all gizmos', () => {

--- a/src/core/scene/test/prefab-editor-preview-canvas.test.ts
+++ b/src/core/scene/test/prefab-editor-preview-canvas.test.ts
@@ -73,8 +73,8 @@ function createPrefabRoot(name: string, options?: { hasCanvas?: boolean; hasUI?:
     };
 }
 
-async function openPrefabWith(prefabRoot: any, scene = new MockScene('virtual-scene')): Promise<{ editor: PrefabEditor; scene: MockScene; }> {
-    (sceneUtils.runScene as jest.Mock).mockResolvedValue(scene);
+async function openPrefabWith(prefabRoot: any): Promise<{ editor: PrefabEditor; scene: MockScene; }> {
+    (sceneUtils.runScene as jest.Mock).mockImplementation(async (scene: MockScene) => scene);
     (sceneUtils.loadAny as jest.Mock).mockResolvedValue({});
     (instantiate as unknown as jest.Mock).mockReturnValue(prefabRoot);
     const editor = new PrefabEditor();
@@ -86,6 +86,7 @@ async function openPrefabWith(prefabRoot: any, scene = new MockScene('virtual-sc
         url: 'db://assets/LabelPrefab.prefab',
     } as never);
 
+    const scene = (sceneUtils.runScene as jest.Mock).mock.calls[0][0] as MockScene;
     return { editor, scene };
 }
 
@@ -105,15 +106,27 @@ describe('PrefabEditor preview Canvas', () => {
     });
 
     it('hosts a UI prefab without its own Canvas under an editor-only Canvas when opened', async () => {
-        const scene = new MockScene('virtual-scene');
         const previewCanvas = { name: 'should_hide_in_hierarchy' };
         const prefabRoot = createPrefabRoot('LabelPrefab');
 
         createShouldHideInHierarchyCanvasNode.mockResolvedValue(previewCanvas);
 
-        await openPrefabWith(prefabRoot, scene);
+        const { scene } = await openPrefabWith(prefabRoot);
 
         expect(createShouldHideInHierarchyCanvasNode).toHaveBeenCalledWith(scene);
+        expect(prefabRoot.parent).toBe(previewCanvas);
+    });
+
+    it('mounts the prefab hierarchy before running the virtual scene', async () => {
+        const previewCanvas = { name: 'should_hide_in_hierarchy' };
+        const prefabRoot = createPrefabRoot('LabelPrefab');
+
+        createShouldHideInHierarchyCanvasNode.mockResolvedValue(previewCanvas);
+
+        await openPrefabWith(prefabRoot);
+
+        expect(createShouldHideInHierarchyCanvasNode.mock.invocationCallOrder[0])
+            .toBeLessThan((sceneUtils.runScene as jest.Mock).mock.invocationCallOrder[0]);
         expect(prefabRoot.parent).toBe(previewCanvas);
     });
 

--- a/src/core/scene/test/selection-prefab-path.test.ts
+++ b/src/core/scene/test/selection-prefab-path.test.ts
@@ -4,10 +4,15 @@ const mockService = {
         getRootNode: jest.fn(),
     },
 };
+const mockCc = {
+    director: {
+        getScene: jest.fn(),
+    },
+};
 
 jest.mock('cc', () => ({
     __esModule: true,
-    default: {},
+    default: mockCc,
 }));
 
 jest.mock('../scene-process/service/core/decorator', () => ({
@@ -21,6 +26,7 @@ describe('SelectionService prefab path resolution', () => {
         jest.clearAllMocks();
         mockService.Editor.getCurrentEditorType.mockReturnValue('unknown');
         mockService.Editor.getRootNode.mockReturnValue(null);
+        mockCc.director.getScene.mockReturnValue(null);
         delete (globalThis as any).EditorExtends;
     });
 
@@ -82,11 +88,37 @@ describe('SelectionService prefab path resolution', () => {
         const selection = new SelectionService();
         jest.spyOn(selection, 'broadcast').mockImplementation(() => undefined);
 
+        mockCc.director.getScene.mockReturnValue({ name: 'virtual-scene' });
         selection.select('virtual-scene/should_hide_in_hierarchy/Node/Child');
 
         expect((selection as any)._selections).toEqual([{
             path: 'virtual-scene/should_hide_in_hierarchy/Node/Child',
             uuid: 'child-uuid',
+        }]);
+    });
+
+    it('does not resolve stale prefab paths from a previous virtual scene', () => {
+        const child = { name: 'Child', uuid: 'child-uuid', children: [], components: [] };
+        const root = { name: 'Node', uuid: 'root-uuid', children: [child], components: [] };
+        (globalThis as any).EditorExtends = {
+            Node: {
+                getNodeUuidByPath: jest.fn(() => ''),
+                getNodeByPath: jest.fn(() => null),
+            },
+        };
+        mockService.Editor.getCurrentEditorType.mockReturnValue('prefab');
+        mockService.Editor.getRootNode.mockReturnValue(root);
+        mockCc.director.getScene.mockReturnValue({ name: 'new-virtual-scene' });
+
+        const { SelectionService } = require('../scene-process/service/selection');
+        const selection = new SelectionService();
+        jest.spyOn(selection, 'broadcast').mockImplementation(() => undefined);
+
+        selection.select('old-virtual-scene/should_hide_in_hierarchy/Node/Child');
+
+        expect((selection as any)._selections).toEqual([{
+            path: 'old-virtual-scene/should_hide_in_hierarchy/Node/Child',
+            uuid: '',
         }]);
     });
 

--- a/src/core/scene/test/selection-prefab-path.test.ts
+++ b/src/core/scene/test/selection-prefab-path.test.ts
@@ -1,0 +1,115 @@
+const mockService = {
+    Editor: {
+        getCurrentEditorType: jest.fn(),
+        getRootNode: jest.fn(),
+    },
+};
+
+jest.mock('cc', () => ({
+    __esModule: true,
+    default: {},
+}));
+
+jest.mock('../scene-process/service/core/decorator', () => ({
+    register: () => () => undefined,
+    Service: mockService,
+}));
+
+describe('SelectionService prefab path resolution', () => {
+    afterEach(() => {
+        jest.resetModules();
+        jest.clearAllMocks();
+        mockService.Editor.getCurrentEditorType.mockReturnValue('unknown');
+        mockService.Editor.getRootNode.mockReturnValue(null);
+        delete (globalThis as any).EditorExtends;
+    });
+
+    it('stores uuid for prefab-root-relative paths when EditorExtends has no absolute path entry', () => {
+        const child = { name: 'Child', uuid: 'child-uuid', children: [], components: [] };
+        const root = { name: 'Node', uuid: 'root-uuid', children: [child], components: [] };
+        (globalThis as any).EditorExtends = {
+            Node: {
+                getNodeUuidByPath: jest.fn(() => ''),
+                getNodeByPath: jest.fn(() => null),
+            },
+        };
+        mockService.Editor.getCurrentEditorType.mockReturnValue('prefab');
+        mockService.Editor.getRootNode.mockReturnValue(root);
+
+        const { SelectionService } = require('../scene-process/service/selection');
+        const selection = new SelectionService();
+        const broadcast = jest.spyOn(selection, 'broadcast').mockImplementation(() => undefined);
+
+        selection.select('Node/Child');
+
+        expect((selection as any)._selections).toEqual([{ path: 'Node/Child', uuid: 'child-uuid' }]);
+        expect(broadcast).toHaveBeenCalledWith('selection:select', 'Node/Child', ['Node/Child']);
+    });
+
+    it('stores uuid for the prefab root path itself', () => {
+        const root = { name: 'Node', uuid: 'root-uuid', children: [], components: [] };
+        (globalThis as any).EditorExtends = {
+            Node: {
+                getNodeUuidByPath: jest.fn(() => ''),
+                getNodeByPath: jest.fn(() => null),
+            },
+        };
+        mockService.Editor.getCurrentEditorType.mockReturnValue('prefab');
+        mockService.Editor.getRootNode.mockReturnValue(root);
+
+        const { SelectionService } = require('../scene-process/service/selection');
+        const selection = new SelectionService();
+        jest.spyOn(selection, 'broadcast').mockImplementation(() => undefined);
+
+        selection.select('Node');
+
+        expect((selection as any)._selections).toEqual([{ path: 'Node', uuid: 'root-uuid' }]);
+    });
+
+    it('stores uuid for prefab paths with scene and hidden Canvas prefixes', () => {
+        const child = { name: 'Child', uuid: 'child-uuid', children: [], components: [] };
+        const root = { name: 'Node', uuid: 'root-uuid', children: [child], components: [] };
+        (globalThis as any).EditorExtends = {
+            Node: {
+                getNodeUuidByPath: jest.fn(() => ''),
+                getNodeByPath: jest.fn(() => null),
+            },
+        };
+        mockService.Editor.getCurrentEditorType.mockReturnValue('prefab');
+        mockService.Editor.getRootNode.mockReturnValue(root);
+
+        const { SelectionService } = require('../scene-process/service/selection');
+        const selection = new SelectionService();
+        jest.spyOn(selection, 'broadcast').mockImplementation(() => undefined);
+
+        selection.select('virtual-scene/should_hide_in_hierarchy/Node/Child');
+
+        expect((selection as any)._selections).toEqual([{
+            path: 'virtual-scene/should_hide_in_hierarchy/Node/Child',
+            uuid: 'child-uuid',
+        }]);
+    });
+
+    it('does not match arbitrary old paths that merely contain the prefab root name', () => {
+        const child = { name: 'Child', uuid: 'child-uuid', children: [], components: [] };
+        const root = { name: 'Node', uuid: 'root-uuid', children: [child], components: [] };
+        (globalThis as any).EditorExtends = {
+            Node: {
+                getNodeUuidByPath: jest.fn(() => ''),
+                getNodeByPath: jest.fn(() => null),
+            },
+        };
+        mockService.Editor.getCurrentEditorType.mockReturnValue('prefab');
+        mockService.Editor.getRootNode.mockReturnValue(root);
+
+        const { SelectionService } = require('../scene-process/service/selection');
+        const selection = new SelectionService();
+        jest.spyOn(selection, 'broadcast').mockImplementation(() => undefined);
+
+        selection.select('Other/Node/Child');
+
+        expect((selection as any)._selections).toEqual([{ path: 'Other/Node/Child', uuid: '' }]);
+    });
+});
+
+export {};


### PR DESCRIPTION
## Summary
- open prefab editor scenes after the prefab hierarchy and preview canvas are mounted
- keep prefab editor camera state keyed by the edited asset and refresh gizmos after camera restore
- resolve prefab selection paths consistently and avoid late gizmo config restoring the previous tool during scene open

## Root Cause
The prefab editor was running the virtual scene before the prefab instance and the editor-only preview canvas were attached. That left Canvas setup, node activation, camera restore, and gizmo rebinding to happen across different initialization phases, so the initial frame could use stale scene or camera state. This showed up as intermittent black screens and transform gizmos rendered at the wrong position or scale.

Prefab views also use the edited prefab asset as the stable identity, while the virtual scene id changes between openings. Restoring camera state from the scene id could reuse the wrong view data. In addition, CLI selection stores node paths, unlike Creator's uuid-based scene selection, so prefab nodes under the hidden preview Canvas needed a strict path resolver to avoid missing or incorrectly rebinding selected nodes.

## Tests
- npx jest src/core/scene/test/gizmo-reload-events.test.ts src/core/scene/test/selection-prefab-path.test.ts src/core/scene/test/camera-current-view-uuid.test.ts src/core/scene/test/prefab-editor-preview-canvas.test.ts --runInBand
- npx tsc -b --pretty false
