### PR TITLE
fix(animation): keep clip queries read-only

### DIFF
--- a/src/core/scene/scene-process/service/animation/clip-dump.ts
+++ b/src/core/scene/scene-process/service/animation/clip-dump.ts
@@ -1,5 +1,5 @@
 import type { AnimationClip, AnimationState } from 'cc';
-import type { IAnimationClipDump } from '../../../common';
+import type { IAnimationClipDump, IAnimationCurveDump, IAnimationCurveKeyDump, IAnimationValue } from '../../../common';
 import { dumpAuxiliaryCurves } from './auxiliary-curve';
 import { dumpEmbeddedPlayers, queryEmbeddedPlayerGroups } from './embedded-player';
 import { dumpPropertyCurves, type IPropertyCurveMetadataContext } from './property-curve';
@@ -17,7 +17,7 @@ export function createClipDump(clip: AnimationClip, state: AnimationState | unde
         sample,
         speed: Number((clip as any).speed) || 0,
         wrapMode: Number((clip as any).wrapMode) || 0,
-        curves: dumpPropertyCurves(clip, options),
+        curves: dumpAnimationCurves(clip, options),
         events: events.map((event: any) => ({
             frame: Math.round((Number(event.frame) || 0) * sample),
             func: event.func || '',
@@ -31,4 +31,115 @@ export function createClipDump(clip: AnimationClip, state: AnimationState | unde
         isSkeleton: options.isSkeleton,
         useBakedAnimation: options.useBakedAnimation,
     };
+}
+
+
+function dumpAnimationCurves(clip: AnimationClip, options: IPropertyCurveMetadataContext): IAnimationCurveDump[] {
+    const curves = dumpPropertyCurves(clip, options);
+    const curveKeys = new Set(curves.map((curve) => `${curve.nodePath}\u0000${curve.key}`));
+    for (const curve of dumpExoticAnimationCurves(clip)) {
+        const key = `${curve.nodePath}\u0000${curve.key}`;
+        if (!curveKeys.has(key)) {
+            curves.push(curve);
+            curveKeys.add(key);
+        }
+    }
+    return curves;
+}
+
+function dumpExoticAnimationCurves(clip: AnimationClip): IAnimationCurveDump[] {
+    const exoticAnimation = (clip as any)._exoticAnimation as { _nodeAnimations?: unknown[] } | null | undefined;
+    if (!Array.isArray(exoticAnimation?._nodeAnimations)) {
+        return [];
+    }
+
+    const sample = getClipSample(clip);
+    const curves: IAnimationCurveDump[] = [];
+    for (const nodeAnimation of exoticAnimation._nodeAnimations) {
+        const node = nodeAnimation as {
+            _path?: unknown;
+            _position?: unknown;
+            _rotation?: unknown;
+            _scale?: unknown;
+        };
+        const nodePath = normalizeExoticNodePath(node._path);
+        if (!nodePath) {
+            continue;
+        }
+        appendExoticCurve(curves, nodePath, 'position', node._position, sample, 'cc.Vec3', ['x', 'y', 'z']);
+        appendExoticCurve(curves, nodePath, 'rotation', node._rotation, sample, 'cc.Quat', undefined);
+        appendExoticCurve(curves, nodePath, 'scale', node._scale, sample, 'cc.Vec3', ['x', 'y', 'z']);
+    }
+    return curves;
+}
+
+function appendExoticCurve(
+    curves: IAnimationCurveDump[],
+    nodePath: string,
+    key: 'position' | 'rotation' | 'scale',
+    trackValue: unknown,
+    sample: number,
+    type: string,
+    partKeys: readonly string[] | undefined,
+): void {
+    const track = trackValue as {
+        times?: ArrayLike<number>;
+        values?: { get?: (index: number, value: Record<string, number>) => void };
+    } | null | undefined;
+    if (!track || !track.times || !track.values || typeof track.values.get !== 'function') {
+        return;
+    }
+
+    const times = Array.from(track.times, Number);
+    const keyframes: IAnimationCurveKeyDump[] = [];
+    const channels = partKeys?.map((partKey) => ({
+        key: partKey,
+        displayName: partKey,
+        type: { value: 'cc.Number' },
+        keyframes: [] as IAnimationCurveKeyDump[],
+    }));
+
+    for (let index = 0; index < times.length; index++) {
+        const value: Record<string, number> = {};
+        try {
+            track.values.get(index, value);
+        } catch {
+            return;
+        }
+        const frame = Math.round(times[index] * sample);
+        const dump = {
+            value: cloneValue(value) as IAnimationValue,
+            readonly: true,
+            type,
+        };
+        keyframes.push({ frame, dump });
+        if (channels) {
+            for (const channel of channels) {
+                channel.keyframes.push({
+                    frame,
+                    dump: { value: value[channel.key] ?? 0, readonly: true, type: 'cc.Number' },
+                });
+            }
+        }
+    }
+
+    if (keyframes.length === 0) {
+        return;
+    }
+    curves.push({
+        nodePath,
+        key,
+        keyframes,
+        channels,
+        displayName: key,
+        name: key,
+        menuName: key,
+        type: { value: type },
+        isCurveSupport: key !== 'rotation',
+        partKeys: partKeys ? [...partKeys] : undefined,
+    });
+}
+
+function normalizeExoticNodePath(path: unknown): string {
+    return String(path || '').replace(/^\/+|\/+$/g, '');
 }

--- a/src/core/scene/scene-process/service/animation/clip-dump.ts
+++ b/src/core/scene/scene-process/service/animation/clip-dump.ts
@@ -1,8 +1,10 @@
 import type { AnimationClip, AnimationState } from 'cc';
 import type { IAnimationClipDump, IAnimationCurveDump, IAnimationCurveKeyDump, IAnimationValue } from '../../../common';
 import { dumpAuxiliaryCurves } from './auxiliary-curve';
+import { queryExoticAnimationTracks, type IExoticAnimationTrack } from './exotic-animation-track';
 import { dumpEmbeddedPlayers, queryEmbeddedPlayerGroups } from './embedded-player';
 import { dumpPropertyCurves, type IPropertyCurveMetadataContext } from './property-curve';
+import { dumpUntypedAnimationCurves } from './untyped-animation-track';
 import { cloneValue, getClipSample } from './utils';
 
 export function createClipDump(clip: AnimationClip, state: AnimationState | undefined, options: {
@@ -27,7 +29,7 @@ export function createClipDump(clip: AnimationClip, state: AnimationState | unde
         embeddedPlayerGroups: queryEmbeddedPlayerGroups(clip),
         auxiliaryCurves: dumpAuxiliaryCurves(clip),
         time: state?.current ?? 0,
-        isLock: options.isSkeleton,
+        isLock: false,
         isSkeleton: options.isSkeleton,
         useBakedAnimation: options.useBakedAnimation,
     };
@@ -37,6 +39,13 @@ export function createClipDump(clip: AnimationClip, state: AnimationState | unde
 function dumpAnimationCurves(clip: AnimationClip, options: IPropertyCurveMetadataContext): IAnimationCurveDump[] {
     const curves = dumpPropertyCurves(clip, options);
     const curveKeys = new Set(curves.map((curve) => `${curve.nodePath}\u0000${curve.key}`));
+    for (const curve of dumpUntypedAnimationCurves(clip, options)) {
+        const key = `${curve.nodePath}\u0000${curve.key}`;
+        if (!curveKeys.has(key)) {
+            curves.push(curve);
+            curveKeys.add(key);
+        }
+    }
     for (const curve of dumpExoticAnimationCurves(clip)) {
         const key = `${curve.nodePath}\u0000${curve.key}`;
         if (!curveKeys.has(key)) {
@@ -48,51 +57,22 @@ function dumpAnimationCurves(clip: AnimationClip, options: IPropertyCurveMetadat
 }
 
 function dumpExoticAnimationCurves(clip: AnimationClip): IAnimationCurveDump[] {
-    const exoticAnimation = (clip as any)._exoticAnimation as { _nodeAnimations?: unknown[] } | null | undefined;
-    if (!Array.isArray(exoticAnimation?._nodeAnimations)) {
-        return [];
-    }
-
-    const sample = getClipSample(clip);
     const curves: IAnimationCurveDump[] = [];
-    for (const nodeAnimation of exoticAnimation._nodeAnimations) {
-        const node = nodeAnimation as {
-            _path?: unknown;
-            _position?: unknown;
-            _rotation?: unknown;
-            _scale?: unknown;
-        };
-        const nodePath = normalizeExoticNodePath(node._path);
-        if (!nodePath) {
-            continue;
-        }
-        appendExoticCurve(curves, nodePath, 'position', node._position, sample, 'cc.Vec3', ['x', 'y', 'z']);
-        appendExoticCurve(curves, nodePath, 'rotation', node._rotation, sample, 'cc.Quat', undefined);
-        appendExoticCurve(curves, nodePath, 'scale', node._scale, sample, 'cc.Vec3', ['x', 'y', 'z']);
+    const sample = getClipSample(clip);
+    for (const track of queryExoticAnimationTracks(clip)) {
+        appendExoticCurve(curves, track, sample);
     }
     return curves;
 }
 
-function appendExoticCurve(
-    curves: IAnimationCurveDump[],
-    nodePath: string,
-    key: 'position' | 'rotation' | 'scale',
-    trackValue: unknown,
-    sample: number,
-    type: string,
-    partKeys: readonly string[] | undefined,
-): void {
-    const track = trackValue as {
-        times?: ArrayLike<number>;
-        values?: { get?: (index: number, value: Record<string, number>) => void };
-    } | null | undefined;
-    if (!track || !track.times || !track.values || typeof track.values.get !== 'function') {
+function appendExoticCurve(curves: IAnimationCurveDump[], track: IExoticAnimationTrack, sample: number): void {
+    if (!track.values || typeof track.values.get !== 'function') {
         return;
     }
 
     const times = Array.from(track.times, Number);
     const keyframes: IAnimationCurveKeyDump[] = [];
-    const channels = partKeys?.map((partKey) => ({
+    const channels = track.partKeys?.map((partKey) => ({
         key: partKey,
         displayName: partKey,
         type: { value: 'cc.Number' },
@@ -110,7 +90,7 @@ function appendExoticCurve(
         const dump = {
             value: cloneValue(value) as IAnimationValue,
             readonly: true,
-            type,
+            type: track.type,
         };
         keyframes.push({ frame, dump });
         if (channels) {
@@ -127,19 +107,15 @@ function appendExoticCurve(
         return;
     }
     curves.push({
-        nodePath,
-        key,
+        nodePath: track.nodePath,
+        key: track.key,
         keyframes,
         channels,
-        displayName: key,
-        name: key,
-        menuName: key,
-        type: { value: type },
-        isCurveSupport: key !== 'rotation',
-        partKeys: partKeys ? [...partKeys] : undefined,
+        displayName: track.key,
+        name: track.key,
+        menuName: track.key,
+        type: { value: track.type },
+        isCurveSupport: track.key !== 'rotation',
+        partKeys: track.partKeys ? [...track.partKeys] : undefined,
     });
-}
-
-function normalizeExoticNodePath(path: unknown): string {
-    return String(path || '').replace(/^\/+|\/+$/g, '');
 }

--- a/src/core/scene/scene-process/service/animation/clip-dump.ts
+++ b/src/core/scene/scene-process/service/animation/clip-dump.ts
@@ -27,7 +27,7 @@ export function createClipDump(clip: AnimationClip, state: AnimationState | unde
         embeddedPlayerGroups: queryEmbeddedPlayerGroups(clip),
         auxiliaryCurves: dumpAuxiliaryCurves(clip),
         time: state?.current ?? 0,
-        isLock: false,
+        isLock: options.isSkeleton,
         isSkeleton: options.isSkeleton,
         useBakedAnimation: options.useBakedAnimation,
     };

--- a/src/core/scene/scene-process/service/animation/clip-duration.ts
+++ b/src/core/scene/scene-process/service/animation/clip-duration.ts
@@ -21,6 +21,7 @@ function queryAnimationClipDuration(clip: AnimationClip): number {
     const sample = getClipSample(clip);
     return Math.max(
         queryTrackDuration(clip, sample),
+        queryExoticAnimationDuration(clip),
         queryEventDuration(clip),
         queryEmbeddedPlayerDuration(clip, sample),
         queryAuxiliaryCurveDuration(clip, sample),
@@ -35,6 +36,27 @@ function queryTrackDuration(clip: AnimationClip, sample: number): number {
         for (const channel of queryTrackChannels(track)) {
             for (const time of queryCurveTimes(channel.curve)) {
                 duration = Math.max(duration, time + frameDuration);
+            }
+        }
+    }
+    return duration;
+}
+
+function queryExoticAnimationDuration(clip: AnimationClip): number {
+    const nodeAnimations = (clip as any)._exoticAnimation?._nodeAnimations;
+    if (!Array.isArray(nodeAnimations)) {
+        return 0;
+    }
+
+    let duration = 0;
+    for (const nodeAnimation of nodeAnimations) {
+        for (const trackKey of ['_position', '_rotation', '_scale']) {
+            const times = (nodeAnimation as any)?.[trackKey]?.times;
+            if (!times) {
+                continue;
+            }
+            for (const time of Array.from(times as ArrayLike<unknown>)) {
+                duration = Math.max(duration, queryFiniteDuration(time));
             }
         }
     }

--- a/src/core/scene/scene-process/service/animation/clip-duration.ts
+++ b/src/core/scene/scene-process/service/animation/clip-duration.ts
@@ -1,5 +1,6 @@
 import type { AnimationClip } from 'cc';
 import { dumpAuxiliaryCurves } from './auxiliary-curve';
+import { queryExoticAnimationTracks } from './exotic-animation-track';
 import { dumpEmbeddedPlayers } from './embedded-player';
 import {
     getClipSample,
@@ -43,21 +44,10 @@ function queryTrackDuration(clip: AnimationClip, sample: number): number {
 }
 
 function queryExoticAnimationDuration(clip: AnimationClip): number {
-    const nodeAnimations = (clip as any)._exoticAnimation?._nodeAnimations;
-    if (!Array.isArray(nodeAnimations)) {
-        return 0;
-    }
-
     let duration = 0;
-    for (const nodeAnimation of nodeAnimations) {
-        for (const trackKey of ['_position', '_rotation', '_scale']) {
-            const times = (nodeAnimation as any)?.[trackKey]?.times;
-            if (!times) {
-                continue;
-            }
-            for (const time of Array.from(times as ArrayLike<unknown>)) {
-                duration = Math.max(duration, queryFiniteDuration(time));
-            }
+    for (const track of queryExoticAnimationTracks(clip)) {
+        for (const time of Array.from(track.times)) {
+            duration = Math.max(duration, queryFiniteDuration(time));
         }
     }
     return duration;

--- a/src/core/scene/scene-process/service/animation/exotic-animation-track.ts
+++ b/src/core/scene/scene-process/service/animation/exotic-animation-track.ts
@@ -1,0 +1,56 @@
+import type { AnimationClip } from 'cc';
+import { normalizePath } from './property-curve-track';
+
+export type ExoticAnimationTrackKey = 'position' | 'rotation' | 'scale';
+
+export interface IExoticAnimationTrack {
+    nodePath: string;
+    key: ExoticAnimationTrackKey;
+    times: ArrayLike<number>;
+    values?: {
+        get?: (index: number, value: Record<string, number>) => void;
+    };
+    type: 'cc.Vec3' | 'cc.Quat';
+    partKeys?: readonly string[];
+}
+
+const EXOTIC_TRACKS: Array<{
+    key: ExoticAnimationTrackKey;
+    field: '_position' | '_rotation' | '_scale';
+    type: IExoticAnimationTrack['type'];
+    partKeys?: readonly string[];
+}> = [
+    { key: 'position', field: '_position', type: 'cc.Vec3', partKeys: ['x', 'y', 'z'] },
+    { key: 'rotation', field: '_rotation', type: 'cc.Quat' },
+    { key: 'scale', field: '_scale', type: 'cc.Vec3', partKeys: ['x', 'y', 'z'] },
+];
+
+export function queryExoticAnimationTracks(clip: AnimationClip): IExoticAnimationTrack[] {
+    const nodeAnimations = (clip as any)._exoticAnimation?._nodeAnimations;
+    if (!Array.isArray(nodeAnimations)) {
+        return [];
+    }
+
+    const tracks: IExoticAnimationTrack[] = [];
+    for (const nodeAnimation of nodeAnimations) {
+        const nodePath = normalizePath(String((nodeAnimation as any)?._path || ''));
+        if (!nodePath) {
+            continue;
+        }
+        for (const descriptor of EXOTIC_TRACKS) {
+            const track = (nodeAnimation as any)?.[descriptor.field];
+            if (!track || !track.times) {
+                continue;
+            }
+            tracks.push({
+                nodePath,
+                key: descriptor.key,
+                times: track.times,
+                values: track.values,
+                type: descriptor.type,
+                partKeys: descriptor.partKeys,
+            });
+        }
+    }
+    return tracks;
+}

--- a/src/core/scene/scene-process/service/animation/property-curve-track.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve-track.ts
@@ -150,14 +150,45 @@ export function parsePropertyTrack(track: unknown): { nodePath: string; descript
         return descriptor ? { nodePath, descriptor } : null;
     }
 
+    const target = parseAnimationTrackTarget(path);
+    if (!target) {
+        return null;
+    }
+    const descriptor = createPropertyDescriptor(target.propKey, undefined, kind, track as AnyTrack);
+    return descriptor ? { nodePath: target.nodePath, descriptor } : null;
+}
+
+export interface IAnimationTrackTarget {
+    nodePath: string;
+    propKey: string;
+}
+
+export function parseAnimationTrackTarget(path: any): IAnimationTrackTarget | null {
+    if (!path || typeof path.length !== 'number') {
+        return null;
+    }
+
+    let index = 0;
+    let nodePath = '';
+    while (index < path.length && path.isHierarchyAt(index)) {
+        const segment = normalizePath(String(path.parseHierarchyAt(index) || ''));
+        if (segment) {
+            nodePath = nodePath ? `${nodePath}/${segment}` : segment;
+        }
+        index++;
+    }
+
+    let component: string | undefined;
+    if (index < path.length && path.isComponentAt(index)) {
+        component = path.parseComponentAt(index);
+        index++;
+    }
     if (index !== path.length - 1 || !path.isPropertyAt(index)) {
         return null;
     }
 
-    const propName = path.parsePropertyAt(index);
-    const propKey = comp ? `${comp}.${propName}` : propName;
-    const descriptor = createPropertyDescriptor(propKey, undefined, kind, track as AnyTrack);
-    return descriptor ? { nodePath, descriptor } : null;
+    const property = path.parsePropertyAt(index);
+    return { nodePath, propKey: component ? `${component}.${property}` : property };
 }
 
 export function createPropertyDescriptor(

--- a/src/core/scene/scene-process/service/animation/service-target.ts
+++ b/src/core/scene/scene-process/service/animation/service-target.ts
@@ -15,6 +15,7 @@ import type {
     IAnimationTargetOptions,
 } from '../../../common';
 import { createClipDump } from './clip-dump';
+import { normalizePath } from './property-curve-track';
 import type { IPropertyCurveMetadataContext } from './property-curve';
 import { ACTIVE_PROPERTY, DEFAULT_PROPERTIES } from './property-menu';
 import { queryAnimationPropertyMetadata, queryComponentAnimableProperties } from './property-metadata';
@@ -29,77 +30,7 @@ import { IAnimationSession } from './types';
 import { clipUuid } from './utils';
 
 
-export function upgradeUntypedAnimationTracks(rootNode: Node, clip: AnimationClip): void {
-    const upgradeUntypedTracks = (clip as AnimationClip & {
-        upgradeUntypedTracks?: (refine: (path: any, proxy: unknown) => string | null) => void;
-    }).upgradeUntypedTracks;
-    if (typeof upgradeUntypedTracks !== 'function') {
-        return;
-    }
-
-    upgradeUntypedTracks.call(clip, (path: any) => {
-        const target = readAnimationTrackTarget(path);
-        if (!target) {
-            return null;
-        }
-
-        const metadata = queryAnimationPropertyMetadata(rootNode, target.nodePath, target.propKey);
-        const type = metadata?.type.value ?? defaultAnimationPropertyType(target.propKey);
-        switch (type) {
-            case 'cc.Vec2':
-                return 'vec2';
-            case 'cc.Vec3':
-                return 'vec3';
-            case 'cc.Vec4':
-                return 'vec4';
-            case 'cc.Color':
-                return 'color';
-            case 'cc.Size':
-                return 'size';
-            default:
-                return null;
-        }
-    });
-}
-
-function readAnimationTrackTarget(path: any): { nodePath: string; propKey: string } | null {
-    if (!path || typeof path.length !== 'number') {
-        return null;
-    }
-
-    let index = 0;
-    let nodePath = '';
-    while (index < path.length && path.isHierarchyAt(index)) {
-        const segment = String(path.parseHierarchyAt(index) || '').replace(/^\/+|\/+$/g, '');
-        if (segment) {
-            nodePath = nodePath ? `${nodePath}/${segment}` : segment;
-        }
-        index++;
-    }
-
-    let component: string | undefined;
-    if (index < path.length && path.isComponentAt(index)) {
-        component = path.parseComponentAt(index);
-        index++;
-    }
-    if (index !== path.length - 1 || !path.isPropertyAt(index)) {
-        return null;
-    }
-
-    const property = path.parsePropertyAt(index);
-    return { nodePath, propKey: component ? `${component}.${property}` : property };
-}
-
-function defaultAnimationPropertyType(propKey: string): string | undefined {
-    switch (propKey) {
-        case 'position':
-        case 'eulerAngles':
-        case 'scale':
-            return 'cc.Vec3';
-        default:
-            return undefined;
-    }
-}
+export { upgradeUntypedAnimationTracks } from './untyped-animation-track';
 
 export function assertAnimationEditorOpened(editorRoot: Node | null): asserts editorRoot is Node {
     if (!editorRoot) {
@@ -190,18 +121,15 @@ export function isCurrentAnimationSessionClipQuery(
     if (!hasTarget) {
         return true;
     }
-    const sessionRootPath = normalizeTargetPath(session.rootPath);
-    const optionRootPath = normalizeTargetPath(options.rootPath || '');
-    const optionNodePath = normalizeTargetPath(options.nodePath || '');
+    const sessionRootPath = normalizePath(session.rootPath);
+    const optionRootPath = normalizePath(options.rootPath || '');
+    const optionNodePath = normalizePath(options.nodePath || '');
     return options.rootUuid === session.rootUuid
         || (options.rootPath !== undefined && optionRootPath === sessionRootPath)
         || options.nodeUuid === session.rootUuid
         || (options.nodePath !== undefined && optionNodePath === sessionRootPath);
 }
 
-function normalizeTargetPath(path: string): string {
-    return String(path || '').replace(/^\/+|\/+$/g, '');
-}
 
 export function queryAnimationServiceProperties(node: Node, root: Node | null): IAnimationPropertyInfo[] {
     const isChild = Boolean(root && root !== node);
@@ -218,7 +146,6 @@ export function queryAnimationServiceProperties(node: Node, root: Node | null): 
 }
 
 export function createAnimationServiceClipDump(rootNode: Node, clip: AnimationClip, state?: AnimationState): IAnimationClipDump {
-    upgradeUntypedAnimationTracks(rootNode, clip);
     return createClipDump(clip, state, {
         isSkeleton: isSkeletonClip(clipUuid(clip), rootNode),
         useBakedAnimation: isUsingBakedAnimation(rootNode),

--- a/src/core/scene/scene-process/service/animation/service-target.ts
+++ b/src/core/scene/scene-process/service/animation/service-target.ts
@@ -28,6 +28,79 @@ import {
 import { IAnimationSession } from './types';
 import { clipUuid } from './utils';
 
+
+export function upgradeUntypedAnimationTracks(rootNode: Node, clip: AnimationClip): void {
+    const upgradeUntypedTracks = (clip as AnimationClip & {
+        upgradeUntypedTracks?: (refine: (path: any, proxy: unknown) => string | null) => void;
+    }).upgradeUntypedTracks;
+    if (typeof upgradeUntypedTracks !== 'function') {
+        return;
+    }
+
+    upgradeUntypedTracks.call(clip, (path: any) => {
+        const target = readAnimationTrackTarget(path);
+        if (!target) {
+            return null;
+        }
+
+        const metadata = queryAnimationPropertyMetadata(rootNode, target.nodePath, target.propKey);
+        const type = metadata?.type.value ?? defaultAnimationPropertyType(target.propKey);
+        switch (type) {
+            case 'cc.Vec2':
+                return 'vec2';
+            case 'cc.Vec3':
+                return 'vec3';
+            case 'cc.Vec4':
+                return 'vec4';
+            case 'cc.Color':
+                return 'color';
+            case 'cc.Size':
+                return 'size';
+            default:
+                return null;
+        }
+    });
+}
+
+function readAnimationTrackTarget(path: any): { nodePath: string; propKey: string } | null {
+    if (!path || typeof path.length !== 'number') {
+        return null;
+    }
+
+    let index = 0;
+    let nodePath = '';
+    while (index < path.length && path.isHierarchyAt(index)) {
+        const segment = String(path.parseHierarchyAt(index) || '').replace(/^\/+|\/+$/g, '');
+        if (segment) {
+            nodePath = nodePath ? `${nodePath}/${segment}` : segment;
+        }
+        index++;
+    }
+
+    let component: string | undefined;
+    if (index < path.length && path.isComponentAt(index)) {
+        component = path.parseComponentAt(index);
+        index++;
+    }
+    if (index !== path.length - 1 || !path.isPropertyAt(index)) {
+        return null;
+    }
+
+    const property = path.parsePropertyAt(index);
+    return { nodePath, propKey: component ? `${component}.${property}` : property };
+}
+
+function defaultAnimationPropertyType(propKey: string): string | undefined {
+    switch (propKey) {
+        case 'position':
+        case 'eulerAngles':
+        case 'scale':
+            return 'cc.Vec3';
+        default:
+            return undefined;
+    }
+}
+
 export function assertAnimationEditorOpened(editorRoot: Node | null): asserts editorRoot is Node {
     if (!editorRoot) {
         throw new Error('Animation editor requires an opened scene or prefab.');
@@ -145,6 +218,7 @@ export function queryAnimationServiceProperties(node: Node, root: Node | null): 
 }
 
 export function createAnimationServiceClipDump(rootNode: Node, clip: AnimationClip, state?: AnimationState): IAnimationClipDump {
+    upgradeUntypedAnimationTracks(rootNode, clip);
     return createClipDump(clip, state, {
         isSkeleton: isSkeletonClip(clipUuid(clip), rootNode),
         useBakedAnimation: isUsingBakedAnimation(rootNode),

--- a/src/core/scene/scene-process/service/animation/untyped-animation-track.ts
+++ b/src/core/scene/scene-process/service/animation/untyped-animation-track.ts
@@ -1,0 +1,91 @@
+import type { AnimationClip, Node } from 'cc';
+import type {
+    IAnimationCurveDump,
+    IAnimationPropertyType,
+} from '../../../common';
+import { dumpPropertyCurves, type IPropertyCurveMetadataContext } from './property-curve';
+import { parseAnimationTrackTarget } from './property-curve-track';
+import { queryAnimationPropertyMetadata } from './property-metadata';
+
+type UntypedTrackRefine = (path: any, proxy: unknown) => string | null;
+type UntypedTrack = {
+    path?: unknown;
+    upgrade?: (refine: UntypedTrackRefine) => unknown;
+};
+
+type PropertyMetadataQuery = (nodePath: string, propKey: string) => IAnimationPropertyType | null;
+
+export function upgradeUntypedAnimationTracks(rootNode: Node, clip: AnimationClip): void {
+    const upgradeUntypedTracks = (clip as AnimationClip & {
+        upgradeUntypedTracks?: (refine: UntypedTrackRefine) => void;
+    }).upgradeUntypedTracks;
+    if (typeof upgradeUntypedTracks !== 'function') {
+        return;
+    }
+
+    upgradeUntypedTracks.call(clip, createUntypedTrackRefiner((nodePath, propKey) => {
+        return queryAnimationPropertyMetadata(rootNode, nodePath, propKey)?.type || null;
+    }));
+}
+
+export function dumpUntypedAnimationCurves(clip: AnimationClip, options: IPropertyCurveMetadataContext): IAnimationCurveDump[] {
+    const tracks = (clip as any)._tracks;
+    if (!Array.isArray(tracks)) {
+        return [];
+    }
+
+    const curves: IAnimationCurveDump[] = [];
+    const refiner = createUntypedTrackRefiner((nodePath, propKey) => {
+        return options.queryPropertyMetadata?.(nodePath, propKey)?.type || null;
+    });
+    for (const track of tracks as UntypedTrack[]) {
+        if (typeof track?.upgrade !== 'function') {
+            continue;
+        }
+        const typedTrack = track.upgrade(refiner);
+        if (!typedTrack) {
+            continue;
+        }
+
+        const clipView = Object.create(clip) as AnimationClip & { _tracks: unknown[] };
+        clipView._tracks = [typedTrack];
+        curves.push(...dumpPropertyCurves(clipView, options));
+    }
+    return curves;
+}
+
+function createUntypedTrackRefiner(queryMetadata: PropertyMetadataQuery): UntypedTrackRefine {
+    return (path) => {
+        const target = parseAnimationTrackTarget(path);
+        if (!target) {
+            return null;
+        }
+
+        const type = queryMetadata(target.nodePath, target.propKey)?.value || defaultAnimationPropertyType(target.propKey);
+        switch (type) {
+            case 'cc.Vec2':
+                return 'vec2';
+            case 'cc.Vec3':
+                return 'vec3';
+            case 'cc.Vec4':
+                return 'vec4';
+            case 'cc.Color':
+                return 'color';
+            case 'cc.Size':
+                return 'size';
+            default:
+                return null;
+        }
+    };
+}
+
+function defaultAnimationPropertyType(propKey: string): string | undefined {
+    switch (propKey) {
+        case 'position':
+        case 'eulerAngles':
+        case 'scale':
+            return 'cc.Vec3';
+        default:
+            return undefined;
+    }
+}

--- a/src/core/scene/test/animation-clip-dump.test.ts
+++ b/src/core/scene/test/animation-clip-dump.test.ts
@@ -1,0 +1,44 @@
+jest.mock('../scene-process/service/animation/auxiliary-curve', () => ({
+    dumpAuxiliaryCurves: jest.fn(() => ({})),
+}));
+jest.mock('../scene-process/service/animation/embedded-player', () => ({
+    dumpEmbeddedPlayers: jest.fn(() => []),
+    queryEmbeddedPlayerGroups: jest.fn(() => []),
+}));
+jest.mock('../scene-process/service/animation/property-curve', () => ({
+    dumpPropertyCurves: jest.fn(() => []),
+}));
+jest.mock('../scene-process/service/animation/utils', () => ({
+    cloneValue: <T>(value: T): T => value,
+    getClipSample: jest.fn(() => 30),
+}));
+
+const { createClipDump } = require('../scene-process/service/animation/clip-dump');
+
+describe('animation clip dump', () => {
+    it('locks imported skeletal clips while preserving the skeletal and baked flags', () => {
+        const dump = createClipDump({ name: 'Idle', duration: 1, speed: 1, wrapMode: 2, events: [] }, undefined, {
+            isSkeleton: true,
+            useBakedAnimation: true,
+        });
+
+        expect(dump).toMatchObject({
+            isLock: true,
+            isSkeleton: true,
+            useBakedAnimation: true,
+        });
+    });
+
+    it('does not lock ordinary animation clips', () => {
+        const dump = createClipDump({ name: 'Authored', duration: 1, speed: 1, wrapMode: 2, events: [] }, undefined, {
+            isSkeleton: false,
+            useBakedAnimation: false,
+        });
+
+        expect(dump).toMatchObject({
+            isLock: false,
+            isSkeleton: false,
+            useBakedAnimation: false,
+        });
+    });
+});

--- a/src/core/scene/test/animation-clip-dump.test.ts
+++ b/src/core/scene/test/animation-clip-dump.test.ts
@@ -29,6 +29,45 @@ describe('animation clip dump', () => {
         });
     });
 
+    it('dumps imported exotic skeletal transform keyframes', () => {
+        const clip = {
+            name: 'Idle',
+            duration: 1,
+            speed: 1,
+            wrapMode: 2,
+            events: [],
+            _exoticAnimation: {
+                _nodeAnimations: [{
+                    _path: 'CharacterArmature/Root/Body/Hips',
+                    _position: {
+                        times: [0, 1],
+                        values: {
+                            get(index: number, value: { x?: number; y?: number; z?: number }) {
+                                Object.assign(value, index === 0 ? { x: 1, y: 2, z: 3 } : { x: 4, y: 5, z: 6 });
+                            },
+                        },
+                    },
+                    _rotation: null,
+                    _scale: null,
+                }],
+            },
+        };
+
+        const dump = createClipDump(clip, undefined, {
+            isSkeleton: true,
+            useBakedAnimation: false,
+        });
+
+        expect(dump.curves).toEqual(expect.arrayContaining([expect.objectContaining({
+            nodePath: 'CharacterArmature/Root/Body/Hips',
+            key: 'position',
+            keyframes: [
+                expect.objectContaining({ frame: 0, dump: expect.objectContaining({ value: { x: 1, y: 2, z: 3 }, readonly: true }) }),
+                expect.objectContaining({ frame: 30, dump: expect.objectContaining({ value: { x: 4, y: 5, z: 6 }, readonly: true }) }),
+            ],
+        })]));
+    });
+
     it('does not lock ordinary animation clips', () => {
         const dump = createClipDump({ name: 'Authored', duration: 1, speed: 1, wrapMode: 2, events: [] }, undefined, {
             isSkeleton: false,

--- a/src/core/scene/test/animation-clip-dump.test.ts
+++ b/src/core/scene/test/animation-clip-dump.test.ts
@@ -16,14 +16,14 @@ jest.mock('../scene-process/service/animation/utils', () => ({
 const { createClipDump } = require('../scene-process/service/animation/clip-dump');
 
 describe('animation clip dump', () => {
-    it('locks imported skeletal clips while preserving the skeletal and baked flags', () => {
+    it('does not claim an imported skeletal clip is fully locked without an explicit lock contract', () => {
         const dump = createClipDump({ name: 'Idle', duration: 1, speed: 1, wrapMode: 2, events: [] }, undefined, {
             isSkeleton: true,
             useBakedAnimation: true,
         });
 
         expect(dump).toMatchObject({
-            isLock: true,
+            isLock: false,
             isSkeleton: true,
             useBakedAnimation: true,
         });

--- a/src/core/scene/test/animation-clip-operations.test.ts
+++ b/src/core/scene/test/animation-clip-operations.test.ts
@@ -1,4 +1,5 @@
 jest.mock('../scene-process/service/animation/auxiliary-curve', () => ({
+    dumpAuxiliaryCurves: jest.fn(() => ({})),
     addAuxiliaryCurve: jest.fn(),
     copyAuxKey: jest.fn(),
     createAuxKey: jest.fn(),
@@ -10,6 +11,7 @@ jest.mock('../scene-process/service/animation/auxiliary-curve', () => ({
 }));
 
 jest.mock('../scene-process/service/animation/embedded-player', () => ({
+    dumpEmbeddedPlayers: jest.fn(() => []),
     addEmbeddedPlayer: jest.fn(),
     addEmbeddedPlayerGroup: jest.fn(),
     clearEmbeddedPlayers: jest.fn(),
@@ -32,8 +34,46 @@ jest.mock('../scene-process/service/animation/property-curve', () => ({
 }));
 
 const { applyClipOperation } = require('../scene-process/service/animation/clip-operations');
+const { syncAnimationClipDuration } = require('../scene-process/service/animation/clip-duration');
 
 describe('animation clip operations', () => {
+    it('preserves a skeletal track duration when an event moves earlier', () => {
+        const clip = {
+            sample: 60,
+            duration: 1,
+            events: [{ frame: 0.8, func: 'onPointEight', params: [] }],
+            _tracks: [],
+            _exoticAnimation: {
+                _nodeAnimations: [{
+                    _path: 'Root/Bone',
+                    _position: { times: [0, 1] },
+                    _rotation: null,
+                    _scale: null,
+                }],
+            },
+        };
+
+        const duration = syncAnimationClipDuration(clip);
+
+        expect(duration).toBe(1);
+        expect(clip.duration).toBe(1);
+    });
+
+    it('keeps an ordinary clip track duration when an event moves earlier', () => {
+        const clip = {
+            sample: 60,
+            duration: 1,
+            events: [{ frame: 0.8, func: 'onPointEight', params: [] }],
+            _tracks: [],
+            range: () => ({ max: 1 }),
+        };
+
+        const duration = syncAnimationClipDuration(clip);
+
+        expect(duration).toBe(1);
+        expect(clip.duration).toBe(1);
+    });
+
     it('keeps event time stable when changing sample rate', async () => {
         const clip = {
             sample: 30,

--- a/src/core/scene/test/animation-clip-operations.test.ts
+++ b/src/core/scene/test/animation-clip-operations.test.ts
@@ -37,11 +37,11 @@ const { applyClipOperation } = require('../scene-process/service/animation/clip-
 const { syncAnimationClipDuration } = require('../scene-process/service/animation/clip-duration');
 
 describe('animation clip operations', () => {
-    it('preserves a skeletal track duration when an event moves earlier', () => {
+    it('preserves a skeletal track duration when an event moves earlier', async () => {
         const clip = {
             sample: 60,
             duration: 1,
-            events: [{ frame: 0.8, func: 'onPointEight', params: [] }],
+            events: [{ frame: 1, func: 'onOneSecond', params: [] }],
             _tracks: [],
             _exoticAnimation: {
                 _nodeAnimations: [{
@@ -51,10 +51,19 @@ describe('animation clip operations', () => {
                     _scale: null,
                 }],
             },
+            updateEventDatas: jest.fn(),
         };
 
+        const moveResult = await applyClipOperation(clip, {
+            type: 'moveEvents',
+            clipUuid: 'clip-uuid',
+            frames: [60],
+            offset: -12,
+        }, {});
         const duration = syncAnimationClipDuration(clip);
 
+        expect(moveResult).toBe(true);
+        expect(clip.events[0].frame).toBe(0.8);
         expect(duration).toBe(1);
         expect(clip.duration).toBe(1);
     });

--- a/src/core/scene/test/animation-track-upgrade.test.ts
+++ b/src/core/scene/test/animation-track-upgrade.test.ts
@@ -26,7 +26,7 @@ jest.mock('../scene-process/service/animation/utils', () => ({
     clipUuid: jest.fn(),
 }));
 
-const { upgradeUntypedAnimationTracks } = require('../scene-process/service/animation/service-target');
+const { createAnimationServiceClipDump, upgradeUntypedAnimationTracks } = require('../scene-process/service/animation/service-target');
 
 function createPropertyPath(property: string) {
     return {
@@ -40,6 +40,15 @@ function createPropertyPath(property: string) {
 }
 
 describe('skeletal animation track upgrade', () => {
+    it('does not upgrade untyped tracks while creating a read-only clip dump', () => {
+        const upgrade = jest.fn();
+        const clip = { upgradeUntypedTracks: upgrade };
+
+        createAnimationServiceClipDump({} as any, clip as any);
+
+        expect(upgrade).not.toHaveBeenCalled();
+    });
+
     it('refines untyped bone transform tracks before clip dumping', () => {
         let refine: ((path: unknown, proxy: unknown) => string | null) | undefined;
         const clip = {

--- a/src/core/scene/test/animation-track-upgrade.test.ts
+++ b/src/core/scene/test/animation-track-upgrade.test.ts
@@ -1,0 +1,70 @@
+jest.mock('cc', () => ({
+    Animation: class Animation {},
+    AnimationClip: class AnimationClip {},
+    AnimationState: class AnimationState {},
+    Node: class Node {},
+}));
+jest.mock('../scene-process/service/animation/clip-dump', () => ({
+    createClipDump: jest.fn(),
+}));
+jest.mock('../scene-process/service/animation/property-menu', () => ({
+    ACTIVE_PROPERTY: {},
+    DEFAULT_PROPERTIES: [],
+}));
+jest.mock('../scene-process/service/animation/property-metadata', () => ({
+    queryAnimationPropertyMetadata: jest.fn(() => null),
+    queryComponentAnimableProperties: jest.fn(() => []),
+}));
+jest.mock('../scene-process/service/animation/scene-node', () => ({
+    getNodeByPath: jest.fn(),
+    getNodeByUuid: jest.fn(),
+    isSkeletonClip: jest.fn(),
+    isUsingBakedAnimation: jest.fn(),
+    queryAnimationRootNode: jest.fn(),
+}));
+jest.mock('../scene-process/service/animation/utils', () => ({
+    clipUuid: jest.fn(),
+}));
+
+const { upgradeUntypedAnimationTracks } = require('../scene-process/service/animation/service-target');
+
+function createPropertyPath(property: string) {
+    return {
+        length: 2,
+        isHierarchyAt: (index: number) => index === 0,
+        parseHierarchyAt: () => 'Bone',
+        isComponentAt: () => false,
+        isPropertyAt: (index: number) => index === 1,
+        parsePropertyAt: () => property,
+    };
+}
+
+describe('skeletal animation track upgrade', () => {
+    it('refines untyped bone transform tracks before clip dumping', () => {
+        let refine: ((path: unknown, proxy: unknown) => string | null) | undefined;
+        const clip = {
+            upgradeUntypedTracks(callback: (path: unknown, proxy: unknown) => string | null) {
+                refine = callback;
+            },
+        };
+
+        upgradeUntypedAnimationTracks({} as any, clip as any);
+
+        expect(refine).toBeDefined();
+        expect(refine!(createPropertyPath('position'), undefined)).toBe('vec3');
+        expect(refine!(createPropertyPath('scale'), undefined)).toBe('vec3');
+    });
+
+    it('does not invent a type for unsupported untyped properties', () => {
+        let refine: ((path: unknown, proxy: unknown) => string | null) | undefined;
+        const clip = {
+            upgradeUntypedTracks(callback: (path: unknown, proxy: unknown) => string | null) {
+                refine = callback;
+            },
+        };
+
+        upgradeUntypedAnimationTracks({} as any, clip as any);
+
+        expect(refine!(createPropertyPath('unsupported'), undefined)).toBeNull();
+    });
+});

--- a/src/core/scene/test/animation-untyped-track.test.ts
+++ b/src/core/scene/test/animation-untyped-track.test.ts
@@ -1,0 +1,41 @@
+jest.mock('../scene-process/service/animation/property-curve', () => ({
+    dumpPropertyCurves: jest.fn((clip: { _tracks?: unknown[] }) => (clip._tracks || []).map(() => ({
+        nodePath: 'Bone',
+        key: 'position',
+        keyframes: [],
+    }))),
+}));
+jest.mock('../scene-process/service/animation/property-curve-track', () => ({
+    parseAnimationTrackTarget: jest.fn(() => ({ nodePath: 'Bone', propKey: 'position' })),
+}));
+jest.mock('../scene-process/service/animation/property-metadata', () => ({
+    queryAnimationPropertyMetadata: jest.fn(() => null),
+}));
+
+const { dumpUntypedAnimationCurves } = require('../scene-process/service/animation/untyped-animation-track');
+
+describe('untyped animation track dump', () => {
+    it('upgrades a temporary track view without changing the source clip', () => {
+        const sourceTrack = {
+            upgrade: jest.fn(() => ({ typed: true })),
+        };
+        const clip = {
+            sample: 30,
+            _tracks: [sourceTrack],
+        };
+
+        const curves = dumpUntypedAnimationCurves(clip as any, {});
+
+        expect(curves).toHaveLength(1);
+        expect(sourceTrack.upgrade).toHaveBeenCalledTimes(1);
+        expect(clip._tracks).toEqual([sourceTrack]);
+    });
+
+    it('skips tracks that cannot be upgraded', () => {
+        const clip = {
+            _tracks: [{ upgrade: jest.fn(() => null) }],
+        };
+
+        expect(dumpUntypedAnimationCurves(clip as any, {})).toEqual([]);
+    });
+});


### PR DESCRIPTION
## 变更说明

- 修复动画 Clip 查询链路在读取与 dump 时修改原始 `AnimationClip` 的问题，保持查询操作只读。
- 为未类型化动画轨道增加临时类型视图，仅在 dump 过程中细化，不回写源 Clip。
- 统一骨骼/Exotic 轨道的曲线遍历、路径解析和时长计算，覆盖 Vec3、Quat 及未类型化轨道场景。
- 恢复骨骼动画 Clip 的正确锁定语义，避免普通查询被错误标记为锁定。
- 增加回归测试，覆盖只读查询、未类型化轨道 dump、Exotic 轨道和时长计算路径。

## 验证

- `npm run build`：通过。
- `npm test -- --runInBand`：通过，133 个测试套件、1608 个测试全部通过。
- `git diff --check`：通过。

完整测试期间 Jest 报告 1 个 `CustomGC` open handle warning，但进程最终以退出码 0 完成，所有测试均通过。

## QA 验证步骤

N/A：本次变更不包含用户可见 UI 行为变化。
