### PR TITLE
feat(scene): decouple node name from path for animation binding.

### DIFF
--- a/src/api/base/schema-identifier.ts
+++ b/src/api/base/schema-identifier.ts
@@ -331,6 +331,6 @@ export const SchemaComponentIdentifier = z.object({
 
 export const SchemaNodeIdentifier = z.object({
     nodeId: z.string().describe('Node ID'), // 节点的 id
-    path: z.string().describe('Parent node path, full node path is parent path + node name; root node path is "/"'), // 父节点路径，完整节点路径为父路径+节点名；根节点路径为 "/"
-    name: z.string().describe('Node name'), // 节点名称
+    path: z.string().describe('Node addressing path (unique), may differ from node name when siblings share the same display name; root node path is "/"'), // 节点寻址路径（唯一），同名兄弟节点时可能与 name 不同；根节点路径为 "/"
+    name: z.string().describe('Node display name (may be duplicated among siblings)'), // 节点显示名称（兄弟节点间可重复）
 }).describe('Node identifier'); // 节点标识符

--- a/src/api/scene/node-schema.ts
+++ b/src/api/scene/node-schema.ts
@@ -8,6 +8,11 @@ import { SchemaPrefabInfo } from './prefab-info-schema';
 import { SchemaAssetDbUrl } from '../base/schema-asset-db-url';
 import { SchemaComponent } from './component-schema';
 
+const SchemaNodeName = z.string().refine(
+    (name) => !/[/\\:*?"<>|]/.test(name),
+    { message: 'Characters /\\:*?"<>| are not allowed in node names.' },
+);
+
 // 节点属性的 schema，
 export const SchemaNodeProperty = z.object({
     position: SchemaVec3.describe('Node position'), // 节点位置
@@ -57,7 +62,7 @@ export const SchemaNodeQueryResult: z.ZodType<INodeInfo> = SchemaNode;
 //节点更新的参数
 export const SchemaNodeUpdate = z.object({
     path: z.string().describe('Relative path of the node'), // 节点相对路径
-    name: z.string().optional().describe('Name of the node to update'), // 更新的节点名称
+    name: SchemaNodeName.optional().describe('Name of the node to update. Characters /\\:*?"<>| are not allowed.'), // Name of the node to update
     properties: SchemaNodeProperty.partial().optional().describe('Node properties to update, can update partial properties'), // 要更新的节点属性，可以只更新部分属性
 }).describe('To configure options for node update, the Scene must be open first.'); // 更新节点的选项参数, 需先打开场景
 
@@ -79,7 +84,7 @@ export const SchemaNodeDelete = z.object({
 
 const SchemaNodeCreateBase = z.object({
     path: z.string().describe('Relative path of the created node, root node is scene node; This path is parent node path, full node path is parent path + node name, and root node path is "/"'), // 创建的节点相对路径，根节点是场景节点; 该路径为父节点路径,完整节点路径为父路径+节点名，根节点路径为 "/"
-    name: z.string().optional().describe('Name of the node, if not passed, the system will default a name'), // 节点的名称，不传，系统会默认一个名字
+    name: SchemaNodeName.optional().describe('Name of the node. Characters /\\:*?"<>| are not allowed. If not passed, the system will default a name.'), // Node name; defaults to a system-generated name if omitted
     workMode: z.enum(['2d', '3d']).optional().describe('Node work mode, 2D or 3D; same nodeType may support both 2d and 3d'), // 节点工作模式，2D 还是 3D; 同一个 nodeType 有些支持2d也支持3d
     keepWorldTransform: z.boolean().optional().describe('Keep world transform'), // 保持世界变换
     position: SchemaVec3.optional().describe('Node position'), // 节点位置

--- a/src/api/scene/node-schema.ts
+++ b/src/api/scene/node-schema.ts
@@ -83,7 +83,7 @@ export const SchemaNodeDelete = z.object({
 }).describe('To configure options for node deletion, the Scene must be open first.'); // 删除节点的选项参数，需先打开场景
 
 const SchemaNodeCreateBase = z.object({
-    path: z.string().describe('Relative path of the created node, root node is scene node; This path is parent node path, full node path is parent path + node name, and root node path is "/"'), // 创建的节点相对路径，根节点是场景节点; 该路径为父节点路径,完整节点路径为父路径+节点名，根节点路径为 "/"
+    path: z.string().describe('Relative path of the created node, root node is scene node; This path is parent node path, full node path is returned by the API, and root node path is "/"'), // 创建的节点相对路径，根节点是场景节点；该路径为父节点路径，完整节点路径以接口返回值为准，根节点路径为 "/"
     name: SchemaNodeName.optional().describe('Name of the node. Characters /\\:*?"<>| are not allowed. If not passed, the system will default a name.'), // Node name; defaults to a system-generated name if omitted
     workMode: z.enum(['2d', '3d']).optional().describe('Node work mode, 2D or 3D; same nodeType may support both 2d and 3d'), // 节点工作模式，2D 还是 3D; 同一个 nodeType 有些支持2d也支持3d
     keepWorldTransform: z.boolean().optional().describe('Keep world transform'), // 保持世界变换

--- a/src/core/engine/editor-extends/manager/node-path-manager.ts
+++ b/src/core/engine/editor-extends/manager/node-path-manager.ts
@@ -1,5 +1,12 @@
-import { formatUniqueName } from './path-utils';
+import { formatUniqueName, sanitizeNodeName } from './path-utils';
 
+/**
+ * Node path manager (singleton).
+ *
+ * Core problem solved: after name/path decoupling, node.name is a repeatable display name,
+ * while system paths must be unique (same-name siblings are disambiguated via _001, _002 suffixes).
+ * This class maintains a bidirectional UUID <-> unique system path mapping with case-insensitive lookup.
+ */
 export class NodePathManager {
     private _uuidToPath: Map<string, string> = new Map();          // UUID -> 路径
     private _pathToUuid: Map<string, string> = new Map();          // 路径 -> UUID
@@ -10,8 +17,7 @@ export class NodePathManager {
         * 清理名称中的非法字符
         */
     private _sanitizeName(name: string): string {
-        // 移除或替换路径中的非法字符
-        return name.replace(/[/\\:*?"<>|]/g, '_');
+        return sanitizeNodeName(name);
     }
 
     /**

--- a/src/core/engine/editor-extends/manager/node-path-manager.ts
+++ b/src/core/engine/editor-extends/manager/node-path-manager.ts
@@ -64,14 +64,14 @@ export class NodePathManager {
         this._addPathMapping(uuid, path);
     }
 
-    remove(uuid: string) {
+    remove(uuid: string, parentUuid?: string) {
         const path = this._uuidToPath.get(uuid);
         this._removePathMapping(uuid, path);
         this._uuidToPath.delete(uuid);
         this._nodeNames.delete(uuid);
-        const parentUuid = this._getParentUuid(path);
-        if (parentUuid && this._nodeNames.has(parentUuid)) {
-            const nameSet = this._nodeNames.get(parentUuid)!;
+        const resolvedParent = parentUuid ?? this._getParentUuid(path);
+        if (resolvedParent && this._nodeNames.has(resolvedParent)) {
+            const nameSet = this._nodeNames.get(resolvedParent)!;
             const nodeName = path ? path.split('/').pop() : undefined;
             if (nodeName) {
                 nameSet.delete(nodeName);
@@ -259,13 +259,6 @@ export class NodePathManager {
         this._replaceSubtreePathPrefix(subtreeEntries, oldPath, newPath);
     }
 
-    getNameSet(uuid: string): Set<string> | null {
-        if (!this._nodeNames.has(uuid)) {
-            return null;
-        }
-
-        return this._nodeNames.get(uuid)!;
-    }
 }
 
 export default new NodePathManager();

--- a/src/core/engine/editor-extends/manager/node.ts
+++ b/src/core/engine/editor-extends/manager/node.ts
@@ -6,6 +6,7 @@ import { EventEmitter } from 'events';
 import * as ObjectWalker from '../missing-reporter/object-walker';
 import utils from '../../../base/utils';
 import pathManager from './node-path-manager';
+import { sanitizeNodeName, validateNodeName } from './path-utils';
 
 const lodash = require('lodash');
 
@@ -28,6 +29,14 @@ export default class NodeManager extends EventEmitter {
     add(uuid: string, node: Node) {
         if (!this.allow) {
             return;
+        }
+        const originalName = node.name;
+        const migratedName = sanitizeNodeName(originalName);
+        if (migratedName !== originalName) {
+            console.warn(
+                `Node: migrated legacy node name "${originalName}" to "${migratedName}" because it contains unsupported characters.`,
+            );
+            node.name = migratedName;
         }
         this._map[uuid] = node;
 
@@ -93,11 +102,18 @@ export default class NodeManager extends EventEmitter {
 
 
     /**
-     * 更新节点名称和路径
+     * Update node name and path.
+     * Must validate illegal characters here because undo/redo (command-utils-shared)
+     * and legacy-node-name-migration bypass NodeService.setProperty and call this directly.
      */
     updateNodeName(uuid: string, newName: string) {
         if (!this._map[uuid]) {
             return;
+        }
+
+        const error = validateNodeName(newName);
+        if (error) {
+            throw new Error(error);
         }
 
         const node = this._map[uuid];

--- a/src/core/engine/editor-extends/manager/node.ts
+++ b/src/core/engine/editor-extends/manager/node.ts
@@ -6,7 +6,7 @@ import { EventEmitter } from 'events';
 import * as ObjectWalker from '../missing-reporter/object-walker';
 import utils from '../../../base/utils';
 import pathManager from './node-path-manager';
-import { sanitizeNodeName, validateNodeName } from './path-utils';
+import { validateNodeName } from './path-utils';
 
 const lodash = require('lodash');
 
@@ -30,13 +30,11 @@ export default class NodeManager extends EventEmitter {
         if (!this.allow) {
             return;
         }
-        const originalName = node.name;
-        const migratedName = sanitizeNodeName(originalName);
-        if (migratedName !== originalName) {
+        const nameError = validateNodeName(node.name);
+        if (nameError) {
             console.warn(
-                `Node: migrated legacy node name "${originalName}" to "${migratedName}" because it contains unsupported characters.`,
+                `Node: preserving legacy node name "${node.name}". ${nameError}`,
             );
-            node.name = migratedName;
         }
         this._map[uuid] = node;
 
@@ -103,8 +101,8 @@ export default class NodeManager extends EventEmitter {
 
     /**
      * Update node name and path.
-     * Must validate illegal characters here because undo/redo (command-utils-shared)
-     * and legacy-node-name-migration bypass NodeService.setProperty and call this directly.
+     * API entry points reject illegal names, but undo/redo may restore a legacy name directly.
+     * Preserve that display name and let NodePathManager sanitize only its system path segment.
      */
     updateNodeName(uuid: string, newName: string) {
         if (!this._map[uuid]) {
@@ -113,7 +111,7 @@ export default class NodeManager extends EventEmitter {
 
         const error = validateNodeName(newName);
         if (error) {
-            throw new Error(error);
+            console.warn(`Node: preserving legacy node name "${newName}". ${error}`);
         }
 
         const node = this._map[uuid];

--- a/src/core/engine/editor-extends/manager/node.ts
+++ b/src/core/engine/editor-extends/manager/node.ts
@@ -62,8 +62,9 @@ export default class NodeManager extends EventEmitter {
             return;
         }
         const node = this._map[uuid];
+        const parentUuid = this._getParentUuid(uuid);
 
-        pathManager.remove(uuid);
+        pathManager.remove(uuid, parentUuid);
 
         // 清理父子关系
         this._cleanupParentRelations(uuid);
@@ -104,10 +105,6 @@ export default class NodeManager extends EventEmitter {
         // 获取父节点UUID
         const parentUuid = this._getParentUuid(uuid);
         pathManager.updateUuid(uuid, newName, parentUuid);
-        // 更新节点名称计数
-        if (parentUuid) {
-            this._updateNameCount(parentUuid, node.name, newName);
-        }
 
         // 更新节点对象的名称
         node.name = newName;
@@ -141,11 +138,6 @@ export default class NodeManager extends EventEmitter {
                 this._parentChildren.set(newParentUuid, new Set());
             }
             this._parentChildren.get(newParentUuid)!.add(uuid);
-        }
-
-        const finalName = newPath.split('/').pop();
-        if (finalName && node.name !== finalName) {
-            node.name = finalName;
         }
 
         return newPath;
@@ -324,7 +316,6 @@ export default class NodeManager extends EventEmitter {
         const parentUuid = this._getParentUuid(uuid);
         if (parentUuid) {
             this._parentChildren.get(parentUuid)?.delete(uuid);
-            this._updateNameCount(parentUuid, this._map[uuid]?.name, null);
         }
 
         // 递归清理所有子节点
@@ -334,24 +325,6 @@ export default class NodeManager extends EventEmitter {
                 this.remove(childUuid);
             }
             this._parentChildren.delete(uuid);
-        }
-    }
-
-    /**
-     * 更新名称计数
-     */
-    private _updateNameCount(parentUuid: string, oldName: string | null, newName: string | null) {
-        const nameSet = pathManager.getNameSet(parentUuid);
-        if (!nameSet) {
-            return;
-        }
-
-        if (oldName) {
-            nameSet.delete(oldName);
-        }
-
-        if (newName) {
-            nameSet.add(newName);
         }
     }
 }

--- a/src/core/engine/editor-extends/manager/path-utils.ts
+++ b/src/core/engine/editor-extends/manager/path-utils.ts
@@ -1,11 +1,38 @@
 /**
- * 生成唯一名称：无重复时返回原名，有重复时添加 _001, _002, ... 后缀
- * @param baseName - 基础名称
- * @param existingCount - 已存在的同名数量（0 表示无重复）
+ * Generate a unique name: returns the original if no conflict, appends _001, _002, ... suffix if duplicate.
+ * @param baseName - base name
+ * @param existingCount - number of existing same-name entries (0 means no conflict)
  */
 export function formatUniqueName(baseName: string, existingCount: number): string {
     if (existingCount <= 0) {
         return baseName;
     }
     return `${baseName}_${String(existingCount).padStart(3, '0')}`;
+}
+
+/**
+ * Characters not allowed in node names. These have special meaning in file system paths
+ * or node path separators and cause path resolution ambiguity
+ * (e.g. '/' conflicts with path separator, ':' is illegal in Windows paths).
+ */
+export const ILLEGAL_NAME_CHARS = /[/\\:*?"<>|]/;
+
+/**
+ * Validate whether a node name is legal.
+ * @returns error description if invalid, null if valid
+ */
+export function validateNodeName(name: string): string | null {
+    const match = name.match(ILLEGAL_NAME_CHARS);
+    if (match) {
+        return `Node name "${name}" contains illegal character '${match[0]}'. Characters /\\:*?"<>| are not allowed.`;
+    }
+    return null;
+}
+
+/**
+ * Replace illegal characters in a name with '_'.
+ * Only for internal NodePathManager fallback; external entry points should reject via validateNodeName.
+ */
+export function sanitizeNodeName(name: string): string {
+    return name.replace(/[/\\:*?"<>|]/g, '_');
 }

--- a/src/core/engine/test/node-manager-change-uuid.test.ts
+++ b/src/core/engine/test/node-manager-change-uuid.test.ts
@@ -99,6 +99,16 @@ describe('NodeManager name/path 解耦', () => {
         return node;
     }
 
+    it('创建重名节点后 name 保持用户输入，不被系统路径后缀覆盖', () => {
+        const nodeA = addNode('a', 'Enemy', 'scene');
+        const nodeB = addNode('b', 'Enemy', 'scene');
+
+        expect(nodeA.name).toBe('Enemy');
+        expect(nodeB.name).toBe('Enemy');
+        expect(manager.getNodePath(nodeA)).toBe('Enemy');
+        expect(manager.getNodePath(nodeB)).toBe('Enemy_001');
+    });
+
     it('重命名为与兄弟同名时，name 取用户输入，path 自动去重', () => {
         const nodeA = addNode('a', 'Enemy', 'scene');
         const nodeB = addNode('b', 'Soldier', 'scene');
@@ -149,6 +159,29 @@ describe('NodeManager name/path 解耦', () => {
 
         expect(node.name).toBe('NewName');
         expect(manager.getNodePath(node)).toBe('NewName');
+    });
+
+    it('重命名为含非法字符的名称时抛出错误', () => {
+        addNode('parent', 'Parent', 'scene');
+        const node = addNode('a', 'OldName', 'parent');
+
+        expect(() => manager.updateNodeName('a', 'A:B')).toThrow(/illegal character/);
+
+        expect(node.name).toBe('OldName');
+        expect(manager.getNodePath(node)).toBe('Parent/OldName');
+    });
+
+    it('加载旧场景节点时将非法字符迁移为下划线', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+        try {
+            const node = addNode('legacy', 'A:B', 'scene');
+
+            expect(node.name).toBe('A_B');
+            expect(manager.getNodePath(node)).toBe('A_B');
+            expect(warn).toHaveBeenCalledWith(expect.stringContaining('migrated legacy node name'));
+        } finally {
+            warn.mockRestore();
+        }
     });
 
     it('删除中间节点后新增应复用已删除的路径段', () => {

--- a/src/core/engine/test/node-manager-change-uuid.test.ts
+++ b/src/core/engine/test/node-manager-change-uuid.test.ts
@@ -161,24 +161,29 @@ describe('NodeManager name/path 解耦', () => {
         expect(manager.getNodePath(node)).toBe('NewName');
     });
 
-    it('重命名为含非法字符的名称时抛出错误', () => {
+    it('底层恢复旧非法名称时保留显示名、清洗系统路径并警告', () => {
         addNode('parent', 'Parent', 'scene');
         const node = addNode('a', 'OldName', 'parent');
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+        try {
+            manager.updateNodeName('a', 'A:B');
 
-        expect(() => manager.updateNodeName('a', 'A:B')).toThrow(/illegal character/);
-
-        expect(node.name).toBe('OldName');
-        expect(manager.getNodePath(node)).toBe('Parent/OldName');
+            expect(node.name).toBe('A:B');
+            expect(manager.getNodePath(node)).toBe('Parent/A_B');
+            expect(warn).toHaveBeenCalledWith(expect.stringContaining('preserving legacy node name'));
+        } finally {
+            warn.mockRestore();
+        }
     });
 
-    it('加载旧场景节点时将非法字符迁移为下划线', () => {
+    it('加载旧场景节点时保留非法显示名、清洗系统路径并警告', () => {
         const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
         try {
             const node = addNode('legacy', 'A:B', 'scene');
 
-            expect(node.name).toBe('A_B');
+            expect(node.name).toBe('A:B');
             expect(manager.getNodePath(node)).toBe('A_B');
-            expect(warn).toHaveBeenCalledWith(expect.stringContaining('migrated legacy node name'));
+            expect(warn).toHaveBeenCalledWith(expect.stringContaining('preserving legacy node name'));
         } finally {
             warn.mockRestore();
         }

--- a/src/core/engine/test/node-manager-change-uuid.test.ts
+++ b/src/core/engine/test/node-manager-change-uuid.test.ts
@@ -83,3 +83,89 @@ describe('NodeManager.updateNodeName', () => {
         expect(manager.getNodeByPath('A/B/D')).toBeNull();
     });
 });
+
+describe('NodeManager name/path 解耦', () => {
+    let manager: NodeManager;
+
+    beforeEach(() => {
+        manager = new NodeManager();
+        manager.allow = true;
+        pathManager.clear();
+    });
+
+    function addNode(uuid: string, name: string, parentUuid?: string) {
+        const node = { uuid, name, _id: uuid, parent: parentUuid ? { uuid: parentUuid } : null } as any;
+        manager.add(uuid, node);
+        return node;
+    }
+
+    it('重命名为与兄弟同名时，name 取用户输入，path 自动去重', () => {
+        const nodeA = addNode('a', 'Enemy', 'scene');
+        const nodeB = addNode('b', 'Soldier', 'scene');
+
+        manager.updateNodeName('b', 'Enemy');
+
+        // name 应为用户输入
+        expect(nodeB.name).toBe('Enemy');
+        // path 应自动去重
+        expect(manager.getNodePath(nodeB)).toBe('Enemy_001');
+        // A 不受影响
+        expect(nodeA.name).toBe('Enemy');
+        expect(manager.getNodePath(nodeA)).toBe('Enemy');
+    });
+
+    it('移动节点后不再回写 path 末段到 name', () => {
+        addNode('parent', 'Parent', 'scene');
+        addNode('existing', 'Child', 'parent');
+        const moving = addNode('moving', 'Child', 'scene');
+
+        // 移动到 parent 下（同名冲突）
+        const newPath = manager.updateNodeParent('moving', 'parent');
+
+        // path 应去重
+        expect(newPath).toBe('Parent/Child_001');
+        // name 不应被回写为路径段，保持原值
+        expect(moving.name).toBe('Child');
+    });
+
+    it('删除节点后不影响兄弟路径', () => {
+        addNode('a', 'Item', 'scene');
+        const nodeB = addNode('b', 'Item', 'scene');
+        const nodeC = addNode('c', 'Item', 'scene');
+
+        const pathB = manager.getNodePath(nodeB);
+        const pathC = manager.getNodePath(nodeC);
+
+        manager.remove('a');
+
+        expect(manager.getNodePath(nodeB)).toBe(pathB);
+        expect(manager.getNodePath(nodeC)).toBe(pathC);
+    });
+
+    it('重命名不冲突时 name 和 path 末段一致', () => {
+        const node = addNode('a', 'OldName', 'scene');
+
+        manager.updateNodeName('a', 'NewName');
+
+        expect(node.name).toBe('NewName');
+        expect(manager.getNodePath(node)).toBe('NewName');
+    });
+
+    it('删除中间节点后新增应复用已删除的路径段', () => {
+        const node0 = addNode('n0', 'GapNode', 'scene');
+        const node1 = addNode('n1', 'GapNode', 'scene');
+        const node2 = addNode('n2', 'GapNode', 'scene');
+
+        expect(manager.getNodePath(node0)).toBe('GapNode');
+        expect(manager.getNodePath(node1)).toBe('GapNode_001');
+        expect(manager.getNodePath(node2)).toBe('GapNode_002');
+
+        manager.remove('n1');
+
+        const node3 = addNode('n3', 'GapNode', 'scene');
+        const node4 = addNode('n4', 'GapNode', 'scene');
+
+        expect(manager.getNodePath(node3)).toBe('GapNode_001');
+        expect(manager.getNodePath(node4)).toBe('GapNode_003');
+    });
+});

--- a/src/core/engine/test/node-path-manager.test.ts
+++ b/src/core/engine/test/node-path-manager.test.ts
@@ -101,11 +101,187 @@ describe('NodePathManager.changeUuid', () => {
         expect(result.error).toBeUndefined();
     });
 
-    it('migrates _nodeNames to the new UUID', () => {
+    it('migrates _nodeNames to the new UUID so new children under the moved node get unique names', () => {
         manager.generateUniquePath('grandchild', 'GC', 'old-uuid');
         manager.changeUuid('old-uuid', 'new-uuid');
 
-        expect(manager.getNameSet('new-uuid')).toBeTruthy();
-        expect(manager.getNameSet('old-uuid')).toBeNull();
+        // 验证迁移后在新 UUID 下创建同名子节点会自动去重
+        // generateUniquePath 返回完整路径，parent 'new-uuid' 的 path 是 'Child'
+        const path = manager.generateUniquePath('grandchild2', 'GC', 'new-uuid');
+        expect(path).toBe('Child/GC_001');
+    });
+});
+
+describe('NodePathManager name/path 解耦', () => {
+    let manager: NodePathManager;
+
+    beforeEach(() => {
+        manager = new NodePathManager();
+    });
+
+    it('重命名为与兄弟同名时，路径段自动去重，兄弟路径不变', () => {
+        manager.generateUniquePath('a', 'Enemy', 'scene');
+        manager.generateUniquePath('b', 'Soldier', 'scene');
+
+        // b 重命名为 Enemy（与 a 同名）
+        manager.updateUuid('b', 'Enemy', 'scene');
+
+        // a 的路径不变
+        expect(manager.getNodePath('a')).toBe('Enemy');
+        // b 获得去重路径
+        expect(manager.getNodePath('b')).toBe('Enemy_001');
+        // 两个路径都能正确查到 UUID
+        expect(manager.getNodeUuid('Enemy')).toBe('a');
+        expect(manager.getNodeUuid('Enemy_001')).toBe('b');
+    });
+
+    it('重命名为同名后再次重命名为不冲突名称，路径正确更新', () => {
+        manager.generateUniquePath('a', 'Enemy', 'scene');
+        manager.generateUniquePath('b', 'Soldier', 'scene');
+
+        // b → Enemy（冲突）
+        manager.updateUuid('b', 'Enemy', 'scene');
+        expect(manager.getNodePath('b')).toBe('Enemy_001');
+
+        // b → Ally（不冲突）
+        manager.updateUuid('b', 'Ally', 'scene');
+        expect(manager.getNodePath('b')).toBe('Ally');
+        // 旧路径失效
+        expect(manager.getNodeResult('Enemy_001').error).toBe('Not found');
+        // a 不受影响
+        expect(manager.getNodePath('a')).toBe('Enemy');
+    });
+
+    it('删除节点后释放路径段，新节点可复用', () => {
+        // 注册 scene 节点使 _getParentUuid 能找到父节点
+        manager.add('scene', 'Scene');
+        manager.generateUniquePath('a', 'Enemy', 'scene');
+        manager.generateUniquePath('b', 'Enemy', 'scene'); // → Scene/Enemy_001
+
+        expect(manager.getNodePath('b')).toBe('Scene/Enemy_001');
+
+        // 删除 a，释放 "Enemy" 路径段
+        manager.remove('a');
+        expect(manager.getNodeResult('Scene/Enemy').error).toBe('Not found');
+
+        // 新节点可以获得 "Enemy" 路径段
+        const path = manager.generateUniquePath('c', 'Enemy', 'scene');
+        expect(path).toBe('Scene/Enemy');
+        // b 的路径不变
+        expect(manager.getNodePath('b')).toBe('Scene/Enemy_001');
+    });
+
+    it('兄弟增删不影响已有节点路径', () => {
+        manager.generateUniquePath('a', 'Item', 'scene');   // Item
+        manager.generateUniquePath('b', 'Item', 'scene');   // Item_001
+        manager.generateUniquePath('c', 'Item', 'scene');   // Item_002
+
+        const pathA = manager.getNodePath('a');
+        const pathB = manager.getNodePath('b');
+        const pathC = manager.getNodePath('c');
+
+        // 删除 a
+        manager.remove('a');
+
+        // b 和 c 的路径不变
+        expect(manager.getNodePath('b')).toBe(pathB);
+        expect(manager.getNodePath('c')).toBe(pathC);
+    });
+
+    it('移动到同名兄弟所在的父节点，路径自动去重', () => {
+        manager.generateUniquePath('parent', 'Parent', 'scene');
+        manager.generateUniquePath('existing', 'Child', 'parent');   // Parent/Child
+        manager.generateUniquePath('moving', 'Child', 'scene');      // Child
+
+        const movedPath = manager.move('moving', 'Child', 'parent', 'scene');
+
+        // 移入后路径自动去重
+        expect(movedPath).toBe('Parent/Child_001');
+        // 已有节点路径不变
+        expect(manager.getNodePath('existing')).toBe('Parent/Child');
+    });
+
+    it('父节点重命名后子树路径全部级联更新', () => {
+        manager.generateUniquePath('parent', 'OldParent', 'scene');
+        manager.generateUniquePath('child', 'ChildA', 'parent');
+        manager.generateUniquePath('grandchild', 'GC', 'child');
+
+        manager.updateUuid('parent', 'NewParent', 'scene');
+
+        expect(manager.getNodePath('parent')).toBe('NewParent');
+        expect(manager.getNodePath('child')).toBe('NewParent/ChildA');
+        expect(manager.getNodePath('grandchild')).toBe('NewParent/ChildA/GC');
+        // 旧路径全部失效
+        expect(manager.getNodeResult('OldParent').error).toBe('Not found');
+        expect(manager.getNodeResult('OldParent/ChildA').error).toBe('Not found');
+        expect(manager.getNodeResult('OldParent/ChildA/GC').error).toBe('Not found');
+    });
+
+    it('连续冲突重命名不会导致路径段泄漏', () => {
+        manager.generateUniquePath('a', 'X', 'scene');
+        manager.generateUniquePath('b', 'Y', 'scene');
+        manager.generateUniquePath('c', 'Z', 'scene');
+
+        // b → X（冲突）→ 获得 X_001
+        manager.updateUuid('b', 'X', 'scene');
+        expect(manager.getNodePath('b')).toBe('X_001');
+
+        // c → X（冲突）→ 获得 X_002
+        manager.updateUuid('c', 'X', 'scene');
+        expect(manager.getNodePath('c')).toBe('X_002');
+
+        // a 不受影响
+        expect(manager.getNodePath('a')).toBe('X');
+
+        // 旧路径全部释放
+        expect(manager.getNodeResult('Y').error).toBe('Not found');
+        expect(manager.getNodeResult('Z').error).toBe('Not found');
+    });
+
+    it('同名父节点下的子节点路径各自独立，不会互相去重', () => {
+        // A 下有两个 name="B" 的节点
+        manager.generateUniquePath('a', 'A', 'scene');
+        manager.generateUniquePath('b1', 'B', 'a');           // A/B
+        manager.generateUniquePath('b2', 'B', 'a');           // A/B_001（自动去重）
+
+        // 各自下面创建 name="C" 的子节点
+        manager.generateUniquePath('c1', 'C', 'b1');          // A/B/C
+        manager.generateUniquePath('c2', 'C', 'b2');          // A/B_001/C
+
+        // 两个 C 的路径段都是 "C"，不需要 _001
+        expect(manager.getNodePath('c1')).toBe('A/B/C');
+        expect(manager.getNodePath('c2')).toBe('A/B_001/C');
+
+        // 两条路径各自能查到正确 UUID
+        expect(manager.getNodeUuid('A/B/C')).toBe('c1');
+        expect(manager.getNodeUuid('A/B_001/C')).toBe('c2');
+
+        // b1、b2 路径不变
+        expect(manager.getNodePath('b1')).toBe('A/B');
+        expect(manager.getNodePath('b2')).toBe('A/B_001');
+    });
+
+    it('重命名父节点为同名后，子树路径级联且子节点不互相干扰', () => {
+        manager.generateUniquePath('a', 'A', 'scene');
+        manager.generateUniquePath('b1', 'B', 'a');
+        manager.generateUniquePath('b2', 'X', 'a');
+        manager.generateUniquePath('c1', 'C', 'b1');          // A/B/C
+        manager.generateUniquePath('c2', 'C', 'b2');          // A/X/C
+
+        // 把 b2 重命名为 "B"（与 b1 同名）
+        manager.updateUuid('b2', 'B', 'a');
+
+        // b2 路径段去重
+        expect(manager.getNodePath('b2')).toBe('A/B_001');
+        // b1 不变
+        expect(manager.getNodePath('b1')).toBe('A/B');
+        // c2 路径跟着 b2 级联
+        expect(manager.getNodePath('c2')).toBe('A/B_001/C');
+        // c1 不受影响
+        expect(manager.getNodePath('c1')).toBe('A/B/C');
+
+        // 各路径查到正确 UUID
+        expect(manager.getNodeUuid('A/B/C')).toBe('c1');
+        expect(manager.getNodeUuid('A/B_001/C')).toBe('c2');
     });
 });

--- a/src/core/engine/test/node-path-manager.test.ts
+++ b/src/core/engine/test/node-path-manager.test.ts
@@ -188,6 +188,21 @@ describe('NodePathManager name/path 解耦', () => {
         expect(manager.getNodePath('c')).toBe(pathC);
     });
 
+    it('当前会话保留现有后缀，但重新加载后按剩余兄弟重新分配路径', () => {
+        manager.add('scene', 'Scene');
+        manager.generateUniquePath('a', 'Enemy', 'scene');
+        manager.generateUniquePath('b', 'Enemy', 'scene');
+
+        manager.remove('a');
+        expect(manager.getNodePath('b')).toBe('Scene/Enemy_001');
+
+        manager.clear();
+        manager.add('scene', 'Scene');
+        manager.generateUniquePath('b', 'Enemy', 'scene');
+
+        expect(manager.getNodePath('b')).toBe('Scene/Enemy');
+    });
+
     it('移动到同名兄弟所在的父节点，路径自动去重', () => {
         manager.generateUniquePath('parent', 'Parent', 'scene');
         manager.generateUniquePath('existing', 'Child', 'parent');   // Parent/Child

--- a/src/core/engine/test/node-path-manager.test.ts
+++ b/src/core/engine/test/node-path-manager.test.ts
@@ -284,4 +284,14 @@ describe('NodePathManager name/path 解耦', () => {
         expect(manager.getNodeUuid('A/B/C')).toBe('c1');
         expect(manager.getNodeUuid('A/B_001/C')).toBe('c2');
     });
+
+    it('含非法字符的节点名经内部清洗后路径自动去重', () => {
+        manager.generateUniquePath('a', 'A:B', 'scene');
+        manager.generateUniquePath('b', 'A:B', 'scene');
+
+        expect(manager.getNodePath('a')).toBe('A_B');
+        expect(manager.getNodePath('b')).toBe('A_B_001');
+        expect(manager.getNodeUuid('A_B')).toBe('a');
+        expect(manager.getNodeUuid('A_B_001')).toBe('b');
+    });
 });

--- a/src/core/engine/test/path-utils.test.ts
+++ b/src/core/engine/test/path-utils.test.ts
@@ -1,0 +1,23 @@
+import {
+    ILLEGAL_NAME_CHARS,
+    sanitizeNodeName,
+    validateNodeName,
+} from '../editor-extends/manager/path-utils';
+
+describe('node path utilities', () => {
+    it.each(['/', '\\', ':', '*', '?', '"', '<', '>', '|'])(
+        'rejects and sanitizes the illegal node-name character %p',
+        (character) => {
+            const name = `A${character}B`;
+
+            expect(validateNodeName(name)).toContain(`illegal character '${character}'`);
+            expect(sanitizeNodeName(name)).toBe('A_B');
+            expect(ILLEGAL_NAME_CHARS.test(name)).toBe(true);
+        },
+    );
+
+    it('preserves legal display names, including duplicate-name suffix text', () => {
+        expect(validateNodeName('Enemy_001')).toBeNull();
+        expect(sanitizeNodeName('Enemy_001')).toBe('Enemy_001');
+    });
+});

--- a/src/core/scene/main-process/proxy/node-proxy.ts
+++ b/src/core/scene/main-process/proxy/node-proxy.ts
@@ -73,9 +73,15 @@ export const NodeProxy: INodeProxy = {
                 path: 'name',
                 dump: { ...nameDef, value: params.name },
             }]);
-            const segments = currentPath.split('/');
-            segments[segments.length - 1] = params.name;
-            currentPath = segments.join('/');
+            const nodeUuid = nodeDump.uuid?.value;
+            if (!nodeUuid) {
+                throw new Error(`Node at '${params.path}' has no uuid, cannot resolve renamed path`);
+            }
+            const realPath = await Rpc.getInstance().request('Node', 'getPathByUuid', [nodeUuid]);
+            if (!realPath) {
+                throw new Error(`Cannot resolve path for node '${nodeUuid}' after rename`);
+            }
+            currentPath = realPath as string;
         }
 
         return { path: currentPath };

--- a/src/core/scene/main-process/proxy/node-proxy.ts
+++ b/src/core/scene/main-process/proxy/node-proxy.ts
@@ -77,6 +77,8 @@ export const NodeProxy: INodeProxy = {
             if (!nodeUuid) {
                 throw new Error(`Node at '${params.path}' has no uuid, cannot resolve renamed path`);
             }
+            // After name/path decoupling, rename no longer simply replaces the last path segment
+            // (same-name siblings produce suffixes); must reverse-lookup via UUID from NodePathManager
             const realPath = await Rpc.getInstance().request('Node', 'getPathByUuid', [nodeUuid]);
             if (!realPath) {
                 throw new Error(`Cannot resolve path for node '${nodeUuid}' after rename`);

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -48,7 +48,6 @@ import { AnimationClipSnapshotCommand } from './animation/undo';
 import { IAnimationSession } from './animation/types';
 import { clipUuid, ensureClipEvents, getClipSample } from './animation/utils';
 import { serializeAnimationPropertyValue } from './animation/property-value';
-import { cacheNodeDisplayPaths, clearNodeDisplayPathCache } from './animation/property-curve';
 import { AnimationServicePlayback } from './animation/service-playback';
 import { isAllowedSkeletonAnimationOperation, isAnimationOperationResult, shouldSyncAnimationClipDuration } from './animation/operation-policy';
 import { normalizeAnimationOperation } from './animation/operation-normalizer';
@@ -69,6 +68,7 @@ import {
     queryAnimationComponent,
     queryAnimationRootNode,
     readPropertyValue,
+    resolveAnimationRelativeNodePath,
 } from './animation/scene-node';
 import {
     assertAnimationEditorOpened,
@@ -149,8 +149,6 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             undoBaseline: Service.Undo.createCheckpoint(),
             globalDirtyAtEnter: Service.Undo.isDirty(),
         };
-        clearNodeDisplayPathCache(rootNode);
-        cacheNodeDisplayPaths(rootNode);
 
         this._playState = 'stop';
         this._curEditTime = 0;
@@ -189,10 +187,6 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             this._restoreSelection(session.previousSelection);
         }
 
-        const rootNode = getNodeByUuid(session.rootUuid);
-        if (rootNode) {
-            clearNodeDisplayPathCache(rootNode);
-        }
         this._session = null;
         this._curEditTime = 0;
         this._playState = 'stop';
@@ -476,6 +470,13 @@ export class AnimationService extends BaseService<Record<string, any>> implement
                 }
                 return inputFailure;
             }
+            const targetFailure = validateAnimationPropertyTarget(inputOperation, rootNode, session.rootPath);
+            if (targetFailure) {
+                if (shouldRestoreOnFailure) {
+                    await this._restoreFailedOperationSnapshot(clip, before, rootNode);
+                }
+                return targetFailure;
+            }
             if (isSkeleton && !isAllowedSkeletonAnimationOperation(inputOperation)) {
                 const skeletonFailure = {
                     state: 'failure',
@@ -659,17 +660,6 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         });
     }
 
-    onBeforeRemoveNode(node: Node): void {
-        if (!this._session) {
-            return;
-        }
-        const rootNode = getNodeByUuid(this._session.rootUuid);
-        if (rootNode) {
-            this._session.rootPath = getNodePath(rootNode);
-            cacheNodeDisplayPaths(rootNode, node);
-        }
-    }
-
     onEditorClosed(): void {
         this._disposeSession();
     }
@@ -717,13 +707,13 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         // newly edited keyframes.
         const snapshot = captureAnimationClipSnapshot(clip, options);
         this._animationStates.reset(uuid);
-        await restoreAnimationClipSnapshot(clip, snapshot, options);
+        await restoreAnimationClipSnapshot(clip, snapshot);
     }
 
-    private async _restoreFailedOperationSnapshot(clip: AnimationClip, snapshot: IAnimationClipSnapshot, rootNode: Node): Promise<void> {
+    private async _restoreFailedOperationSnapshot(clip: AnimationClip, snapshot: IAnimationClipSnapshot, _rootNode: Node): Promise<void> {
         const uuid = clipUuid(clip);
         try {
-            await this._restoreClipSnapshotWithStateRecreation(uuid, clip, snapshot, rootNode);
+            await this._restoreClipSnapshotWithStateRecreation(uuid, clip, snapshot);
         } catch (error) {
             console.error('[Animation] restore failed operation snapshot failed:', error);
             throw error;
@@ -739,8 +729,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
         const state = await this._getAnimationState(uuid);
         const clip = state.clip;
-        const rootNode = session.rootUuid ? getNodeByUuid(session.rootUuid) || undefined : undefined;
-        await this._restoreClipSnapshotWithStateRecreation(uuid, clip, snapshot, rootNode, true);
+        await this._restoreClipSnapshotWithStateRecreation(uuid, clip, snapshot, true);
         await this.setTime({ time: this._curEditTime });
         this._broadcastClipChanged('undo-redo');
     }
@@ -761,9 +750,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             return;
         }
 
-        await this._restoreClipSnapshotWithStateRecreation(
-            uuid, clip, snapshot, propertyMetadataContext.rootNode, true,
-        );
+        await this._restoreClipSnapshotWithStateRecreation(uuid, clip, snapshot, true);
         await this.setTime({ time: this._curEditTime });
     }
 
@@ -771,7 +758,6 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         uuid: string,
         clip: AnimationClip,
         snapshot: IAnimationClipSnapshot,
-        rootNode?: Node,
         shouldRecreateState = Boolean(this._animationStates.get(uuid)),
     ): Promise<void> {
         if (shouldRecreateState) {
@@ -779,7 +765,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             this._animationStates.reset(uuid);
         }
         try {
-            await restoreAnimationClipSnapshot(clip, snapshot, rootNode ? { rootNode } : {});
+            await restoreAnimationClipSnapshot(clip, snapshot);
         } catch (error) {
             if (shouldRecreateState) {
                 this._animationStates.create(uuid, clip);
@@ -838,12 +824,6 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     private _disposeSession(): void {
-        if (this._session) {
-            const rootNode = getNodeByUuid(this._session.rootUuid);
-            if (rootNode) {
-                clearNodeDisplayPathCache(rootNode);
-            }
-        }
         this._playback.dispose();
         this._animationStates.clear();
         this._session = null;
@@ -1026,4 +1006,28 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
 function normalizeSceneNodePath(path: string): string {
     return String(path || '').replace(/^\/+|\/+$/g, '');
+}
+
+function validateAnimationPropertyTarget(
+    operation: IAnimationOperation,
+    rootNode: Node,
+    rootPath: string,
+): IAnimationOperationResult | null {
+    if (!('propKey' in operation)) {
+        return null;
+    }
+    if (resolveAnimationRelativeNodePath(rootNode, rootPath, operation) !== null) {
+        return null;
+    }
+
+    const target = operation.nodeUuid
+        ? `UUID "${operation.nodeUuid}"`
+        : `path "${operation.nodePath || '<root>'}"`;
+    const reason = `Animation property target ${target} is not bound by the current animation hierarchy.`;
+    console.warn(`[Animation] ${reason}`);
+    return {
+        state: 'failure',
+        result: false,
+        reason,
+    };
 }

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -898,14 +898,20 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     private _getSessionRootNode(): Node {
         const session = requireAnimationSession(this._session);
         const rootNode = getAnimationSessionRootNode(session);
-        session.rootPath = getNodePath(rootNode);
+        const rootPath = getNodePath(rootNode);
+        if (rootPath) {
+            session.rootPath = rootPath;
+        }
         return rootNode;
     }
 
     private _refreshSessionRootPath(session: IAnimationSession): void {
         const rootNode = getNodeByUuid(session.rootUuid);
         if (rootNode) {
-            session.rootPath = getNodePath(rootNode);
+            const rootPath = getNodePath(rootNode);
+            if (rootPath) {
+                session.rootPath = rootPath;
+            }
         }
     }
 

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -48,6 +48,7 @@ import { AnimationClipSnapshotCommand } from './animation/undo';
 import { IAnimationSession } from './animation/types';
 import { clipUuid, ensureClipEvents, getClipSample } from './animation/utils';
 import { serializeAnimationPropertyValue } from './animation/property-value';
+import { cacheNodeDisplayPaths, clearNodeDisplayPathCache } from './animation/property-curve';
 import { AnimationServicePlayback } from './animation/service-playback';
 import { isAllowedSkeletonAnimationOperation, isAnimationOperationResult, shouldSyncAnimationClipDuration } from './animation/operation-policy';
 import { normalizeAnimationOperation } from './animation/operation-normalizer';
@@ -148,6 +149,8 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             undoBaseline: Service.Undo.createCheckpoint(),
             globalDirtyAtEnter: Service.Undo.isDirty(),
         };
+        clearNodeDisplayPathCache(rootNode);
+        cacheNodeDisplayPaths(rootNode);
 
         this._playState = 'stop';
         this._curEditTime = 0;
@@ -186,6 +189,10 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             this._restoreSelection(session.previousSelection);
         }
 
+        const rootNode = getNodeByUuid(session.rootUuid);
+        if (rootNode) {
+            clearNodeDisplayPathCache(rootNode);
+        }
         this._session = null;
         this._curEditTime = 0;
         this._playState = 'stop';
@@ -214,6 +221,8 @@ export class AnimationService extends BaseService<Record<string, any>> implement
                 restoreSelectionOnExit: true,
             };
         }
+
+        this._refreshSessionRootPath(this._session);
 
         return {
             active: true,
@@ -275,6 +284,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     async queryClip(options: IAnimationQueryClipOptions): Promise<IAnimationClipDump> {
         const hasTarget = Boolean(options.rootPath || options.rootUuid || options.nodePath || options.nodeUuid);
         if (this._session) {
+            this._refreshSessionRootPath(this._session);
             const uuid = options.clipUuid || this._session.clipUuid;
             const state = isCurrentAnimationSessionClipQuery(this._session, options, uuid, hasTarget)
                 ? this._animationStates.get(uuid)
@@ -312,6 +322,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
     async queryPropertyValueAtFrame(options: IAnimationQueryPropertyValueAtFrameOptions): Promise<IAnimationValue> {
         const session = requireAnimationSession(this._session);
+        this._refreshSessionRootPath(session);
         const uuid = options.clipUuid || session.clipUuid;
         if (uuid !== session.clipUuid) {
             throw new Error(`current edit clip: '${session.clipUuid}' but you want to operate: '${uuid}'`);
@@ -648,6 +659,17 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         });
     }
 
+    onBeforeRemoveNode(node: Node): void {
+        if (!this._session) {
+            return;
+        }
+        const rootNode = getNodeByUuid(this._session.rootUuid);
+        if (rootNode) {
+            this._session.rootPath = getNodePath(rootNode);
+            cacheNodeDisplayPaths(rootNode, node);
+        }
+    }
+
     onEditorClosed(): void {
         this._disposeSession();
     }
@@ -695,13 +717,13 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         // newly edited keyframes.
         const snapshot = captureAnimationClipSnapshot(clip, options);
         this._animationStates.reset(uuid);
-        await restoreAnimationClipSnapshot(clip, snapshot);
+        await restoreAnimationClipSnapshot(clip, snapshot, options);
     }
 
-    private async _restoreFailedOperationSnapshot(clip: AnimationClip, snapshot: IAnimationClipSnapshot, _rootNode: Node): Promise<void> {
+    private async _restoreFailedOperationSnapshot(clip: AnimationClip, snapshot: IAnimationClipSnapshot, rootNode: Node): Promise<void> {
         const uuid = clipUuid(clip);
         try {
-            await this._restoreClipSnapshotWithStateRecreation(uuid, clip, snapshot);
+            await this._restoreClipSnapshotWithStateRecreation(uuid, clip, snapshot, rootNode);
         } catch (error) {
             console.error('[Animation] restore failed operation snapshot failed:', error);
             throw error;
@@ -717,7 +739,8 @@ export class AnimationService extends BaseService<Record<string, any>> implement
 
         const state = await this._getAnimationState(uuid);
         const clip = state.clip;
-        await this._restoreClipSnapshotWithStateRecreation(uuid, clip, snapshot, true);
+        const rootNode = session.rootUuid ? getNodeByUuid(session.rootUuid) || undefined : undefined;
+        await this._restoreClipSnapshotWithStateRecreation(uuid, clip, snapshot, rootNode, true);
         await this.setTime({ time: this._curEditTime });
         this._broadcastClipChanged('undo-redo');
     }
@@ -738,7 +761,9 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             return;
         }
 
-        await this._restoreClipSnapshotWithStateRecreation(uuid, clip, snapshot, true);
+        await this._restoreClipSnapshotWithStateRecreation(
+            uuid, clip, snapshot, propertyMetadataContext.rootNode, true,
+        );
         await this.setTime({ time: this._curEditTime });
     }
 
@@ -746,6 +771,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         uuid: string,
         clip: AnimationClip,
         snapshot: IAnimationClipSnapshot,
+        rootNode?: Node,
         shouldRecreateState = Boolean(this._animationStates.get(uuid)),
     ): Promise<void> {
         if (shouldRecreateState) {
@@ -753,7 +779,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
             this._animationStates.reset(uuid);
         }
         try {
-            await restoreAnimationClipSnapshot(clip, snapshot);
+            await restoreAnimationClipSnapshot(clip, snapshot, rootNode ? { rootNode } : {});
         } catch (error) {
             if (shouldRecreateState) {
                 this._animationStates.create(uuid, clip);
@@ -812,6 +838,12 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     private _disposeSession(): void {
+        if (this._session) {
+            const rootNode = getNodeByUuid(this._session.rootUuid);
+            if (rootNode) {
+                clearNodeDisplayPathCache(rootNode);
+            }
+        }
         this._playback.dispose();
         this._animationStates.clear();
         this._session = null;
@@ -841,6 +873,9 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     private _broadcastTimeChanged(reason: AnimationEventReason): void {
+        if (this._session) {
+            this._refreshSessionRootPath(this._session);
+        }
         const event = createAnimationServiceClipEvent(this._session, reason);
         if (!event) {
             return;
@@ -853,6 +888,9 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     private _broadcastClipChanged(reason: AnimationEventReason): void {
+        if (this._session) {
+            this._refreshSessionRootPath(this._session);
+        }
         const event = createAnimationServiceClipEvent(this._session, reason);
         if (!event) {
             return;
@@ -878,7 +916,17 @@ export class AnimationService extends BaseService<Record<string, any>> implement
     }
 
     private _getSessionRootNode(): Node {
-        return getAnimationSessionRootNode(requireAnimationSession(this._session));
+        const session = requireAnimationSession(this._session);
+        const rootNode = getAnimationSessionRootNode(session);
+        session.rootPath = getNodePath(rootNode);
+        return rootNode;
+    }
+
+    private _refreshSessionRootPath(session: IAnimationSession): void {
+        const rootNode = getNodeByUuid(session.rootUuid);
+        if (rootNode) {
+            session.rootPath = getNodePath(rootNode);
+        }
     }
 
     private async _discardAnimationSessionChanges(session: IAnimationSession): Promise<void> {

--- a/src/core/scene/scene-process/service/animation/clip-snapshot.ts
+++ b/src/core/scene/scene-process/service/animation/clip-snapshot.ts
@@ -20,8 +20,16 @@ import {
     replaceEmbeddedPlayerGroups,
     replaceEmbeddedPlayers,
 } from './embedded-player';
-import { dumpPropertyCurves, replacePropertyCurves } from './property-curve';
-import type { IPropertyCurveMetadataContext } from './property-curve';
+import {
+    capturePropertyTrackOwners,
+    dumpPropertyCurves,
+    replacePropertyCurves,
+    restorePropertyTrackOwners,
+} from './property-curve';
+import type {
+    IPropertyCurveMetadataContext,
+    IPropertyTrackOwnersSnapshot,
+} from './property-curve';
 import {
     cloneValue,
     getClipSample,
@@ -39,6 +47,8 @@ export interface IAnimationClipSnapshot {
     embeddedPlayers: IAnimationEmbeddedPlayerDump[];
     embeddedPlayerGroups: IAnimationEmbeddedPlayerGroup[];
     auxiliaryCurves: Record<string, IAnimationAuxiliaryCurveDump>;
+    // With same-name siblings, undo/redo must persist track ownership to restore correct bindings
+    propertyTrackOwners?: IPropertyTrackOwnersSnapshot;
 }
 
 type AnimationAssetCtor = new () => Asset;
@@ -61,17 +71,24 @@ export function captureAnimationClipSnapshot(clip: AnimationClip, options: IProp
         embeddedPlayers: dumpEmbeddedPlayers(clip),
         embeddedPlayerGroups: queryEmbeddedPlayerGroups(clip),
         auxiliaryCurves: dumpAuxiliaryCurves(clip, { includeDefaults: true }),
+        propertyTrackOwners: options.rootNode
+            ? capturePropertyTrackOwners(options.rootNode, clip)
+            : undefined,
     };
 }
 
-export async function restoreAnimationClipSnapshot(clip: AnimationClip, snapshot: IAnimationClipSnapshot): Promise<void> {
-    const previous = captureAnimationClipSnapshot(clip);
+export async function restoreAnimationClipSnapshot(
+    clip: AnimationClip,
+    snapshot: IAnimationClipSnapshot,
+    options: IPropertyCurveMetadataContext = {},
+): Promise<void> {
+    const previous = captureAnimationClipSnapshot(clip, options);
     const pendingAssetLoads: PendingAnimationAssetLoads = new Map();
     try {
-        await applyAnimationClipSnapshot(clip, snapshot, pendingAssetLoads);
+        await applyAnimationClipSnapshot(clip, snapshot, pendingAssetLoads, options);
     } catch (error) {
         try {
-            await applyAnimationClipSnapshot(clip, previous, pendingAssetLoads);
+            await applyAnimationClipSnapshot(clip, previous, pendingAssetLoads, options);
         } catch (restoreError) {
             console.error('[Animation] rollback failed animation clip snapshot restore:', restoreError);
         }
@@ -83,6 +100,7 @@ async function applyAnimationClipSnapshot(
     clip: AnimationClip,
     snapshot: IAnimationClipSnapshot,
     pendingAssetLoads: PendingAnimationAssetLoads,
+    options: IPropertyCurveMetadataContext,
 ): Promise<void> {
     (clip as any).duration = snapshot.duration;
     (clip as any).sample = snapshot.sample;
@@ -91,6 +109,9 @@ async function applyAnimationClipSnapshot(
     const curves = await hydrateAnimationAssetCurveValues(snapshot.curves, pendingAssetLoads);
     if (!replacePropertyCurves(clip, curves)) {
         throw new Error('Failed to restore animation property curves.');
+    }
+    if (options.rootNode) {
+        restorePropertyTrackOwners(options.rootNode, clip, snapshot.propertyTrackOwners ?? {});
     }
     restoreEvents(clip, snapshot);
     replaceEmbeddedPlayerGroups(clip, snapshot.embeddedPlayerGroups);
@@ -182,8 +203,11 @@ function loadAnimationAssetOnce(
     return pending;
 }
 
+// propertyTrackOwners is internal bookkeeping, not animation content; exclude it to correctly detect "content changed"
 export function animationClipSnapshotsEqual(left: IAnimationClipSnapshot, right: IAnimationClipSnapshot): boolean {
-    return JSON.stringify(left) === JSON.stringify(right);
+    const { propertyTrackOwners: _leftOwners, ...leftData } = left;
+    const { propertyTrackOwners: _rightOwners, ...rightData } = right;
+    return JSON.stringify(leftData) === JSON.stringify(rightData);
 }
 
 function restoreEvents(clip: AnimationClip, snapshot: IAnimationClipSnapshot): void {

--- a/src/core/scene/scene-process/service/animation/clip-snapshot.ts
+++ b/src/core/scene/scene-process/service/animation/clip-snapshot.ts
@@ -20,16 +20,8 @@ import {
     replaceEmbeddedPlayerGroups,
     replaceEmbeddedPlayers,
 } from './embedded-player';
-import {
-    capturePropertyTrackOwners,
-    dumpPropertyCurves,
-    replacePropertyCurves,
-    restorePropertyTrackOwners,
-} from './property-curve';
-import type {
-    IPropertyCurveMetadataContext,
-    IPropertyTrackOwnersSnapshot,
-} from './property-curve';
+import { dumpPropertyCurves, replacePropertyCurves } from './property-curve';
+import type { IPropertyCurveMetadataContext } from './property-curve';
 import {
     cloneValue,
     getClipSample,
@@ -47,8 +39,6 @@ export interface IAnimationClipSnapshot {
     embeddedPlayers: IAnimationEmbeddedPlayerDump[];
     embeddedPlayerGroups: IAnimationEmbeddedPlayerGroup[];
     auxiliaryCurves: Record<string, IAnimationAuxiliaryCurveDump>;
-    // With same-name siblings, undo/redo must persist track ownership to restore correct bindings
-    propertyTrackOwners?: IPropertyTrackOwnersSnapshot;
 }
 
 type AnimationAssetCtor = new () => Asset;
@@ -71,24 +61,17 @@ export function captureAnimationClipSnapshot(clip: AnimationClip, options: IProp
         embeddedPlayers: dumpEmbeddedPlayers(clip),
         embeddedPlayerGroups: queryEmbeddedPlayerGroups(clip),
         auxiliaryCurves: dumpAuxiliaryCurves(clip, { includeDefaults: true }),
-        propertyTrackOwners: options.rootNode
-            ? capturePropertyTrackOwners(options.rootNode, clip)
-            : undefined,
     };
 }
 
-export async function restoreAnimationClipSnapshot(
-    clip: AnimationClip,
-    snapshot: IAnimationClipSnapshot,
-    options: IPropertyCurveMetadataContext = {},
-): Promise<void> {
-    const previous = captureAnimationClipSnapshot(clip, options);
+export async function restoreAnimationClipSnapshot(clip: AnimationClip, snapshot: IAnimationClipSnapshot): Promise<void> {
+    const previous = captureAnimationClipSnapshot(clip);
     const pendingAssetLoads: PendingAnimationAssetLoads = new Map();
     try {
-        await applyAnimationClipSnapshot(clip, snapshot, pendingAssetLoads, options);
+        await applyAnimationClipSnapshot(clip, snapshot, pendingAssetLoads);
     } catch (error) {
         try {
-            await applyAnimationClipSnapshot(clip, previous, pendingAssetLoads, options);
+            await applyAnimationClipSnapshot(clip, previous, pendingAssetLoads);
         } catch (restoreError) {
             console.error('[Animation] rollback failed animation clip snapshot restore:', restoreError);
         }
@@ -100,7 +83,6 @@ async function applyAnimationClipSnapshot(
     clip: AnimationClip,
     snapshot: IAnimationClipSnapshot,
     pendingAssetLoads: PendingAnimationAssetLoads,
-    options: IPropertyCurveMetadataContext,
 ): Promise<void> {
     (clip as any).duration = snapshot.duration;
     (clip as any).sample = snapshot.sample;
@@ -109,9 +91,6 @@ async function applyAnimationClipSnapshot(
     const curves = await hydrateAnimationAssetCurveValues(snapshot.curves, pendingAssetLoads);
     if (!replacePropertyCurves(clip, curves)) {
         throw new Error('Failed to restore animation property curves.');
-    }
-    if (options.rootNode) {
-        restorePropertyTrackOwners(options.rootNode, clip, snapshot.propertyTrackOwners ?? {});
     }
     restoreEvents(clip, snapshot);
     replaceEmbeddedPlayerGroups(clip, snapshot.embeddedPlayerGroups);
@@ -203,11 +182,8 @@ function loadAnimationAssetOnce(
     return pending;
 }
 
-// propertyTrackOwners is internal bookkeeping, not animation content; exclude it to correctly detect "content changed"
 export function animationClipSnapshotsEqual(left: IAnimationClipSnapshot, right: IAnimationClipSnapshot): boolean {
-    const { propertyTrackOwners: _leftOwners, ...leftData } = left;
-    const { propertyTrackOwners: _rightOwners, ...rightData } = right;
-    return JSON.stringify(leftData) === JSON.stringify(rightData);
+    return JSON.stringify(left) === JSON.stringify(right);
 }
 
 function restoreEvents(clip: AnimationClip, snapshot: IAnimationClipSnapshot): void {

--- a/src/core/scene/scene-process/service/animation/operation-normalizer.ts
+++ b/src/core/scene/scene-process/service/animation/operation-normalizer.ts
@@ -6,9 +6,7 @@ import type {
     IAnimationValue,
 } from '../../../common';
 import { normalizeProvidedAnimationPropertyOperationValue } from './property-value';
-import {
-    extractSampledOperationValue,
-} from './scene-node';
+import { extractSampledOperationValue } from './scene-node';
 
 type PropertyKeyOperation = Extract<IAnimationOperation, { type: 'createPropertyKey' | 'updatePropertyKey' }>;
 

--- a/src/core/scene/scene-process/service/animation/operation-normalizer.ts
+++ b/src/core/scene/scene-process/service/animation/operation-normalizer.ts
@@ -8,8 +8,6 @@ import type {
 import { normalizeProvidedAnimationPropertyOperationValue } from './property-value';
 import {
     extractSampledOperationValue,
-    getNodeByUuid,
-    getNodePath,
 } from './scene-node';
 
 type PropertyKeyOperation = Extract<IAnimationOperation, { type: 'createPropertyKey' | 'updatePropertyKey' }>;
@@ -44,10 +42,7 @@ async function normalizePropertyKeyOperation(
 ): Promise<IAnimationOperation | IAnimationOperationResult> {
     const keyData = operation.keyData ?? operation.curveData;
     if (operation.value !== undefined) {
-        const value = await normalizeProvidedAnimationPropertyOperationValue(context.rootNode, context.rootPath, operation, {
-            queryNodeByUuid: getNodeByUuid,
-            queryNodePath: getNodePath,
-        });
+        const value = await normalizeProvidedAnimationPropertyOperationValue(context.rootNode, context.rootPath, operation);
         return { ...operation, keyData, value };
     }
     if (operation.type === 'updatePropertyKey' && keyData) {

--- a/src/core/scene/scene-process/service/animation/property-curve.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve.ts
@@ -415,7 +415,7 @@ function resolveRelativeNodePath(context: IPropertyCurveOperationContext, operat
     return relativePath;
 }
 
-function hasSameNameSiblings(rootNode: Node, relativePath: string): boolean {
+export function hasSameNameSiblings(rootNode: Node, relativePath: string): boolean {
     const segments = relativePath.split('/');
     let current: Node = rootNode;
     for (const segment of segments) {

--- a/src/core/scene/scene-process/service/animation/property-curve.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve.ts
@@ -4,7 +4,7 @@ import type {
     IAnimationPropertyType,
     IAnimationValue,
 } from '../../../common';
-import { getNodeBySystemPath, getNodePath } from './scene-node';
+import { resolveAnimationRelativeNodePath } from './scene-node';
 import {
     getClipSample,
     normalizeFrames,
@@ -27,7 +27,6 @@ import {
     createPropertyTrack,
     findPropertyTrack,
     getClipTracks,
-    normalizePath,
     parsePropertyTrack,
     queryFirstRealCurve,
     removeSupportedPropertyTracks,
@@ -45,68 +44,9 @@ import type {
     IUpdatePropertyKeyDataOperation,
 } from './property-curve-types';
 
-// After decoupling, the operation target must carry both the display path and a reliability flag
 interface IResolvedPropertyTarget {
-    nodePath: string;   // Display path used by animation tracks (joined from node.name)
-    propKey: string;     // Property key (e.g. position, rotation)
-    reliable: boolean;   // Whether the path was reliably resolved (false on lenient fallback, blocks writes)
-    nodeUuid?: string;   // UUID of the target node, used for trackOwnership verification
-}
-
-/**
- * After name/path decoupling, animation track nodePath uses display paths (joined from node.name),
- * while NodePathManager maintains unique system paths. This cache maps multiple key types to
- * display paths, so tracks of deleted nodes can still be located and cleaned up via cached paths.
- */
-interface ICachedNodePath {
-    uuid: string;          // Node UUID, retained after node deletion
-    displayPath: string;   // Display path (joined from node.name), used as animation track nodePath
-    ambiguous: boolean;    // Whether the same display path maps to multiple UUIDs (same-name siblings)
-}
-
-// Per-rootNode (scene/prefab) cache with four key types mapping to the same ICachedNodePath
-interface INodePathCache {
-    byUuid: Map<string, ICachedNodePath>;                  // UUID -> cache entry (most precise)
-    byAbsoluteSystemPath: Map<string, ICachedNodePath>;    // Absolute system path -> cache entry
-    byRelativeSystemPath: Map<string, ICachedNodePath>;    // Relative system path (relative to rootNode) -> cache entry
-    byDisplayPath: Map<string, Set<ICachedNodePath>>;      // Display path -> entry set (Set for same-name sibling detection)
-    // Records which node UUID owns each animation track, for precise matching with same-name siblings
-    // key = JSON.stringify([nodePath, propKey]), value = nodeUuid
-    trackOwners: WeakMap<AnimationClip, Map<string, string>>;
-}
-
-// WeakMap keyed by rootNode: cache is auto-collected when scene/prefab closes and rootNode is GC'd
-const displayPathCache = new WeakMap<Node, INodePathCache>();
-
-// Cache a single node's display path by UUID (called externally on node creation/move)
-export function cacheNodeDisplayPath(rootNode: Node, nodeUuid: string): void {
-    const target = findNodeByUuid(rootNode, nodeUuid); // Recursively find the node instance
-    if (target) {
-        cacheNodeDisplayPaths(rootNode, target); // Cache this node and all its children
-    }
-}
-
-// Recursively cache display paths for all nodes under subtreeRoot, joined from node.name
-export function cacheNodeDisplayPaths(rootNode: Node, subtreeRoot: Node = rootNode): void {
-    // Compute the display path prefix of subtreeRoot relative to rootNode
-    const subtreePath = findRelativeNodePathByUuid(rootNode, subtreeRoot.uuid);
-    if (subtreePath === null) {
-        return; // subtreeRoot is not within rootNode's subtree, skip
-    }
-
-    const visit = (node: Node, displayPath: string): void => {
-        cacheDisplayPathEntry(rootNode, node, displayPath); // Write into multi-key cache
-        for (const child of node.children) {
-            // Child display path = parent path + "/" + child.name (empty prefix for root)
-            visit(child, displayPath ? `${displayPath}/${child.name}` : child.name);
-        }
-    };
-    visit(subtreeRoot, subtreePath);
-}
-
-// Clear cache when scene/prefab is closed or reloaded
-export function clearNodeDisplayPathCache(rootNode: Node): void {
-    displayPathCache.delete(rootNode);
+    nodePath: string;
+    propKey: string;
 }
 
 export interface IAnimationPropertyMetadata {
@@ -115,62 +55,12 @@ export interface IAnimationPropertyMetadata {
 }
 
 export interface IPropertyCurveMetadataContext {
-    rootNode?: Node;
     queryPropertyMetadata?: (nodePath: string, propKey: string) => IAnimationPropertyMetadata | null;
 }
 
-// trackOwners snapshot type: key = JSON.stringify([nodePath, propKey]), value = nodeUuid
-export type IPropertyTrackOwnersSnapshot = Record<string, string>;
-
-// Serialize the current clip's track ownership map into a persistable snapshot object.
-// Used by undo/redo: capture before operation, restore after undo to recover precise track-node bindings.
-// Solves: after undo with same-name siblings, we need to know exactly which track belongs to which node.
-export function capturePropertyTrackOwners(
-    rootNode: Node, clip: AnimationClip,
-): IPropertyTrackOwnersSnapshot {
-    // Retrieve the trackOwners Map for this clip from cache
-    const owners = displayPathCache.get(rootNode)?.trackOwners.get(clip);
-    if (!owners) {
-        return {}; // No ownership records, return empty snapshot
-    }
-
-    // Only retain ownership records for tracks that still exist in the clip (discard deleted tracks)
-    const existingKeys = queryPropertyTrackKeys(clip);
-    const snapshot: IPropertyTrackOwnersSnapshot = {};
-    for (const [key, uuid] of owners) {
-        if (existingKeys.has(key)) {
-            snapshot[key] = uuid; // Track still exists, preserve ownership
-        }
-    }
-    return snapshot;
-}
-
-// Restore track ownership map from a snapshot, replacing the current clip's trackOwners.
-// Typical scenario: after undo restores to a historical state, rebuild precise track-node bindings.
-export function restorePropertyTrackOwners(
-    rootNode: Node, clip: AnimationClip, snapshot: IPropertyTrackOwnersSnapshot,
-): void {
-    const cache = getNodePathCache(rootNode);
-    const existingKeys = queryPropertyTrackKeys(clip); // Tracks currently in the clip
-    const owners = new Map<string, string>();
-    for (const [key, uuid] of Object.entries(snapshot)) {
-        // Only restore tracks that still exist in the clip; ignore stale snapshot entries
-        if (existingKeys.has(key) && uuid) {
-            owners.set(key, uuid);
-        }
-    }
-    if (owners.size > 0) {
-        cache.trackOwners.set(clip, owners); // Replace trackOwners entirely
-    } else {
-        cache.trackOwners.delete(clip); // Remove empty Map to avoid stale entries
-    }
-}
-
-// Operation context: after decoupling, rootNode (scene/prefab root) and rootPath (root's system path) are needed
-// to convert nodeUuid/nodePath in operations into display paths used by animation tracks
 export interface IPropertyCurveOperationContext extends IPropertyCurveMetadataContext {
-    rootNode: Node;    // Root node reference for the animation editing session
-    rootPath: string;  // System path of rootNode in the scene hierarchy
+    rootNode: Node;
+    rootPath: string;
 }
 
 export function dumpPropertyCurves(clip: AnimationClip, options: IDumpRealKeyDataOptions & IPropertyCurveMetadataContext = {}): IAnimationCurveDump[] {
@@ -199,21 +89,13 @@ export function createPropertyKey(
     context: IPropertyCurveOperationContext,
     operation: ICreatePropertyKeyOperation,
 ): boolean {
-    // Core decoupling: resolve nodeUuid/nodePath from the operation into a display path
     const target = resolvePropertyTarget(context, operation);
     const frame = Number(operation.frame);
     if (!target || !Number.isFinite(frame) || frame < 0) {
         return false;
     }
 
-    // Find existing track using the resolved display path
-    const matchedTrack = findPropertyTrack(clip, target.nodePath, target.propKey);
-    const existedTrack = matchedTrack
-        ? verifyTrackOwnership(clip, matchedTrack, target.reliable, context.rootNode, target.nodeUuid)
-        : null;
-    if (matchedTrack && !existedTrack) {
-        return false;
-    }
+    const existedTrack = findPropertyTrack(clip, target.nodePath, target.propKey);
     const descriptor = existedTrack
         ? queryTrackDescriptor(context, existedTrack)
         : createDescriptor(context, target, operation.value);
@@ -223,14 +105,7 @@ export function createPropertyKey(
 
     const track = existedTrack || createPropertyTrack(clip, target.nodePath, descriptor);
     const time = frame / getClipSample(clip);
-    const changed = setTrackKey(
-        track, descriptor, time, operation.value, operation.channel, operation.keyData ?? operation.curveData,
-    );
-    // Establish ownership for both new tracks and safely adopted legacy tracks.
-    if (changed) {
-        recordTrackOwnership(context.rootNode, clip, track, target.nodeUuid);
-    }
-    return changed;
+    return setTrackKey(track, descriptor, time, operation.value, operation.channel, operation.keyData ?? operation.curveData);
 }
 
 export function addPropertyCurve(
@@ -238,23 +113,13 @@ export function addPropertyCurve(
     context: IPropertyCurveOperationContext,
     operation: IPropertyTarget & { value?: IAnimationValue },
 ): boolean {
-    // Core decoupling: nodeUuid/nodePath -> display path
     const target = resolvePropertyTarget(context, operation);
     if (!target) {
         return false;
     }
 
-    // Match existing track by display path
-    const matchedTrack = findPropertyTrack(clip, target.nodePath, target.propKey);
-    if (matchedTrack) {
-        const ownedTrack = verifyTrackOwnership(
-            clip, matchedTrack, target.reliable, context.rootNode, target.nodeUuid,
-        );
-        if (!ownedTrack) {
-            return false;
-        }
-        recordTrackOwnership(context.rootNode, clip, ownedTrack, target.nodeUuid);
-        return true; // Track already exists and belongs to this node.
+    if (findPropertyTrack(clip, target.nodePath, target.propKey)) {
+        return true;
     }
 
     const descriptor = createDescriptor(context, target, operation.value);
@@ -262,9 +127,7 @@ export function addPropertyCurve(
         return false;
     }
 
-    const track = createPropertyTrack(clip, target.nodePath, descriptor);
-    // Record track ownership on creation
-    recordTrackOwnership(context.rootNode, clip, track, target.nodeUuid);
+    createPropertyTrack(clip, target.nodePath, descriptor);
     return true;
 }
 
@@ -279,23 +142,10 @@ export function updatePropertyKey(
         return false;
     }
 
-    const matchedTrack = findPropertyTrack(clip, target.nodePath, target.propKey);
-    const track = matchedTrack
-        ? verifyTrackOwnership(clip, matchedTrack, target.reliable, context.rootNode, target.nodeUuid)
-        : null;
-    if (matchedTrack && !track) {
-        return false;
-    }
+    const track = findPropertyTrack(clip, target.nodePath, target.propKey);
     const descriptor = track ? queryTrackDescriptor(context, track) : null;
     if (track && descriptor) {
-        const changed = updateTrackKey(
-            track, descriptor, frame / getClipSample(clip), operation.value,
-            operation.channel, operation.keyData ?? operation.curveData,
-        );
-        if (changed) {
-            recordTrackOwnership(context.rootNode, clip, track, target.nodeUuid);
-        }
-        return changed;
+        return updateTrackKey(track, descriptor, frame / getClipSample(clip), operation.value, operation.channel, operation.keyData ?? operation.curveData);
     }
 
     return createPropertyKey(clip, context, operation);
@@ -312,23 +162,13 @@ export function updatePropertyKeyData(
         return false;
     }
 
-    const matchedTrack = findPropertyTrack(clip, target.nodePath, target.propKey);
-    const track = matchedTrack
-        ? verifyTrackOwnership(clip, matchedTrack, target.reliable, context.rootNode, target.nodeUuid)
-        : null;
+    const track = findPropertyTrack(clip, target.nodePath, target.propKey);
     const descriptor = track ? queryTrackDescriptor(context, track) : null;
     if (!track || !descriptor) {
         return false;
     }
 
-    const changed = updateTrackKey(
-        track, descriptor, frame / getClipSample(clip), undefined,
-        operation.channel, operation.keyData ?? operation.curveData,
-    );
-    if (changed) {
-        recordTrackOwnership(context.rootNode, clip, track, target.nodeUuid);
-    }
-    return changed;
+    return updateTrackKey(track, descriptor, frame / getClipSample(clip), undefined, operation.channel, operation.keyData ?? operation.curveData);
 }
 
 export function removePropertyKey(
@@ -336,19 +176,13 @@ export function removePropertyKey(
     context: IPropertyCurveOperationContext,
     operation: IPropertyKeyFramesOperation,
 ): boolean {
-    // lenient=true: deletion scenario allows fallback to cache/string derivation
-    const target = resolvePropertyTarget(context, operation, true);
+    const target = resolvePropertyTarget(context, operation);
     const frames = normalizeFrames(operation.frames);
     if (!target || frames.length === 0) {
         return false;
     }
 
-    let track = findPropertyTrack(clip, target.nodePath, target.propKey);
-    if (track) {
-        // Core decoupling: verify the found track truly belongs to the target node,
-        // preventing accidental deletion of a same-name sibling's track
-        track = verifyTrackOwnership(clip, track, target.reliable, context.rootNode, target.nodeUuid);
-    }
+    const track = findPropertyTrack(clip, target.nodePath, target.propKey);
     const descriptor = track ? queryTrackDescriptor(context, track) : null;
     if (!track || !descriptor) {
         return false;
@@ -357,9 +191,6 @@ export function removePropertyKey(
     let changed = false;
     for (const curve of queryTargetCurves(track, descriptor, operation.channel)) {
         changed = removeCurveKeys(clip, curve, frames) || changed;
-    }
-    if (changed) {
-        recordTrackOwnership(context.rootNode, clip, track, target.nodeUuid);
     }
     return changed;
 }
@@ -377,17 +208,12 @@ export function removePropertyCurve(
     context: IPropertyCurveOperationContext,
     operation: IPropertyTarget,
 ): boolean {
-    // lenient=true: deletion scenario allows fallback to cache/string derivation
-    const target = resolvePropertyTarget(context, operation, true);
+    const target = resolvePropertyTarget(context, operation);
     if (!target) {
         return false;
     }
 
-    let track = findPropertyTrack(clip, target.nodePath, target.propKey);
-    if (track) {
-        // Core decoupling: verify track ownership to prevent deleting a same-name sibling's track
-        track = verifyTrackOwnership(clip, track, target.reliable, context.rootNode, target.nodeUuid);
-    }
+    const track = findPropertyTrack(clip, target.nodePath, target.propKey);
     if (!track) {
         return false;
     }
@@ -396,8 +222,6 @@ export function removePropertyCurve(
     for (let index = tracks.length - 1; index >= 0; index--) {
         if (clip.getTrack(index) === track) {
             clip.removeTrack(index);
-            // Clean up ownership record after track removal
-            forgetTrackOwnership(context.rootNode, clip, track);
             return true;
         }
     }
@@ -416,10 +240,7 @@ export function movePropertyKeys(
         return false;
     }
 
-    const matchedTrack = findPropertyTrack(clip, target.nodePath, target.propKey);
-    const track = matchedTrack
-        ? verifyTrackOwnership(clip, matchedTrack, target.reliable, context.rootNode, target.nodeUuid)
-        : null;
+    const track = findPropertyTrack(clip, target.nodePath, target.propKey);
     const descriptor = track ? queryTrackDescriptor(context, track) : null;
     if (!track || !descriptor) {
         return false;
@@ -428,9 +249,6 @@ export function movePropertyKeys(
     let changed = false;
     for (const curve of queryTargetCurves(track, descriptor, operation.channel)) {
         changed = moveCurveKeys(clip, curve, frames, offset) || changed;
-    }
-    if (changed) {
-        recordTrackOwnership(context.rootNode, clip, track, target.nodeUuid);
     }
     return changed;
 }
@@ -447,10 +265,7 @@ export function copyPropertyKeysTo(
         return false;
     }
 
-    const matchedTrack = findPropertyTrack(clip, target.nodePath, target.propKey);
-    const track = matchedTrack
-        ? verifyTrackOwnership(clip, matchedTrack, target.reliable, context.rootNode, target.nodeUuid)
-        : null;
+    const track = findPropertyTrack(clip, target.nodePath, target.propKey);
     const descriptor = track ? queryTrackDescriptor(context, track) : null;
     if (!track || !descriptor) {
         return false;
@@ -459,9 +274,6 @@ export function copyPropertyKeysTo(
     let changed = false;
     for (const curve of queryTargetCurves(track, descriptor, operation.channel)) {
         changed = copyCurveKeysTo(clip, curve, frames, dstFrame) || changed;
-    }
-    if (changed) {
-        recordTrackOwnership(context.rootNode, clip, track, target.nodeUuid);
     }
     return changed;
 }
@@ -476,16 +288,12 @@ export function setPropertyCurveExtrapolation(
         return false;
     }
 
-    const matchedTrack = findPropertyTrack(clip, target.nodePath, target.propKey);
-    const track = matchedTrack
-        ? verifyTrackOwnership(clip, matchedTrack, target.reliable, context.rootNode, target.nodeUuid)
-        : null;
+    const track = findPropertyTrack(clip, target.nodePath, target.propKey);
     if (!track || !queryFirstRealCurve(track)) {
         return false;
     }
 
     applyTrackExtrapolation(track, operation.preExtrap, operation.postExtrap);
-    recordTrackOwnership(context.rootNode, clip, track, target.nodeUuid);
     return true;
 }
 
@@ -510,122 +318,21 @@ export function replacePropertyCurves(clip: AnimationClip, curves: IAnimationCur
     return true;
 }
 
-/**
- * Three-layer verification to prevent deleting/modifying the wrong track
- * (when same-name siblings cause system path != display path):
- * 1. Live node check: the live node resolved from track's nodePath must match the operation target UUID
- * 2. Ownership record check: the UUID in trackOwners cache must match
- * 3. Reliability fallback: if path resolution was unreliable (lenient fallback), reject outright
- */
-function verifyTrackOwnership(
-    clip: AnimationClip, track: AnyTrack, reliable: boolean, rootNode: Node, nodeUuid?: string,
-): AnyTrack | null {
-    // Layer 1: find the live node via the track's recorded display path
-    const parsed = parsePropertyTrack(track);
-    const trackLabel = parsed
-        ? `${parsed.nodePath || '<root>'}.${parsed.descriptor.propKey}`
-        : '<unknown>';
-    if (parsed && parsed.nodePath) {
-        const liveNode = rootNode.getChildByPath(parsed.nodePath); // Look up live node by display path
-        // If a live node exists but its UUID doesn't match the operation target -> track belongs to another same-name node, reject
-        if (liveNode && nodeUuid && liveNode.uuid !== nodeUuid) {
-            console.warn(
-                `Animation: rejected operation on track "${trackLabel}" because its display path resolves to node `
-                + `"${liveNode.uuid}", but the requested target is "${nodeUuid}".`,
-            );
-            return null;
-        }
-    }
-    // Layer 2: check trackOwners ownership record
-    const key = createPropertyTrackKey(track); // JSON.stringify([nodePath, propKey])
-    const ownerUuid = key
-        ? displayPathCache.get(rootNode)?.trackOwners.get(clip)?.get(key)
-        : undefined;
-    // If both operation and ownership record have UUIDs, do exact matching
-    if (nodeUuid && ownerUuid) {
-        if (ownerUuid !== nodeUuid) {
-            console.warn(
-                `Animation: rejected operation on track "${trackLabel}" because it is owned by node `
-                + `"${ownerUuid}", but the requested target is "${nodeUuid}".`,
-            );
-            return null;
-        }
-        return track;
-    }
-    // Layer 3: no ownership record — check whether path resolution was reliable
-    // reliable=false means the path came from lenient fallback (string derivation), untrustworthy -> reject
-    if (!reliable) {
+function resolvePropertyTarget(context: IPropertyCurveOperationContext, operation: IPropertyTarget): IResolvedPropertyTarget | null {
+    const nodePath = resolveAnimationRelativeNodePath(context.rootNode, context.rootPath, operation);
+    if (nodePath === null) {
+        const target = operation.nodeUuid
+            ? `UUID "${operation.nodeUuid}"`
+            : `path "${operation.nodePath || '<root>'}"`;
         console.warn(
-            `Animation: rejected operation on track "${trackLabel}" because the target path could not be resolved reliably.`,
+            `[Animation] Rejected property operation because target ${target} is not bound by the current animation hierarchy.`,
         );
-        return null;
-    }
-    return track; // Path is reliable and no contradictory evidence -> allow operation
-}
-
-// Record the owning node UUID when a track is created (written to trackOwners).
-// Used by verifyTrackOwnership and capturePropertyTrackOwners downstream.
-function recordTrackOwnership(
-    rootNode: Node, clip: AnimationClip, track: AnyTrack, nodeUuid?: string,
-): void {
-    const key = createPropertyTrackKey(track); // JSON.stringify([nodePath, propKey])
-    if (nodeUuid && key) {
-        const cache = getNodePathCache(rootNode);
-        let owners = cache.trackOwners.get(clip);
-        if (!owners) {
-            owners = new Map(); // First trackOwners creation for this clip
-            cache.trackOwners.set(clip, owners);
-        }
-        owners.set(key, nodeUuid); // trackKey -> nodeUuid
-    }
-}
-
-// Clean up ownership record after track removal; prevents stale records from interfering with future verification
-function forgetTrackOwnership(rootNode: Node, clip: AnimationClip, track: AnyTrack): void {
-    const key = createPropertyTrackKey(track);
-    const owners = displayPathCache.get(rootNode)?.trackOwners.get(clip);
-    if (!key || !owners) {
-        return;
-    }
-    owners.delete(key);
-    // Remove the entire Map when empty to avoid stale entries
-    if (owners.size === 0) {
-        displayPathCache.get(rootNode)?.trackOwners.delete(clip);
-    }
-}
-
-// Collect the set of unique track keys in the clip, used by capture/restore to filter out deleted tracks
-function queryPropertyTrackKeys(clip: AnimationClip): Set<string> {
-    const keys = new Set<string>();
-    for (const track of getClipTracks(clip)) {
-        const key = createPropertyTrackKey(track);
-        if (key) {
-            keys.add(key);
-        }
-    }
-    return keys;
-}
-
-// Track unique key = JSON.stringify([nodePath, propKey])
-// A node's property has exactly one track, so [nodePath, propKey] is a unique identifier
-function createPropertyTrackKey(track: AnyTrack): string | null {
-    const parsed = parsePropertyTrack(track);
-    return parsed ? JSON.stringify([parsed.nodePath, parsed.descriptor.propKey]) : null;
-}
-
-// Wrap operation's nodeUuid/nodePath + propKey into IResolvedPropertyTarget.
-// lenient=true allows fallback (deletion scenario) but marks reliable=false to block write operations.
-function resolvePropertyTarget(context: IPropertyCurveOperationContext, operation: IPropertyTarget, lenient = false): IResolvedPropertyTarget | null {
-    const result = resolveRelativeNodePath(context, operation, lenient);
-    if (result === null) {
         return null;
     }
 
     return {
-        nodePath: result.path,      // Display path used by animation tracks
-        propKey: operation.propKey,  // Pass through the property key from the operation
-        reliable: result.reliable,  // Whether path resolution was reliable
-        nodeUuid: result.nodeUuid,  // Target node UUID
+        nodePath,
+        propKey: operation.propKey,
     };
 }
 
@@ -660,313 +367,4 @@ function applyPropertyMetadata(
         type: metadata.type,
         valueCtor: metadata.valueCtor,
     };
-}
-
-// Path resolution result
-interface IResolvedNodePath {
-    path: string;       // Display path used by animation tracks
-    reliable: boolean;  // Whether resolved precisely (false = from lenient fallback)
-    nodeUuid?: string;  // Resolved node UUID
-}
-
-// Get or lazily create the cache instance for a given rootNode
-function getNodePathCache(rootNode: Node): INodePathCache {
-    let cache = displayPathCache.get(rootNode);
-    if (!cache) {
-        cache = {
-            byUuid: new Map(),
-            byAbsoluteSystemPath: new Map(),
-            byRelativeSystemPath: new Map(),
-            byDisplayPath: new Map(),
-            trackOwners: new WeakMap(), // WeakMap<AnimationClip>: auto-cleaned when clip is GC'd
-        };
-        displayPathCache.set(rootNode, cache);
-    }
-    return cache;
-}
-
-// Build a multi-key cache entry for a node (UUID / absolute system path / relative system path / display path).
-// Cache persists after node deletion, used by findCachedPathBySystemPath and lenient fallback.
-function cacheDisplayPathEntry(rootNode: Node, node: Node, displayPath: string): void {
-    const cache = getNodePathCache(rootNode);
-    // Reuse existing entry if displayPath hasn't changed (preserves ambiguous state etc.)
-    const previousEntry = cache.byUuid.get(node.uuid);
-    removeCachedSystemPathEntries(cache, node.uuid);
-    if (previousEntry && previousEntry.displayPath !== displayPath) {
-        removePreviousDisplayPathEntry(rootNode, cache, previousEntry);
-    }
-    const entry = previousEntry?.displayPath === displayPath
-        ? previousEntry
-        : { uuid: node.uuid, displayPath, ambiguous: false };
-    // Detect same-name siblings at this path (affects animation binding stability)
-    entry.ambiguous ||= displayPath ? hasSameNameSiblings(rootNode, displayPath) : false;
-
-    if (displayPath) {
-        // byDisplayPath uses Set: a single display path may map to multiple UUIDs (same-name siblings)
-        let entries = cache.byDisplayPath.get(displayPath);
-        if (!entries) {
-            entries = new Set();
-            cache.byDisplayPath.set(displayPath, entries);
-        }
-        // Different UUIDs under the same display path -> mark both as ambiguous
-        for (const cached of entries) {
-            if (cached.uuid !== node.uuid) {
-                cached.ambiguous = true;
-                entry.ambiguous = true;
-            }
-        }
-        entries.add(entry);
-    }
-    cache.byUuid.set(node.uuid, entry); // UUID -> entry
-
-    // Record system path mapping (getNodePath returns the unique path maintained by NodePathManager)
-    const systemPath = normalizePath(getNodePath(node));
-    if (!systemPath) {
-        return;
-    }
-    cache.byAbsoluteSystemPath.set(systemPath, entry); // Absolute system path -> entry
-
-    // Compute and cache the system path relative to rootNode
-    const rootSystemPath = normalizePath(getNodePath(rootNode));
-    const relativeSystemPath = toRelativePathByString(rootSystemPath, systemPath);
-    cache.byRelativeSystemPath.set(relativeSystemPath, entry); // Relative system path -> entry
-}
-
-function removeCachedSystemPathEntries(cache: INodePathCache, nodeUuid: string): void {
-    for (const [path, cached] of cache.byAbsoluteSystemPath) {
-        if (cached.uuid === nodeUuid) {
-            cache.byAbsoluteSystemPath.delete(path);
-        }
-    }
-    for (const [path, cached] of cache.byRelativeSystemPath) {
-        if (cached.uuid === nodeUuid) {
-            cache.byRelativeSystemPath.delete(path);
-        }
-    }
-}
-
-function removePreviousDisplayPathEntry(
-    rootNode: Node,
-    cache: INodePathCache,
-    previousEntry: ICachedNodePath,
-): void {
-    if (!previousEntry.displayPath) {
-        return;
-    }
-    const entries = cache.byDisplayPath.get(previousEntry.displayPath);
-    if (!entries) {
-        return;
-    }
-    entries.delete(previousEntry);
-    if (entries.size === 0) {
-        cache.byDisplayPath.delete(previousEntry.displayPath);
-        return;
-    }
-
-    const ambiguousByHistory = entries.size > 1;
-    for (const cached of entries) {
-        const liveNode = findNodeByUuid(rootNode, cached.uuid);
-        cached.ambiguous = ambiguousByHistory || Boolean(
-            liveNode && hasSameNameSiblings(rootNode, cached.displayPath),
-        );
-    }
-}
-
-// Reverse-lookup a deleted node's former display path via its system path in cache.
-// Use case: after a node is deleted, animation operations only have the system path (from nodePath field);
-// this function finds the node's former display path to locate the corresponding animation track.
-function findCachedPathBySystemPath(rootNode: Node, rootPath: string, nodePath: string): ICachedNodePath | null {
-    const cache = displayPathCache.get(rootNode);
-    if (!cache) {
-        return null; // No cache means paths were never cached for this rootNode
-    }
-    const normalizedRoot = normalizePath(rootPath);
-    const normalizedPath = normalizePath(nodePath);
-    // Determine if nodePath is absolute or relative, and use the corresponding cache Map
-    const isAbsolute = Boolean(
-        normalizedRoot && (normalizedPath === normalizedRoot || normalizedPath.startsWith(`${normalizedRoot}/`)),
-    );
-    return (isAbsolute
-        ? cache.byAbsoluteSystemPath.get(normalizedPath)   // Absolute path -> byAbsoluteSystemPath
-        : cache.byRelativeSystemPath.get(normalizedPath))  // Relative path -> byRelativeSystemPath
-        ?? null;
-}
-
-/**
- * Core path resolution pipeline: resolves nodeUuid/nodePath from an operation
- * into the display path used by animation tracks.
- *
- * Resolution strategy (highest to lowest priority):
- * 1. Has nodeUuid -> traverse node tree to find node -> join display path from node.name
- * 2. No nodeUuid -> treat nodePath as system path -> getNodeBySystemPath -> get UUID -> same as strategy 1
- * 3. Node not found + lenient=true -> fall back to cache or string derivation, mark reliable=false
- * 4. Node not found + lenient=false -> return null to reject the operation
- *
- * lenient=true is only used for deletion scenarios (removePropertyKey/removePropertyCurve),
- * allowing tracks of deleted nodes to be found via cache, but reliable=false triggers
- * verifyTrackOwnership rejection.
- */
-function resolveRelativeNodePath(
-    context: IPropertyCurveOperationContext, operation: IPropertyTarget, lenient = false,
-): IResolvedNodePath | null {
-    let targetUuid = operation.nodeUuid;
-    // Branch A: operation only provides nodePath (system path), no UUID
-    if (!targetUuid) {
-        const nodePath = normalizePath(operation.nodePath || '');
-        if (!nodePath) {
-            // Empty path = the root node itself
-            return { path: '', reliable: true, nodeUuid: context.rootNode.uuid };
-        }
-        // Find a live node by system path (exact match first, then case-insensitive fallback)
-        const node = getNodeBySystemPath(context.rootNode, context.rootPath, nodePath);
-        if (!node) {
-            // Node not found (may have been deleted)
-            if (lenient) {
-                // Lenient fallback 1: reverse-lookup the former display path from cache
-                const cached = findCachedPathBySystemPath(context.rootNode, context.rootPath, nodePath);
-                if (cached) {
-                    return {
-                        path: cached.displayPath,
-                        reliable: !cached.ambiguous, // Unreliable when same-name siblings exist
-                        nodeUuid: cached.uuid,
-                    };
-                }
-                // Lenient fallback 2: pure string derivation (strip rootPath prefix)
-                // reliable=false causes verifyTrackOwnership to reject misoperations
-                return { path: toRelativePathByString(context.rootPath, nodePath), reliable: false };
-            }
-            return null; // Non-lenient mode, reject
-        }
-        targetUuid = node.uuid; // Node is alive -> get its UUID and proceed to branch B
-    }
-
-    // Branch B: have UUID, traverse node tree to build display path (joined from node.name)
-    const relativePath = findRelativeNodePathByUuid(context.rootNode, targetUuid);
-    if (relativePath === null) {
-        // UUID's node is not in rootNode's subtree (deleted or outside current editing scope)
-        if (lenient) {
-            // Lenient fallback 3: retrieve former display path from UUID cache
-            const cached = displayPathCache.get(context.rootNode)?.byUuid.get(targetUuid);
-            if (cached) {
-                return {
-                    path: cached.displayPath,
-                    reliable: !cached.ambiguous,
-                    nodeUuid: cached.uuid,
-                };
-            }
-            // Lenient fallback 4: string derivation from the operation's original nodePath
-            if (operation.nodePath) {
-                return {
-                    path: toRelativePathByString(context.rootPath, operation.nodePath),
-                    reliable: false,
-                    nodeUuid: targetUuid,
-                };
-            }
-        }
-        return null;
-    }
-
-    // Node is alive and display path found -> update cache (available for future deletions)
-    const targetNode = findNodeByUuid(context.rootNode, targetUuid);
-    if (targetNode) {
-        cacheDisplayPathEntry(context.rootNode, targetNode, relativePath);
-    }
-
-    // Root node itself: display path is empty
-    if (relativePath === '') {
-        return { path: '', reliable: true, nodeUuid: targetUuid };
-    }
-
-    // Same-name sibling detection: animation binding is unstable when display path has same-name siblings
-    if (hasSameNameSiblings(context.rootNode, relativePath)) {
-        if (!lenient) {
-            // Non-deletion scenario (create/update keyframes): reject with warning
-            console.warn(
-                `Animation: path "${relativePath}" contains same-name siblings. `
-                + `Animation binding is unstable because sibling order may change.`,
-            );
-            return null;
-        }
-        // Deletion scenario: verify the display path resolves to the intended target node
-        const resolved = context.rootNode.getChildByPath(relativePath);
-        if (!resolved || resolved.uuid !== targetUuid) {
-            return null; // Path resolved to the wrong same-name sibling -> reject
-        }
-    }
-
-    return { path: relativePath, reliable: true, nodeUuid: targetUuid };
-}
-
-// Detect whether the display path contains same-name sibling nodes.
-// Animation tracks use display paths (joined from node.name); same-name siblings create ambiguity
-// (e.g., two children both named "Enemy" -> display path "Enemy" can't distinguish which one).
-// getChildByPath("Enemy") returns the first match, but sibling order may change.
-export function hasSameNameSiblings(rootNode: Node, relativePath: string): boolean {
-    const segments = relativePath.split('/');
-    let current: Node = rootNode;
-    for (const segment of segments) {
-        let count = 0;
-        let next: Node | null = null;
-        for (const child of current.children) {
-            if (child.name === segment) {
-                count++;
-                if (!next) {
-                    next = child; // Remember the first matching child
-                }
-                if (count > 1) {
-                    return true; // Found a second same-name child -> has same-name siblings
-                }
-            }
-        }
-        if (!next) {
-            return true; // Path broken mid-way (no matching node for segment), treat as unsafe
-        }
-        current = next; // Descend to next level
-    }
-    return false; // No same-name siblings at any level
-}
-
-// Pure string operation: strip rootPath prefix from an absolute path to get a relative path.
-// Does not depend on the node tree (node may be deleted); only used for lenient fallback.
-function toRelativePathByString(rootPath: string, nodePath: string): string {
-    const normalized = normalizePath(nodePath);
-    if (!normalized) return '';                     // Empty path
-    const normalizedRoot = normalizePath(rootPath);
-    if (!normalizedRoot) return normalized;         // No root path, return as-is
-    if (normalized === normalizedRoot) return '';   // Path equals root -> relative path is empty
-    if (normalized.startsWith(`${normalizedRoot}/`)) return normalized.slice(normalizedRoot.length + 1); // Strip root prefix + "/"
-    return normalized;                             // Doesn't start with root -> already relative
-}
-
-// Recursively find a node by UUID in the tree and build its display path (joined from node.name).
-// Returns the display path relative to `node`; root node returns `prefix` (initially empty string).
-// Returns null if UUID is not in the subtree.
-export function findRelativeNodePathByUuid(node: Node, uuid: string, prefix = ''): string | null {
-    if (node.uuid === uuid) {
-        return prefix; // Found the target node, return accumulated display path
-    }
-    for (const child of node.children) {
-        // Join using child.name (display name), not system path
-        const path = prefix ? `${prefix}/${child.name}` : child.name;
-        const result = findRelativeNodePathByUuid(child, uuid, path);
-        if (result !== null) {
-            return result;
-        }
-    }
-    return null; // Not found
-}
-
-// Recursively find a node instance by UUID in the tree.
-// Similar to findRelativeNodePathByUuid but returns the node object instead of a path string.
-function findNodeByUuid(node: Node, uuid: string): Node | null {
-    if (node.uuid === uuid) {
-        return node;
-    }
-    for (const child of node.children) {
-        const result = findNodeByUuid(child, uuid);
-        if (result) {
-            return result;
-        }
-    }
-    return null;
 }

--- a/src/core/scene/scene-process/service/animation/property-curve.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve.ts
@@ -4,7 +4,7 @@ import type {
     IAnimationPropertyType,
     IAnimationValue,
 } from '../../../common';
-import { getNodeByPath } from './scene-node';
+import { getNodeBySystemPath, getNodePath } from './scene-node';
 import {
     getClipSample,
     normalizeFrames,
@@ -45,9 +45,68 @@ import type {
     IUpdatePropertyKeyDataOperation,
 } from './property-curve-types';
 
+// After decoupling, the operation target must carry both the display path and a reliability flag
 interface IResolvedPropertyTarget {
-    nodePath: string;
-    propKey: string;
+    nodePath: string;   // Display path used by animation tracks (joined from node.name)
+    propKey: string;     // Property key (e.g. position, rotation)
+    reliable: boolean;   // Whether the path was reliably resolved (false on lenient fallback, blocks writes)
+    nodeUuid?: string;   // UUID of the target node, used for trackOwnership verification
+}
+
+/**
+ * After name/path decoupling, animation track nodePath uses display paths (joined from node.name),
+ * while NodePathManager maintains unique system paths. This cache maps multiple key types to
+ * display paths, so tracks of deleted nodes can still be located and cleaned up via cached paths.
+ */
+interface ICachedNodePath {
+    uuid: string;          // Node UUID, retained after node deletion
+    displayPath: string;   // Display path (joined from node.name), used as animation track nodePath
+    ambiguous: boolean;    // Whether the same display path maps to multiple UUIDs (same-name siblings)
+}
+
+// Per-rootNode (scene/prefab) cache with four key types mapping to the same ICachedNodePath
+interface INodePathCache {
+    byUuid: Map<string, ICachedNodePath>;                  // UUID -> cache entry (most precise)
+    byAbsoluteSystemPath: Map<string, ICachedNodePath>;    // Absolute system path -> cache entry
+    byRelativeSystemPath: Map<string, ICachedNodePath>;    // Relative system path (relative to rootNode) -> cache entry
+    byDisplayPath: Map<string, Set<ICachedNodePath>>;      // Display path -> entry set (Set for same-name sibling detection)
+    // Records which node UUID owns each animation track, for precise matching with same-name siblings
+    // key = JSON.stringify([nodePath, propKey]), value = nodeUuid
+    trackOwners: WeakMap<AnimationClip, Map<string, string>>;
+}
+
+// WeakMap keyed by rootNode: cache is auto-collected when scene/prefab closes and rootNode is GC'd
+const displayPathCache = new WeakMap<Node, INodePathCache>();
+
+// Cache a single node's display path by UUID (called externally on node creation/move)
+export function cacheNodeDisplayPath(rootNode: Node, nodeUuid: string): void {
+    const target = findNodeByUuid(rootNode, nodeUuid); // Recursively find the node instance
+    if (target) {
+        cacheNodeDisplayPaths(rootNode, target); // Cache this node and all its children
+    }
+}
+
+// Recursively cache display paths for all nodes under subtreeRoot, joined from node.name
+export function cacheNodeDisplayPaths(rootNode: Node, subtreeRoot: Node = rootNode): void {
+    // Compute the display path prefix of subtreeRoot relative to rootNode
+    const subtreePath = findRelativeNodePathByUuid(rootNode, subtreeRoot.uuid);
+    if (subtreePath === null) {
+        return; // subtreeRoot is not within rootNode's subtree, skip
+    }
+
+    const visit = (node: Node, displayPath: string): void => {
+        cacheDisplayPathEntry(rootNode, node, displayPath); // Write into multi-key cache
+        for (const child of node.children) {
+            // Child display path = parent path + "/" + child.name (empty prefix for root)
+            visit(child, displayPath ? `${displayPath}/${child.name}` : child.name);
+        }
+    };
+    visit(subtreeRoot, subtreePath);
+}
+
+// Clear cache when scene/prefab is closed or reloaded
+export function clearNodeDisplayPathCache(rootNode: Node): void {
+    displayPathCache.delete(rootNode);
 }
 
 export interface IAnimationPropertyMetadata {
@@ -56,12 +115,62 @@ export interface IAnimationPropertyMetadata {
 }
 
 export interface IPropertyCurveMetadataContext {
+    rootNode?: Node;
     queryPropertyMetadata?: (nodePath: string, propKey: string) => IAnimationPropertyMetadata | null;
 }
 
+// trackOwners snapshot type: key = JSON.stringify([nodePath, propKey]), value = nodeUuid
+export type IPropertyTrackOwnersSnapshot = Record<string, string>;
+
+// Serialize the current clip's track ownership map into a persistable snapshot object.
+// Used by undo/redo: capture before operation, restore after undo to recover precise track-node bindings.
+// Solves: after undo with same-name siblings, we need to know exactly which track belongs to which node.
+export function capturePropertyTrackOwners(
+    rootNode: Node, clip: AnimationClip,
+): IPropertyTrackOwnersSnapshot {
+    // Retrieve the trackOwners Map for this clip from cache
+    const owners = displayPathCache.get(rootNode)?.trackOwners.get(clip);
+    if (!owners) {
+        return {}; // No ownership records, return empty snapshot
+    }
+
+    // Only retain ownership records for tracks that still exist in the clip (discard deleted tracks)
+    const existingKeys = queryPropertyTrackKeys(clip);
+    const snapshot: IPropertyTrackOwnersSnapshot = {};
+    for (const [key, uuid] of owners) {
+        if (existingKeys.has(key)) {
+            snapshot[key] = uuid; // Track still exists, preserve ownership
+        }
+    }
+    return snapshot;
+}
+
+// Restore track ownership map from a snapshot, replacing the current clip's trackOwners.
+// Typical scenario: after undo restores to a historical state, rebuild precise track-node bindings.
+export function restorePropertyTrackOwners(
+    rootNode: Node, clip: AnimationClip, snapshot: IPropertyTrackOwnersSnapshot,
+): void {
+    const cache = getNodePathCache(rootNode);
+    const existingKeys = queryPropertyTrackKeys(clip); // Tracks currently in the clip
+    const owners = new Map<string, string>();
+    for (const [key, uuid] of Object.entries(snapshot)) {
+        // Only restore tracks that still exist in the clip; ignore stale snapshot entries
+        if (existingKeys.has(key) && uuid) {
+            owners.set(key, uuid);
+        }
+    }
+    if (owners.size > 0) {
+        cache.trackOwners.set(clip, owners); // Replace trackOwners entirely
+    } else {
+        cache.trackOwners.delete(clip); // Remove empty Map to avoid stale entries
+    }
+}
+
+// Operation context: after decoupling, rootNode (scene/prefab root) and rootPath (root's system path) are needed
+// to convert nodeUuid/nodePath in operations into display paths used by animation tracks
 export interface IPropertyCurveOperationContext extends IPropertyCurveMetadataContext {
-    rootNode: Node;
-    rootPath: string;
+    rootNode: Node;    // Root node reference for the animation editing session
+    rootPath: string;  // System path of rootNode in the scene hierarchy
 }
 
 export function dumpPropertyCurves(clip: AnimationClip, options: IDumpRealKeyDataOptions & IPropertyCurveMetadataContext = {}): IAnimationCurveDump[] {
@@ -90,13 +199,21 @@ export function createPropertyKey(
     context: IPropertyCurveOperationContext,
     operation: ICreatePropertyKeyOperation,
 ): boolean {
+    // Core decoupling: resolve nodeUuid/nodePath from the operation into a display path
     const target = resolvePropertyTarget(context, operation);
     const frame = Number(operation.frame);
     if (!target || !Number.isFinite(frame) || frame < 0) {
         return false;
     }
 
-    const existedTrack = findPropertyTrack(clip, target.nodePath, target.propKey);
+    // Find existing track using the resolved display path
+    const matchedTrack = findPropertyTrack(clip, target.nodePath, target.propKey);
+    const existedTrack = matchedTrack
+        ? verifyTrackOwnership(clip, matchedTrack, target.reliable, context.rootNode, target.nodeUuid)
+        : null;
+    if (matchedTrack && !existedTrack) {
+        return false;
+    }
     const descriptor = existedTrack
         ? queryTrackDescriptor(context, existedTrack)
         : createDescriptor(context, target, operation.value);
@@ -106,7 +223,14 @@ export function createPropertyKey(
 
     const track = existedTrack || createPropertyTrack(clip, target.nodePath, descriptor);
     const time = frame / getClipSample(clip);
-    return setTrackKey(track, descriptor, time, operation.value, operation.channel, operation.keyData ?? operation.curveData);
+    const changed = setTrackKey(
+        track, descriptor, time, operation.value, operation.channel, operation.keyData ?? operation.curveData,
+    );
+    // Establish ownership for both new tracks and safely adopted legacy tracks.
+    if (changed) {
+        recordTrackOwnership(context.rootNode, clip, track, target.nodeUuid);
+    }
+    return changed;
 }
 
 export function addPropertyCurve(
@@ -114,13 +238,23 @@ export function addPropertyCurve(
     context: IPropertyCurveOperationContext,
     operation: IPropertyTarget & { value?: IAnimationValue },
 ): boolean {
+    // Core decoupling: nodeUuid/nodePath -> display path
     const target = resolvePropertyTarget(context, operation);
     if (!target) {
         return false;
     }
 
-    if (findPropertyTrack(clip, target.nodePath, target.propKey)) {
-        return true;
+    // Match existing track by display path
+    const matchedTrack = findPropertyTrack(clip, target.nodePath, target.propKey);
+    if (matchedTrack) {
+        const ownedTrack = verifyTrackOwnership(
+            clip, matchedTrack, target.reliable, context.rootNode, target.nodeUuid,
+        );
+        if (!ownedTrack) {
+            return false;
+        }
+        recordTrackOwnership(context.rootNode, clip, ownedTrack, target.nodeUuid);
+        return true; // Track already exists and belongs to this node.
     }
 
     const descriptor = createDescriptor(context, target, operation.value);
@@ -128,7 +262,9 @@ export function addPropertyCurve(
         return false;
     }
 
-    createPropertyTrack(clip, target.nodePath, descriptor);
+    const track = createPropertyTrack(clip, target.nodePath, descriptor);
+    // Record track ownership on creation
+    recordTrackOwnership(context.rootNode, clip, track, target.nodeUuid);
     return true;
 }
 
@@ -143,10 +279,23 @@ export function updatePropertyKey(
         return false;
     }
 
-    const track = findPropertyTrack(clip, target.nodePath, target.propKey);
+    const matchedTrack = findPropertyTrack(clip, target.nodePath, target.propKey);
+    const track = matchedTrack
+        ? verifyTrackOwnership(clip, matchedTrack, target.reliable, context.rootNode, target.nodeUuid)
+        : null;
+    if (matchedTrack && !track) {
+        return false;
+    }
     const descriptor = track ? queryTrackDescriptor(context, track) : null;
     if (track && descriptor) {
-        return updateTrackKey(track, descriptor, frame / getClipSample(clip), operation.value, operation.channel, operation.keyData ?? operation.curveData);
+        const changed = updateTrackKey(
+            track, descriptor, frame / getClipSample(clip), operation.value,
+            operation.channel, operation.keyData ?? operation.curveData,
+        );
+        if (changed) {
+            recordTrackOwnership(context.rootNode, clip, track, target.nodeUuid);
+        }
+        return changed;
     }
 
     return createPropertyKey(clip, context, operation);
@@ -163,13 +312,23 @@ export function updatePropertyKeyData(
         return false;
     }
 
-    const track = findPropertyTrack(clip, target.nodePath, target.propKey);
+    const matchedTrack = findPropertyTrack(clip, target.nodePath, target.propKey);
+    const track = matchedTrack
+        ? verifyTrackOwnership(clip, matchedTrack, target.reliable, context.rootNode, target.nodeUuid)
+        : null;
     const descriptor = track ? queryTrackDescriptor(context, track) : null;
     if (!track || !descriptor) {
         return false;
     }
 
-    return updateTrackKey(track, descriptor, frame / getClipSample(clip), undefined, operation.channel, operation.keyData ?? operation.curveData);
+    const changed = updateTrackKey(
+        track, descriptor, frame / getClipSample(clip), undefined,
+        operation.channel, operation.keyData ?? operation.curveData,
+    );
+    if (changed) {
+        recordTrackOwnership(context.rootNode, clip, track, target.nodeUuid);
+    }
+    return changed;
 }
 
 export function removePropertyKey(
@@ -177,13 +336,19 @@ export function removePropertyKey(
     context: IPropertyCurveOperationContext,
     operation: IPropertyKeyFramesOperation,
 ): boolean {
+    // lenient=true: deletion scenario allows fallback to cache/string derivation
     const target = resolvePropertyTarget(context, operation, true);
     const frames = normalizeFrames(operation.frames);
     if (!target || frames.length === 0) {
         return false;
     }
 
-    const track = findPropertyTrack(clip, target.nodePath, target.propKey);
+    let track = findPropertyTrack(clip, target.nodePath, target.propKey);
+    if (track) {
+        // Core decoupling: verify the found track truly belongs to the target node,
+        // preventing accidental deletion of a same-name sibling's track
+        track = verifyTrackOwnership(clip, track, target.reliable, context.rootNode, target.nodeUuid);
+    }
     const descriptor = track ? queryTrackDescriptor(context, track) : null;
     if (!track || !descriptor) {
         return false;
@@ -192,6 +357,9 @@ export function removePropertyKey(
     let changed = false;
     for (const curve of queryTargetCurves(track, descriptor, operation.channel)) {
         changed = removeCurveKeys(clip, curve, frames) || changed;
+    }
+    if (changed) {
+        recordTrackOwnership(context.rootNode, clip, track, target.nodeUuid);
     }
     return changed;
 }
@@ -209,12 +377,17 @@ export function removePropertyCurve(
     context: IPropertyCurveOperationContext,
     operation: IPropertyTarget,
 ): boolean {
+    // lenient=true: deletion scenario allows fallback to cache/string derivation
     const target = resolvePropertyTarget(context, operation, true);
     if (!target) {
         return false;
     }
 
-    const track = findPropertyTrack(clip, target.nodePath, target.propKey);
+    let track = findPropertyTrack(clip, target.nodePath, target.propKey);
+    if (track) {
+        // Core decoupling: verify track ownership to prevent deleting a same-name sibling's track
+        track = verifyTrackOwnership(clip, track, target.reliable, context.rootNode, target.nodeUuid);
+    }
     if (!track) {
         return false;
     }
@@ -223,6 +396,8 @@ export function removePropertyCurve(
     for (let index = tracks.length - 1; index >= 0; index--) {
         if (clip.getTrack(index) === track) {
             clip.removeTrack(index);
+            // Clean up ownership record after track removal
+            forgetTrackOwnership(context.rootNode, clip, track);
             return true;
         }
     }
@@ -241,7 +416,10 @@ export function movePropertyKeys(
         return false;
     }
 
-    const track = findPropertyTrack(clip, target.nodePath, target.propKey);
+    const matchedTrack = findPropertyTrack(clip, target.nodePath, target.propKey);
+    const track = matchedTrack
+        ? verifyTrackOwnership(clip, matchedTrack, target.reliable, context.rootNode, target.nodeUuid)
+        : null;
     const descriptor = track ? queryTrackDescriptor(context, track) : null;
     if (!track || !descriptor) {
         return false;
@@ -250,6 +428,9 @@ export function movePropertyKeys(
     let changed = false;
     for (const curve of queryTargetCurves(track, descriptor, operation.channel)) {
         changed = moveCurveKeys(clip, curve, frames, offset) || changed;
+    }
+    if (changed) {
+        recordTrackOwnership(context.rootNode, clip, track, target.nodeUuid);
     }
     return changed;
 }
@@ -266,7 +447,10 @@ export function copyPropertyKeysTo(
         return false;
     }
 
-    const track = findPropertyTrack(clip, target.nodePath, target.propKey);
+    const matchedTrack = findPropertyTrack(clip, target.nodePath, target.propKey);
+    const track = matchedTrack
+        ? verifyTrackOwnership(clip, matchedTrack, target.reliable, context.rootNode, target.nodeUuid)
+        : null;
     const descriptor = track ? queryTrackDescriptor(context, track) : null;
     if (!track || !descriptor) {
         return false;
@@ -275,6 +459,9 @@ export function copyPropertyKeysTo(
     let changed = false;
     for (const curve of queryTargetCurves(track, descriptor, operation.channel)) {
         changed = copyCurveKeysTo(clip, curve, frames, dstFrame) || changed;
+    }
+    if (changed) {
+        recordTrackOwnership(context.rootNode, clip, track, target.nodeUuid);
     }
     return changed;
 }
@@ -289,12 +476,16 @@ export function setPropertyCurveExtrapolation(
         return false;
     }
 
-    const track = findPropertyTrack(clip, target.nodePath, target.propKey);
+    const matchedTrack = findPropertyTrack(clip, target.nodePath, target.propKey);
+    const track = matchedTrack
+        ? verifyTrackOwnership(clip, matchedTrack, target.reliable, context.rootNode, target.nodeUuid)
+        : null;
     if (!track || !queryFirstRealCurve(track)) {
         return false;
     }
 
     applyTrackExtrapolation(track, operation.preExtrap, operation.postExtrap);
+    recordTrackOwnership(context.rootNode, clip, track, target.nodeUuid);
     return true;
 }
 
@@ -319,15 +510,122 @@ export function replacePropertyCurves(clip: AnimationClip, curves: IAnimationCur
     return true;
 }
 
+/**
+ * Three-layer verification to prevent deleting/modifying the wrong track
+ * (when same-name siblings cause system path != display path):
+ * 1. Live node check: the live node resolved from track's nodePath must match the operation target UUID
+ * 2. Ownership record check: the UUID in trackOwners cache must match
+ * 3. Reliability fallback: if path resolution was unreliable (lenient fallback), reject outright
+ */
+function verifyTrackOwnership(
+    clip: AnimationClip, track: AnyTrack, reliable: boolean, rootNode: Node, nodeUuid?: string,
+): AnyTrack | null {
+    // Layer 1: find the live node via the track's recorded display path
+    const parsed = parsePropertyTrack(track);
+    const trackLabel = parsed
+        ? `${parsed.nodePath || '<root>'}.${parsed.descriptor.propKey}`
+        : '<unknown>';
+    if (parsed && parsed.nodePath) {
+        const liveNode = rootNode.getChildByPath(parsed.nodePath); // Look up live node by display path
+        // If a live node exists but its UUID doesn't match the operation target -> track belongs to another same-name node, reject
+        if (liveNode && nodeUuid && liveNode.uuid !== nodeUuid) {
+            console.warn(
+                `Animation: rejected operation on track "${trackLabel}" because its display path resolves to node `
+                + `"${liveNode.uuid}", but the requested target is "${nodeUuid}".`,
+            );
+            return null;
+        }
+    }
+    // Layer 2: check trackOwners ownership record
+    const key = createPropertyTrackKey(track); // JSON.stringify([nodePath, propKey])
+    const ownerUuid = key
+        ? displayPathCache.get(rootNode)?.trackOwners.get(clip)?.get(key)
+        : undefined;
+    // If both operation and ownership record have UUIDs, do exact matching
+    if (nodeUuid && ownerUuid) {
+        if (ownerUuid !== nodeUuid) {
+            console.warn(
+                `Animation: rejected operation on track "${trackLabel}" because it is owned by node `
+                + `"${ownerUuid}", but the requested target is "${nodeUuid}".`,
+            );
+            return null;
+        }
+        return track;
+    }
+    // Layer 3: no ownership record — check whether path resolution was reliable
+    // reliable=false means the path came from lenient fallback (string derivation), untrustworthy -> reject
+    if (!reliable) {
+        console.warn(
+            `Animation: rejected operation on track "${trackLabel}" because the target path could not be resolved reliably.`,
+        );
+        return null;
+    }
+    return track; // Path is reliable and no contradictory evidence -> allow operation
+}
+
+// Record the owning node UUID when a track is created (written to trackOwners).
+// Used by verifyTrackOwnership and capturePropertyTrackOwners downstream.
+function recordTrackOwnership(
+    rootNode: Node, clip: AnimationClip, track: AnyTrack, nodeUuid?: string,
+): void {
+    const key = createPropertyTrackKey(track); // JSON.stringify([nodePath, propKey])
+    if (nodeUuid && key) {
+        const cache = getNodePathCache(rootNode);
+        let owners = cache.trackOwners.get(clip);
+        if (!owners) {
+            owners = new Map(); // First trackOwners creation for this clip
+            cache.trackOwners.set(clip, owners);
+        }
+        owners.set(key, nodeUuid); // trackKey -> nodeUuid
+    }
+}
+
+// Clean up ownership record after track removal; prevents stale records from interfering with future verification
+function forgetTrackOwnership(rootNode: Node, clip: AnimationClip, track: AnyTrack): void {
+    const key = createPropertyTrackKey(track);
+    const owners = displayPathCache.get(rootNode)?.trackOwners.get(clip);
+    if (!key || !owners) {
+        return;
+    }
+    owners.delete(key);
+    // Remove the entire Map when empty to avoid stale entries
+    if (owners.size === 0) {
+        displayPathCache.get(rootNode)?.trackOwners.delete(clip);
+    }
+}
+
+// Collect the set of unique track keys in the clip, used by capture/restore to filter out deleted tracks
+function queryPropertyTrackKeys(clip: AnimationClip): Set<string> {
+    const keys = new Set<string>();
+    for (const track of getClipTracks(clip)) {
+        const key = createPropertyTrackKey(track);
+        if (key) {
+            keys.add(key);
+        }
+    }
+    return keys;
+}
+
+// Track unique key = JSON.stringify([nodePath, propKey])
+// A node's property has exactly one track, so [nodePath, propKey] is a unique identifier
+function createPropertyTrackKey(track: AnyTrack): string | null {
+    const parsed = parsePropertyTrack(track);
+    return parsed ? JSON.stringify([parsed.nodePath, parsed.descriptor.propKey]) : null;
+}
+
+// Wrap operation's nodeUuid/nodePath + propKey into IResolvedPropertyTarget.
+// lenient=true allows fallback (deletion scenario) but marks reliable=false to block write operations.
 function resolvePropertyTarget(context: IPropertyCurveOperationContext, operation: IPropertyTarget, lenient = false): IResolvedPropertyTarget | null {
-    const nodePath = resolveRelativeNodePath(context, operation, lenient);
-    if (nodePath === null) {
+    const result = resolveRelativeNodePath(context, operation, lenient);
+    if (result === null) {
         return null;
     }
 
     return {
-        nodePath,
-        propKey: operation.propKey,
+        nodePath: result.path,      // Display path used by animation tracks
+        propKey: operation.propKey,  // Pass through the property key from the operation
+        reliable: result.reliable,  // Whether path resolution was reliable
+        nodeUuid: result.nodeUuid,  // Target node UUID
     };
 }
 
@@ -364,57 +662,245 @@ function applyPropertyMetadata(
     };
 }
 
-function resolveRelativeNodePath(context: IPropertyCurveOperationContext, operation: IPropertyTarget, lenient = false): string | null {
+// Path resolution result
+interface IResolvedNodePath {
+    path: string;       // Display path used by animation tracks
+    reliable: boolean;  // Whether resolved precisely (false = from lenient fallback)
+    nodeUuid?: string;  // Resolved node UUID
+}
+
+// Get or lazily create the cache instance for a given rootNode
+function getNodePathCache(rootNode: Node): INodePathCache {
+    let cache = displayPathCache.get(rootNode);
+    if (!cache) {
+        cache = {
+            byUuid: new Map(),
+            byAbsoluteSystemPath: new Map(),
+            byRelativeSystemPath: new Map(),
+            byDisplayPath: new Map(),
+            trackOwners: new WeakMap(), // WeakMap<AnimationClip>: auto-cleaned when clip is GC'd
+        };
+        displayPathCache.set(rootNode, cache);
+    }
+    return cache;
+}
+
+// Build a multi-key cache entry for a node (UUID / absolute system path / relative system path / display path).
+// Cache persists after node deletion, used by findCachedPathBySystemPath and lenient fallback.
+function cacheDisplayPathEntry(rootNode: Node, node: Node, displayPath: string): void {
+    const cache = getNodePathCache(rootNode);
+    // Reuse existing entry if displayPath hasn't changed (preserves ambiguous state etc.)
+    const previousEntry = cache.byUuid.get(node.uuid);
+    removeCachedSystemPathEntries(cache, node.uuid);
+    if (previousEntry && previousEntry.displayPath !== displayPath) {
+        removePreviousDisplayPathEntry(rootNode, cache, previousEntry);
+    }
+    const entry = previousEntry?.displayPath === displayPath
+        ? previousEntry
+        : { uuid: node.uuid, displayPath, ambiguous: false };
+    // Detect same-name siblings at this path (affects animation binding stability)
+    entry.ambiguous ||= displayPath ? hasSameNameSiblings(rootNode, displayPath) : false;
+
+    if (displayPath) {
+        // byDisplayPath uses Set: a single display path may map to multiple UUIDs (same-name siblings)
+        let entries = cache.byDisplayPath.get(displayPath);
+        if (!entries) {
+            entries = new Set();
+            cache.byDisplayPath.set(displayPath, entries);
+        }
+        // Different UUIDs under the same display path -> mark both as ambiguous
+        for (const cached of entries) {
+            if (cached.uuid !== node.uuid) {
+                cached.ambiguous = true;
+                entry.ambiguous = true;
+            }
+        }
+        entries.add(entry);
+    }
+    cache.byUuid.set(node.uuid, entry); // UUID -> entry
+
+    // Record system path mapping (getNodePath returns the unique path maintained by NodePathManager)
+    const systemPath = normalizePath(getNodePath(node));
+    if (!systemPath) {
+        return;
+    }
+    cache.byAbsoluteSystemPath.set(systemPath, entry); // Absolute system path -> entry
+
+    // Compute and cache the system path relative to rootNode
+    const rootSystemPath = normalizePath(getNodePath(rootNode));
+    const relativeSystemPath = toRelativePathByString(rootSystemPath, systemPath);
+    cache.byRelativeSystemPath.set(relativeSystemPath, entry); // Relative system path -> entry
+}
+
+function removeCachedSystemPathEntries(cache: INodePathCache, nodeUuid: string): void {
+    for (const [path, cached] of cache.byAbsoluteSystemPath) {
+        if (cached.uuid === nodeUuid) {
+            cache.byAbsoluteSystemPath.delete(path);
+        }
+    }
+    for (const [path, cached] of cache.byRelativeSystemPath) {
+        if (cached.uuid === nodeUuid) {
+            cache.byRelativeSystemPath.delete(path);
+        }
+    }
+}
+
+function removePreviousDisplayPathEntry(
+    rootNode: Node,
+    cache: INodePathCache,
+    previousEntry: ICachedNodePath,
+): void {
+    if (!previousEntry.displayPath) {
+        return;
+    }
+    const entries = cache.byDisplayPath.get(previousEntry.displayPath);
+    if (!entries) {
+        return;
+    }
+    entries.delete(previousEntry);
+    if (entries.size === 0) {
+        cache.byDisplayPath.delete(previousEntry.displayPath);
+        return;
+    }
+
+    const ambiguousByHistory = entries.size > 1;
+    for (const cached of entries) {
+        const liveNode = findNodeByUuid(rootNode, cached.uuid);
+        cached.ambiguous = ambiguousByHistory || Boolean(
+            liveNode && hasSameNameSiblings(rootNode, cached.displayPath),
+        );
+    }
+}
+
+// Reverse-lookup a deleted node's former display path via its system path in cache.
+// Use case: after a node is deleted, animation operations only have the system path (from nodePath field);
+// this function finds the node's former display path to locate the corresponding animation track.
+function findCachedPathBySystemPath(rootNode: Node, rootPath: string, nodePath: string): ICachedNodePath | null {
+    const cache = displayPathCache.get(rootNode);
+    if (!cache) {
+        return null; // No cache means paths were never cached for this rootNode
+    }
+    const normalizedRoot = normalizePath(rootPath);
+    const normalizedPath = normalizePath(nodePath);
+    // Determine if nodePath is absolute or relative, and use the corresponding cache Map
+    const isAbsolute = Boolean(
+        normalizedRoot && (normalizedPath === normalizedRoot || normalizedPath.startsWith(`${normalizedRoot}/`)),
+    );
+    return (isAbsolute
+        ? cache.byAbsoluteSystemPath.get(normalizedPath)   // Absolute path -> byAbsoluteSystemPath
+        : cache.byRelativeSystemPath.get(normalizedPath))  // Relative path -> byRelativeSystemPath
+        ?? null;
+}
+
+/**
+ * Core path resolution pipeline: resolves nodeUuid/nodePath from an operation
+ * into the display path used by animation tracks.
+ *
+ * Resolution strategy (highest to lowest priority):
+ * 1. Has nodeUuid -> traverse node tree to find node -> join display path from node.name
+ * 2. No nodeUuid -> treat nodePath as system path -> getNodeBySystemPath -> get UUID -> same as strategy 1
+ * 3. Node not found + lenient=true -> fall back to cache or string derivation, mark reliable=false
+ * 4. Node not found + lenient=false -> return null to reject the operation
+ *
+ * lenient=true is only used for deletion scenarios (removePropertyKey/removePropertyCurve),
+ * allowing tracks of deleted nodes to be found via cache, but reliable=false triggers
+ * verifyTrackOwnership rejection.
+ */
+function resolveRelativeNodePath(
+    context: IPropertyCurveOperationContext, operation: IPropertyTarget, lenient = false,
+): IResolvedNodePath | null {
     let targetUuid = operation.nodeUuid;
+    // Branch A: operation only provides nodePath (system path), no UUID
     if (!targetUuid) {
         const nodePath = normalizePath(operation.nodePath || '');
         if (!nodePath) {
-            return '';
+            // Empty path = the root node itself
+            return { path: '', reliable: true, nodeUuid: context.rootNode.uuid };
         }
-        const rootPath = normalizePath(context.rootPath);
-        let node: Node | null = null;
-        if (rootPath && (nodePath === rootPath || nodePath.startsWith(`${rootPath}/`))) {
-            node = getNodeByPath(nodePath);
-        } else {
-            node = context.rootNode.getChildByPath(nodePath);
-        }
+        // Find a live node by system path (exact match first, then case-insensitive fallback)
+        const node = getNodeBySystemPath(context.rootNode, context.rootPath, nodePath);
         if (!node) {
+            // Node not found (may have been deleted)
             if (lenient) {
-                return toRelativePathByString(context.rootPath, nodePath);
+                // Lenient fallback 1: reverse-lookup the former display path from cache
+                const cached = findCachedPathBySystemPath(context.rootNode, context.rootPath, nodePath);
+                if (cached) {
+                    return {
+                        path: cached.displayPath,
+                        reliable: !cached.ambiguous, // Unreliable when same-name siblings exist
+                        nodeUuid: cached.uuid,
+                    };
+                }
+                // Lenient fallback 2: pure string derivation (strip rootPath prefix)
+                // reliable=false causes verifyTrackOwnership to reject misoperations
+                return { path: toRelativePathByString(context.rootPath, nodePath), reliable: false };
             }
-            return null;
+            return null; // Non-lenient mode, reject
         }
-        targetUuid = node.uuid;
+        targetUuid = node.uuid; // Node is alive -> get its UUID and proceed to branch B
     }
 
+    // Branch B: have UUID, traverse node tree to build display path (joined from node.name)
     const relativePath = findRelativeNodePathByUuid(context.rootNode, targetUuid);
     if (relativePath === null) {
-        if (lenient && operation.nodePath) {
-            return toRelativePathByString(context.rootPath, operation.nodePath);
+        // UUID's node is not in rootNode's subtree (deleted or outside current editing scope)
+        if (lenient) {
+            // Lenient fallback 3: retrieve former display path from UUID cache
+            const cached = displayPathCache.get(context.rootNode)?.byUuid.get(targetUuid);
+            if (cached) {
+                return {
+                    path: cached.displayPath,
+                    reliable: !cached.ambiguous,
+                    nodeUuid: cached.uuid,
+                };
+            }
+            // Lenient fallback 4: string derivation from the operation's original nodePath
+            if (operation.nodePath) {
+                return {
+                    path: toRelativePathByString(context.rootPath, operation.nodePath),
+                    reliable: false,
+                    nodeUuid: targetUuid,
+                };
+            }
         }
         return null;
     }
-    if (relativePath === '') {
-        return '';
+
+    // Node is alive and display path found -> update cache (available for future deletions)
+    const targetNode = findNodeByUuid(context.rootNode, targetUuid);
+    if (targetNode) {
+        cacheDisplayPathEntry(context.rootNode, targetNode, relativePath);
     }
 
+    // Root node itself: display path is empty
+    if (relativePath === '') {
+        return { path: '', reliable: true, nodeUuid: targetUuid };
+    }
+
+    // Same-name sibling detection: animation binding is unstable when display path has same-name siblings
     if (hasSameNameSiblings(context.rootNode, relativePath)) {
         if (!lenient) {
+            // Non-deletion scenario (create/update keyframes): reject with warning
             console.warn(
                 `Animation: path "${relativePath}" contains same-name siblings. `
                 + `Animation binding is unstable because sibling order may change.`,
             );
             return null;
         }
+        // Deletion scenario: verify the display path resolves to the intended target node
         const resolved = context.rootNode.getChildByPath(relativePath);
         if (!resolved || resolved.uuid !== targetUuid) {
-            return null;
+            return null; // Path resolved to the wrong same-name sibling -> reject
         }
     }
 
-    return relativePath;
+    return { path: relativePath, reliable: true, nodeUuid: targetUuid };
 }
 
+// Detect whether the display path contains same-name sibling nodes.
+// Animation tracks use display paths (joined from node.name); same-name siblings create ambiguity
+// (e.g., two children both named "Enemy" -> display path "Enemy" can't distinguish which one).
+// getChildByPath("Enemy") returns the first match, but sibling order may change.
 export function hasSameNameSiblings(rootNode: Node, relativePath: string): boolean {
     const segments = relativePath.split('/');
     let current: Node = rootNode;
@@ -425,39 +911,60 @@ export function hasSameNameSiblings(rootNode: Node, relativePath: string): boole
             if (child.name === segment) {
                 count++;
                 if (!next) {
-                    next = child;
+                    next = child; // Remember the first matching child
                 }
                 if (count > 1) {
-                    return true;
+                    return true; // Found a second same-name child -> has same-name siblings
                 }
             }
         }
         if (!next) {
-            return true;
+            return true; // Path broken mid-way (no matching node for segment), treat as unsafe
         }
-        current = next;
+        current = next; // Descend to next level
     }
-    return false;
+    return false; // No same-name siblings at any level
 }
 
+// Pure string operation: strip rootPath prefix from an absolute path to get a relative path.
+// Does not depend on the node tree (node may be deleted); only used for lenient fallback.
 function toRelativePathByString(rootPath: string, nodePath: string): string {
     const normalized = normalizePath(nodePath);
-    if (!normalized) return '';
+    if (!normalized) return '';                     // Empty path
     const normalizedRoot = normalizePath(rootPath);
-    if (!normalizedRoot) return normalized;
-    if (normalized === normalizedRoot) return '';
-    if (normalized.startsWith(`${normalizedRoot}/`)) return normalized.slice(normalizedRoot.length + 1);
-    return normalized;
+    if (!normalizedRoot) return normalized;         // No root path, return as-is
+    if (normalized === normalizedRoot) return '';   // Path equals root -> relative path is empty
+    if (normalized.startsWith(`${normalizedRoot}/`)) return normalized.slice(normalizedRoot.length + 1); // Strip root prefix + "/"
+    return normalized;                             // Doesn't start with root -> already relative
 }
 
+// Recursively find a node by UUID in the tree and build its display path (joined from node.name).
+// Returns the display path relative to `node`; root node returns `prefix` (initially empty string).
+// Returns null if UUID is not in the subtree.
 export function findRelativeNodePathByUuid(node: Node, uuid: string, prefix = ''): string | null {
     if (node.uuid === uuid) {
-        return prefix;
+        return prefix; // Found the target node, return accumulated display path
     }
     for (const child of node.children) {
+        // Join using child.name (display name), not system path
         const path = prefix ? `${prefix}/${child.name}` : child.name;
         const result = findRelativeNodePathByUuid(child, uuid, path);
         if (result !== null) {
+            return result;
+        }
+    }
+    return null; // Not found
+}
+
+// Recursively find a node instance by UUID in the tree.
+// Similar to findRelativeNodePathByUuid but returns the node object instead of a path string.
+function findNodeByUuid(node: Node, uuid: string): Node | null {
+    if (node.uuid === uuid) {
+        return node;
+    }
+    for (const child of node.children) {
+        const result = findNodeByUuid(child, uuid);
+        if (result) {
             return result;
         }
     }

--- a/src/core/scene/scene-process/service/animation/property-curve.ts
+++ b/src/core/scene/scene-process/service/animation/property-curve.ts
@@ -4,6 +4,7 @@ import type {
     IAnimationPropertyType,
     IAnimationValue,
 } from '../../../common';
+import { getNodeByPath } from './scene-node';
 import {
     getClipSample,
     normalizeFrames,
@@ -176,7 +177,7 @@ export function removePropertyKey(
     context: IPropertyCurveOperationContext,
     operation: IPropertyKeyFramesOperation,
 ): boolean {
-    const target = resolvePropertyTarget(context, operation);
+    const target = resolvePropertyTarget(context, operation, true);
     const frames = normalizeFrames(operation.frames);
     if (!target || frames.length === 0) {
         return false;
@@ -208,7 +209,7 @@ export function removePropertyCurve(
     context: IPropertyCurveOperationContext,
     operation: IPropertyTarget,
 ): boolean {
-    const target = resolvePropertyTarget(context, operation);
+    const target = resolvePropertyTarget(context, operation, true);
     if (!target) {
         return false;
     }
@@ -318,8 +319,8 @@ export function replacePropertyCurves(clip: AnimationClip, curves: IAnimationCur
     return true;
 }
 
-function resolvePropertyTarget(context: IPropertyCurveOperationContext, operation: IPropertyTarget): IResolvedPropertyTarget | null {
-    const nodePath = resolveRelativeNodePath(context, operation);
+function resolvePropertyTarget(context: IPropertyCurveOperationContext, operation: IPropertyTarget, lenient = false): IResolvedPropertyTarget | null {
+    const nodePath = resolveRelativeNodePath(context, operation, lenient);
     if (nodePath === null) {
         return null;
     }
@@ -363,22 +364,93 @@ function applyPropertyMetadata(
     };
 }
 
-function resolveRelativeNodePath(context: IPropertyCurveOperationContext, operation: IPropertyTarget): string | null {
-    const nodePath = normalizePath(operation.nodePath || '');
-    if (nodePath) {
-        const rootPath = normalizePath(context.rootPath);
-        if (nodePath === rootPath) {
+function resolveRelativeNodePath(context: IPropertyCurveOperationContext, operation: IPropertyTarget, lenient = false): string | null {
+    let targetUuid = operation.nodeUuid;
+    if (!targetUuid) {
+        const nodePath = normalizePath(operation.nodePath || '');
+        if (!nodePath) {
             return '';
         }
-        if (rootPath && nodePath.startsWith(`${rootPath}/`)) {
-            return nodePath.slice(rootPath.length + 1);
+        const rootPath = normalizePath(context.rootPath);
+        let node: Node | null = null;
+        if (rootPath && (nodePath === rootPath || nodePath.startsWith(`${rootPath}/`))) {
+            node = getNodeByPath(nodePath);
+        } else {
+            node = context.rootNode.getChildByPath(nodePath);
         }
-        return context.rootNode.getChildByPath(nodePath) ? nodePath : null;
+        if (!node) {
+            if (lenient) {
+                return toRelativePathByString(context.rootPath, nodePath);
+            }
+            return null;
+        }
+        targetUuid = node.uuid;
     }
-    return operation.nodeUuid ? findRelativeNodePathByUuid(context.rootNode, operation.nodeUuid) : '';
+
+    const relativePath = findRelativeNodePathByUuid(context.rootNode, targetUuid);
+    if (relativePath === null) {
+        if (lenient && operation.nodePath) {
+            return toRelativePathByString(context.rootPath, operation.nodePath);
+        }
+        return null;
+    }
+    if (relativePath === '') {
+        return '';
+    }
+
+    if (hasSameNameSiblings(context.rootNode, relativePath)) {
+        if (!lenient) {
+            console.warn(
+                `Animation: path "${relativePath}" contains same-name siblings. `
+                + `Animation binding is unstable because sibling order may change.`,
+            );
+            return null;
+        }
+        const resolved = context.rootNode.getChildByPath(relativePath);
+        if (!resolved || resolved.uuid !== targetUuid) {
+            return null;
+        }
+    }
+
+    return relativePath;
 }
 
-function findRelativeNodePathByUuid(node: Node, uuid: string, prefix = ''): string | null {
+function hasSameNameSiblings(rootNode: Node, relativePath: string): boolean {
+    const segments = relativePath.split('/');
+    let current: Node = rootNode;
+    for (const segment of segments) {
+        let count = 0;
+        let next: Node | null = null;
+        for (const child of current.children) {
+            if (child.name === segment) {
+                count++;
+                if (!next) {
+                    next = child;
+                }
+                if (count > 1) {
+                    return true;
+                }
+            }
+        }
+        if (!next) {
+            return true;
+        }
+        current = next;
+    }
+    return false;
+}
+
+function toRelativePathByString(rootPath: string, nodePath: string): string {
+    const normalized = normalizePath(nodePath);
+    if (!normalized) return '';
+    const normalizedRoot = normalizePath(rootPath);
+    if (!normalizedRoot) return normalized;
+    if (normalized === normalizedRoot) return '';
+    if (normalized.startsWith(`${normalizedRoot}/`)) return normalized.slice(normalizedRoot.length + 1);
+    return normalized;
+}
+
+export function findRelativeNodePathByUuid(node: Node, uuid: string, prefix = ''): string | null {
     if (node.uuid === uuid) {
         return prefix;
     }

--- a/src/core/scene/scene-process/service/animation/property-value.ts
+++ b/src/core/scene/scene-process/service/animation/property-value.ts
@@ -1,7 +1,7 @@
 import { Node } from 'cc';
 import type { IAnimationOperation, IAnimationValue } from '../../../common';
 import type { IAnimationPropertyMetadata } from './property-curve';
-import { findRelativeNodePathByUuid } from './property-curve';
+import { findRelativeNodePathByUuid, hasSameNameSiblings } from './property-curve';
 import { queryAnimationPropertyMetadata } from './property-metadata';
 import { getNodeByPath } from './scene-node';
 import {
@@ -44,17 +44,13 @@ export async function normalizeProvidedAnimationPropertyOperationValue(
     rootNode: Node,
     rootPath: string,
     operation: PropertyKeyOperation,
-    options: {
-        queryNodeByUuid: (uuid: string) => Node | null;
-        queryNodePath: (node: Node) => string;
-    },
 ): Promise<IAnimationValue> {
     const value = operation.value;
     if (value === null || value === undefined) {
         return value as IAnimationValue;
     }
 
-    const nodePath = resolveOperationRelativeNodePath(rootNode, rootPath, operation, options);
+    const nodePath = resolveOperationRelativeNodePath(rootNode, rootPath, operation);
     if (nodePath === null) {
         return value;
     }
@@ -91,7 +87,6 @@ function resolveOperationRelativeNodePath(
     rootNode: Node,
     rootPath: string,
     operation: { nodeUuid?: string; nodePath?: string },
-    options: { queryNodeByUuid: (uuid: string) => Node | null; queryNodePath: (node: Node) => string },
 ): string | null {
     let targetUuid = operation.nodeUuid;
     if (!targetUuid) {
@@ -112,7 +107,16 @@ function resolveOperationRelativeNodePath(
         targetUuid = node.uuid;
     }
 
-    return findRelativeNodePathByUuid(rootNode, targetUuid);
+    const relativePath = findRelativeNodePathByUuid(rootNode, targetUuid);
+    if (relativePath === null || relativePath === '') {
+        return relativePath;
+    }
+
+    if (hasSameNameSiblings(rootNode, relativePath)) {
+        return null;
+    }
+
+    return relativePath;
 }
 
 function normalizeNodePath(path: string): string {

--- a/src/core/scene/scene-process/service/animation/property-value.ts
+++ b/src/core/scene/scene-process/service/animation/property-value.ts
@@ -1,9 +1,8 @@
 import { Node } from 'cc';
 import type { IAnimationOperation, IAnimationValue } from '../../../common';
 import type { IAnimationPropertyMetadata } from './property-curve';
-import { findRelativeNodePathByUuid, hasSameNameSiblings } from './property-curve';
 import { queryAnimationPropertyMetadata } from './property-metadata';
-import { getNodeBySystemPath } from './scene-node';
+import { resolveAnimationRelativeNodePath } from './scene-node';
 import {
     isAnimationAssetValue,
     loadAnimationAssetValue,
@@ -50,7 +49,7 @@ export async function normalizeProvidedAnimationPropertyOperationValue(
         return value as IAnimationValue;
     }
 
-    const nodePath = resolveOperationRelativeNodePath(rootNode, rootPath, operation);
+    const nodePath = resolveAnimationRelativeNodePath(rootNode, rootPath, operation);
     if (nodePath === null) {
         return value;
     }
@@ -81,52 +80,4 @@ async function normalizeProvidedAnimationPropertyValue(
     }
 
     return await loadAnimationAssetValue(assetCtor, uuid) as unknown as IAnimationValue;
-}
-
-/**
- * Resolve nodeUuid/nodePath from an operation into a relative display path for property value normalization.
- * UUID takes priority; returns null when same-name siblings exist (sibling order is unstable);
- * falls back to getNodeBySystemPath's two-phase lookup.
- */
-function resolveOperationRelativeNodePath(
-    rootNode: Node,
-    rootPath: string,
-    operation: { nodeUuid?: string; nodePath?: string },
-): string | null {
-    if (operation.nodeUuid) {
-        const relativePath = findRelativeNodePathByUuid(rootNode, operation.nodeUuid);
-        if (relativePath !== null) {
-            if (relativePath === '') {
-                return '';
-            }
-            if (hasSameNameSiblings(rootNode, relativePath)) {
-                return null;
-            }
-            return relativePath;
-        }
-    }
-
-    const nodePath = normalizeNodePath(operation.nodePath || '');
-    if (!nodePath) {
-        return operation.nodeUuid ? null : '';
-    }
-    const node = getNodeBySystemPath(rootNode, rootPath, nodePath);
-    if (!node) {
-        return null;
-    }
-
-    const relativePath = findRelativeNodePathByUuid(rootNode, node.uuid);
-    if (relativePath === null || relativePath === '') {
-        return relativePath;
-    }
-
-    if (hasSameNameSiblings(rootNode, relativePath)) {
-        return null;
-    }
-
-    return relativePath;
-}
-
-function normalizeNodePath(path: string): string {
-    return String(path || '').replace(/^\/+|\/+$/g, '');
 }

--- a/src/core/scene/scene-process/service/animation/property-value.ts
+++ b/src/core/scene/scene-process/service/animation/property-value.ts
@@ -3,7 +3,7 @@ import type { IAnimationOperation, IAnimationValue } from '../../../common';
 import type { IAnimationPropertyMetadata } from './property-curve';
 import { findRelativeNodePathByUuid, hasSameNameSiblings } from './property-curve';
 import { queryAnimationPropertyMetadata } from './property-metadata';
-import { getNodeByPath } from './scene-node';
+import { getNodeBySystemPath } from './scene-node';
 import {
     isAnimationAssetValue,
     loadAnimationAssetValue,
@@ -83,31 +83,39 @@ async function normalizeProvidedAnimationPropertyValue(
     return await loadAnimationAssetValue(assetCtor, uuid) as unknown as IAnimationValue;
 }
 
+/**
+ * Resolve nodeUuid/nodePath from an operation into a relative display path for property value normalization.
+ * UUID takes priority; returns null when same-name siblings exist (sibling order is unstable);
+ * falls back to getNodeBySystemPath's two-phase lookup.
+ */
 function resolveOperationRelativeNodePath(
     rootNode: Node,
     rootPath: string,
     operation: { nodeUuid?: string; nodePath?: string },
 ): string | null {
-    let targetUuid = operation.nodeUuid;
-    if (!targetUuid) {
-        const nodePath = normalizeNodePath(operation.nodePath || '');
-        if (!nodePath) {
-            return '';
+    if (operation.nodeUuid) {
+        const relativePath = findRelativeNodePathByUuid(rootNode, operation.nodeUuid);
+        if (relativePath !== null) {
+            if (relativePath === '') {
+                return '';
+            }
+            if (hasSameNameSiblings(rootNode, relativePath)) {
+                return null;
+            }
+            return relativePath;
         }
-        const normalizedRootPath = normalizeNodePath(rootPath);
-        let node: Node | null = null;
-        if (normalizedRootPath && (nodePath === normalizedRootPath || nodePath.startsWith(`${normalizedRootPath}/`))) {
-            node = getNodeByPath(nodePath);
-        } else {
-            node = rootNode.getChildByPath(nodePath);
-        }
-        if (!node) {
-            return null;
-        }
-        targetUuid = node.uuid;
     }
 
-    const relativePath = findRelativeNodePathByUuid(rootNode, targetUuid);
+    const nodePath = normalizeNodePath(operation.nodePath || '');
+    if (!nodePath) {
+        return operation.nodeUuid ? null : '';
+    }
+    const node = getNodeBySystemPath(rootNode, rootPath, nodePath);
+    if (!node) {
+        return null;
+    }
+
+    const relativePath = findRelativeNodePathByUuid(rootNode, node.uuid);
     if (relativePath === null || relativePath === '') {
         return relativePath;
     }

--- a/src/core/scene/scene-process/service/animation/property-value.ts
+++ b/src/core/scene/scene-process/service/animation/property-value.ts
@@ -1,7 +1,9 @@
 import { Node } from 'cc';
 import type { IAnimationOperation, IAnimationValue } from '../../../common';
 import type { IAnimationPropertyMetadata } from './property-curve';
+import { findRelativeNodePathByUuid } from './property-curve';
 import { queryAnimationPropertyMetadata } from './property-metadata';
+import { getNodeByPath } from './scene-node';
 import {
     isAnimationAssetValue,
     loadAnimationAssetValue,
@@ -91,26 +93,26 @@ function resolveOperationRelativeNodePath(
     operation: { nodeUuid?: string; nodePath?: string },
     options: { queryNodeByUuid: (uuid: string) => Node | null; queryNodePath: (node: Node) => string },
 ): string | null {
-    if (operation.nodePath) {
-        return toRelativeNodePath(rootNode, rootPath, operation.nodePath);
+    let targetUuid = operation.nodeUuid;
+    if (!targetUuid) {
+        const nodePath = normalizeNodePath(operation.nodePath || '');
+        if (!nodePath) {
+            return '';
+        }
+        const normalizedRootPath = normalizeNodePath(rootPath);
+        let node: Node | null = null;
+        if (normalizedRootPath && (nodePath === normalizedRootPath || nodePath.startsWith(`${normalizedRootPath}/`))) {
+            node = getNodeByPath(nodePath);
+        } else {
+            node = rootNode.getChildByPath(nodePath);
+        }
+        if (!node) {
+            return null;
+        }
+        targetUuid = node.uuid;
     }
-    const node = options.queryNodeByUuid(operation.nodeUuid || '');
-    if (node) {
-        return toRelativeNodePath(rootNode, rootPath, options.queryNodePath(node));
-    }
-    return toRelativeNodePath(rootNode, rootPath, '');
-}
 
-function toRelativeNodePath(rootNode: Node, rootPath: string, nodePath: string): string | null {
-    const normalizedRootPath = normalizeNodePath(rootPath);
-    const normalizedNodePath = normalizeNodePath(nodePath);
-    if (!normalizedNodePath || normalizedNodePath === normalizedRootPath) {
-        return '';
-    }
-    if (normalizedRootPath && normalizedNodePath.startsWith(`${normalizedRootPath}/`)) {
-        return normalizedNodePath.slice(normalizedRootPath.length + 1);
-    }
-    return rootNode.getChildByPath(normalizedNodePath) ? normalizedNodePath : null;
+    return findRelativeNodePathByUuid(rootNode, targetUuid);
 }
 
 function normalizeNodePath(path: string): string {

--- a/src/core/scene/scene-process/service/animation/scene-node.ts
+++ b/src/core/scene/scene-process/service/animation/scene-node.ts
@@ -34,7 +34,7 @@ export function getNodeByUuid(uuid: string): Node | null {
 }
 
 export function getNodeByPath(path: string): Node | null {
-    if (!path) {
+    if (!path || !NodeMgr.getNodeByPath) {
         return null;
     }
     return NodeMgr.getNodeByPath(path) || null;

--- a/src/core/scene/scene-process/service/animation/scene-node.ts
+++ b/src/core/scene/scene-process/service/animation/scene-node.ts
@@ -34,62 +34,83 @@ export function getNodeByUuid(uuid: string): Node | null {
 }
 
 export function getNodeByPath(path: string): Node | null {
-    if (!path || !NodeMgr.getNodeByPath) {
+    if (!path) {
         return null;
     }
     return NodeMgr.getNodeByPath(path) || null;
 }
 
 export function getNodePath(node: Node): string {
-    return NodeMgr.getNodePath?.(node) || '';
+    return NodeMgr.getNodePath(node) || '';
 }
 
-/**
- * Resolve both the unique system paths used by the CLI and the relative display paths stored in
- * animation tracks. If the same string resolves to different nodes in the two namespaces, the
- * path is ambiguous and the caller must provide a UUID instead.
- */
-export function getNodeBySystemPath(rootNode: Node, rootPath: string, nodePath: string): Node | null {
-    const normalizedRootPath = normalizeNodePath(rootPath);
-    const normalizedNodePath = normalizeNodePath(nodePath);
-    if (!normalizedNodePath) {
-        return rootNode;
-    }
-
-    const isAbsolute = Boolean(
-        normalizedRootPath
-        && (normalizedNodePath === normalizedRootPath || normalizedNodePath.startsWith(`${normalizedRootPath}/`)),
-    );
-    const absolutePath = normalizedRootPath && !isAbsolute
-        ? `${normalizedRootPath}/${normalizedNodePath}`
-        : normalizedNodePath;
-    const systemNode = getNodeByPath(absolutePath);
-
-    // A path that already contains rootPath is explicitly an absolute system path. Do not reinterpret
-    // a missing/stale absolute path as a display path, or it may bind to a different live node.
-    if (isAbsolute) {
-        return systemNode;
-    }
-
-    const relativePath = normalizedNodePath;
-    const displayNode = relativePath ? findUniqueNodeByDisplayPath(rootNode, relativePath) : rootNode;
-
-    if (systemNode && displayNode && systemNode.uuid !== displayNode.uuid) {
-        return null;
-    }
-    return systemNode || displayNode;
-}
-
-function findUniqueNodeByDisplayPath(rootNode: Node, relativePath: string): Node | null {
-    let current = rootNode;
-    for (const segment of relativePath.split('/').filter(Boolean)) {
-        const matches = current.children.filter((child) => child.name === segment);
-        if (matches.length !== 1) {
+export function resolveAnimationRelativeNodePath(
+    rootNode: Node,
+    rootPath: string,
+    target: { nodePath?: string; nodeUuid?: string },
+): string | null {
+    if (target.nodeUuid) {
+        const relativePath = findRelativeNodePathByUuid(rootNode, target.nodeUuid);
+        if (relativePath === null) {
             return null;
         }
-        current = matches[0];
+        const boundNode = relativePath ? rootNode.getChildByPath(relativePath) : rootNode;
+        return boundNode?.uuid === target.nodeUuid ? relativePath : null;
     }
-    return current;
+
+    const nodePath = normalizeNodePath(target.nodePath || '');
+    if (!nodePath) {
+        return '';
+    }
+
+    const normalizedRootPath = normalizeNodePath(rootPath);
+    if (nodePath === normalizedRootPath) {
+        return '';
+    }
+
+    if (normalizedRootPath && nodePath.startsWith(`${normalizedRootPath}/`)) {
+        const relativePath = nodePath.slice(normalizedRootPath.length + 1);
+        const animationNode = rootNode.getChildByPath(relativePath);
+        const systemNode = getNodeBySystemPathIfAvailable(nodePath);
+        // Keep the old absolute-path behavior for compatibility, including orphaned tracks whose
+        // scene node has already been deleted. A live system node is rejected only when its unique
+        // path suffix cannot represent the name-based path used by Cocos animation tracks.
+        return systemNode && systemNode !== animationNode ? null : relativePath;
+    }
+
+    if (rootNode.getChildByPath(nodePath)) {
+        return nodePath;
+    }
+    return null;
+}
+
+function getNodeBySystemPathIfAvailable(path: string): Node | null {
+    if (typeof NodeMgr.getNodeByPath !== 'function') {
+        return null;
+    }
+    try {
+        return NodeMgr.getNodeByPath(path) || null;
+    } catch {
+        return null;
+    }
+}
+
+function findRelativeNodePathByUuid(node: Node, uuid: string, prefix = ''): string | null {
+    if (node.uuid === uuid) {
+        return prefix;
+    }
+    for (const child of node.children) {
+        const path = prefix ? `${prefix}/${child.name}` : child.name;
+        const result = findRelativeNodePathByUuid(child, uuid, path);
+        if (result !== null) {
+            return result;
+        }
+    }
+    return null;
+}
+
+function normalizeNodePath(path: string): string {
+    return String(path || '').replace(/\\/g, '/').replace(/^\/+|\/+$/g, '').replace(/\/+/g, '/');
 }
 
 export function queryAnimationRootNode(node: Node, editorRoot: Node | null): Node {
@@ -180,8 +201,4 @@ function readPathValue(target: unknown, path: string): unknown {
         value = value[key];
     }
     return value;
-}
-
-function normalizeNodePath(path: string): string {
-    return path.replace(/\\/g, '/').replace(/^\/+|\/+$/g, '').replace(/\/+/g, '/');
 }

--- a/src/core/scene/scene-process/service/animation/scene-node.ts
+++ b/src/core/scene/scene-process/service/animation/scene-node.ts
@@ -41,7 +41,55 @@ export function getNodeByPath(path: string): Node | null {
 }
 
 export function getNodePath(node: Node): string {
-    return NodeMgr.getNodePath(node) || '';
+    return NodeMgr.getNodePath?.(node) || '';
+}
+
+/**
+ * Resolve both the unique system paths used by the CLI and the relative display paths stored in
+ * animation tracks. If the same string resolves to different nodes in the two namespaces, the
+ * path is ambiguous and the caller must provide a UUID instead.
+ */
+export function getNodeBySystemPath(rootNode: Node, rootPath: string, nodePath: string): Node | null {
+    const normalizedRootPath = normalizeNodePath(rootPath);
+    const normalizedNodePath = normalizeNodePath(nodePath);
+    if (!normalizedNodePath) {
+        return rootNode;
+    }
+
+    const isAbsolute = Boolean(
+        normalizedRootPath
+        && (normalizedNodePath === normalizedRootPath || normalizedNodePath.startsWith(`${normalizedRootPath}/`)),
+    );
+    const absolutePath = normalizedRootPath && !isAbsolute
+        ? `${normalizedRootPath}/${normalizedNodePath}`
+        : normalizedNodePath;
+    const systemNode = getNodeByPath(absolutePath);
+
+    // A path that already contains rootPath is explicitly an absolute system path. Do not reinterpret
+    // a missing/stale absolute path as a display path, or it may bind to a different live node.
+    if (isAbsolute) {
+        return systemNode;
+    }
+
+    const relativePath = normalizedNodePath;
+    const displayNode = relativePath ? findUniqueNodeByDisplayPath(rootNode, relativePath) : rootNode;
+
+    if (systemNode && displayNode && systemNode.uuid !== displayNode.uuid) {
+        return null;
+    }
+    return systemNode || displayNode;
+}
+
+function findUniqueNodeByDisplayPath(rootNode: Node, relativePath: string): Node | null {
+    let current = rootNode;
+    for (const segment of relativePath.split('/').filter(Boolean)) {
+        const matches = current.children.filter((child) => child.name === segment);
+        if (matches.length !== 1) {
+            return null;
+        }
+        current = matches[0];
+    }
+    return current;
 }
 
 export function queryAnimationRootNode(node: Node, editorRoot: Node | null): Node {
@@ -132,4 +180,8 @@ function readPathValue(target: unknown, path: string): unknown {
         value = value[key];
     }
     return value;
+}
+
+function normalizeNodePath(path: string): string {
+    return path.replace(/\\/g, '/').replace(/^\/+|\/+$/g, '').replace(/\/+/g, '/');
 }

--- a/src/core/scene/scene-process/service/animation/scene-node.ts
+++ b/src/core/scene/scene-process/service/animation/scene-node.ts
@@ -49,39 +49,39 @@ export function resolveAnimationRelativeNodePath(
     rootPath: string,
     target: { nodePath?: string; nodeUuid?: string },
 ): string | null {
+    const nodePath = normalizeNodePath(target.nodePath || '');
+    const normalizedRootPath = normalizeNodePath(rootPath);
+    if (nodePath) {
+        if (nodePath === normalizedRootPath) {
+            return '';
+        }
+
+        if (normalizedRootPath && nodePath.startsWith(`${normalizedRootPath}/`)) {
+            const relativePath = nodePath.slice(normalizedRootPath.length + 1);
+            const animationNode = rootNode.getChildByPath(relativePath);
+            const systemNode = getNodeBySystemPathIfAvailable(nodePath);
+            // Keep the old absolute-path behavior for compatibility, including orphaned tracks whose
+            // scene node has already been deleted. A live system node is rejected only when its unique
+            // path suffix cannot represent the name-based path used by Cocos animation tracks.
+            if (!systemNode || systemNode === animationNode) {
+                return relativePath;
+            }
+        } else if (rootNode.getChildByPath(nodePath)) {
+            return nodePath;
+        }
+    }
+
     if (target.nodeUuid) {
         const relativePath = findRelativeNodePathByUuid(rootNode, target.nodeUuid);
-        if (relativePath === null) {
-            return null;
+        if (relativePath !== null) {
+            const boundNode = relativePath ? rootNode.getChildByPath(relativePath) : rootNode;
+            if (boundNode?.uuid === target.nodeUuid) {
+                return relativePath;
+            }
         }
-        const boundNode = relativePath ? rootNode.getChildByPath(relativePath) : rootNode;
-        return boundNode?.uuid === target.nodeUuid ? relativePath : null;
     }
 
-    const nodePath = normalizeNodePath(target.nodePath || '');
-    if (!nodePath) {
-        return '';
-    }
-
-    const normalizedRootPath = normalizeNodePath(rootPath);
-    if (nodePath === normalizedRootPath) {
-        return '';
-    }
-
-    if (normalizedRootPath && nodePath.startsWith(`${normalizedRootPath}/`)) {
-        const relativePath = nodePath.slice(normalizedRootPath.length + 1);
-        const animationNode = rootNode.getChildByPath(relativePath);
-        const systemNode = getNodeBySystemPathIfAvailable(nodePath);
-        // Keep the old absolute-path behavior for compatibility, including orphaned tracks whose
-        // scene node has already been deleted. A live system node is rejected only when its unique
-        // path suffix cannot represent the name-based path used by Cocos animation tracks.
-        return systemNode && systemNode !== animationNode ? null : relativePath;
-    }
-
-    if (rootNode.getChildByPath(nodePath)) {
-        return nodePath;
-    }
-    return null;
+    return nodePath || target.nodeUuid ? null : '';
 }
 
 function getNodeBySystemPathIfAvailable(path: string): Node | null {

--- a/src/core/scene/scene-process/service/animation/service-target.ts
+++ b/src/core/scene/scene-process/service/animation/service-target.ts
@@ -156,6 +156,7 @@ export function createAnimationServiceClipDump(rootNode: Node, clip: AnimationCl
 
 export function createAnimationPropertyCurveMetadataContext(rootNode: Node): IPropertyCurveMetadataContext {
     return {
+        rootNode,
         queryPropertyMetadata: (nodePath, propKey) => queryAnimationPropertyMetadata(rootNode, nodePath, propKey),
     };
 }

--- a/src/core/scene/scene-process/service/animation/service-target.ts
+++ b/src/core/scene/scene-process/service/animation/service-target.ts
@@ -25,6 +25,7 @@ import {
     isSkeletonClip,
     isUsingBakedAnimation,
     queryAnimationRootNode,
+    resolveAnimationRelativeNodePath,
 } from './scene-node';
 import { IAnimationSession } from './types';
 import { clipUuid } from './utils';
@@ -76,38 +77,23 @@ export function resolveAnimationTargetNode(
 }
 
 export function resolveAnimationFrameQueryNode(options: IAnimationQueryPropertyValueAtFrameOptions, session: IAnimationSession): Node {
-    if (options.nodePath) {
-        const path = options.nodePath;
-        if (path === session.rootPath || path.startsWith(`${session.rootPath}/`)) {
-            const nodeByPath = getNodeByPath(path);
-            if (nodeByPath) {
-                return nodeByPath;
-            }
-        }
-
-        const relativeNode = getNodeByPath(`${session.rootPath}/${path}`);
-        if (relativeNode) {
-            return relativeNode;
-        }
-
-        const nodeByPath = getNodeByPath(path);
-        if (nodeByPath) {
-            return nodeByPath;
-        }
+    const rootNode = getNodeByUuid(session.rootUuid) || getNodeByPath(session.rootPath);
+    const relativePath = rootNode
+        ? resolveAnimationRelativeNodePath(rootNode, session.rootPath, options)
+        : null;
+    const node = relativePath === ''
+        ? rootNode
+        : relativePath && rootNode?.getChildByPath(relativePath);
+    if (node) {
+        return node;
     }
 
-    const nodeByUuid = getNodeByUuid(options.nodeUuid || '');
-    if (nodeByUuid) {
-        return nodeByUuid;
-    }
-    if (!options.nodePath) {
-        const rootNode = getNodeByPath(session.rootPath);
-        if (rootNode) {
-            return rootNode;
-        }
-    }
-
-    throw new Error(`Animation target node is required: ${options.nodePath || session.rootPath}`);
+    const target = options.nodeUuid
+        ? `UUID "${options.nodeUuid}"`
+        : `path "${options.nodePath || '<root>'}"`;
+    const reason = `Animation target ${target} is not bound by the current animation hierarchy.`;
+    console.warn(`[Animation] ${reason}`);
+    throw new Error(reason);
 }
 
 export function isCurrentAnimationSessionClipQuery(
@@ -156,7 +142,6 @@ export function createAnimationServiceClipDump(rootNode: Node, clip: AnimationCl
 
 export function createAnimationPropertyCurveMetadataContext(rootNode: Node): IPropertyCurveMetadataContext {
     return {
-        rootNode,
         queryPropertyMetadata: (nodePath, propKey) => queryAnimationPropertyMetadata(rootNode, nodePath, propKey),
     };
 }

--- a/src/core/scene/scene-process/service/animation/service-target.ts
+++ b/src/core/scene/scene-process/service/animation/service-target.ts
@@ -81,9 +81,17 @@ export function resolveAnimationFrameQueryNode(options: IAnimationQueryPropertyV
     const relativePath = rootNode
         ? resolveAnimationRelativeNodePath(rootNode, session.rootPath, options)
         : null;
-    const node = relativePath === ''
+    let node = relativePath === ''
         ? rootNode
         : relativePath && rootNode?.getChildByPath(relativePath);
+    if (!node && rootNode && options.nodePath && options.nodeUuid) {
+        const uuidRelativePath = resolveAnimationRelativeNodePath(rootNode, session.rootPath, {
+            nodeUuid: options.nodeUuid,
+        });
+        node = uuidRelativePath === ''
+            ? rootNode
+            : uuidRelativePath && rootNode.getChildByPath(uuidRelativePath);
+    }
     if (node) {
         return node;
     }

--- a/src/core/scene/scene-process/service/gizmo/utils/editor-node.ts
+++ b/src/core/scene/scene-process/service/gizmo/utils/editor-node.ts
@@ -7,6 +7,7 @@ function getEditorNodeApi(): any {
         || (globalThis as any).EditorExtends?.Node;
 }
 
+// After name/path decoupling, fall back to prefab-relative path lookup when system path lookup fails
 export function getEditorNodeByPath(path: string): Node | null {
     if (!path) {
         return null;
@@ -49,18 +50,50 @@ function getPrefabNodeByRelativePath(path: string): Node | null {
     }
 }
 
+/**
+ * Find child node within a prefab by traversing path segments level by level.
+ * After name/path decoupling, prefers matching by system path last segment (uniquely determined);
+ * falls back to child.name matching when the API is unavailable (backward compatible).
+ */
 function findNodeFromPrefabRoot(root: Node, path: string): Node | null {
     const normalized = path.replace(/\\/g, '/').replace(/^\/+/, '');
-    const segments = normalizePrefabPathSegments(normalized.split('/').filter(Boolean), root.name, getCurrentSceneName());
+    const api = getEditorNodeApi();
+    const rootPath: string = api?.getNodePath?.(root) ?? '';
+    const rootPathSegment = rootPath.replace(/\\/g, '/').split('/').filter(Boolean).pop() ?? '';
+    const segments = normalizePrefabPathSegments(
+        normalized.split('/').filter(Boolean),
+        root.name,
+        rootPathSegment,
+        getCurrentSceneName(),
+    );
     if (!segments) {
         return null;
     }
     let node: Node | null = root;
     for (const segment of segments) {
-        node = node.children?.find((child) => child.name === segment) ?? null;
         if (!node) {
             return null;
         }
+        const children: readonly Node[] = node.children ?? [];
+        let hasSystemPath = false;
+        let systemPathMatch: Node | null = null;
+        for (const child of children) {
+            const childPath: string = api?.getNodePath?.(child) ?? '';
+            const childPathSegment = childPath.replace(/\\/g, '/').split('/').filter(Boolean).pop();
+            if (!childPathSegment) {
+                continue;
+            }
+            hasSystemPath = true;
+            if (childPathSegment === segment) {
+                systemPathMatch = child;
+                break;
+            }
+        }
+        if (hasSystemPath) {
+            node = systemPathMatch;
+            continue;
+        }
+        node = children.find((child: Node) => child.name === segment) ?? null;
     }
     return node;
 }
@@ -69,15 +102,29 @@ function getCurrentSceneName(): string {
     return (cc as any).director?.getScene?.()?.name ?? '';
 }
 
-function normalizePrefabPathSegments(segments: string[], rootName: string, currentSceneName: string): string[] | null {
-    if (segments[0] === rootName) {
+// Match root segment by both system path last segment and display name, preventing mismatch when name != path segment after rename
+function normalizePrefabPathSegments(
+    segments: string[],
+    rootName: string,
+    rootPathSegment: string,
+    currentSceneName: string,
+): string[] | null {
+    const matchesRoot = (segment: string | undefined): boolean => {
+        const authoritativeRootSegment = rootPathSegment || rootName;
+        return Boolean(authoritativeRootSegment && segment === authoritativeRootSegment);
+    };
+    if (matchesRoot(segments[0])) {
         return segments.slice(1);
     }
-    if (segments[0] === 'should_hide_in_hierarchy' && segments[1] === rootName) {
-        return segments.slice(2);
+    if (segments[0] === 'should_hide_in_hierarchy') {
+        if (matchesRoot(segments[1])) {
+            return segments.slice(2);
+        }
     }
-    if (segments[0] === currentSceneName && segments[1] === 'should_hide_in_hierarchy' && segments[2] === rootName) {
-        return segments.slice(3);
+    if (segments[0] === currentSceneName && segments[1] === 'should_hide_in_hierarchy') {
+        if (matchesRoot(segments[2])) {
+            return segments.slice(3);
+        }
     }
     return null;
 }

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -242,7 +242,8 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         // 逐级检查并创建路径
         for (let i = 0; i < pathParts.length; i++) {
             const pathPart = pathParts[i];
-            let nextNode = currentParent.getChildByName(pathPart);
+            const accumulatedPath = pathParts.slice(0, i + 1).join('/');
+            let nextNode = NodeMgr.getNodeByPath(accumulatedPath) as Node | null;
 
             if (!nextNode) {
                 if (pathPart === 'Canvas') {

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -38,6 +38,7 @@ import NodeConfig from './node/node-type-config';
 import { RemoveNodeCommand } from './undo/commands/remove-node-command';
 import { RemoveComponentCommand } from './undo/commands/remove-component-command';
 import { broadcastAnimationPropertyCommitted } from './animation/property-commit-event';
+import { sanitizeNodeName, validateNodeName } from '../../../engine/editor-extends/manager/path-utils';
 
 const NodeMgr = EditorExtends.Node;
 
@@ -50,6 +51,7 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
     private readonly _undo = new NodeUndoHelper((event, ...args) => this.emit(event as any, ...args));
 
     async createByType(params: ICreateByNodeTypeParams): Promise<INode | null> {
+        this._validateCreateParams(params);
         try {
             await Service.Editor.lock();
             const beforeNodeUuids = this._collectSceneNodeUuidsForUndo();
@@ -80,6 +82,7 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
     }
 
     async createByAsset(params: ICreateByAssetParams): Promise<INode | null> {
+        this._validateCreateParams(params);
         try {
             await Service.Editor.lock();
             const beforeNodeUuids = this._collectSceneNodeUuidsForUndo();
@@ -141,6 +144,8 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             return null;
         }
 
+        this._migrateLegacyNodeNames(resultNode);
+
         /**
          * 默认创建节点是从 prefab 模板，所以初始是 prefab 节点
          * 是否要 unlink 为普通节点
@@ -175,12 +180,6 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         }
 
         resultNode.setParent(parent, params.keepWorldTransform);
-        // setParent 后，node的path可能会变，node的name需要同步path中对应的name
-        const path = NodeMgr.getNodePath(resultNode);
-        const name = path.split('/').pop();
-        if (name && resultNode.name !== name) {
-            resultNode.name = name;
-        }
         // 挂到 prefab instance 下时，setParent 相关流程可能重新补回模板 prefab 信息。
         // 但在 prefab asset 编辑器中，新节点需要保留 setParent 补齐的 prefab 元数据。
         if (shouldUnlinkPrefab && Service.Editor.getCurrentEditorType() !== 'prefab') {
@@ -219,6 +218,44 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         return await this._ensurePathExists(path, currentScene);
     }
 
+    private _validateCreateParams(params: ICreateByNodeTypeParams | ICreateByAssetParams): void {
+        this._validateRequestedNodeName(params.name);
+        this._validateRequestedNodePath(params.path);
+    }
+
+    private _validateRequestedNodeName(name: string | undefined): void {
+        if (name === undefined) {
+            return;
+        }
+        const error = validateNodeName(name);
+        if (error) {
+            throw new Error(error);
+        }
+    }
+
+    private _validateRequestedNodePath(path: string): void {
+        for (const segment of path.split('/').filter((part) => part.trim() !== '')) {
+            this._validateRequestedNodeName(segment);
+        }
+    }
+
+    private _migrateLegacyNodeNames(root: Node): void {
+        const visit = (node: Node): void => {
+            const originalName = node.name;
+            const migratedName = sanitizeNodeName(originalName);
+            if (migratedName !== originalName) {
+                console.warn(
+                    `Node: migrated legacy node name "${originalName}" to "${migratedName}" because it contains unsupported characters.`,
+                );
+                node.name = migratedName;
+            }
+            for (const child of node.children) {
+                visit(child);
+            }
+        };
+        visit(root);
+    }
+
     /**
      * 确保路径存在，如果不存在则创建空节点
      */
@@ -242,8 +279,11 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         // 逐级检查并创建路径
         for (let i = 0; i < pathParts.length; i++) {
             const pathPart = pathParts[i];
-            const accumulatedPath = pathParts.slice(0, i + 1).join('/');
-            let nextNode = NodeMgr.getNodeByPath(accumulatedPath) as Node | null;
+            const currentParentPath = NodeMgr.getNodePath(currentParent);
+            const candidatePath = currentParentPath && currentParentPath !== '/'
+                ? `${currentParentPath}/${pathPart}`
+                : pathPart;
+            let nextNode = NodeMgr.getNodeByPath(candidatePath) as Node | null;
 
             if (!nextNode) {
                 if (pathPart === 'Canvas') {
@@ -499,8 +539,11 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             },
         }, async () => {
             if (options.path === 'name' && options.dump.value !== node.name) {
-                // 这里相当于是做个hack的补充功能，因为setProperty并没有改变path。
-                // 而在cli上是期望改变path的，后期感觉可以通过node:change消息来实现这个功能
+                // Validate at the API boundary early, before the before-change event fires and updateNodeName rejects
+                const nameError = validateNodeName(options.dump.value as string);
+                if (nameError) {
+                    throw new Error(nameError);
+                }
                 this.emit('node:before-change', node);
                 NodeMgr.updateNodeName(node.uuid, options.dump.value as string);
                 this.emit('node:change', node, { type: NodeEventType.SET_PROPERTY, propPath: 'name' });

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -38,7 +38,7 @@ import NodeConfig from './node/node-type-config';
 import { RemoveNodeCommand } from './undo/commands/remove-node-command';
 import { RemoveComponentCommand } from './undo/commands/remove-component-command';
 import { broadcastAnimationPropertyCommitted } from './animation/property-commit-event';
-import { sanitizeNodeName, validateNodeName } from '../../../engine/editor-extends/manager/path-utils';
+import { validateNodeName } from '../../../engine/editor-extends/manager/path-utils';
 
 const NodeMgr = EditorExtends.Node;
 
@@ -144,8 +144,6 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             return null;
         }
 
-        this._migrateLegacyNodeNames(resultNode);
-
         /**
          * 默认创建节点是从 prefab 模板，所以初始是 prefab 节点
          * 是否要 unlink 为普通节点
@@ -237,23 +235,6 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         for (const segment of path.split('/').filter((part) => part.trim() !== '')) {
             this._validateRequestedNodeName(segment);
         }
-    }
-
-    private _migrateLegacyNodeNames(root: Node): void {
-        const visit = (node: Node): void => {
-            const originalName = node.name;
-            const migratedName = sanitizeNodeName(originalName);
-            if (migratedName !== originalName) {
-                console.warn(
-                    `Node: migrated legacy node name "${originalName}" to "${migratedName}" because it contains unsupported characters.`,
-                );
-                node.name = migratedName;
-            }
-            for (const child of node.children) {
-                visit(child);
-            }
-        };
-        visit(root);
     }
 
     /**
@@ -539,7 +520,7 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             },
         }, async () => {
             if (options.path === 'name' && options.dump.value !== node.name) {
-                // Validate at the API boundary early, before the before-change event fires and updateNodeName rejects
+                // Reject new illegal input at the API boundary; the lower-level manager accepts it only for legacy undo/redo restoration.
                 const nameError = validateNodeName(options.dump.value as string);
                 if (nameError) {
                     throw new Error(nameError);

--- a/src/core/scene/test/animation-operation-normalizer.test.ts
+++ b/src/core/scene/test/animation-operation-normalizer.test.ts
@@ -1,3 +1,5 @@
+export {};
+
 const mockNormalizeProvidedValue = jest.fn();
 const mockExtractSampledValue = jest.fn();
 

--- a/src/core/scene/test/animation-operation-normalizer.test.ts
+++ b/src/core/scene/test/animation-operation-normalizer.test.ts
@@ -1,0 +1,180 @@
+const mockNormalizeProvidedValue = jest.fn();
+const mockExtractSampledValue = jest.fn();
+
+jest.mock('../scene-process/service/animation/property-value', () => ({
+    normalizeProvidedAnimationPropertyOperationValue: mockNormalizeProvidedValue,
+}));
+
+jest.mock('../scene-process/service/animation/scene-node', () => ({
+    extractSampledOperationValue: mockExtractSampledValue,
+}));
+
+const { normalizeAnimationOperation } = require('../scene-process/service/animation/operation-normalizer');
+
+describe('normalizeAnimationOperation', () => {
+    const rootNode = {} as any;
+    const queryPropertyValueAtFrame = jest.fn();
+    const context = {
+        currentClipUuid: 'current-clip',
+        rootNode,
+        rootPath: 'Root',
+        queryPropertyValueAtFrame,
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('passes unrelated operations through unchanged', async () => {
+        const operation = { type: 'changeSample', clipUuid: 'current-clip', sample: 60 };
+
+        await expect(normalizeAnimationOperation(operation, context)).resolves.toBe(operation);
+        expect(mockNormalizeProvidedValue).not.toHaveBeenCalled();
+    });
+
+    it('keeps updatePropertyKeyData unchanged when keyData is already present', async () => {
+        const operation = {
+            type: 'updatePropertyKeyData',
+            clipUuid: 'current-clip',
+            nodePath: 'Enemy',
+            propKey: 'position',
+            frame: 10,
+            keyData: { interpMode: 1 },
+        };
+
+        await expect(normalizeAnimationOperation(operation, context)).resolves.toBe(operation);
+    });
+
+    it('upgrades legacy curveData on updatePropertyKeyData', async () => {
+        const operation = {
+            type: 'updatePropertyKeyData',
+            clipUuid: 'current-clip',
+            nodePath: 'Enemy',
+            propKey: 'position',
+            frame: 10,
+            curveData: { interpMode: 1 },
+        };
+
+        await expect(normalizeAnimationOperation(operation, context)).resolves.toEqual({
+            ...operation,
+            keyData: operation.curveData,
+        });
+    });
+
+    it('normalizes a provided property value and upgrades legacy curveData to keyData', async () => {
+        const operation = {
+            type: 'createPropertyKey',
+            clipUuid: 'current-clip',
+            nodeUuid: 'enemy-uuid',
+            propKey: 'position',
+            frame: 0,
+            value: { x: 1, y: 2, z: 3 },
+            curveData: { interpMode: 1 },
+        };
+        const normalizedValue = { x: 4, y: 5, z: 6 };
+        mockNormalizeProvidedValue.mockResolvedValue(normalizedValue);
+
+        await expect(normalizeAnimationOperation(operation, context)).resolves.toEqual({
+            ...operation,
+            keyData: operation.curveData,
+            value: normalizedValue,
+        });
+        expect(mockNormalizeProvidedValue).toHaveBeenCalledWith(rootNode, 'Root', operation);
+        expect(queryPropertyValueAtFrame).not.toHaveBeenCalled();
+    });
+
+    it('converts an update containing only key data without sampling a value', async () => {
+        const operation = {
+            type: 'updatePropertyKey',
+            clipUuid: 'current-clip',
+            nodePath: 'Enemy',
+            propKey: 'position',
+            frame: 10,
+            channel: 'x',
+            keyData: { broken: true },
+        };
+
+        await expect(normalizeAnimationOperation(operation, context)).resolves.toEqual({
+            ...operation,
+            type: 'updatePropertyKeyData',
+        });
+        expect(queryPropertyValueAtFrame).not.toHaveBeenCalled();
+    });
+
+    it('samples an omitted value and extracts the requested channel', async () => {
+        const operation = {
+            type: 'createPropertyKey',
+            clipUuid: '',
+            nodeUuid: 'enemy-uuid',
+            nodePath: 'ignored-when-uuid-is-present',
+            propKey: 'position',
+            frame: 15,
+            channel: 'y',
+        };
+        queryPropertyValueAtFrame.mockResolvedValue({ x: 1, y: 2, z: 3 });
+        mockExtractSampledValue.mockReturnValue(2);
+
+        await expect(normalizeAnimationOperation(operation, context)).resolves.toEqual({
+            ...operation,
+            keyData: undefined,
+            value: 2,
+        });
+        expect(queryPropertyValueAtFrame).toHaveBeenCalledWith({
+            clipUuid: 'current-clip',
+            nodePath: operation.nodePath,
+            nodeUuid: operation.nodeUuid,
+            propKey: operation.propKey,
+            frame: operation.frame,
+        });
+        expect(mockExtractSampledValue).toHaveBeenCalledWith({ x: 1, y: 2, z: 3 }, 'y');
+    });
+
+    it('returns a failure when sampling produces no usable value', async () => {
+        const operation = {
+            type: 'createPropertyKey',
+            clipUuid: 'current-clip',
+            propKey: 'position',
+            frame: 20,
+        };
+        queryPropertyValueAtFrame.mockResolvedValue({ x: 1 });
+        mockExtractSampledValue.mockReturnValue(undefined);
+
+        await expect(normalizeAnimationOperation(operation, context)).resolves.toEqual({
+            state: 'failure',
+            result: false,
+            reason: 'Failed to sample animation property value: position',
+        });
+    });
+
+    it('returns the sampling error as an operation failure', async () => {
+        const operation = {
+            type: 'createPropertyKey',
+            clipUuid: 'current-clip',
+            propKey: 'position',
+            frame: 30,
+        };
+        queryPropertyValueAtFrame.mockRejectedValue(new Error('sample failed'));
+
+        await expect(normalizeAnimationOperation(operation, context)).resolves.toEqual({
+            state: 'failure',
+            result: false,
+            reason: 'sample failed',
+        });
+    });
+
+    it('normalizes a non-Error sampling rejection into a failure reason', async () => {
+        const operation = {
+            type: 'createPropertyKey',
+            clipUuid: 'current-clip',
+            propKey: 'position',
+            frame: 30,
+        };
+        queryPropertyValueAtFrame.mockRejectedValue('sample failed');
+
+        await expect(normalizeAnimationOperation(operation, context)).resolves.toEqual({
+            state: 'failure',
+            result: false,
+            reason: 'sample failed',
+        });
+    });
+});

--- a/src/core/scene/test/animation-property-value.test.ts
+++ b/src/core/scene/test/animation-property-value.test.ts
@@ -1,0 +1,136 @@
+const mockQueryPropertyMetadata = jest.fn();
+const mockResolveRelativeNodePath = jest.fn();
+const mockIsAssetValue = jest.fn();
+const mockLoadAssetValue = jest.fn();
+const mockQueryAssetCtor = jest.fn();
+const mockQueryAssetUuid = jest.fn();
+const mockSerializeAssetValue = jest.fn();
+
+jest.mock('cc', () => ({ Node: class Node {} }));
+
+jest.mock('../scene-process/service/animation/property-metadata', () => ({
+    queryAnimationPropertyMetadata: mockQueryPropertyMetadata,
+}));
+
+jest.mock('../scene-process/service/animation/scene-node', () => ({
+    resolveAnimationRelativeNodePath: mockResolveRelativeNodePath,
+}));
+
+jest.mock('../scene-process/service/animation/asset-value', () => ({
+    isAnimationAssetValue: mockIsAssetValue,
+    loadAnimationAssetValue: mockLoadAssetValue,
+    queryAnimationAssetCtor: mockQueryAssetCtor,
+    queryAnimationAssetUuid: mockQueryAssetUuid,
+    serializeAnimationAssetValue: mockSerializeAssetValue,
+}));
+
+jest.mock('../scene-process/service/animation/utils', () => ({
+    cloneSerializableValue: (value: unknown) => value,
+}));
+
+const { normalizeProvidedAnimationPropertyOperationValue } = require('../scene-process/service/animation/property-value');
+
+describe('normalizeProvidedAnimationPropertyOperationValue', () => {
+    const rootNode = {} as any;
+    const createOperation = (value: unknown) => ({
+        type: 'createPropertyKey',
+        clipUuid: 'clip-uuid',
+        nodePath: 'Enemy',
+        propKey: 'cc.Sprite.spriteFrame',
+        frame: 0,
+        value,
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockResolveRelativeNodePath.mockReturnValue('Enemy');
+        mockQueryPropertyMetadata.mockReturnValue({ type: { value: 'cc.SpriteFrame' } });
+        mockQueryAssetCtor.mockReturnValue(null);
+    });
+
+    it.each([null, undefined])('returns %p without resolving the target', async (value) => {
+        await expect(normalizeProvidedAnimationPropertyOperationValue(
+            rootNode,
+            'Root',
+            createOperation(value),
+        )).resolves.toBe(value);
+
+        expect(mockResolveRelativeNodePath).not.toHaveBeenCalled();
+        expect(mockQueryPropertyMetadata).not.toHaveBeenCalled();
+    });
+
+    it('returns the provided value when the animation target is not bound', async () => {
+        const value = { uuid: 'asset-uuid' };
+        mockResolveRelativeNodePath.mockReturnValue(null);
+
+        await expect(normalizeProvidedAnimationPropertyOperationValue(
+            rootNode,
+            'Root',
+            createOperation(value),
+        )).resolves.toBe(value);
+
+        expect(mockQueryPropertyMetadata).not.toHaveBeenCalled();
+        expect(mockQueryAssetCtor).not.toHaveBeenCalled();
+    });
+
+    it('returns non-asset property values unchanged', async () => {
+        const value = { x: 1, y: 2, z: 3 };
+        mockQueryPropertyMetadata.mockReturnValue({ type: { value: 'cc.Vec3' } });
+
+        await expect(normalizeProvidedAnimationPropertyOperationValue(
+            rootNode,
+            'Root',
+            { ...createOperation(value), propKey: 'position' },
+        )).resolves.toBe(value);
+
+        expect(mockQueryPropertyMetadata).toHaveBeenCalledWith(rootNode, 'Enemy', 'position');
+        expect(mockQueryAssetUuid).not.toHaveBeenCalled();
+    });
+
+    it('keeps an already-instantiated asset value without loading it again', async () => {
+        class SpriteFrame {}
+        const value = new SpriteFrame();
+        mockQueryAssetCtor.mockReturnValue(SpriteFrame);
+
+        await expect(normalizeProvidedAnimationPropertyOperationValue(
+            rootNode,
+            'Root',
+            createOperation(value),
+        )).resolves.toBe(value);
+
+        expect(mockQueryAssetUuid).not.toHaveBeenCalled();
+        expect(mockLoadAssetValue).not.toHaveBeenCalled();
+    });
+
+    it('keeps an asset-shaped value without a UUID unchanged', async () => {
+        class SpriteFrame {}
+        const value = { name: 'missing-uuid' };
+        mockQueryAssetCtor.mockReturnValue(SpriteFrame);
+        mockQueryAssetUuid.mockReturnValue('');
+
+        await expect(normalizeProvidedAnimationPropertyOperationValue(
+            rootNode,
+            'Root',
+            createOperation(value),
+        )).resolves.toBe(value);
+
+        expect(mockLoadAssetValue).not.toHaveBeenCalled();
+    });
+
+    it('loads an asset instance from a provided UUID value', async () => {
+        class SpriteFrame {}
+        const value = { uuid: 'asset-uuid' };
+        const loaded = new SpriteFrame();
+        mockQueryAssetCtor.mockReturnValue(SpriteFrame);
+        mockQueryAssetUuid.mockReturnValue('asset-uuid');
+        mockLoadAssetValue.mockResolvedValue(loaded);
+
+        await expect(normalizeProvidedAnimationPropertyOperationValue(
+            rootNode,
+            'Root',
+            createOperation(value),
+        )).resolves.toBe(loaded);
+
+        expect(mockLoadAssetValue).toHaveBeenCalledWith(SpriteFrame, 'asset-uuid');
+    });
+});

--- a/src/core/scene/test/animation-service-animatable.test.ts
+++ b/src/core/scene/test/animation-service-animatable.test.ts
@@ -1337,10 +1337,6 @@ describe('property-value 碰撞后缀路径解析', () => {
                 frame: 0,
                 value: { x: 0, y: 0, z: 0 },
             },
-            {
-                queryNodeByUuid: (uuid: string) => uuid === enemy.uuid ? enemy : null,
-                queryNodePath: () => 'Root/Enemy_001',
-            },
         );
 
         expect(capturedNodePath).toBe('Enemy');
@@ -1381,12 +1377,46 @@ describe('property-value 碰撞后缀路径解析', () => {
                 frame: 0,
                 value: { x: 0, y: 0, z: 0 },
             },
-            {
-                queryNodeByUuid: () => null,
-                queryNodePath: () => 'Root/Enemy_001',
-            },
         );
 
         expect(capturedNodePath).toBe('Enemy');
+    });
+
+    it('同名兄弟时 resolveOperationRelativeNodePath 返回 null，value 原样返回', async () => {
+        jest.resetModules();
+        (global as any).EditorExtends = { Node: {} };
+        (global as any).cc = require('cc');
+
+        let metadataCalled = false;
+        jest.doMock('../scene-process/service/animation/property-metadata', () => ({
+            queryAnimationPropertyMetadata: () => {
+                metadataCalled = true;
+                return null;
+            },
+        }));
+
+        const { Node } = require('cc');
+        const { normalizeProvidedAnimationPropertyOperationValue } = require('../scene-process/service/animation/property-value');
+
+        const root = new Node('Root');
+        const enemy1 = new Node('Enemy');
+        const enemy2 = new Node('Enemy');
+        root.children = [enemy1, enemy2];
+
+        const inputValue = { x: 1, y: 2, z: 3 };
+        const result = await normalizeProvidedAnimationPropertyOperationValue(
+            root, '',
+            {
+                type: 'createPropertyKey',
+                clipUuid: 'clip',
+                nodeUuid: enemy1.uuid,
+                propKey: 'position',
+                frame: 0,
+                value: inputValue,
+            },
+        );
+
+        expect(metadataCalled).toBe(false);
+        expect(result).toEqual(inputValue);
     });
 });

--- a/src/core/scene/test/animation-service-animatable.test.ts
+++ b/src/core/scene/test/animation-service-animatable.test.ts
@@ -31,13 +31,16 @@ jest.mock('cc', () => {
             public height = 0,
         ) { }
     }
+    let _nextMockUuid = 0;
     class Node {
         components: Component[] = [];
         children: Node[] = [];
         name = '';
+        uuid = '';
 
         constructor(name = '') {
             this.name = name;
+            this.uuid = `mock-node-${_nextMockUuid++}`;
         }
 
         getChildByPath(path: string) {
@@ -944,5 +947,446 @@ describe('AnimationService animatable property metadata', () => {
                 type: { value: 'cc.Number' },
             }),
         ]);
+    });
+});
+
+describe('resolveRelativeNodePath 同名兄弟歧义检测', () => {
+    beforeEach(() => {
+        (global as any).cc = require('cc');
+        (global as any).EditorExtends = {
+            Node: {},
+        };
+    });
+
+    function makeTree(structure: Record<string, string[]>): any {
+        const { Node } = require('cc');
+        const nodes: Record<string, any> = {};
+        for (const name of Object.keys(structure)) {
+            nodes[name] = new Node(name);
+        }
+        for (const [name, childNames] of Object.entries(structure)) {
+            nodes[name].children = childNames.map((cn: string) => {
+                if (!nodes[cn]) {
+                    nodes[cn] = new Node(cn);
+                }
+                return nodes[cn];
+            });
+        }
+        return nodes;
+    }
+
+    it('无同名兄弟时通过 nodeUuid 正常绑定', () => {
+        const { AnimationClip } = require('cc');
+        const { addPropertyCurve } = require('../scene-process/service/animation/property-curve');
+        const nodes = makeTree({ Root: ['A', 'B'] });
+        const clip = new AnimationClip();
+        const context = { rootNode: nodes.Root, rootPath: '' };
+
+        const result = addPropertyCurve(clip, context, {
+            type: 'addPropertyCurve', clipUuid: 'clip',
+            nodeUuid: nodes.A.uuid, propKey: 'position',
+            value: { x: 0, y: 0, z: 0 },
+        });
+        expect(result).toBe(true);
+    });
+
+    it('同名兄弟的第一个节点也被拦截', () => {
+        const { AnimationClip, Node } = require('cc');
+        const { addPropertyCurve } = require('../scene-process/service/animation/property-curve');
+        const root = new Node('Root');
+        const enemy1 = new Node('Enemy');
+        const enemy2 = new Node('Enemy');
+        root.children = [enemy1, enemy2];
+        const clip = new AnimationClip();
+        const context = { rootNode: root, rootPath: '' };
+
+        const result = addPropertyCurve(clip, context, {
+            type: 'addPropertyCurve', clipUuid: 'clip',
+            nodeUuid: enemy1.uuid, propKey: 'position',
+            value: { x: 0, y: 0, z: 0 },
+        });
+        expect(result).toBe(false);
+    });
+
+    it('同名兄弟的第二个节点也被拦截', () => {
+        const { AnimationClip, Node } = require('cc');
+        const { addPropertyCurve } = require('../scene-process/service/animation/property-curve');
+        const root = new Node('Root');
+        const enemy1 = new Node('Enemy');
+        const enemy2 = new Node('Enemy');
+        root.children = [enemy1, enemy2];
+        const clip = new AnimationClip();
+        const context = { rootNode: root, rootPath: '' };
+
+        const result = addPropertyCurve(clip, context, {
+            type: 'addPropertyCurve', clipUuid: 'clip',
+            nodeUuid: enemy2.uuid, propKey: 'position',
+            value: { x: 0, y: 0, z: 0 },
+        });
+        expect(result).toBe(false);
+    });
+
+    it('中间层级同名兄弟被拦截', () => {
+        const { AnimationClip, Node } = require('cc');
+        const { addPropertyCurve } = require('../scene-process/service/animation/property-curve');
+        const root = new Node('Root');
+        const group1 = new Node('Group');
+        const group2 = new Node('Group');
+        const target = new Node('Target');
+        group1.children = [target];
+        group2.children = [];
+        root.children = [group1, group2];
+        const clip = new AnimationClip();
+        const context = { rootNode: root, rootPath: '' };
+
+        const result = addPropertyCurve(clip, context, {
+            type: 'addPropertyCurve', clipUuid: 'clip',
+            nodeUuid: target.uuid, propKey: 'position',
+            value: { x: 0, y: 0, z: 0 },
+        });
+        expect(result).toBe(false);
+    });
+
+    it('nodePath 分支无歧义时正常绑定', () => {
+        const { AnimationClip } = require('cc');
+        const { addPropertyCurve } = require('../scene-process/service/animation/property-curve');
+        const nodes = makeTree({ Root: ['Child'] });
+        const clip = new AnimationClip();
+        const context = { rootNode: nodes.Root, rootPath: '' };
+
+        const result = addPropertyCurve(clip, context, {
+            type: 'addPropertyCurve', clipUuid: 'clip',
+            nodePath: 'Child', propKey: 'position',
+            value: { x: 0, y: 0, z: 0 },
+        });
+        expect(result).toBe(true);
+    });
+
+    it('nodePath 分支同名兄弟被拦截', () => {
+        const { AnimationClip, Node } = require('cc');
+        const { addPropertyCurve } = require('../scene-process/service/animation/property-curve');
+        const root = new Node('Root');
+        root.children = [new Node('Enemy'), new Node('Enemy')];
+        const clip = new AnimationClip();
+        const context = { rootNode: root, rootPath: '' };
+
+        const result = addPropertyCurve(clip, context, {
+            type: 'addPropertyCurve', clipUuid: 'clip',
+            nodePath: 'Enemy', propKey: 'position',
+            value: { x: 0, y: 0, z: 0 },
+        });
+        expect(result).toBe(false);
+    });
+
+    it('系统路径分支: rootPath 非空时通过 NodeMgr.getNodeByPath 解析', () => {
+        jest.resetModules();
+        const nodeMgr: any = {};
+        (global as any).EditorExtends = { Node: nodeMgr };
+        (global as any).cc = require('cc');
+
+        const { AnimationClip, Node } = require('cc');
+        const { addPropertyCurve } = require('../scene-process/service/animation/property-curve');
+        const root = new Node('Root');
+        const child = new Node('Child');
+        root.children = [child];
+        nodeMgr.getNodeByPath = (path: string) => {
+            if (path === 'Root/Child') return child;
+            return null;
+        };
+        const clip = new AnimationClip();
+
+        const result = addPropertyCurve(clip, { rootNode: root, rootPath: 'Root' }, {
+            type: 'addPropertyCurve', clipUuid: 'clip',
+            nodePath: 'Root/Child', propKey: 'position',
+            value: { x: 0, y: 0, z: 0 },
+        });
+        expect(result).toBe(true);
+    });
+
+    it('系统路径分支: 系统后缀路径不走 getChildByPath 误匹配', () => {
+        jest.resetModules();
+        const nodeMgr: any = {};
+        (global as any).EditorExtends = { Node: nodeMgr };
+        (global as any).cc = require('cc');
+
+        const { AnimationClip, Node } = require('cc');
+        const { addPropertyCurve } = require('../scene-process/service/animation/property-curve');
+        const root = new Node('Root');
+        const enemy = new Node('Enemy');
+        root.children = [enemy];
+        nodeMgr.getNodeByPath = (path: string) => {
+            if (path === 'Root/Enemy_001') return enemy;
+            return null;
+        };
+        const clip = new AnimationClip();
+
+        const result = addPropertyCurve(clip, { rootNode: root, rootPath: 'Root' }, {
+            type: 'addPropertyCurve', clipUuid: 'clip',
+            nodePath: 'Root/Enemy_001', propKey: 'position',
+            value: { x: 0, y: 0, z: 0 },
+        });
+        expect(result).toBe(true);
+    });
+
+    it('删除操作在同名兄弟歧义时仍然放行', () => {
+        const { AnimationClip, Node } = require('cc');
+        const { addPropertyCurve, removePropertyCurve } = require('../scene-process/service/animation/property-curve');
+
+        const root = new Node('Root');
+        const child = new Node('Enemy');
+        root.children = [child];
+        const clip = new AnimationClip();
+        const context = { rootNode: root, rootPath: '' };
+
+        expect(addPropertyCurve(clip, context, {
+            type: 'addPropertyCurve', clipUuid: 'clip',
+            nodeUuid: child.uuid, propKey: 'position',
+            value: { x: 0, y: 0, z: 0 },
+        })).toBe(true);
+        expect(clip._tracks).toHaveLength(1);
+
+        const sibling = new Node('Enemy');
+        root.children.push(sibling);
+
+        expect(removePropertyCurve(clip, context, {
+            nodeUuid: child.uuid, propKey: 'position',
+        })).toBe(true);
+        expect(clip._tracks).toHaveLength(0);
+    });
+
+    it('removePropertyKey 在同名兄弟歧义时仍然放行第一个节点', () => {
+        const { AnimationClip, Node } = require('cc');
+        const { createPropertyKey, removePropertyKey } = require('../scene-process/service/animation/property-curve');
+
+        const root = new Node('Root');
+        const child = new Node('Enemy');
+        root.children = [child];
+        const clip = new AnimationClip();
+        const context = { rootNode: root, rootPath: '' };
+
+        expect(createPropertyKey(clip, context, {
+            type: 'createPropertyKey', clipUuid: 'clip',
+            nodeUuid: child.uuid, propKey: 'position',
+            frame: 0, value: { x: 0, y: 0, z: 0 },
+        })).toBe(true);
+        expect(clip._tracks).toHaveLength(1);
+
+        const sibling = new Node('Enemy');
+        root.children.push(sibling);
+
+        const channelsBefore = clip._tracks[0].channels();
+        expect(channelsBefore.every((ch: any) => ch.curve.keyFramesCount === 1)).toBe(true);
+
+        expect(removePropertyKey(clip, context, {
+            nodeUuid: child.uuid, propKey: 'position', frames: [0],
+        })).toBe(true);
+
+        const channelsAfter = clip._tracks[0].channels();
+        expect(channelsAfter.every((ch: any) => ch.curve.keyFramesCount === 0)).toBe(true);
+    });
+
+    it('removePropertyKey 不会误删另一同名节点的关键帧', () => {
+        const { AnimationClip, Node } = require('cc');
+        const { createPropertyKey, removePropertyKey } = require('../scene-process/service/animation/property-curve');
+
+        const root = new Node('Root');
+        const first = new Node('Enemy');
+        root.children = [first];
+        const clip = new AnimationClip();
+        const context = { rootNode: root, rootPath: '' };
+
+        expect(createPropertyKey(clip, context, {
+            type: 'createPropertyKey', clipUuid: 'clip',
+            nodeUuid: first.uuid, propKey: 'position',
+            frame: 0, value: { x: 0, y: 0, z: 0 },
+        })).toBe(true);
+
+        const second = new Node('Enemy');
+        root.children.push(second);
+
+        expect(removePropertyKey(clip, context, {
+            nodeUuid: second.uuid, propKey: 'position', frames: [0],
+        })).toBe(false);
+
+        const channels = clip._tracks[0].channels();
+        expect(channels.every((ch: any) => ch.curve.keyFramesCount === 1)).toBe(true);
+    });
+
+    it('删除操作不会误删另一同名节点的轨道', () => {
+        const { AnimationClip, Node } = require('cc');
+        const { addPropertyCurve, removePropertyCurve } = require('../scene-process/service/animation/property-curve');
+
+        const root = new Node('Root');
+        const first = new Node('Enemy');
+        root.children = [first];
+        const clip = new AnimationClip();
+        const context = { rootNode: root, rootPath: '' };
+
+        expect(addPropertyCurve(clip, context, {
+            type: 'addPropertyCurve', clipUuid: 'clip',
+            nodeUuid: first.uuid, propKey: 'position',
+            value: { x: 0, y: 0, z: 0 },
+        })).toBe(true);
+        expect(clip._tracks).toHaveLength(1);
+
+        const second = new Node('Enemy');
+        root.children.push(second);
+
+        expect(removePropertyCurve(clip, context, {
+            nodeUuid: second.uuid, propKey: 'position',
+        })).toBe(false);
+        expect(clip._tracks).toHaveLength(1);
+    });
+
+    it('removePropertyCurve 节点已删除时通过 nodePath 字符串裁剪删除孤立轨道', () => {
+        const { AnimationClip, Node } = require('cc');
+        const { createPropertyKey, removePropertyCurve } = require('../scene-process/service/animation/property-curve');
+
+        const root = new Node('Root');
+        const enemy = new Node('Enemy');
+        root.children = [enemy];
+
+        const clip = new AnimationClip();
+        const context: any = { rootNode: root, rootPath: 'Root' };
+
+        expect(createPropertyKey(clip, context, {
+            nodeUuid: enemy.uuid, propKey: 'position', frame: 0, value: { x: 0, y: 0, z: 0 },
+        })).toBe(true);
+        expect(clip._tracks).toHaveLength(1);
+
+        root.children = [];
+
+        expect(removePropertyCurve(clip, context, {
+            nodePath: 'Root/Enemy', propKey: 'position',
+        })).toBe(true);
+        expect(clip._tracks).toHaveLength(0);
+    });
+
+    it('removePropertyCurve 节点已删除时通过 nodeUuid + nodePath 兜底删除孤立轨道', () => {
+        const { AnimationClip, Node } = require('cc');
+        const { createPropertyKey, removePropertyCurve } = require('../scene-process/service/animation/property-curve');
+
+        const root = new Node('Root');
+        const enemy = new Node('Enemy');
+        root.children = [enemy];
+
+        const clip = new AnimationClip();
+        const context: any = { rootNode: root, rootPath: 'Root' };
+
+        expect(createPropertyKey(clip, context, {
+            nodeUuid: enemy.uuid, propKey: 'position', frame: 0, value: { x: 0, y: 0, z: 0 },
+        })).toBe(true);
+
+        const deletedUuid = enemy.uuid;
+        root.children = [];
+
+        expect(removePropertyCurve(clip, context, {
+            nodeUuid: deletedUuid, nodePath: 'Root/Enemy', propKey: 'position',
+        })).toBe(true);
+        expect(clip._tracks).toHaveLength(0);
+    });
+
+    it('createPropertyKey 节点已删除时仍然拒绝（非 lenient）', () => {
+        const { AnimationClip, Node } = require('cc');
+        const { createPropertyKey } = require('../scene-process/service/animation/property-curve');
+
+        const root = new Node('Root');
+        const enemy = new Node('Enemy');
+        root.children = [enemy];
+
+        const clip = new AnimationClip();
+        const context: any = { rootNode: root, rootPath: 'Root' };
+
+        root.children = [];
+
+        expect(createPropertyKey(clip, context, {
+            nodePath: 'Root/Enemy', propKey: 'position', frame: 0, value: { x: 0, y: 0, z: 0 },
+        })).toBe(false);
+        expect(clip._tracks).toHaveLength(0);
+    });
+});
+
+describe('property-value 碰撞后缀路径解析', () => {
+    it('nodeUuid 分支: 碰撞后缀节点解析出 name-based 相对路径', async () => {
+        jest.resetModules();
+        (global as any).EditorExtends = { Node: {} };
+        (global as any).cc = require('cc');
+
+        let capturedNodePath: string | undefined;
+        jest.doMock('../scene-process/service/animation/property-metadata', () => ({
+            queryAnimationPropertyMetadata: (_rootNode: any, nodePath: string) => {
+                capturedNodePath = nodePath;
+                return null;
+            },
+        }));
+
+        const { Node } = require('cc');
+        const { normalizeProvidedAnimationPropertyOperationValue } = require('../scene-process/service/animation/property-value');
+
+        const root = new Node('Root');
+        const enemy = new Node('Enemy');
+        root.children = [enemy];
+
+        await normalizeProvidedAnimationPropertyOperationValue(
+            root, '',
+            {
+                type: 'createPropertyKey',
+                clipUuid: 'clip',
+                nodeUuid: enemy.uuid,
+                propKey: 'position',
+                frame: 0,
+                value: { x: 0, y: 0, z: 0 },
+            },
+            {
+                queryNodeByUuid: (uuid: string) => uuid === enemy.uuid ? enemy : null,
+                queryNodePath: () => 'Root/Enemy_001',
+            },
+        );
+
+        expect(capturedNodePath).toBe('Enemy');
+    });
+
+    it('nodePath 分支: 系统路径碰撞后缀解析出 name-based 相对路径', async () => {
+        jest.resetModules();
+        const nodeMgr: any = {};
+        (global as any).EditorExtends = { Node: nodeMgr };
+        (global as any).cc = require('cc');
+
+        let capturedNodePath: string | undefined;
+        jest.doMock('../scene-process/service/animation/property-metadata', () => ({
+            queryAnimationPropertyMetadata: (_rootNode: any, nodePath: string) => {
+                capturedNodePath = nodePath;
+                return null;
+            },
+        }));
+
+        const { Node } = require('cc');
+        const { normalizeProvidedAnimationPropertyOperationValue } = require('../scene-process/service/animation/property-value');
+
+        const root = new Node('Root');
+        const enemy = new Node('Enemy');
+        root.children = [enemy];
+        nodeMgr.getNodeByPath = (path: string) => {
+            if (path === 'Root/Enemy_001') return enemy;
+            return null;
+        };
+
+        await normalizeProvidedAnimationPropertyOperationValue(
+            root, 'Root',
+            {
+                type: 'createPropertyKey',
+                clipUuid: 'clip',
+                nodePath: 'Root/Enemy_001',
+                propKey: 'position',
+                frame: 0,
+                value: { x: 0, y: 0, z: 0 },
+            },
+            {
+                queryNodeByUuid: () => null,
+                queryNodePath: () => 'Root/Enemy_001',
+            },
+        );
+
+        expect(capturedNodePath).toBe('Enemy');
     });
 });

--- a/src/core/scene/test/animation-service-animatable.test.ts
+++ b/src/core/scene/test/animation-service-animatable.test.ts
@@ -1025,6 +1025,66 @@ describe('AnimationService animatable property metadata', () => {
         expect(clip._tracks[0].path.parseHierarchyAt(0)).toBe('Enemy');
     });
 
+    it('动画根节点 UUID 解析为空相对路径，层级外 UUID 被拒绝', () => {
+        const { Node } = require('cc');
+        const { resolveAnimationRelativeNodePath } = require('../scene-process/service/animation/scene-node');
+        const root = new Node('Root');
+        const outside = new Node('Outside');
+
+        expect(resolveAnimationRelativeNodePath(root, 'Scene/Root', {
+            nodeUuid: root.uuid,
+        })).toBe('');
+        expect(resolveAnimationRelativeNodePath(root, 'Scene/Root', {
+            nodeUuid: outside.uuid,
+        })).toBeNull();
+    });
+
+    it('动画 path 解析覆盖根节点、相对子节点和无效相对路径', () => {
+        const { Node } = require('cc');
+        const { resolveAnimationRelativeNodePath } = require('../scene-process/service/animation/scene-node');
+        const root = new Node('Root');
+        const enemy = new Node('Enemy');
+        root.children = [enemy];
+
+        expect(resolveAnimationRelativeNodePath(root, 'Scene/Root', {})).toBe('');
+        expect(resolveAnimationRelativeNodePath(root, 'Scene/Root', {
+            nodePath: '/Scene/Root/',
+        })).toBe('');
+        expect(resolveAnimationRelativeNodePath(root, 'Scene/Root', {
+            nodePath: 'Enemy',
+        })).toBe('Enemy');
+        expect(resolveAnimationRelativeNodePath(root, 'Scene/Root', {
+            nodePath: 'Missing',
+        })).toBeNull();
+    });
+
+    it('动画路径解析会规范化反斜杠、重复斜杠和首尾斜杠', () => {
+        const { Node } = require('cc');
+        const { resolveAnimationRelativeNodePath } = require('../scene-process/service/animation/scene-node');
+        const root = new Node('Root');
+        const enemy = new Node('Enemy');
+        root.children = [enemy];
+
+        expect(resolveAnimationRelativeNodePath(root, '/Scene//Root/', {
+            nodePath: '\\Scene\\Root\\Enemy\\',
+        })).toBe('Enemy');
+    });
+
+    it('系统路径查询发生大小写歧义时仍按旧动画 name path 解析', () => {
+        const { Node } = require('cc');
+        (global as any).EditorExtends.Node.getNodeByPath = jest.fn(() => {
+            throw new Error('ambiguous');
+        });
+        const { resolveAnimationRelativeNodePath } = require('../scene-process/service/animation/scene-node');
+        const root = new Node('Root');
+        const enemy = new Node('Enemy');
+        root.children = [enemy];
+
+        expect(resolveAnimationRelativeNodePath(root, 'Root', {
+            nodePath: 'Root/Enemy',
+        })).toBe('Enemy');
+    });
+
     it('拒绝不能解析为动画 name path 的系统后缀路径', () => {
         const { AnimationClip, Node } = require('cc');
         const { addPropertyCurve } = require('../scene-process/service/animation/property-curve');

--- a/src/core/scene/test/animation-service-animatable.test.ts
+++ b/src/core/scene/test/animation-service-animatable.test.ts
@@ -3,6 +3,7 @@ export {};
 const mockAttr = jest.fn();
 
 jest.mock('cc', () => {
+    let nextNodeId = 0;
     class Component { }
     class Renderer extends Component { }
     class Color {
@@ -31,16 +32,14 @@ jest.mock('cc', () => {
             public height = 0,
         ) { }
     }
-    let _nextMockUuid = 0;
     class Node {
+        uuid = `mock-node-${++nextNodeId}`;
         components: Component[] = [];
         children: Node[] = [];
         name = '';
-        uuid = '';
 
         constructor(name = '') {
             this.name = name;
-            this.uuid = `mock-node-${_nextMockUuid++}`;
         }
 
         getChildByPath(path: string) {
@@ -948,955 +947,176 @@ describe('AnimationService animatable property metadata', () => {
             }),
         ]);
     });
-});
 
-describe('resolveRelativeNodePath 同名兄弟歧义检测', () => {
-    beforeEach(() => {
-        (global as any).cc = require('cc');
-        (global as any).EditorExtends = {
-            Node: {},
-        };
-    });
-
-    function makeTree(structure: Record<string, string[]>): any {
-        const { Node } = require('cc');
-        const nodes: Record<string, any> = {};
-        for (const name of Object.keys(structure)) {
-            nodes[name] = new Node(name);
-        }
-        for (const [name, childNames] of Object.entries(structure)) {
-            nodes[name].children = childNames.map((cn: string) => {
-                if (!nodes[cn]) {
-                    nodes[cn] = new Node(cn);
-                }
-                return nodes[cn];
-            });
-        }
-        return nodes;
-    }
-
-    it('无同名兄弟时通过 nodeUuid 正常绑定', () => {
-        const { AnimationClip } = require('cc');
-        const { addPropertyCurve } = require('../scene-process/service/animation/property-curve');
-        const nodes = makeTree({ Root: ['A', 'B'] });
-        const clip = new AnimationClip();
-        const context = { rootNode: nodes.Root, rootPath: '' };
-
-        const result = addPropertyCurve(clip, context, {
-            type: 'addPropertyCurve', clipUuid: 'clip',
-            nodeUuid: nodes.A.uuid, propKey: 'position',
-            value: { x: 0, y: 0, z: 0 },
-        });
-        expect(result).toBe(true);
-    });
-
-    it('同名兄弟的第一个节点也被拦截', () => {
+    it('同名兄弟按 Cocos 路径语义绑定第一个节点', () => {
         const { AnimationClip, Node } = require('cc');
         const { addPropertyCurve } = require('../scene-process/service/animation/property-curve');
-        const root = new Node('Root');
-        const enemy1 = new Node('Enemy');
-        const enemy2 = new Node('Enemy');
-        root.children = [enemy1, enemy2];
-        const clip = new AnimationClip();
-        const context = { rootNode: root, rootPath: '' };
-
-        const result = addPropertyCurve(clip, context, {
-            type: 'addPropertyCurve', clipUuid: 'clip',
-            nodeUuid: enemy1.uuid, propKey: 'position',
-            value: { x: 0, y: 0, z: 0 },
-        });
-        expect(result).toBe(false);
-    });
-
-    it('同名兄弟的第二个节点也被拦截', () => {
-        const { AnimationClip, Node } = require('cc');
-        const { addPropertyCurve } = require('../scene-process/service/animation/property-curve');
-        const root = new Node('Root');
-        const enemy1 = new Node('Enemy');
-        const enemy2 = new Node('Enemy');
-        root.children = [enemy1, enemy2];
-        const clip = new AnimationClip();
-        const context = { rootNode: root, rootPath: '' };
-
-        const result = addPropertyCurve(clip, context, {
-            type: 'addPropertyCurve', clipUuid: 'clip',
-            nodeUuid: enemy2.uuid, propKey: 'position',
-            value: { x: 0, y: 0, z: 0 },
-        });
-        expect(result).toBe(false);
-    });
-
-    it('中间层级同名兄弟被拦截', () => {
-        const { AnimationClip, Node } = require('cc');
-        const { addPropertyCurve } = require('../scene-process/service/animation/property-curve');
-        const root = new Node('Root');
-        const group1 = new Node('Group');
-        const group2 = new Node('Group');
-        const target = new Node('Target');
-        group1.children = [target];
-        group2.children = [];
-        root.children = [group1, group2];
-        const clip = new AnimationClip();
-        const context = { rootNode: root, rootPath: '' };
-
-        const result = addPropertyCurve(clip, context, {
-            type: 'addPropertyCurve', clipUuid: 'clip',
-            nodeUuid: target.uuid, propKey: 'position',
-            value: { x: 0, y: 0, z: 0 },
-        });
-        expect(result).toBe(false);
-    });
-
-    it('nodePath 分支无歧义时正常绑定', () => {
-        const { AnimationClip } = require('cc');
-        const { addPropertyCurve } = require('../scene-process/service/animation/property-curve');
-        const nodes = makeTree({ Root: ['Child'] });
-        const clip = new AnimationClip();
-        const context = { rootNode: nodes.Root, rootPath: '' };
-
-        const result = addPropertyCurve(clip, context, {
-            type: 'addPropertyCurve', clipUuid: 'clip',
-            nodePath: 'Child', propKey: 'position',
-            value: { x: 0, y: 0, z: 0 },
-        });
-        expect(result).toBe(true);
-    });
-
-    it('nodePath 分支同名兄弟被拦截', () => {
-        const { AnimationClip, Node } = require('cc');
-        const { addPropertyCurve } = require('../scene-process/service/animation/property-curve');
-        const root = new Node('Root');
-        root.children = [new Node('Enemy'), new Node('Enemy')];
-        const clip = new AnimationClip();
-        const context = { rootNode: root, rootPath: '' };
-
-        const result = addPropertyCurve(clip, context, {
-            type: 'addPropertyCurve', clipUuid: 'clip',
-            nodePath: 'Enemy', propKey: 'position',
-            value: { x: 0, y: 0, z: 0 },
-        });
-        expect(result).toBe(false);
-    });
-
-    it('系统路径分支: rootPath 非空时通过 NodeMgr.getNodeByPath 解析', () => {
-        jest.resetModules();
-        const nodeMgr: any = {};
-        (global as any).EditorExtends = { Node: nodeMgr };
-        (global as any).cc = require('cc');
-
-        const { AnimationClip, Node } = require('cc');
-        const { addPropertyCurve } = require('../scene-process/service/animation/property-curve');
-        const root = new Node('Root');
-        const child = new Node('Child');
-        root.children = [child];
-        nodeMgr.getNodeByPath = (path: string) => {
-            if (path === 'Root/Child') return child;
-            return null;
-        };
-        const clip = new AnimationClip();
-
-        const result = addPropertyCurve(clip, { rootNode: root, rootPath: 'Root' }, {
-            type: 'addPropertyCurve', clipUuid: 'clip',
-            nodePath: 'Root/Child', propKey: 'position',
-            value: { x: 0, y: 0, z: 0 },
-        });
-        expect(result).toBe(true);
-    });
-
-    it('系统路径分支: 系统后缀路径不走 getChildByPath 误匹配', () => {
-        jest.resetModules();
-        const nodeMgr: any = {};
-        (global as any).EditorExtends = { Node: nodeMgr };
-        (global as any).cc = require('cc');
-
-        const { AnimationClip, Node } = require('cc');
-        const { addPropertyCurve } = require('../scene-process/service/animation/property-curve');
-        const root = new Node('Root');
-        const enemy = new Node('Enemy');
-        root.children = [enemy];
-        nodeMgr.getNodeByPath = (path: string) => {
-            if (path === 'Root/Enemy_001') return enemy;
-            return null;
-        };
-        const clip = new AnimationClip();
-
-        const result = addPropertyCurve(clip, { rootNode: root, rootPath: 'Root' }, {
-            type: 'addPropertyCurve', clipUuid: 'clip',
-            nodePath: 'Root/Enemy_001', propKey: 'position',
-            value: { x: 0, y: 0, z: 0 },
-        });
-        expect(result).toBe(true);
-    });
-
-    it('兼容 queryClip 返回的唯一 display path，即使 system path 带去重后缀', () => {
-        jest.resetModules();
-        const nodeMgr: any = {};
-        (global as any).EditorExtends = { Node: nodeMgr };
-        (global as any).cc = require('cc');
-
-        const { AnimationClip, Node } = require('cc');
-        const { addPropertyCurve } = require('../scene-process/service/animation/property-curve');
-        const root = new Node('Root');
-        const enemy = new Node('Enemy');
-        root.children = [enemy];
-        nodeMgr.getNodeByPath = (path: string) => path === 'Root/Enemy_001' ? enemy : null;
-        const clip = new AnimationClip();
-
-        expect(addPropertyCurve(clip, { rootNode: root, rootPath: 'Root' }, {
-            type: 'addPropertyCurve', clipUuid: 'clip',
-            nodePath: 'Enemy', propKey: 'position',
-            value: { x: 0, y: 0, z: 0 },
-        })).toBe(true);
-        expect(clip._tracks).toHaveLength(1);
-    });
-
-    it('相对路径同时命中不同的 system/display 节点时拒绝操作', () => {
-        jest.resetModules();
-        const nodeMgr: any = {};
-        (global as any).EditorExtends = { Node: nodeMgr };
-        (global as any).cc = require('cc');
-
-        const { AnimationClip, Node, animation } = require('cc');
-        const { removePropertyCurve } = require('../scene-process/service/animation/property-curve');
-        const root = new Node('Root');
-        const target = new Node('Enemy');
-        const literalPathNode = new Node('Enemy_1');
-        root.children = [target, literalPathNode];
-        nodeMgr.getNodeByPath = (path: string) => path === 'Root/Enemy_1' ? target : null;
-
-        const clip = new AnimationClip();
-        const targetTrack = new animation.VectorTrack();
-        targetTrack.componentsCount = 3;
-        targetTrack.path.toHierarchy('Enemy').toProperty('position');
-        clip.addTrack(targetTrack);
-        const literalPathTrack = new animation.VectorTrack();
-        literalPathTrack.componentsCount = 3;
-        literalPathTrack.path.toHierarchy('Enemy_1').toProperty('position');
-        clip.addTrack(literalPathTrack);
-
-        expect(removePropertyCurve(clip, { rootNode: root, rootPath: 'Root' }, {
-            nodePath: 'Enemy_1', propKey: 'position',
-        })).toBe(false);
-        expect(clip._tracks).toEqual([targetTrack, literalPathTrack]);
-    });
-
-    it('removePropertyCurve 仅允许删除同名兄弟中当前实际绑定的节点轨道', () => {
-        const { AnimationClip, Node } = require('cc');
-        const { addPropertyCurve, removePropertyCurve } = require('../scene-process/service/animation/property-curve');
-
-        const root = new Node('Root');
-        const child = new Node('Enemy');
-        root.children = [child];
-        const clip = new AnimationClip();
-        const context = { rootNode: root, rootPath: '' };
-
-        expect(addPropertyCurve(clip, context, {
-            type: 'addPropertyCurve', clipUuid: 'clip',
-            nodeUuid: child.uuid, propKey: 'position',
-            value: { x: 0, y: 0, z: 0 },
-        })).toBe(true);
-        expect(clip._tracks).toHaveLength(1);
-
-        const sibling = new Node('Enemy');
-        root.children.push(sibling);
-
-        expect(removePropertyCurve(clip, context, {
-            nodeUuid: child.uuid, propKey: 'position',
-        })).toBe(true);
-        expect(clip._tracks).toHaveLength(0);
-    });
-
-    it('removePropertyKey 仅允许删除同名兄弟中当前实际绑定节点的关键帧', () => {
-        const { AnimationClip, Node } = require('cc');
-        const { createPropertyKey, removePropertyKey } = require('../scene-process/service/animation/property-curve');
-
-        const root = new Node('Root');
-        const child = new Node('Enemy');
-        root.children = [child];
-        const clip = new AnimationClip();
-        const context = { rootNode: root, rootPath: '' };
-
-        expect(createPropertyKey(clip, context, {
-            type: 'createPropertyKey', clipUuid: 'clip',
-            nodeUuid: child.uuid, propKey: 'position',
-            frame: 0, value: { x: 0, y: 0, z: 0 },
-        })).toBe(true);
-        expect(clip._tracks).toHaveLength(1);
-
-        const sibling = new Node('Enemy');
-        root.children.push(sibling);
-
-        const channelsBefore = clip._tracks[0].channels();
-        expect(channelsBefore.every((ch: any) => ch.curve.keyFramesCount === 1)).toBe(true);
-
-        expect(removePropertyKey(clip, context, {
-            nodeUuid: child.uuid, propKey: 'position', frames: [0],
-        })).toBe(true);
-
-        const channelsAfter = clip._tracks[0].channels();
-        expect(channelsAfter.every((ch: any) => ch.curve.keyFramesCount === 0)).toBe(true);
-    });
-
-    it('removePropertyKey 不会误删另一同名节点的关键帧', () => {
-        const { AnimationClip, Node } = require('cc');
-        const { createPropertyKey, removePropertyKey } = require('../scene-process/service/animation/property-curve');
-
         const root = new Node('Root');
         const first = new Node('Enemy');
-        root.children = [first];
-        const clip = new AnimationClip();
-        const context = { rootNode: root, rootPath: '' };
-
-        expect(createPropertyKey(clip, context, {
-            type: 'createPropertyKey', clipUuid: 'clip',
-            nodeUuid: first.uuid, propKey: 'position',
-            frame: 0, value: { x: 0, y: 0, z: 0 },
-        })).toBe(true);
-
         const second = new Node('Enemy');
-        root.children.push(second);
-
-        expect(removePropertyKey(clip, context, {
-            nodeUuid: second.uuid, propKey: 'position', frames: [0],
-        })).toBe(false);
-
-        const channels = clip._tracks[0].channels();
-        expect(channels.every((ch: any) => ch.curve.keyFramesCount === 1)).toBe(true);
-    });
-
-    it('删除操作不会误删另一同名节点的轨道', () => {
-        const { AnimationClip, Node } = require('cc');
-        const { addPropertyCurve, removePropertyCurve } = require('../scene-process/service/animation/property-curve');
-
-        const root = new Node('Root');
-        const first = new Node('Enemy');
-        root.children = [first];
+        root.children = [first, second];
         const clip = new AnimationClip();
-        const context = { rootNode: root, rootPath: '' };
 
-        expect(addPropertyCurve(clip, context, {
-            type: 'addPropertyCurve', clipUuid: 'clip',
-            nodeUuid: first.uuid, propKey: 'position',
+        expect(root.getChildByPath('Enemy')).toBe(first);
+        expect(addPropertyCurve(clip, { rootNode: root, rootPath: '' }, {
+            type: 'addPropertyCurve',
+            clipUuid: 'clip',
+            nodePath: 'Enemy',
+            propKey: 'position',
             value: { x: 0, y: 0, z: 0 },
         })).toBe(true);
         expect(clip._tracks).toHaveLength(1);
-
-        const second = new Node('Enemy');
-        root.children.push(second);
-
-        expect(removePropertyCurve(clip, context, {
-            nodeUuid: second.uuid, propKey: 'position',
-        })).toBe(false);
-        expect(clip._tracks).toHaveLength(1);
+        expect(clip._tracks[0].path.parseHierarchyAt(0)).toBe('Enemy');
     });
 
-    it('removePropertyCurve 节点已删除且无缓存时拒绝按 nodePath 猜测孤立轨道', () => {
+    it('UUID 只能操作动画路径当前绑定的第一个同名节点', () => {
         const { AnimationClip, Node } = require('cc');
-        const { createPropertyKey, removePropertyCurve } = require('../scene-process/service/animation/property-curve');
-
-        const root = new Node('Root');
-        const enemy = new Node('Enemy');
-        root.children = [enemy];
-
-        const clip = new AnimationClip();
-        const context: any = { rootNode: root, rootPath: 'Root' };
-
-        expect(createPropertyKey(clip, context, {
-            nodeUuid: enemy.uuid, propKey: 'position', frame: 0, value: { x: 0, y: 0, z: 0 },
-        })).toBe(true);
-        expect(clip._tracks).toHaveLength(1);
-
-        root.children = [];
-
-        expect(removePropertyCurve(clip, context, {
-            nodePath: 'Root/Enemy', propKey: 'position',
-        })).toBe(false);
-        expect(clip._tracks).toHaveLength(1);
-    });
-
-    it('removePropertyCurve 节点已删除且无缓存时拒绝按 nodeUuid + nodePath 猜测孤立轨道', () => {
-        const { AnimationClip, Node, animation } = require('cc');
-        const { removePropertyCurve } = require('../scene-process/service/animation/property-curve');
-
-        const root = new Node('Root');
-        const enemy = new Node('Enemy');
-        root.children = [enemy];
-
-        const clip = new AnimationClip();
-        const context: any = { rootNode: root, rootPath: 'Root' };
-        const track = new animation.VectorTrack();
-        track.componentsCount = 3;
-        track.path.toHierarchy('Enemy').toProperty('position');
-        clip.addTrack(track);
-
-        const deletedUuid = enemy.uuid;
-        root.children = [];
-
-        expect(removePropertyCurve(clip, context, {
-            nodeUuid: deletedUuid, nodePath: 'Root/Enemy', propKey: 'position',
-        })).toBe(false);
-        expect(clip._tracks).toHaveLength(1);
-    });
-
-    it('removePropertyCurve 节点 name≠系统路径时通过 displayPath 缓存清理轨道', () => {
-        jest.resetModules();
-        const nodeMgr: any = {};
-        (global as any).EditorExtends = { Node: nodeMgr };
-        (global as any).cc = require('cc');
-
-        const { AnimationClip, Node } = require('cc');
-        const { addPropertyCurve, removePropertyCurve } = require('../scene-process/service/animation/property-curve');
-
-        const root = new Node('Root');
-        const enemy = new Node('Enemy');
-        root.children = [enemy];
-        nodeMgr.getNodeByPath = (path: string) => {
-            if (path === 'Root/Enemy_001') return enemy;
-            return null;
-        };
-
-        const clip = new AnimationClip();
-        const context: any = { rootNode: root, rootPath: 'Root' };
-
-        expect(addPropertyCurve(clip, context, {
-            type: 'addPropertyCurve', clipUuid: 'clip',
-            nodePath: 'Root/Enemy_001', propKey: 'position',
-            value: { x: 0, y: 0, z: 0 },
-        })).toBe(true);
-        expect(clip._tracks).toHaveLength(1);
-
-        const deletedUuid = enemy.uuid;
-        root.children = [];
-
-        expect(removePropertyCurve(clip, context, {
-            nodeUuid: deletedUuid, propKey: 'position',
-        })).toBe(true);
-        expect(clip._tracks).toHaveLength(0);
-    });
-
-    it('removePropertyKey 节点 name≠系统路径时通过 displayPath 缓存清理关键帧', () => {
-        jest.resetModules();
-        const nodeMgr: any = {};
-        (global as any).EditorExtends = { Node: nodeMgr };
-        (global as any).cc = require('cc');
-
-        const { AnimationClip, Node } = require('cc');
-        const { createPropertyKey, removePropertyKey } = require('../scene-process/service/animation/property-curve');
-
-        const root = new Node('Root');
-        const enemy = new Node('Enemy');
-        root.children = [enemy];
-        nodeMgr.getNodeByPath = (path: string) => {
-            if (path === 'Root/Enemy_001') return enemy;
-            return null;
-        };
-
-        const clip = new AnimationClip();
-        const context: any = { rootNode: root, rootPath: 'Root' };
-
-        expect(createPropertyKey(clip, context, {
-            nodePath: 'Root/Enemy_001', propKey: 'position', frame: 0, value: { x: 0, y: 0, z: 0 },
-        })).toBe(true);
-        expect(clip._tracks).toHaveLength(1);
-
-        const deletedUuid = enemy.uuid;
-        root.children = [];
-
-        expect(removePropertyKey(clip, context, {
-            nodeUuid: deletedUuid, propKey: 'position', frames: [0],
-        })).toBe(true);
-    });
-
-    it('removePropertyCurve 无缓存且无 nodePath 时拒绝删除（无法证明归属）', () => {
-        const { AnimationClip, Node, animation } = require('cc');
-        const { removePropertyCurve } = require('../scene-process/service/animation/property-curve');
-
-        const root = new Node('Root');
-        const clip = new AnimationClip();
-
-        const track = new animation.VectorTrack();
-        track.componentsCount = 3;
-        track.path.toHierarchy('Deleted').toProperty('position');
-        clip.addTrack(track);
-
-        expect(removePropertyCurve(clip, { rootNode: root, rootPath: '' }, {
-            nodeUuid: 'deleted-uuid', propKey: 'position',
-        })).toBe(false);
-        expect(clip._tracks).toHaveLength(1);
-    });
-
-    it('removePropertyCurve 预缓存 displayPath 后可正确删除已删除节点的轨道', () => {
-        const { AnimationClip, Node, animation } = require('cc');
-        const { removePropertyCurve, cacheNodeDisplayPath } = require('../scene-process/service/animation/property-curve');
-
-        const root = new Node('Root');
-        const enemy = new Node('Enemy');
-        root.children = [enemy];
-
-        const clip = new AnimationClip();
-        const track = new animation.VectorTrack();
-        track.componentsCount = 3;
-        track.path.toHierarchy('Enemy').toProperty('position');
-        clip.addTrack(track);
-
-        const deletedUuid = enemy.uuid;
-        cacheNodeDisplayPath(root, deletedUuid);
-        root.children = [];
-
-        expect(removePropertyCurve(clip, { rootNode: root, rootPath: '' }, {
-            nodeUuid: deletedUuid, propKey: 'position',
-        })).toBe(true);
-        expect(clip._tracks).toHaveLength(0);
-    });
-
-    it('removePropertyCurve 活节点无轨道时不会误删其他孤立轨道', () => {
-        const { AnimationClip, Node, animation } = require('cc');
-        const { removePropertyCurve } = require('../scene-process/service/animation/property-curve');
-
-        const root = new Node('Root');
-        const alive = new Node('Alive');
-        root.children = [alive];
-        const clip = new AnimationClip();
-
-        const orphanTrack = new animation.VectorTrack();
-        orphanTrack.componentsCount = 3;
-        orphanTrack.path.toHierarchy('Deleted').toProperty('position');
-        clip.addTrack(orphanTrack);
-
-        expect(removePropertyCurve(clip, { rootNode: root, rootPath: '' }, {
-            nodeUuid: alive.uuid, propKey: 'position',
-        })).toBe(false);
-        expect(clip._tracks).toHaveLength(1);
-    });
-
-    it('removePropertyCurve 不可靠路径匹配到活节点轨道时拒绝删除', () => {
-        jest.resetModules();
-        const nodeMgr: any = {};
-        (global as any).EditorExtends = { Node: nodeMgr };
-        (global as any).cc = require('cc');
-
-        const { AnimationClip, Node, animation } = require('cc');
-        const { removePropertyCurve } = require('../scene-process/service/animation/property-curve');
-
-        const root = new Node('Root');
-        const nodeC = new Node('Enemy_001');
-        root.children = [nodeC];
-
-        const clip = new AnimationClip();
-        const track = new animation.VectorTrack();
-        track.componentsCount = 3;
-        track.path.toHierarchy('Enemy_001').toProperty('position');
-        clip.addTrack(track);
-
-        nodeMgr.getNodeByPath = () => null;
-
-        expect(removePropertyCurve(clip, { rootNode: root, rootPath: 'Root' }, {
-            nodePath: 'Root/Enemy_001', propKey: 'position',
-        })).toBe(false);
-        expect(clip._tracks).toHaveLength(1);
-    });
-
-    it('removePropertyCurve 无缓存时不会用系统路径误删同名的孤立轨道', () => {
-        jest.resetModules();
-        const nodeMgr: any = {
-            getNodeByPath: () => null,
-        };
-        (global as any).EditorExtends = { Node: nodeMgr };
-        (global as any).cc = require('cc');
-
-        const { AnimationClip, Node, animation } = require('cc');
-        const { removePropertyCurve } = require('../scene-process/service/animation/property-curve');
-        const root = new Node('Root');
-        const clip = new AnimationClip();
-
-        const targetTrack = new animation.VectorTrack();
-        targetTrack.componentsCount = 3;
-        targetTrack.path.toHierarchy('Enemy').toProperty('position');
-        clip.addTrack(targetTrack);
-
-        const collidingTrack = new animation.VectorTrack();
-        collidingTrack.componentsCount = 3;
-        collidingTrack.path.toHierarchy('Enemy_001').toProperty('position');
-        clip.addTrack(collidingTrack);
-
-        expect(removePropertyCurve(clip, { rootNode: root, rootPath: 'Root' }, {
-            nodeUuid: 'deleted-enemy-uuid',
-            nodePath: 'Root/Enemy_001',
-            propKey: 'position',
-        })).toBe(false);
-        expect(clip._tracks).toEqual([targetTrack, collidingTrack]);
-    });
-
-    it('removePropertyCurve 不把同名兄弟的缓存系统路径当成可靠轨道归属', () => {
-        jest.resetModules();
-        const nodeMgr: any = {};
-        (global as any).EditorExtends = { Node: nodeMgr };
-        (global as any).cc = require('cc');
-
-        const { AnimationClip, Node, animation } = require('cc');
-        const { cacheNodeDisplayPaths, removePropertyCurve } = require('../scene-process/service/animation/property-curve');
-        const root = new Node('Root');
-        const owner = new Node('Enemy');
-        const target = new Node('Enemy');
-        const literalSuffix = new Node('Enemy_001');
-        root.children = [owner, target, literalSuffix];
-        nodeMgr.getNodeByPath = () => null;
-        nodeMgr.getNodePath = (node: any) => {
-            if (node === root) return 'Root';
-            if (node === owner) return 'Root/Enemy';
-            if (node === target) return 'Root/Enemy_001';
-            if (node === literalSuffix) return 'Root/Enemy_001_001';
-            return '';
-        };
-
-        const clip = new AnimationClip();
-        const ownerTrack = new animation.VectorTrack();
-        ownerTrack.componentsCount = 3;
-        ownerTrack.path.toHierarchy('Enemy').toProperty('position');
-        clip.addTrack(ownerTrack);
-        const literalSuffixTrack = new animation.VectorTrack();
-        literalSuffixTrack.componentsCount = 3;
-        literalSuffixTrack.path.toHierarchy('Enemy_001').toProperty('position');
-        clip.addTrack(literalSuffixTrack);
-
-        cacheNodeDisplayPaths(root);
-        root.children = [owner, literalSuffix];
-
-        expect(removePropertyCurve(clip, { rootNode: root, rootPath: 'Root' }, {
-            nodePath: 'Root/Enemy_001',
-            propKey: 'position',
-        })).toBe(false);
-        expect(clip._tracks).toEqual([ownerTrack, literalSuffixTrack]);
-    });
-
-    it('removePropertyCurve 不把会话内被不同 UUID 复用的 display path 当成可靠归属', () => {
-        const { AnimationClip, Node, animation } = require('cc');
-        const { cacheNodeDisplayPaths, removePropertyCurve } = require('../scene-process/service/animation/property-curve');
+        const { addPropertyCurve } = require('../scene-process/service/animation/property-curve');
         const root = new Node('Root');
         const first = new Node('Enemy');
-        root.children = [first];
-
-        const clip = new AnimationClip();
-        const track = new animation.VectorTrack();
-        track.componentsCount = 3;
-        track.path.toHierarchy('Enemy').toProperty('position');
-        clip.addTrack(track);
-
-        cacheNodeDisplayPaths(root);
-        const firstUuid = first.uuid;
-        root.children = [];
-
         const second = new Node('Enemy');
-        root.children = [second];
-        cacheNodeDisplayPaths(root, second);
-        root.children = [];
-
-        expect(removePropertyCurve(clip, { rootNode: root, rootPath: '' }, {
-            nodeUuid: firstUuid,
-            propKey: 'position',
-        })).toBe(false);
-        expect(removePropertyCurve(clip, { rootNode: root, rootPath: '' }, {
-            nodeUuid: second.uuid,
-            propKey: 'position',
-        })).toBe(false);
-        expect(clip._tracks).toEqual([track]);
-    });
-
-    it('removePropertyCurve 在轨道快照重建后仍允许清理新 UUID 创建的同路径轨道', async () => {
-        const { AnimationClip, Node } = require('cc');
-        const { cacheNodeDisplayPaths, createPropertyKey, removePropertyCurve } = require('../scene-process/service/animation/property-curve');
-        const { captureAnimationClipSnapshot, restoreAnimationClipSnapshot } = require('../scene-process/service/animation/clip-snapshot');
-        const root = new Node('Root');
-        const first = new Node('Enemy');
-        root.children = [first];
-        cacheNodeDisplayPaths(root);
-
-        first.name = 'Soldier';
-        cacheNodeDisplayPaths(root, first);
-
-        const second = new Node('Enemy');
-        root.children.push(second);
-        const clip = new AnimationClip();
-        expect(createPropertyKey(clip, { rootNode: root, rootPath: '' }, {
-            nodeUuid: second.uuid,
-            propKey: 'position',
-            frame: 0,
-            value: { x: 0, y: 0, z: 0 },
-        })).toBe(true);
-
-        const originalTrack = clip._tracks[0];
-        const snapshot = captureAnimationClipSnapshot(clip, { rootNode: root });
-        await restoreAnimationClipSnapshot(clip, snapshot, { rootNode: root });
-        expect(clip._tracks[0]).not.toBe(originalTrack);
-
-        root.children = [first];
-        expect(removePropertyCurve(clip, { rootNode: root, rootPath: '' }, {
-            nodeUuid: second.uuid,
-            propKey: 'position',
-        })).toBe(true);
-        expect(clip._tracks).toHaveLength(0);
-    });
-
-    it('rename 后重新缓存会移除旧 displayPath entry，不把新同名节点标记为 ambiguous', () => {
-        const { AnimationClip, Node, animation } = require('cc');
-        const { cacheNodeDisplayPaths, removePropertyCurve } = require('../scene-process/service/animation/property-curve');
-        const root = new Node('Root');
-        const first = new Node('Enemy');
-        root.children = [first];
-        cacheNodeDisplayPaths(root);
-
-        first.name = 'Soldier';
-        cacheNodeDisplayPaths(root, first);
-        const second = new Node('Enemy');
-        root.children.push(second);
-        cacheNodeDisplayPaths(root, second);
-
-        const clip = new AnimationClip();
-        const track = new animation.VectorTrack();
-        track.componentsCount = 3;
-        track.path.toHierarchy('Enemy').toProperty('position');
-        clip.addTrack(track);
-
-        root.children = [first];
-        expect(removePropertyCurve(clip, { rootNode: root, rootPath: '' }, {
-            nodeUuid: second.uuid,
-            propKey: 'position',
-        })).toBe(true);
-        expect(clip._tracks).toHaveLength(0);
-    });
-
-    it('removePropertyCurve 在轨道快照重建后也不把旧 UUID 轨道转交给新节点', async () => {
-        const { AnimationClip, Node } = require('cc');
-        const { cacheNodeDisplayPaths, createPropertyKey, removePropertyCurve } = require('../scene-process/service/animation/property-curve');
-        const { captureAnimationClipSnapshot, restoreAnimationClipSnapshot } = require('../scene-process/service/animation/clip-snapshot');
-        const root = new Node('Root');
-        const first = new Node('Enemy');
-        root.children = [first];
-        const clip = new AnimationClip();
-        expect(createPropertyKey(clip, { rootNode: root, rootPath: '' }, {
-            nodeUuid: first.uuid,
-            propKey: 'position',
-            frame: 0,
-            value: { x: 0, y: 0, z: 0 },
-        })).toBe(true);
-
-        first.name = 'Soldier';
-        cacheNodeDisplayPaths(root, first);
-        const second = new Node('Enemy');
-        root.children.push(second);
-        cacheNodeDisplayPaths(root, second);
-        root.children = [first];
-
-        const snapshot = captureAnimationClipSnapshot(clip, { rootNode: root });
-        await restoreAnimationClipSnapshot(clip, snapshot, { rootNode: root });
-
-        expect(removePropertyCurve(clip, { rootNode: root, rootPath: '' }, {
-            nodeUuid: second.uuid,
-            propKey: 'position',
-        })).toBe(false);
-        expect(clip._tracks).toHaveLength(1);
-    });
-
-    it('普通编辑和快照恢复都不会把旧轨道归属转交给新 UUID', async () => {
-        const { AnimationClip, Node } = require('cc');
-        const {
-            cacheNodeDisplayPaths,
-            createPropertyKey,
-            removePropertyCurve,
-            updatePropertyKey,
-        } = require('../scene-process/service/animation/property-curve');
-        const {
-            captureAnimationClipSnapshot,
-            restoreAnimationClipSnapshot,
-        } = require('../scene-process/service/animation/clip-snapshot');
-        const root = new Node('Root');
-        const first = new Node('Enemy');
-        root.children = [first];
-        const clip = new AnimationClip();
-        expect(createPropertyKey(clip, { rootNode: root, rootPath: '' }, {
-            nodeUuid: first.uuid,
-            propKey: 'position',
-            frame: 0,
-            value: { x: 0, y: 0, z: 0 },
-        })).toBe(true);
-        const before = captureAnimationClipSnapshot(clip, { rootNode: root });
-
-        first.name = 'Soldier';
-        cacheNodeDisplayPaths(root, first);
-        const second = new Node('Enemy');
-        root.children.push(second);
-        cacheNodeDisplayPaths(root, second);
+        root.children = [first, second];
+        const context = { rootNode: root, rootPath: 'Root' };
         const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
         try {
-            expect(updatePropertyKey(clip, { rootNode: root, rootPath: '' }, {
+            const rejectedClip = new AnimationClip();
+            expect(addPropertyCurve(rejectedClip, context, {
+                type: 'addPropertyCurve',
+                clipUuid: 'clip',
                 nodeUuid: second.uuid,
                 propKey: 'position',
-                frame: 0,
-                value: { x: 1, y: 0, z: 0 },
+                value: { x: 0, y: 0, z: 0 },
             })).toBe(false);
-            expect(warn).toHaveBeenCalledWith(expect.stringContaining('is owned by node'));
+            expect(rejectedClip._tracks).toHaveLength(0);
+            expect(warn).toHaveBeenCalledWith(expect.stringContaining(second.uuid));
+
+            const acceptedClip = new AnimationClip();
+            expect(addPropertyCurve(acceptedClip, context, {
+                type: 'addPropertyCurve',
+                clipUuid: 'clip',
+                nodeUuid: first.uuid,
+                propKey: 'position',
+                value: { x: 0, y: 0, z: 0 },
+            })).toBe(true);
+            expect(acceptedClip._tracks[0].path.parseHierarchyAt(0)).toBe('Enemy');
         } finally {
             warn.mockRestore();
         }
-        const after = captureAnimationClipSnapshot(clip, { rootNode: root });
-        root.children = [first];
-
-        await restoreAnimationClipSnapshot(clip, before, { rootNode: root });
-        expect(removePropertyCurve(clip, { rootNode: root, rootPath: '' }, {
-            nodeUuid: second.uuid,
-            propKey: 'position',
-        })).toBe(false);
-
-        await restoreAnimationClipSnapshot(clip, after, { rootNode: root });
-        expect(removePropertyCurve(clip, { rootNode: root, rootPath: '' }, {
-            nodeUuid: second.uuid,
-            propKey: 'position',
-        })).toBe(false);
-        expect(clip._tracks).toHaveLength(1);
     });
 
-    it('createPropertyKey 节点已删除时仍然拒绝（非 lenient）', () => {
+    it('第一个同名节点删除后，原第二个节点可通过 UUID 操作', () => {
         const { AnimationClip, Node } = require('cc');
-        const { createPropertyKey } = require('../scene-process/service/animation/property-curve');
-
+        const { addPropertyCurve } = require('../scene-process/service/animation/property-curve');
         const root = new Node('Root');
-        const enemy = new Node('Enemy');
-        root.children = [enemy];
+        const first = new Node('Enemy');
+        const second = new Node('Enemy');
+        root.children = [first, second];
 
+        root.children = [second];
         const clip = new AnimationClip();
-        const context: any = { rootNode: root, rootPath: 'Root' };
-
-        root.children = [];
-
-        expect(createPropertyKey(clip, context, {
-            nodePath: 'Root/Enemy', propKey: 'position', frame: 0, value: { x: 0, y: 0, z: 0 },
-        })).toBe(false);
-        expect(clip._tracks).toHaveLength(0);
-    });
-});
-
-describe('property-value 碰撞后缀路径解析', () => {
-    it('nodeUuid 分支: 碰撞后缀节点解析出 name-based 相对路径', async () => {
-        jest.resetModules();
-        (global as any).EditorExtends = { Node: {} };
-        (global as any).cc = require('cc');
-
-        let capturedNodePath: string | undefined;
-        jest.doMock('../scene-process/service/animation/property-metadata', () => ({
-            queryAnimationPropertyMetadata: (_rootNode: any, nodePath: string) => {
-                capturedNodePath = nodePath;
-                return null;
-            },
-        }));
-
-        const { Node } = require('cc');
-        const { normalizeProvidedAnimationPropertyOperationValue } = require('../scene-process/service/animation/property-value');
-
-        const root = new Node('Root');
-        const enemy = new Node('Enemy');
-        root.children = [enemy];
-
-        await normalizeProvidedAnimationPropertyOperationValue(
-            root, '',
-            {
-                type: 'createPropertyKey',
-                clipUuid: 'clip',
-                nodeUuid: enemy.uuid,
-                propKey: 'position',
-                frame: 0,
-                value: { x: 0, y: 0, z: 0 },
-            },
-        );
-
-        expect(capturedNodePath).toBe('Enemy');
+        expect(addPropertyCurve(clip, { rootNode: root, rootPath: 'Root' }, {
+            type: 'addPropertyCurve',
+            clipUuid: 'clip',
+            nodeUuid: second.uuid,
+            propKey: 'position',
+            value: { x: 0, y: 0, z: 0 },
+        })).toBe(true);
+        expect(clip._tracks[0].path.parseHierarchyAt(0)).toBe('Enemy');
     });
 
-    it('nodePath 分支: 系统路径碰撞后缀解析出 name-based 相对路径', async () => {
-        jest.resetModules();
-        const nodeMgr: any = {};
-        (global as any).EditorExtends = { Node: nodeMgr };
-        (global as any).cc = require('cc');
-
-        let capturedNodePath: string | undefined;
-        jest.doMock('../scene-process/service/animation/property-metadata', () => ({
-            queryAnimationPropertyMetadata: (_rootNode: any, nodePath: string) => {
-                capturedNodePath = nodePath;
-                return null;
-            },
-        }));
-
-        const { Node } = require('cc');
-        const { normalizeProvidedAnimationPropertyOperationValue } = require('../scene-process/service/animation/property-value');
-
+    it('拒绝不能解析为动画 name path 的系统后缀路径', () => {
+        const { AnimationClip, Node } = require('cc');
+        const { addPropertyCurve } = require('../scene-process/service/animation/property-curve');
         const root = new Node('Root');
-        const enemy = new Node('Enemy');
-        root.children = [enemy];
-        nodeMgr.getNodeByPath = (path: string) => {
-            if (path === 'Root/Enemy_001') return enemy;
-            return null;
-        };
+        const remaining = new Node('Enemy');
+        root.children = [remaining];
+        (global as any).EditorExtends.Node.getNodeByPath = jest.fn((path: string) => (
+            path === 'Root/Enemy_001' ? remaining : null
+        ));
+        const clip = new AnimationClip();
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
 
-        await normalizeProvidedAnimationPropertyOperationValue(
-            root, 'Root',
-            {
-                type: 'createPropertyKey',
+        try {
+            expect(addPropertyCurve(clip, { rootNode: root, rootPath: 'Root' }, {
+                type: 'addPropertyCurve',
                 clipUuid: 'clip',
                 nodePath: 'Root/Enemy_001',
                 propKey: 'position',
-                frame: 0,
                 value: { x: 0, y: 0, z: 0 },
-            },
-        );
-
-        expect(capturedNodePath).toBe('Enemy');
+            })).toBe(false);
+            expect(clip._tracks).toHaveLength(0);
+            expect(warn).toHaveBeenCalledWith(expect.stringContaining('Root/Enemy_001'));
+        } finally {
+            warn.mockRestore();
+        }
     });
 
-    it('nodePath 分支: 兼容唯一 display path，即使 system path 带去重后缀', async () => {
-        jest.resetModules();
-        const nodeMgr: any = {};
-        (global as any).EditorExtends = { Node: nodeMgr };
-        (global as any).cc = require('cc');
+    it('完整系统路径保持旧的 root 前缀优先解析行为', () => {
+        const { AnimationClip, Node } = require('cc');
+        const { addPropertyCurve } = require('../scene-process/service/animation/property-curve');
+        const root = new Node('Root');
+        const direct = new Node('B');
+        const nestedRoot = new Node('Root');
+        const nested = new Node('B');
+        nestedRoot.children = [nested];
+        root.children = [direct, nestedRoot];
+        root.getChildByPath = (path: string) => {
+            if (path === 'B') return direct;
+            if (path === 'Root/B') return nested;
+            return null;
+        };
+        (global as any).EditorExtends.Node.getNodeByPath = jest.fn((path: string) => (
+            path === 'Root/B' ? direct : null
+        ));
+        const clip = new AnimationClip();
 
-        let capturedNodePath: string | undefined;
-        jest.doMock('../scene-process/service/animation/property-metadata', () => ({
-            queryAnimationPropertyMetadata: (_rootNode: any, nodePath: string) => {
-                capturedNodePath = nodePath;
-                return null;
-            },
-        }));
+        expect(addPropertyCurve(clip, { rootNode: root, rootPath: 'Root' }, {
+            type: 'addPropertyCurve',
+            clipUuid: 'clip',
+            nodePath: 'Root/B',
+            propKey: 'position',
+            value: { x: 0, y: 0, z: 0 },
+        })).toBe(true);
+        expect(clip._tracks[0].path.parseHierarchyAt(0)).toBe('B');
+    });
 
-        const { Node } = require('cc');
-        const { normalizeProvidedAnimationPropertyOperationValue } = require('../scene-process/service/animation/property-value');
+    it('节点删除后仍可通过完整系统路径清理孤立轨道', () => {
+        const { AnimationClip, Node } = require('cc');
+        const {
+            addPropertyCurve,
+            removePropertyCurve,
+        } = require('../scene-process/service/animation/property-curve');
         const root = new Node('Root');
         const enemy = new Node('Enemy');
         root.children = [enemy];
-        nodeMgr.getNodeByPath = (path: string) => path === 'Root/Enemy_001' ? enemy : null;
+        const clip = new AnimationClip();
+        const context = { rootNode: root, rootPath: 'Root' };
 
-        await normalizeProvidedAnimationPropertyOperationValue(
-            root, 'Root',
-            {
-                type: 'createPropertyKey',
-                clipUuid: 'clip',
-                nodePath: 'Enemy',
-                propKey: 'position',
-                frame: 0,
-                value: { x: 0, y: 0, z: 0 },
-            },
-        );
+        expect(addPropertyCurve(clip, context, {
+            type: 'addPropertyCurve',
+            clipUuid: 'clip',
+            nodePath: 'Root/Enemy',
+            propKey: 'position',
+            value: { x: 0, y: 0, z: 0 },
+        })).toBe(true);
+        root.children = [];
+        (global as any).EditorExtends.Node.getNodeByPath = jest.fn(() => null);
 
-        expect(capturedNodePath).toBe('Enemy');
+        expect(removePropertyCurve(clip, context, {
+            type: 'removePropertyCurve',
+            clipUuid: 'clip',
+            nodePath: 'Root/Enemy',
+            propKey: 'position',
+        })).toBe(true);
+        expect(clip._tracks).toHaveLength(0);
     });
 
-    it('nodePath 分支: 相对路径同时命中不同 system/display 节点时拒绝解析', async () => {
-        jest.resetModules();
-        const nodeMgr: any = {};
-        (global as any).EditorExtends = { Node: nodeMgr };
-        (global as any).cc = require('cc');
-
-        let capturedNodePath: string | undefined;
+    it('属性值归一化通过 UUID 使用动画 name path，而不是系统后缀路径', async () => {
+        let capturedPath: string | undefined;
         jest.doMock('../scene-process/service/animation/property-metadata', () => ({
-            queryAnimationPropertyMetadata: (_rootNode: any, nodePath: string) => {
-                capturedNodePath = nodePath;
+            queryAnimationPropertyMetadata: (_rootNode: unknown, nodePath: string) => {
+                capturedPath = nodePath;
                 return null;
             },
         }));
@@ -1904,61 +1124,21 @@ describe('property-value 碰撞后缀路径解析', () => {
         const { Node } = require('cc');
         const { normalizeProvidedAnimationPropertyOperationValue } = require('../scene-process/service/animation/property-value');
         const root = new Node('Root');
-        const target = new Node('Enemy');
-        const literalPathNode = new Node('Enemy_1');
-        root.children = [target, literalPathNode];
-        nodeMgr.getNodeByPath = (path: string) => path === 'Root/Enemy_1' ? target : null;
+        const remaining = new Node('Enemy');
+        root.children = [remaining];
 
-        await normalizeProvidedAnimationPropertyOperationValue(
-            root, 'Root',
-            {
+        try {
+            await normalizeProvidedAnimationPropertyOperationValue(root, 'Root', {
                 type: 'createPropertyKey',
                 clipUuid: 'clip',
-                nodePath: 'Enemy_1',
+                nodeUuid: remaining.uuid,
                 propKey: 'position',
                 frame: 0,
                 value: { x: 0, y: 0, z: 0 },
-            },
-        );
-
-        expect(capturedNodePath).toBeUndefined();
-    });
-
-    it('同名兄弟时 resolveOperationRelativeNodePath 返回 null，value 原样返回', async () => {
-        jest.resetModules();
-        (global as any).EditorExtends = { Node: {} };
-        (global as any).cc = require('cc');
-
-        let metadataCalled = false;
-        jest.doMock('../scene-process/service/animation/property-metadata', () => ({
-            queryAnimationPropertyMetadata: () => {
-                metadataCalled = true;
-                return null;
-            },
-        }));
-
-        const { Node } = require('cc');
-        const { normalizeProvidedAnimationPropertyOperationValue } = require('../scene-process/service/animation/property-value');
-
-        const root = new Node('Root');
-        const enemy1 = new Node('Enemy');
-        const enemy2 = new Node('Enemy');
-        root.children = [enemy1, enemy2];
-
-        const inputValue = { x: 1, y: 2, z: 3 };
-        const result = await normalizeProvidedAnimationPropertyOperationValue(
-            root, '',
-            {
-                type: 'createPropertyKey',
-                clipUuid: 'clip',
-                nodeUuid: enemy1.uuid,
-                propKey: 'position',
-                frame: 0,
-                value: inputValue,
-            },
-        );
-
-        expect(metadataCalled).toBe(false);
-        expect(result).toEqual(inputValue);
+            });
+            expect(capturedPath).toBe('Enemy');
+        } finally {
+            jest.dontMock('../scene-process/service/animation/property-metadata');
+        }
     });
 });

--- a/src/core/scene/test/animation-service-animatable.test.ts
+++ b/src/core/scene/test/animation-service-animatable.test.ts
@@ -1128,7 +1128,59 @@ describe('resolveRelativeNodePath 同名兄弟歧义检测', () => {
         expect(result).toBe(true);
     });
 
-    it('删除操作在同名兄弟歧义时仍然放行', () => {
+    it('兼容 queryClip 返回的唯一 display path，即使 system path 带去重后缀', () => {
+        jest.resetModules();
+        const nodeMgr: any = {};
+        (global as any).EditorExtends = { Node: nodeMgr };
+        (global as any).cc = require('cc');
+
+        const { AnimationClip, Node } = require('cc');
+        const { addPropertyCurve } = require('../scene-process/service/animation/property-curve');
+        const root = new Node('Root');
+        const enemy = new Node('Enemy');
+        root.children = [enemy];
+        nodeMgr.getNodeByPath = (path: string) => path === 'Root/Enemy_001' ? enemy : null;
+        const clip = new AnimationClip();
+
+        expect(addPropertyCurve(clip, { rootNode: root, rootPath: 'Root' }, {
+            type: 'addPropertyCurve', clipUuid: 'clip',
+            nodePath: 'Enemy', propKey: 'position',
+            value: { x: 0, y: 0, z: 0 },
+        })).toBe(true);
+        expect(clip._tracks).toHaveLength(1);
+    });
+
+    it('相对路径同时命中不同的 system/display 节点时拒绝操作', () => {
+        jest.resetModules();
+        const nodeMgr: any = {};
+        (global as any).EditorExtends = { Node: nodeMgr };
+        (global as any).cc = require('cc');
+
+        const { AnimationClip, Node, animation } = require('cc');
+        const { removePropertyCurve } = require('../scene-process/service/animation/property-curve');
+        const root = new Node('Root');
+        const target = new Node('Enemy');
+        const literalPathNode = new Node('Enemy_1');
+        root.children = [target, literalPathNode];
+        nodeMgr.getNodeByPath = (path: string) => path === 'Root/Enemy_1' ? target : null;
+
+        const clip = new AnimationClip();
+        const targetTrack = new animation.VectorTrack();
+        targetTrack.componentsCount = 3;
+        targetTrack.path.toHierarchy('Enemy').toProperty('position');
+        clip.addTrack(targetTrack);
+        const literalPathTrack = new animation.VectorTrack();
+        literalPathTrack.componentsCount = 3;
+        literalPathTrack.path.toHierarchy('Enemy_1').toProperty('position');
+        clip.addTrack(literalPathTrack);
+
+        expect(removePropertyCurve(clip, { rootNode: root, rootPath: 'Root' }, {
+            nodePath: 'Enemy_1', propKey: 'position',
+        })).toBe(false);
+        expect(clip._tracks).toEqual([targetTrack, literalPathTrack]);
+    });
+
+    it('removePropertyCurve 仅允许删除同名兄弟中当前实际绑定的节点轨道', () => {
         const { AnimationClip, Node } = require('cc');
         const { addPropertyCurve, removePropertyCurve } = require('../scene-process/service/animation/property-curve');
 
@@ -1154,7 +1206,7 @@ describe('resolveRelativeNodePath 同名兄弟歧义检测', () => {
         expect(clip._tracks).toHaveLength(0);
     });
 
-    it('removePropertyKey 在同名兄弟歧义时仍然放行第一个节点', () => {
+    it('removePropertyKey 仅允许删除同名兄弟中当前实际绑定节点的关键帧', () => {
         const { AnimationClip, Node } = require('cc');
         const { createPropertyKey, removePropertyKey } = require('../scene-process/service/animation/property-curve');
 
@@ -1238,7 +1290,7 @@ describe('resolveRelativeNodePath 同名兄弟歧义检测', () => {
         expect(clip._tracks).toHaveLength(1);
     });
 
-    it('removePropertyCurve 节点已删除时通过 nodePath 字符串裁剪删除孤立轨道', () => {
+    it('removePropertyCurve 节点已删除且无缓存时拒绝按 nodePath 猜测孤立轨道', () => {
         const { AnimationClip, Node } = require('cc');
         const { createPropertyKey, removePropertyCurve } = require('../scene-process/service/animation/property-curve');
 
@@ -1258,13 +1310,13 @@ describe('resolveRelativeNodePath 同名兄弟歧义检测', () => {
 
         expect(removePropertyCurve(clip, context, {
             nodePath: 'Root/Enemy', propKey: 'position',
-        })).toBe(true);
-        expect(clip._tracks).toHaveLength(0);
+        })).toBe(false);
+        expect(clip._tracks).toHaveLength(1);
     });
 
-    it('removePropertyCurve 节点已删除时通过 nodeUuid + nodePath 兜底删除孤立轨道', () => {
-        const { AnimationClip, Node } = require('cc');
-        const { createPropertyKey, removePropertyCurve } = require('../scene-process/service/animation/property-curve');
+    it('removePropertyCurve 节点已删除且无缓存时拒绝按 nodeUuid + nodePath 猜测孤立轨道', () => {
+        const { AnimationClip, Node, animation } = require('cc');
+        const { removePropertyCurve } = require('../scene-process/service/animation/property-curve');
 
         const root = new Node('Root');
         const enemy = new Node('Enemy');
@@ -1272,18 +1324,435 @@ describe('resolveRelativeNodePath 同名兄弟歧义检测', () => {
 
         const clip = new AnimationClip();
         const context: any = { rootNode: root, rootPath: 'Root' };
-
-        expect(createPropertyKey(clip, context, {
-            nodeUuid: enemy.uuid, propKey: 'position', frame: 0, value: { x: 0, y: 0, z: 0 },
-        })).toBe(true);
+        const track = new animation.VectorTrack();
+        track.componentsCount = 3;
+        track.path.toHierarchy('Enemy').toProperty('position');
+        clip.addTrack(track);
 
         const deletedUuid = enemy.uuid;
         root.children = [];
 
         expect(removePropertyCurve(clip, context, {
             nodeUuid: deletedUuid, nodePath: 'Root/Enemy', propKey: 'position',
+        })).toBe(false);
+        expect(clip._tracks).toHaveLength(1);
+    });
+
+    it('removePropertyCurve 节点 name≠系统路径时通过 displayPath 缓存清理轨道', () => {
+        jest.resetModules();
+        const nodeMgr: any = {};
+        (global as any).EditorExtends = { Node: nodeMgr };
+        (global as any).cc = require('cc');
+
+        const { AnimationClip, Node } = require('cc');
+        const { addPropertyCurve, removePropertyCurve } = require('../scene-process/service/animation/property-curve');
+
+        const root = new Node('Root');
+        const enemy = new Node('Enemy');
+        root.children = [enemy];
+        nodeMgr.getNodeByPath = (path: string) => {
+            if (path === 'Root/Enemy_001') return enemy;
+            return null;
+        };
+
+        const clip = new AnimationClip();
+        const context: any = { rootNode: root, rootPath: 'Root' };
+
+        expect(addPropertyCurve(clip, context, {
+            type: 'addPropertyCurve', clipUuid: 'clip',
+            nodePath: 'Root/Enemy_001', propKey: 'position',
+            value: { x: 0, y: 0, z: 0 },
+        })).toBe(true);
+        expect(clip._tracks).toHaveLength(1);
+
+        const deletedUuid = enemy.uuid;
+        root.children = [];
+
+        expect(removePropertyCurve(clip, context, {
+            nodeUuid: deletedUuid, propKey: 'position',
         })).toBe(true);
         expect(clip._tracks).toHaveLength(0);
+    });
+
+    it('removePropertyKey 节点 name≠系统路径时通过 displayPath 缓存清理关键帧', () => {
+        jest.resetModules();
+        const nodeMgr: any = {};
+        (global as any).EditorExtends = { Node: nodeMgr };
+        (global as any).cc = require('cc');
+
+        const { AnimationClip, Node } = require('cc');
+        const { createPropertyKey, removePropertyKey } = require('../scene-process/service/animation/property-curve');
+
+        const root = new Node('Root');
+        const enemy = new Node('Enemy');
+        root.children = [enemy];
+        nodeMgr.getNodeByPath = (path: string) => {
+            if (path === 'Root/Enemy_001') return enemy;
+            return null;
+        };
+
+        const clip = new AnimationClip();
+        const context: any = { rootNode: root, rootPath: 'Root' };
+
+        expect(createPropertyKey(clip, context, {
+            nodePath: 'Root/Enemy_001', propKey: 'position', frame: 0, value: { x: 0, y: 0, z: 0 },
+        })).toBe(true);
+        expect(clip._tracks).toHaveLength(1);
+
+        const deletedUuid = enemy.uuid;
+        root.children = [];
+
+        expect(removePropertyKey(clip, context, {
+            nodeUuid: deletedUuid, propKey: 'position', frames: [0],
+        })).toBe(true);
+    });
+
+    it('removePropertyCurve 无缓存且无 nodePath 时拒绝删除（无法证明归属）', () => {
+        const { AnimationClip, Node, animation } = require('cc');
+        const { removePropertyCurve } = require('../scene-process/service/animation/property-curve');
+
+        const root = new Node('Root');
+        const clip = new AnimationClip();
+
+        const track = new animation.VectorTrack();
+        track.componentsCount = 3;
+        track.path.toHierarchy('Deleted').toProperty('position');
+        clip.addTrack(track);
+
+        expect(removePropertyCurve(clip, { rootNode: root, rootPath: '' }, {
+            nodeUuid: 'deleted-uuid', propKey: 'position',
+        })).toBe(false);
+        expect(clip._tracks).toHaveLength(1);
+    });
+
+    it('removePropertyCurve 预缓存 displayPath 后可正确删除已删除节点的轨道', () => {
+        const { AnimationClip, Node, animation } = require('cc');
+        const { removePropertyCurve, cacheNodeDisplayPath } = require('../scene-process/service/animation/property-curve');
+
+        const root = new Node('Root');
+        const enemy = new Node('Enemy');
+        root.children = [enemy];
+
+        const clip = new AnimationClip();
+        const track = new animation.VectorTrack();
+        track.componentsCount = 3;
+        track.path.toHierarchy('Enemy').toProperty('position');
+        clip.addTrack(track);
+
+        const deletedUuid = enemy.uuid;
+        cacheNodeDisplayPath(root, deletedUuid);
+        root.children = [];
+
+        expect(removePropertyCurve(clip, { rootNode: root, rootPath: '' }, {
+            nodeUuid: deletedUuid, propKey: 'position',
+        })).toBe(true);
+        expect(clip._tracks).toHaveLength(0);
+    });
+
+    it('removePropertyCurve 活节点无轨道时不会误删其他孤立轨道', () => {
+        const { AnimationClip, Node, animation } = require('cc');
+        const { removePropertyCurve } = require('../scene-process/service/animation/property-curve');
+
+        const root = new Node('Root');
+        const alive = new Node('Alive');
+        root.children = [alive];
+        const clip = new AnimationClip();
+
+        const orphanTrack = new animation.VectorTrack();
+        orphanTrack.componentsCount = 3;
+        orphanTrack.path.toHierarchy('Deleted').toProperty('position');
+        clip.addTrack(orphanTrack);
+
+        expect(removePropertyCurve(clip, { rootNode: root, rootPath: '' }, {
+            nodeUuid: alive.uuid, propKey: 'position',
+        })).toBe(false);
+        expect(clip._tracks).toHaveLength(1);
+    });
+
+    it('removePropertyCurve 不可靠路径匹配到活节点轨道时拒绝删除', () => {
+        jest.resetModules();
+        const nodeMgr: any = {};
+        (global as any).EditorExtends = { Node: nodeMgr };
+        (global as any).cc = require('cc');
+
+        const { AnimationClip, Node, animation } = require('cc');
+        const { removePropertyCurve } = require('../scene-process/service/animation/property-curve');
+
+        const root = new Node('Root');
+        const nodeC = new Node('Enemy_001');
+        root.children = [nodeC];
+
+        const clip = new AnimationClip();
+        const track = new animation.VectorTrack();
+        track.componentsCount = 3;
+        track.path.toHierarchy('Enemy_001').toProperty('position');
+        clip.addTrack(track);
+
+        nodeMgr.getNodeByPath = () => null;
+
+        expect(removePropertyCurve(clip, { rootNode: root, rootPath: 'Root' }, {
+            nodePath: 'Root/Enemy_001', propKey: 'position',
+        })).toBe(false);
+        expect(clip._tracks).toHaveLength(1);
+    });
+
+    it('removePropertyCurve 无缓存时不会用系统路径误删同名的孤立轨道', () => {
+        jest.resetModules();
+        const nodeMgr: any = {
+            getNodeByPath: () => null,
+        };
+        (global as any).EditorExtends = { Node: nodeMgr };
+        (global as any).cc = require('cc');
+
+        const { AnimationClip, Node, animation } = require('cc');
+        const { removePropertyCurve } = require('../scene-process/service/animation/property-curve');
+        const root = new Node('Root');
+        const clip = new AnimationClip();
+
+        const targetTrack = new animation.VectorTrack();
+        targetTrack.componentsCount = 3;
+        targetTrack.path.toHierarchy('Enemy').toProperty('position');
+        clip.addTrack(targetTrack);
+
+        const collidingTrack = new animation.VectorTrack();
+        collidingTrack.componentsCount = 3;
+        collidingTrack.path.toHierarchy('Enemy_001').toProperty('position');
+        clip.addTrack(collidingTrack);
+
+        expect(removePropertyCurve(clip, { rootNode: root, rootPath: 'Root' }, {
+            nodeUuid: 'deleted-enemy-uuid',
+            nodePath: 'Root/Enemy_001',
+            propKey: 'position',
+        })).toBe(false);
+        expect(clip._tracks).toEqual([targetTrack, collidingTrack]);
+    });
+
+    it('removePropertyCurve 不把同名兄弟的缓存系统路径当成可靠轨道归属', () => {
+        jest.resetModules();
+        const nodeMgr: any = {};
+        (global as any).EditorExtends = { Node: nodeMgr };
+        (global as any).cc = require('cc');
+
+        const { AnimationClip, Node, animation } = require('cc');
+        const { cacheNodeDisplayPaths, removePropertyCurve } = require('../scene-process/service/animation/property-curve');
+        const root = new Node('Root');
+        const owner = new Node('Enemy');
+        const target = new Node('Enemy');
+        const literalSuffix = new Node('Enemy_001');
+        root.children = [owner, target, literalSuffix];
+        nodeMgr.getNodeByPath = () => null;
+        nodeMgr.getNodePath = (node: any) => {
+            if (node === root) return 'Root';
+            if (node === owner) return 'Root/Enemy';
+            if (node === target) return 'Root/Enemy_001';
+            if (node === literalSuffix) return 'Root/Enemy_001_001';
+            return '';
+        };
+
+        const clip = new AnimationClip();
+        const ownerTrack = new animation.VectorTrack();
+        ownerTrack.componentsCount = 3;
+        ownerTrack.path.toHierarchy('Enemy').toProperty('position');
+        clip.addTrack(ownerTrack);
+        const literalSuffixTrack = new animation.VectorTrack();
+        literalSuffixTrack.componentsCount = 3;
+        literalSuffixTrack.path.toHierarchy('Enemy_001').toProperty('position');
+        clip.addTrack(literalSuffixTrack);
+
+        cacheNodeDisplayPaths(root);
+        root.children = [owner, literalSuffix];
+
+        expect(removePropertyCurve(clip, { rootNode: root, rootPath: 'Root' }, {
+            nodePath: 'Root/Enemy_001',
+            propKey: 'position',
+        })).toBe(false);
+        expect(clip._tracks).toEqual([ownerTrack, literalSuffixTrack]);
+    });
+
+    it('removePropertyCurve 不把会话内被不同 UUID 复用的 display path 当成可靠归属', () => {
+        const { AnimationClip, Node, animation } = require('cc');
+        const { cacheNodeDisplayPaths, removePropertyCurve } = require('../scene-process/service/animation/property-curve');
+        const root = new Node('Root');
+        const first = new Node('Enemy');
+        root.children = [first];
+
+        const clip = new AnimationClip();
+        const track = new animation.VectorTrack();
+        track.componentsCount = 3;
+        track.path.toHierarchy('Enemy').toProperty('position');
+        clip.addTrack(track);
+
+        cacheNodeDisplayPaths(root);
+        const firstUuid = first.uuid;
+        root.children = [];
+
+        const second = new Node('Enemy');
+        root.children = [second];
+        cacheNodeDisplayPaths(root, second);
+        root.children = [];
+
+        expect(removePropertyCurve(clip, { rootNode: root, rootPath: '' }, {
+            nodeUuid: firstUuid,
+            propKey: 'position',
+        })).toBe(false);
+        expect(removePropertyCurve(clip, { rootNode: root, rootPath: '' }, {
+            nodeUuid: second.uuid,
+            propKey: 'position',
+        })).toBe(false);
+        expect(clip._tracks).toEqual([track]);
+    });
+
+    it('removePropertyCurve 在轨道快照重建后仍允许清理新 UUID 创建的同路径轨道', async () => {
+        const { AnimationClip, Node } = require('cc');
+        const { cacheNodeDisplayPaths, createPropertyKey, removePropertyCurve } = require('../scene-process/service/animation/property-curve');
+        const { captureAnimationClipSnapshot, restoreAnimationClipSnapshot } = require('../scene-process/service/animation/clip-snapshot');
+        const root = new Node('Root');
+        const first = new Node('Enemy');
+        root.children = [first];
+        cacheNodeDisplayPaths(root);
+
+        first.name = 'Soldier';
+        cacheNodeDisplayPaths(root, first);
+
+        const second = new Node('Enemy');
+        root.children.push(second);
+        const clip = new AnimationClip();
+        expect(createPropertyKey(clip, { rootNode: root, rootPath: '' }, {
+            nodeUuid: second.uuid,
+            propKey: 'position',
+            frame: 0,
+            value: { x: 0, y: 0, z: 0 },
+        })).toBe(true);
+
+        const originalTrack = clip._tracks[0];
+        const snapshot = captureAnimationClipSnapshot(clip, { rootNode: root });
+        await restoreAnimationClipSnapshot(clip, snapshot, { rootNode: root });
+        expect(clip._tracks[0]).not.toBe(originalTrack);
+
+        root.children = [first];
+        expect(removePropertyCurve(clip, { rootNode: root, rootPath: '' }, {
+            nodeUuid: second.uuid,
+            propKey: 'position',
+        })).toBe(true);
+        expect(clip._tracks).toHaveLength(0);
+    });
+
+    it('rename 后重新缓存会移除旧 displayPath entry，不把新同名节点标记为 ambiguous', () => {
+        const { AnimationClip, Node, animation } = require('cc');
+        const { cacheNodeDisplayPaths, removePropertyCurve } = require('../scene-process/service/animation/property-curve');
+        const root = new Node('Root');
+        const first = new Node('Enemy');
+        root.children = [first];
+        cacheNodeDisplayPaths(root);
+
+        first.name = 'Soldier';
+        cacheNodeDisplayPaths(root, first);
+        const second = new Node('Enemy');
+        root.children.push(second);
+        cacheNodeDisplayPaths(root, second);
+
+        const clip = new AnimationClip();
+        const track = new animation.VectorTrack();
+        track.componentsCount = 3;
+        track.path.toHierarchy('Enemy').toProperty('position');
+        clip.addTrack(track);
+
+        root.children = [first];
+        expect(removePropertyCurve(clip, { rootNode: root, rootPath: '' }, {
+            nodeUuid: second.uuid,
+            propKey: 'position',
+        })).toBe(true);
+        expect(clip._tracks).toHaveLength(0);
+    });
+
+    it('removePropertyCurve 在轨道快照重建后也不把旧 UUID 轨道转交给新节点', async () => {
+        const { AnimationClip, Node } = require('cc');
+        const { cacheNodeDisplayPaths, createPropertyKey, removePropertyCurve } = require('../scene-process/service/animation/property-curve');
+        const { captureAnimationClipSnapshot, restoreAnimationClipSnapshot } = require('../scene-process/service/animation/clip-snapshot');
+        const root = new Node('Root');
+        const first = new Node('Enemy');
+        root.children = [first];
+        const clip = new AnimationClip();
+        expect(createPropertyKey(clip, { rootNode: root, rootPath: '' }, {
+            nodeUuid: first.uuid,
+            propKey: 'position',
+            frame: 0,
+            value: { x: 0, y: 0, z: 0 },
+        })).toBe(true);
+
+        first.name = 'Soldier';
+        cacheNodeDisplayPaths(root, first);
+        const second = new Node('Enemy');
+        root.children.push(second);
+        cacheNodeDisplayPaths(root, second);
+        root.children = [first];
+
+        const snapshot = captureAnimationClipSnapshot(clip, { rootNode: root });
+        await restoreAnimationClipSnapshot(clip, snapshot, { rootNode: root });
+
+        expect(removePropertyCurve(clip, { rootNode: root, rootPath: '' }, {
+            nodeUuid: second.uuid,
+            propKey: 'position',
+        })).toBe(false);
+        expect(clip._tracks).toHaveLength(1);
+    });
+
+    it('普通编辑和快照恢复都不会把旧轨道归属转交给新 UUID', async () => {
+        const { AnimationClip, Node } = require('cc');
+        const {
+            cacheNodeDisplayPaths,
+            createPropertyKey,
+            removePropertyCurve,
+            updatePropertyKey,
+        } = require('../scene-process/service/animation/property-curve');
+        const {
+            captureAnimationClipSnapshot,
+            restoreAnimationClipSnapshot,
+        } = require('../scene-process/service/animation/clip-snapshot');
+        const root = new Node('Root');
+        const first = new Node('Enemy');
+        root.children = [first];
+        const clip = new AnimationClip();
+        expect(createPropertyKey(clip, { rootNode: root, rootPath: '' }, {
+            nodeUuid: first.uuid,
+            propKey: 'position',
+            frame: 0,
+            value: { x: 0, y: 0, z: 0 },
+        })).toBe(true);
+        const before = captureAnimationClipSnapshot(clip, { rootNode: root });
+
+        first.name = 'Soldier';
+        cacheNodeDisplayPaths(root, first);
+        const second = new Node('Enemy');
+        root.children.push(second);
+        cacheNodeDisplayPaths(root, second);
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+        try {
+            expect(updatePropertyKey(clip, { rootNode: root, rootPath: '' }, {
+                nodeUuid: second.uuid,
+                propKey: 'position',
+                frame: 0,
+                value: { x: 1, y: 0, z: 0 },
+            })).toBe(false);
+            expect(warn).toHaveBeenCalledWith(expect.stringContaining('is owned by node'));
+        } finally {
+            warn.mockRestore();
+        }
+        const after = captureAnimationClipSnapshot(clip, { rootNode: root });
+        root.children = [first];
+
+        await restoreAnimationClipSnapshot(clip, before, { rootNode: root });
+        expect(removePropertyCurve(clip, { rootNode: root, rootPath: '' }, {
+            nodeUuid: second.uuid,
+            propKey: 'position',
+        })).toBe(false);
+
+        await restoreAnimationClipSnapshot(clip, after, { rootNode: root });
+        expect(removePropertyCurve(clip, { rootNode: root, rootPath: '' }, {
+            nodeUuid: second.uuid,
+            propKey: 'position',
+        })).toBe(false);
+        expect(clip._tracks).toHaveLength(1);
     });
 
     it('createPropertyKey 节点已删除时仍然拒绝（非 lenient）', () => {
@@ -1380,6 +1849,79 @@ describe('property-value 碰撞后缀路径解析', () => {
         );
 
         expect(capturedNodePath).toBe('Enemy');
+    });
+
+    it('nodePath 分支: 兼容唯一 display path，即使 system path 带去重后缀', async () => {
+        jest.resetModules();
+        const nodeMgr: any = {};
+        (global as any).EditorExtends = { Node: nodeMgr };
+        (global as any).cc = require('cc');
+
+        let capturedNodePath: string | undefined;
+        jest.doMock('../scene-process/service/animation/property-metadata', () => ({
+            queryAnimationPropertyMetadata: (_rootNode: any, nodePath: string) => {
+                capturedNodePath = nodePath;
+                return null;
+            },
+        }));
+
+        const { Node } = require('cc');
+        const { normalizeProvidedAnimationPropertyOperationValue } = require('../scene-process/service/animation/property-value');
+        const root = new Node('Root');
+        const enemy = new Node('Enemy');
+        root.children = [enemy];
+        nodeMgr.getNodeByPath = (path: string) => path === 'Root/Enemy_001' ? enemy : null;
+
+        await normalizeProvidedAnimationPropertyOperationValue(
+            root, 'Root',
+            {
+                type: 'createPropertyKey',
+                clipUuid: 'clip',
+                nodePath: 'Enemy',
+                propKey: 'position',
+                frame: 0,
+                value: { x: 0, y: 0, z: 0 },
+            },
+        );
+
+        expect(capturedNodePath).toBe('Enemy');
+    });
+
+    it('nodePath 分支: 相对路径同时命中不同 system/display 节点时拒绝解析', async () => {
+        jest.resetModules();
+        const nodeMgr: any = {};
+        (global as any).EditorExtends = { Node: nodeMgr };
+        (global as any).cc = require('cc');
+
+        let capturedNodePath: string | undefined;
+        jest.doMock('../scene-process/service/animation/property-metadata', () => ({
+            queryAnimationPropertyMetadata: (_rootNode: any, nodePath: string) => {
+                capturedNodePath = nodePath;
+                return null;
+            },
+        }));
+
+        const { Node } = require('cc');
+        const { normalizeProvidedAnimationPropertyOperationValue } = require('../scene-process/service/animation/property-value');
+        const root = new Node('Root');
+        const target = new Node('Enemy');
+        const literalPathNode = new Node('Enemy_1');
+        root.children = [target, literalPathNode];
+        nodeMgr.getNodeByPath = (path: string) => path === 'Root/Enemy_1' ? target : null;
+
+        await normalizeProvidedAnimationPropertyOperationValue(
+            root, 'Root',
+            {
+                type: 'createPropertyKey',
+                clipUuid: 'clip',
+                nodePath: 'Enemy_1',
+                propKey: 'position',
+                frame: 0,
+                value: { x: 0, y: 0, z: 0 },
+            },
+        );
+
+        expect(capturedNodePath).toBeUndefined();
     });
 
     it('同名兄弟时 resolveOperationRelativeNodePath 返回 null，value 原样返回', async () => {

--- a/src/core/scene/test/animation-service-enter.test.ts
+++ b/src/core/scene/test/animation-service-enter.test.ts
@@ -251,6 +251,54 @@ describe('AnimationService enter', () => {
         });
     });
 
+    it('caches the removed subtree paths before it leaves the animation root', () => {
+        const propertyCurve = require('../scene-process/service/animation/property-curve');
+        const cacheSpy = jest.spyOn(propertyCurve, 'cacheNodeDisplayPaths');
+        const service = new AnimationService() as any;
+        const removedNode = { uuid: 'removed-uuid', name: 'Enemy', children: [] };
+        const rootNode = { uuid: 'root-uuid', name: 'Root', children: [removedNode] };
+        service._session = { rootUuid: rootNode.uuid };
+        (globalThis as any).EditorExtends.Node.getNode.mockReturnValueOnce(rootNode);
+
+        service.onBeforeRemoveNode(removedNode);
+
+        expect(cacheSpy).toHaveBeenCalledWith(rootNode, removedNode);
+        cacheSpy.mockRestore();
+    });
+
+    it('refreshes the session root path after the animation root is renamed', async () => {
+        const service = new AnimationService() as any;
+        const rootNode = { uuid: 'root-uuid', name: 'RenamedRoot', children: [] };
+        service._session = {
+            rootUuid: rootNode.uuid,
+            rootPath: 'Canvas/OldRoot',
+            clipUuid: 'clip-uuid',
+            undoBaseline: { commandId: null, generation: 0 },
+            restoreSelectionOnExit: true,
+        };
+        (globalThis as any).EditorExtends.Node.getNode.mockReturnValueOnce(rootNode);
+        (globalThis as any).EditorExtends.Node.getNodePath.mockReturnValueOnce('Canvas/RenamedRoot');
+
+        const state = await service.queryState();
+
+        expect(state.rootPath).toBe('Canvas/RenamedRoot');
+        expect(service._session.rootPath).toBe('Canvas/RenamedRoot');
+    });
+
+    it('clears the root-scoped path cache when the animation session is disposed', () => {
+        const propertyCurve = require('../scene-process/service/animation/property-curve');
+        const clearSpy = jest.spyOn(propertyCurve, 'clearNodeDisplayPathCache');
+        const service = new AnimationService() as any;
+        const rootNode = { uuid: 'root-uuid', name: 'Root', children: [] };
+        service._session = { rootUuid: rootNode.uuid };
+        (globalThis as any).EditorExtends.Node.getNode.mockReturnValueOnce(rootNode);
+
+        service.onEditorClosed();
+
+        expect(clearSpy).toHaveBeenCalledWith(rootNode);
+        clearSpy.mockRestore();
+    });
+
     it('waits for animation state initialization before sampling time zero', async () => {
         const { Animation } = require('cc');
         const service = new AnimationService() as any;
@@ -557,7 +605,7 @@ describe('AnimationService enter', () => {
 
         expect(service._restoreClipSnapshotWithStateRecreation).toHaveBeenCalledWith('clip-uuid', currentClip, expect.objectContaining({
             events: [{ frame: 0, func: 'before-save', params: ['ok'] }],
-        }), true);
+        }), rootNode, true);
         expect(service._animationStates.reset).toHaveBeenCalledWith('clip-uuid');
         expect(service._animationStates.create).toHaveBeenCalledWith('clip-uuid', currentClip);
         expect(service.setTime).toHaveBeenCalledWith({ time: 0 });

--- a/src/core/scene/test/animation-service-enter.test.ts
+++ b/src/core/scene/test/animation-service-enter.test.ts
@@ -525,6 +525,48 @@ describe('AnimationService enter', () => {
         }
     });
 
+    it('prefers nodePath over a stale nodeUuid and supports nodeUuid-only frame queries', () => {
+        const pathNode = { uuid: 'path-node', name: 'Body', children: [] };
+        const uuidNode = { uuid: 'legacy-node', name: 'Legacy', children: [] };
+        const rootNode = {
+            uuid: 'root-uuid',
+            name: 'AnimatedRoot',
+            children: [pathNode, uuidNode],
+            getChildByPath: jest.fn((path: string) => (
+                path === 'Body' ? pathNode : path === 'Legacy' ? uuidNode : null
+            )),
+        };
+        const session = { rootUuid: rootNode.uuid, rootPath: 'Canvas/AnimatedRoot' };
+        const nodeManager = (globalThis as any).EditorExtends.Node;
+        nodeManager.getNode.mockImplementation((uuid: string) => uuid === rootNode.uuid ? rootNode : null);
+        nodeManager.getNodeByPath.mockImplementation((path: string) => (
+            path === 'Canvas/AnimatedRoot/Body' ? pathNode : null
+        ));
+
+        try {
+            expect(resolveAnimationFrameQueryNode({
+                nodePath: 'Canvas/AnimatedRoot/Body',
+                nodeUuid: uuidNode.uuid,
+                propKey: 'position',
+                frame: 0,
+            }, session)).toBe(pathNode);
+            expect(resolveAnimationFrameQueryNode({
+                nodeUuid: uuidNode.uuid,
+                propKey: 'position',
+                frame: 0,
+            }, session)).toBe(uuidNode);
+            expect(resolveAnimationFrameQueryNode({
+                nodePath: 'Canvas/AnimatedRoot/Missing',
+                nodeUuid: uuidNode.uuid,
+                propKey: 'position',
+                frame: 0,
+            }, session)).toBe(uuidNode);
+        } finally {
+            nodeManager.getNode.mockReset();
+            nodeManager.getNodeByPath.mockReset();
+        }
+    });
+
     it('waits for animation state initialization before sampling time zero', async () => {
         const { Animation } = require('cc');
         const service = new AnimationService() as any;

--- a/src/core/scene/test/animation-service-enter.test.ts
+++ b/src/core/scene/test/animation-service-enter.test.ts
@@ -210,23 +210,170 @@ describe('AnimationService enter', () => {
     });
 
 
-    it('refreshes the session root path after the animation root is renamed', async () => {
+    it.each([
+        ['the animation root is renamed', 'Canvas/OldRoot', 'Canvas/RenamedRoot'],
+        ['the animation root is moved', 'Canvas/AnimatedRoot', 'UI/AnimatedRoot'],
+        ['an ancestor is renamed', 'Canvas/OldGroup/AnimatedRoot', 'Canvas/RenamedGroup/AnimatedRoot'],
+    ])('refreshes the session root path after %s', async (_scenario, oldPath, currentPath) => {
         const service = new AnimationService() as any;
-        const rootNode = { uuid: 'root-uuid', name: 'RenamedRoot', children: [] };
+        const rootNode = { uuid: 'root-uuid', name: 'AnimatedRoot', children: [] };
         service._session = {
             rootUuid: rootNode.uuid,
-            rootPath: 'Canvas/OldRoot',
+            rootPath: oldPath,
             clipUuid: 'clip-uuid',
             undoBaseline: { commandId: null, generation: 0 },
             restoreSelectionOnExit: true,
         };
         (globalThis as any).EditorExtends.Node.getNode.mockReturnValueOnce(rootNode);
-        (globalThis as any).EditorExtends.Node.getNodePath.mockReturnValueOnce('Canvas/RenamedRoot');
+        (globalThis as any).EditorExtends.Node.getNodePath.mockReturnValueOnce(currentPath);
 
         const state = await service.queryState();
 
-        expect(state.rootPath).toBe('Canvas/RenamedRoot');
-        expect(service._session.rootPath).toBe('Canvas/RenamedRoot');
+        expect(state.rootPath).toBe(currentPath);
+        expect(service._session.rootPath).toBe(currentPath);
+    });
+
+    it('keeps the last valid session root path while the path index is temporarily unavailable', async () => {
+        const service = new AnimationService() as any;
+        const rootNode = { uuid: 'root-uuid', name: 'AnimatedRoot', children: [] };
+        service._session = {
+            rootUuid: rootNode.uuid,
+            rootPath: 'Canvas/AnimatedRoot',
+            clipUuid: 'clip-uuid',
+            undoBaseline: { commandId: null, generation: 0 },
+            restoreSelectionOnExit: true,
+        };
+        (globalThis as any).EditorExtends.Node.getNode.mockReturnValueOnce(rootNode);
+        (globalThis as any).EditorExtends.Node.getNodePath.mockReturnValueOnce('');
+
+        const state = await service.queryState();
+
+        expect(state.rootPath).toBe('Canvas/AnimatedRoot');
+        expect(service._session.rootPath).toBe('Canvas/AnimatedRoot');
+    });
+
+    it('keeps the last valid session root path while the root UUID index is temporarily unavailable', async () => {
+        const service = new AnimationService() as any;
+        service._session = {
+            rootUuid: 'root-uuid',
+            rootPath: 'Canvas/AnimatedRoot',
+            clipUuid: 'clip-uuid',
+            undoBaseline: { commandId: null, generation: 0 },
+            restoreSelectionOnExit: true,
+        };
+        (globalThis as any).EditorExtends.Node.getNode.mockReturnValueOnce(null);
+
+        const state = await service.queryState();
+
+        expect(state.rootPath).toBe('Canvas/AnimatedRoot');
+        expect(service._session.rootPath).toBe('Canvas/AnimatedRoot');
+        expect((globalThis as any).EditorExtends.Node.getNodePath).not.toHaveBeenCalled();
+    });
+
+    it('does not clear the cached root path when resolving the session root during path reindexing', () => {
+        const service = new AnimationService() as any;
+        const rootNode = { uuid: 'root-uuid', name: 'AnimatedRoot', children: [] };
+        service._session = {
+            rootUuid: rootNode.uuid,
+            rootPath: 'Canvas/AnimatedRoot',
+            clipUuid: 'clip-uuid',
+        };
+        (globalThis as any).EditorExtends.Node.getNode.mockReturnValueOnce(rootNode);
+        (globalThis as any).EditorExtends.Node.getNodePath.mockReturnValueOnce('');
+
+        expect(service._getSessionRootNode()).toBe(rootNode);
+        expect(service._session.rootPath).toBe('Canvas/AnimatedRoot');
+    });
+
+    it('uses the current in-memory clip state when queryClip receives the refreshed root path', async () => {
+        const { AnimationClip } = require('cc');
+        const service = new AnimationService() as any;
+        const clip = new AnimationClip();
+        clip._uuid = 'clip-uuid';
+        clip.name = 'Current';
+        const state = { clip, current: 0.75 };
+        const rootNode = {
+            uuid: 'root-uuid',
+            name: 'AnimatedRoot',
+            children: [],
+            components: [],
+            getComponent: jest.fn(() => null),
+        };
+        service._session = {
+            rootUuid: rootNode.uuid,
+            rootPath: 'Canvas/OldGroup/AnimatedRoot',
+            clipUuid: clip._uuid,
+        };
+        service._animationStates.get = jest.fn(() => state);
+        service._resolveClipForQuery = jest.fn(() => {
+            throw new Error('queryClip fell back to resolving a stale root path');
+        });
+
+        const editorNode = (globalThis as any).EditorExtends.Node;
+        editorNode.getNode.mockImplementation(() => rootNode);
+        editorNode.getNodePath.mockReturnValue('Canvas/RenamedGroup/AnimatedRoot');
+        try {
+            const dump = await service.queryClip({
+                rootPath: 'Canvas/RenamedGroup/AnimatedRoot',
+                clipUuid: clip._uuid,
+            });
+
+            expect(dump.time).toBe(0.75);
+            expect(service._session.rootPath).toBe('Canvas/RenamedGroup/AnimatedRoot');
+            expect(service._animationStates.get).toHaveBeenCalledWith(clip._uuid);
+            expect(service._resolveClipForQuery).not.toHaveBeenCalled();
+        } finally {
+            editorNode.getNode.mockReset();
+            editorNode.getNodePath.mockReset().mockReturnValue('Canvas/AnimatedRoot');
+        }
+    });
+
+    it('broadcasts the refreshed root path after the animation root path changes', () => {
+        const service = new AnimationService() as any;
+        const rootNode = { uuid: 'root-uuid', name: 'AnimatedRoot', children: [] };
+        service._session = {
+            rootUuid: rootNode.uuid,
+            rootPath: 'Canvas/AnimatedRoot',
+            clipUuid: 'clip-uuid',
+        };
+        service._curEditTime = 0.5;
+        service._playState = 'stop';
+        service.broadcast = jest.fn();
+        (globalThis as any).EditorExtends.Node.getNode.mockReturnValueOnce(rootNode);
+        (globalThis as any).EditorExtends.Node.getNodePath.mockReturnValueOnce('UI/AnimatedRoot');
+
+        service._broadcastTimeChanged('set-time');
+
+        expect(service.broadcast).toHaveBeenCalledWith('animation:time-changed', {
+            reason: 'set-time',
+            rootUuid: rootNode.uuid,
+            rootPath: 'UI/AnimatedRoot',
+            clipUuid: 'clip-uuid',
+            time: 0.5,
+            playState: 'stop',
+        });
+    });
+
+    it('broadcasts clip changes with the refreshed root path', () => {
+        const service = new AnimationService() as any;
+        const rootNode = { uuid: 'root-uuid', name: 'AnimatedRoot', children: [] };
+        service._session = {
+            rootUuid: rootNode.uuid,
+            rootPath: 'Canvas/AnimatedRoot',
+            clipUuid: 'clip-uuid',
+        };
+        service.broadcast = jest.fn();
+        (globalThis as any).EditorExtends.Node.getNode.mockReturnValueOnce(rootNode);
+        (globalThis as any).EditorExtends.Node.getNodePath.mockReturnValueOnce('UI/AnimatedRoot');
+
+        service._broadcastClipChanged('operation');
+
+        expect(service.broadcast).toHaveBeenCalledWith('animation:clip-changed', {
+            reason: 'operation',
+            rootUuid: rootNode.uuid,
+            rootPath: 'UI/AnimatedRoot',
+            clipUuid: 'clip-uuid',
+        });
     });
 
     it('frame query rejects a later same-name sibling and accepts it after it becomes first', () => {
@@ -262,6 +409,119 @@ describe('AnimationService enter', () => {
         } finally {
             warn.mockRestore();
             getNode.mockReset();
+        }
+    });
+
+    it('applyOperations rejects a later same-name sibling before mutating the clip', async () => {
+        const service = new AnimationService() as any;
+        const first = { uuid: 'enemy-a', name: 'Enemy', children: [] };
+        const second = { uuid: 'enemy-b', name: 'Enemy', children: [] };
+        const rootNode = {
+            uuid: 'root-uuid',
+            name: 'Root',
+            components: [],
+            children: [first, second],
+            getChildByPath: jest.fn(() => first),
+            getComponent: jest.fn(() => null),
+        };
+        const clip = {
+            _uuid: 'clip-uuid',
+            _tracks: [],
+            sample: 30,
+            duration: 0,
+            speed: 1,
+            wrapMode: 1,
+            events: [],
+        };
+        service._session = {
+            rootUuid: rootNode.uuid,
+            rootPath: 'Root',
+            clipUuid: clip._uuid,
+        };
+        service._getSessionRootNode = jest.fn(() => rootNode);
+        service._getAnimationState = jest.fn(async () => ({ clip }));
+        service._resetAnimationStatePreservingClip = jest.fn();
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        try {
+            await expect(service.applyOperations({
+                operations: [{
+                    type: 'createPropertyKey',
+                    clipUuid: clip._uuid,
+                    nodeUuid: second.uuid,
+                    propKey: 'position',
+                    frame: 0,
+                    value: { x: 1, y: 2, z: 3 },
+                }],
+                recordUndo: false,
+            })).resolves.toEqual({
+                state: 'failure',
+                result: false,
+                reason: expect.stringContaining(second.uuid),
+            });
+            expect(service._resetAnimationStatePreservingClip).not.toHaveBeenCalled();
+            expect(clip._tracks).toHaveLength(0);
+            expect(warn).toHaveBeenCalledWith(expect.stringContaining(second.uuid));
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    it('applyOperations restores earlier changes when a later property target is rejected', async () => {
+        const service = new AnimationService() as any;
+        const first = { uuid: 'enemy-a', name: 'Enemy', children: [] };
+        const second = { uuid: 'enemy-b', name: 'Enemy', children: [] };
+        const rootNode = {
+            uuid: 'root-uuid',
+            name: 'Root',
+            components: [],
+            children: [first, second],
+            getChildByPath: jest.fn(() => first),
+            getComponent: jest.fn(() => null),
+        };
+        const clip = {
+            _uuid: 'clip-uuid',
+            _tracks: [],
+            sample: 30,
+            duration: 0,
+            speed: 1,
+            wrapMode: 1,
+            events: [],
+        };
+        service._session = {
+            rootUuid: rootNode.uuid,
+            rootPath: 'Root',
+            clipUuid: clip._uuid,
+        };
+        service._getSessionRootNode = jest.fn(() => rootNode);
+        service._getAnimationState = jest.fn(async () => ({ clip }));
+        service._resetAnimationStatePreservingClip = jest.fn(async () => undefined);
+        service._restoreFailedOperationSnapshot = jest.fn(async () => undefined);
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        try {
+            await expect(service.applyOperations({
+                operations: [
+                    { type: 'changeSample', clipUuid: clip._uuid, sample: 60 },
+                    {
+                        type: 'createPropertyKey',
+                        clipUuid: clip._uuid,
+                        nodeUuid: second.uuid,
+                        propKey: 'position',
+                        frame: 0,
+                        value: { x: 1, y: 2, z: 3 },
+                    },
+                ],
+                recordUndo: false,
+            })).resolves.toEqual({
+                state: 'failure',
+                result: false,
+                reason: expect.stringContaining(second.uuid),
+            });
+            expect(service._resetAnimationStatePreservingClip).toHaveBeenCalledTimes(1);
+            expect(service._restoreFailedOperationSnapshot).toHaveBeenCalledTimes(1);
+        } finally {
+            warn.mockRestore();
         }
     });
 
@@ -657,7 +917,10 @@ describe('AnimationService enter', () => {
                 rootNode.position = current === 0.5 ? { x: 10, y: 11, z: 12 } : { x: 4, y: 5, z: 6 };
             }),
         };
-        (globalThis as any).EditorExtends.Node.getNodeByPath.mockReturnValue(rootNode);
+        (globalThis as any).EditorExtends.Node.getNode
+            .mockReturnValueOnce(rootNode)
+            .mockReturnValueOnce(rootNode);
+        (globalThis as any).EditorExtends.Node.getNodePath.mockReturnValueOnce('UI/AnimatedRoot');
         service._session = {
             clipUuid: 'clip-uuid',
             rootUuid: rootNode.uuid,
@@ -668,12 +931,13 @@ describe('AnimationService enter', () => {
 
         const value = await service.queryPropertyValueAtFrame({
             clipUuid: 'clip-uuid',
-            nodePath: 'Canvas/AnimatedRoot',
+            nodePath: 'UI/AnimatedRoot',
             propKey: 'position',
             frame: 15,
         });
 
         expect(value).toEqual({ x: 10, y: 11, z: 12 });
+        expect(service._session.rootPath).toBe('UI/AnimatedRoot');
         expect(state.pause).toHaveBeenCalled();
         expect(state.resume).toHaveBeenCalled();
         expect(state.current).toBe(0.4);

--- a/src/core/scene/test/animation-service-enter.test.ts
+++ b/src/core/scene/test/animation-service-enter.test.ts
@@ -96,7 +96,10 @@ jest.mock('../scene-process/service/animation/service-save', () => ({
 };
 
 const { AnimationService } = require('../scene-process/service/animation');
-const { isCurrentAnimationSessionClipQuery, resolveAnimationFrameQueryNode } = require('../scene-process/service/animation/service-target');
+const {
+    isCurrentAnimationSessionClipQuery,
+    resolveAnimationFrameQueryNode,
+} = require('../scene-process/service/animation/service-target');
 const { normalizeAnimationOperation } = require('../scene-process/service/animation/operation-normalizer');
 const { saveAnimationServiceClip: saveAnimationServiceClipMock } = require('../scene-process/service/animation/service-save');
 
@@ -206,65 +209,6 @@ describe('AnimationService enter', () => {
         }, 'clip-uuid', true)).toBe(true);
     });
 
-    it('prefers nodePath over a stale nodeUuid and supports nodeUuid-only frame queries', () => {
-        const nodeByPath = { uuid: 'path-node' };
-        const nodeByUuid = { uuid: 'uuid-node' };
-        const nodeManager = (globalThis as any).EditorExtends.Node;
-        nodeManager.getNode.mockImplementation((uuid: string) => uuid === 'legacy-node' ? nodeByUuid : null);
-        nodeManager.getNodeByPath.mockImplementation((path: string) => path === 'Canvas/AnimatedRoot/Body' ? nodeByPath : null);
-        const session = { rootPath: 'Canvas/AnimatedRoot' };
-
-        expect(resolveAnimationFrameQueryNode({
-            nodePath: 'Canvas/AnimatedRoot/Body',
-            nodeUuid: 'legacy-node',
-            propKey: 'position',
-            frame: 0,
-        }, session)).toBe(nodeByPath);
-        expect(resolveAnimationFrameQueryNode({
-            nodeUuid: 'legacy-node',
-            propKey: 'position',
-            frame: 0,
-        }, session)).toBe(nodeByUuid);
-    });
-
-    it('forwards nodeUuid-only property keys to frame sampling', async () => {
-        const queryPropertyValueAtFrame = jest.fn(async () => true);
-
-        await expect(normalizeAnimationOperation({
-            type: 'createPropertyKey',
-            clipUuid: 'clip-uuid',
-            nodeUuid: 'legacy-node',
-            propKey: 'active',
-            frame: 0,
-        }, {
-            currentClipUuid: 'current-clip',
-            rootNode: {},
-            rootPath: 'Canvas/AnimatedRoot',
-            queryPropertyValueAtFrame,
-        })).resolves.toMatchObject({ value: true });
-        expect(queryPropertyValueAtFrame).toHaveBeenCalledWith({
-            clipUuid: 'clip-uuid',
-            nodePath: undefined,
-            nodeUuid: 'legacy-node',
-            propKey: 'active',
-            frame: 0,
-        });
-    });
-
-    it('caches the removed subtree paths before it leaves the animation root', () => {
-        const propertyCurve = require('../scene-process/service/animation/property-curve');
-        const cacheSpy = jest.spyOn(propertyCurve, 'cacheNodeDisplayPaths');
-        const service = new AnimationService() as any;
-        const removedNode = { uuid: 'removed-uuid', name: 'Enemy', children: [] };
-        const rootNode = { uuid: 'root-uuid', name: 'Root', children: [removedNode] };
-        service._session = { rootUuid: rootNode.uuid };
-        (globalThis as any).EditorExtends.Node.getNode.mockReturnValueOnce(rootNode);
-
-        service.onBeforeRemoveNode(removedNode);
-
-        expect(cacheSpy).toHaveBeenCalledWith(rootNode, removedNode);
-        cacheSpy.mockRestore();
-    });
 
     it('refreshes the session root path after the animation root is renamed', async () => {
         const service = new AnimationService() as any;
@@ -285,18 +229,40 @@ describe('AnimationService enter', () => {
         expect(service._session.rootPath).toBe('Canvas/RenamedRoot');
     });
 
-    it('clears the root-scoped path cache when the animation session is disposed', () => {
-        const propertyCurve = require('../scene-process/service/animation/property-curve');
-        const clearSpy = jest.spyOn(propertyCurve, 'clearNodeDisplayPathCache');
-        const service = new AnimationService() as any;
-        const rootNode = { uuid: 'root-uuid', name: 'Root', children: [] };
-        service._session = { rootUuid: rootNode.uuid };
-        (globalThis as any).EditorExtends.Node.getNode.mockReturnValueOnce(rootNode);
+    it('frame query rejects a later same-name sibling and accepts it after it becomes first', () => {
+        const first = { uuid: 'enemy-a', name: 'Enemy', children: [] };
+        const second = { uuid: 'enemy-b', name: 'Enemy', children: [] };
+        const rootNode = {
+            uuid: 'root-uuid',
+            name: 'Root',
+            children: [first, second],
+            getChildByPath: jest.fn(() => first),
+        };
+        const session = { rootUuid: rootNode.uuid, rootPath: 'Root' };
+        const getNode = (globalThis as any).EditorExtends.Node.getNode;
+        getNode.mockImplementation((uuid: string) => (
+            uuid === rootNode.uuid ? rootNode : null
+        ));
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
 
-        service.onEditorClosed();
+        try {
+            expect(() => resolveAnimationFrameQueryNode({
+                nodeUuid: second.uuid,
+                propKey: 'position',
+                frame: 0,
+            }, session)).toThrow('not bound by the current animation hierarchy');
 
-        expect(clearSpy).toHaveBeenCalledWith(rootNode);
-        clearSpy.mockRestore();
+            rootNode.children = [second];
+            rootNode.getChildByPath.mockReturnValue(second);
+            expect(resolveAnimationFrameQueryNode({
+                nodeUuid: second.uuid,
+                propKey: 'position',
+                frame: 0,
+            }, session)).toBe(second);
+        } finally {
+            warn.mockRestore();
+            getNode.mockReset();
+        }
     });
 
     it('waits for animation state initialization before sampling time zero', async () => {
@@ -605,7 +571,7 @@ describe('AnimationService enter', () => {
 
         expect(service._restoreClipSnapshotWithStateRecreation).toHaveBeenCalledWith('clip-uuid', currentClip, expect.objectContaining({
             events: [{ frame: 0, func: 'before-save', params: ['ok'] }],
-        }), rootNode, true);
+        }), true);
         expect(service._animationStates.reset).toHaveBeenCalledWith('clip-uuid');
         expect(service._animationStates.create).toHaveBeenCalledWith('clip-uuid', currentClip);
         expect(service.setTime).toHaveBeenCalledWith({ time: 0 });

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -1136,7 +1136,7 @@ describe('Animation Service 场景进程测试', () => {
                 ],
                 recordUndo: false,
             }]);
-            expect(firstResult).toEqual({ state: 'success', result: true });
+            expect(firstResult).toEqual({ state: 'success', result: true, undoRecorded: false });
 
             const rejected = await request('applyOperations', [{
                 operations: [
@@ -1157,7 +1157,7 @@ describe('Animation Service 场景进程测试', () => {
                 ],
                 recordUndo: false,
             }]);
-            expect(secondResult).toEqual({ state: 'success', result: true });
+            expect(secondResult).toEqual({ state: 'success', result: true, undoRecorded: false });
 
             const dump = await request('queryClip', [{ rootPath, clipUuid: duplicateClipUuid }]);
             const curve = dump.curves.find((item: any) => item.nodePath === duplicateName && item.key === 'position');

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -1106,6 +1106,74 @@ describe('Animation Service 场景进程测试', () => {
         expect(sampled).toMatchObject({ x: 7, y: 8, z: 9 });
     });
 
+    it('applyOperations 通过 UUID 只操作同名节点当前绑定的第一个节点', async () => {
+        const { nodePath: rootPath, clipUuid: duplicateClipUuid } = await createIsolatedAnimationNode('AnimationServiceDuplicateNameCase', { duration: 0 });
+        const duplicateName = `AnimationServiceDuplicateTarget_${testRunId}`;
+        const first = await NodeProxy.createByType({
+            path: rootPath,
+            name: duplicateName,
+            nodeType: NodeType.EMPTY,
+        });
+        const second = await NodeProxy.createByType({
+            path: rootPath,
+            name: duplicateName,
+            nodeType: NodeType.EMPTY,
+        });
+        if (!first || !second) {
+            throw new Error('Failed to create duplicate-name animation targets.');
+        }
+
+        try {
+            expect(first.name).toBe(duplicateName);
+            expect(second.name).toBe(duplicateName);
+            expect(first.path).not.toBe(second.path);
+            await ensureAnimationSession(rootPath, duplicateClipUuid);
+
+            const firstResult = await request('applyOperations', [{
+                operations: [
+                    { type: 'addPropertyCurve', clipUuid: duplicateClipUuid, nodeUuid: first.nodeId, propKey: 'position', value: { x: 0, y: 0, z: 0 } },
+                    { type: 'createPropertyKey', clipUuid: duplicateClipUuid, nodeUuid: first.nodeId, propKey: 'position', frame: 0, value: { x: 1, y: 2, z: 3 } },
+                ],
+                recordUndo: false,
+            }]);
+            expect(firstResult).toEqual({ state: 'success', result: true });
+
+            const rejected = await request('applyOperations', [{
+                operations: [
+                    { type: 'createPropertyKey', clipUuid: duplicateClipUuid, nodeUuid: second.nodeId, propKey: 'position', frame: 30, value: { x: 4, y: 5, z: 6 } },
+                ],
+                recordUndo: false,
+            }]);
+            expect(rejected).toMatchObject({
+                state: 'failure',
+                result: false,
+                reason: expect.stringContaining(second.nodeId),
+            });
+
+            await NodeProxy.delete({ path: first.path, keepWorldTransform: false });
+            const secondResult = await request('applyOperations', [{
+                operations: [
+                    { type: 'createPropertyKey', clipUuid: duplicateClipUuid, nodeUuid: second.nodeId, propKey: 'position', frame: 30, value: { x: 4, y: 5, z: 6 } },
+                ],
+                recordUndo: false,
+            }]);
+            expect(secondResult).toEqual({ state: 'success', result: true });
+
+            const dump = await request('queryClip', [{ rootPath, clipUuid: duplicateClipUuid }]);
+            const curve = dump.curves.find((item: any) => item.nodePath === duplicateName && item.key === 'position');
+            expect(curve?.keyframes).toEqual(expect.arrayContaining([
+                expect.objectContaining({ frame: 0 }),
+                expect.objectContaining({ frame: 30 }),
+            ]));
+        } finally {
+            const state = await request('queryState');
+            if (state.active) {
+                await request('exit', [{ save: false, restoreSelection: false, restoreSampledSceneState: false }]);
+            }
+            await NodeProxy.delete({ path: rootPath, keepWorldTransform: false }).catch(() => undefined);
+        }
+    });
+
     it('applyOperations 支持普通属性曲线的创建、更新、复制、批量删除和 extrapolation', async () => {
         await ensureAnimationSession(nodePath, clipUuid);
 

--- a/src/core/scene/test/animation-snapshot-undo.test.ts
+++ b/src/core/scene/test/animation-snapshot-undo.test.ts
@@ -62,7 +62,11 @@ jest.mock('../scene-process/service/animation/auxiliary-curve', () => ({
 
 import { editorExtrasTag } from 'cc';
 import { SceneUndoManager } from '../scene-process/service/undo/scene-undo-manager';
-import { restoreAnimationClipSnapshot, type IAnimationClipSnapshot } from '../scene-process/service/animation/clip-snapshot';
+import {
+    animationClipSnapshotsEqual,
+    restoreAnimationClipSnapshot,
+    type IAnimationClipSnapshot,
+} from '../scene-process/service/animation/clip-snapshot';
 import { AnimationClipSnapshotCommand } from '../scene-process/service/animation/undo';
 
 function createSnapshot(partial: Partial<IAnimationClipSnapshot> = {}): IAnimationClipSnapshot {
@@ -169,6 +173,17 @@ describe('Animation clip snapshot undo', () => {
             ],
             requestedUuids: [spriteFrameA._uuid, spriteFrameB._uuid],
         });
+    });
+
+    it('does not treat internal property track ownership as clip asset data', () => {
+        const before = createSnapshot({
+            propertyTrackOwners: { '["Enemy","position"]': 'old-uuid' },
+        });
+        const after = createSnapshot({
+            propertyTrackOwners: { '["Enemy","position"]': 'new-uuid' },
+        });
+
+        expect(animationClipSnapshotsEqual(before, after)).toBe(true);
     });
 
     it('treats empty embedded players as a restorable state for zero-duration child addPropertyCurve undo/redo', async () => {

--- a/src/core/scene/test/animation-snapshot-undo.test.ts
+++ b/src/core/scene/test/animation-snapshot-undo.test.ts
@@ -62,11 +62,7 @@ jest.mock('../scene-process/service/animation/auxiliary-curve', () => ({
 
 import { editorExtrasTag } from 'cc';
 import { SceneUndoManager } from '../scene-process/service/undo/scene-undo-manager';
-import {
-    animationClipSnapshotsEqual,
-    restoreAnimationClipSnapshot,
-    type IAnimationClipSnapshot,
-} from '../scene-process/service/animation/clip-snapshot';
+import { restoreAnimationClipSnapshot, type IAnimationClipSnapshot } from '../scene-process/service/animation/clip-snapshot';
 import { AnimationClipSnapshotCommand } from '../scene-process/service/animation/undo';
 
 function createSnapshot(partial: Partial<IAnimationClipSnapshot> = {}): IAnimationClipSnapshot {
@@ -173,17 +169,6 @@ describe('Animation clip snapshot undo', () => {
             ],
             requestedUuids: [spriteFrameA._uuid, spriteFrameB._uuid],
         });
-    });
-
-    it('does not treat internal property track ownership as clip asset data', () => {
-        const before = createSnapshot({
-            propertyTrackOwners: { '["Enemy","position"]': 'old-uuid' },
-        });
-        const after = createSnapshot({
-            propertyTrackOwners: { '["Enemy","position"]': 'new-uuid' },
-        });
-
-        expect(animationClipSnapshotsEqual(before, after)).toBe(true);
     });
 
     it('treats empty embedded players as a restorable state for zero-duration child addPropertyCurve undo/redo', async () => {

--- a/src/core/scene/test/node-for-editor.testcase.ts
+++ b/src/core/scene/test/node-for-editor.testcase.ts
@@ -226,9 +226,8 @@ describe('Node ForEditor 接口测试', () => {
             });
             expect(result).toBe(true);
 
-            const segments = oldPath.split('/');
-            segments[segments.length - 1] = 'RenamedNode';
-            const newPath = segments.join('/');
+            const nodeUuid = dump.uuid.value as string;
+            const newPath = await rpcRequest('getPathByUuid', [nodeUuid]) as string;
             testNode!.path = newPath;
 
             const updatedDump = await queryNodeDump(newPath) as INode;
@@ -784,6 +783,207 @@ describe('Node ForEditor 接口测试', () => {
                 }
             }
             expect(count).toBeGreaterThan(0);
+        });
+    });
+
+    describe('10. name 与 path 解耦 - 允许同名节点', () => {
+        const parentPath = '/';
+
+        async function createNode(name: string, path = parentPath): Promise<INodeInfo> {
+            const node = await NodeProxy.createByType({ path, name, nodeType: NodeType.EMPTY });
+            expect(node).toBeDefined();
+            return node!;
+        }
+
+        async function deleteNode(path: string) {
+            try {
+                await NodeProxy.delete({ path, keepWorldTransform: false });
+            } catch {
+                // ignore if already deleted
+            }
+        }
+
+        async function renameNode(nodePath: string, newName: string): Promise<{ name: string; path: string }> {
+            const dump = await queryNodeDump(nodePath) as INode;
+            await setNodeProperty({
+                nodePath,
+                path: 'name',
+                dump: { ...dump.name, value: newName },
+            });
+            const nodeUuid = dump.uuid.value as string;
+            const realPath = await rpcRequest('getPathByUuid', [nodeUuid]) as string;
+            const updatedDump = await queryNodeDump(realPath) as INode;
+            return { name: updatedDump.name.value as string, path: realPath };
+        }
+
+        it('场景1：重命名为与兄弟同名后，再次重命名为另一个名字', async () => {
+            const nodeA = await createNode('Enemy');
+            const nodeB = await createNode('Soldier');
+            let currentBPath = nodeB.path;
+
+            try {
+                // 把 B 重命名为 "Enemy"（与 A 同名）
+                const afterFirst = await renameNode(nodeB.path, 'Enemy');
+                currentBPath = afterFirst.path;
+                expect(afterFirst.name).toBe('Enemy');
+                // path 应该唯一，不等于 A 的 path
+                expect(afterFirst.path).not.toBe(nodeA.path);
+
+                // 再次把 B 重命名为 "Ally"（不冲突）
+                const afterSecond = await renameNode(afterFirst.path, 'Ally');
+                currentBPath = afterSecond.path;
+                expect(afterSecond.name).toBe('Ally');
+                expect(afterSecond.path).toContain('Ally');
+
+                // A 的路径不应受影响
+                const aDump = await queryNodeDump(nodeA.path);
+                expect(aDump).not.toBeNull();
+            } finally {
+                try { await deleteNode(currentBPath); } catch { /* */ }
+                try { await deleteNode(nodeA.path); } catch { /* */ }
+            }
+        });
+
+        it('场景2：重命名为同名的节点被删除后，创建同名新节点', async () => {
+            const nodeA = await createNode('Target');
+            const nodeB = await createNode('Other');
+            let currentBPath = nodeB.path;
+
+            try {
+                // 把 B 重命名为 "Target"（与 A 同名）
+                const renamedB = await renameNode(nodeB.path, 'Target');
+                currentBPath = renamedB.path;
+                expect(renamedB.name).toBe('Target');
+
+                // 删除 A
+                await deleteNode(nodeA.path);
+
+                // 创建同名新节点
+                const nodeC = await createNode('Target');
+                // 新节点应该成功创建，路径唯一
+                expect(nodeC).toBeDefined();
+                expect(nodeC.path).not.toBe(renamedB.path);
+
+                // B 的路径不应受影响
+                const bDump = await queryNodeDump(renamedB.path);
+                expect(bDump).not.toBeNull();
+
+                await deleteNode(nodeC.path);
+            } finally {
+                try { await deleteNode(currentBPath); } catch { /* */ }
+                try { await deleteNode(nodeA.path); } catch { /* */ }
+            }
+        });
+
+        it('场景3：移动节点到已存在同名节点的父节点下', async () => {
+            // 创建目标父节点
+            const parent = await createNode('MoveParent');
+            // 在 parent 下创建一个叫 "Child" 的节点
+            const existingChild = await createNode('Child', parent.path);
+            // 在根下创建另一个叫 "Child" 的节点
+            const movingNode = await createNode('Child');
+
+            try {
+                // 移动 movingNode 到 parent 下（同名冲突）
+                const result = await rpcRequest('setParent', [{ paths: [movingNode.path], parentPath: parent.path }]) as string[];
+                expect(result).toBeDefined();
+                expect(result.length).toBe(1);
+                const movedPath = result[0];
+
+                // 移入后路径应唯一，不等于 existingChild 的路径
+                expect(movedPath).not.toBe(existingChild.path);
+
+                // existingChild 的路径不应受影响
+                const existingDump = await queryNodeDump(existingChild.path);
+                expect(existingDump).not.toBeNull();
+
+                await deleteNode(movedPath);
+            } finally {
+                try { await deleteNode(existingChild.path); } catch { /* */ }
+                try { await deleteNode(parent.path); } catch { /* */ }
+                try { await deleteNode(movingNode.path); } catch { /* */ }
+            }
+        });
+
+        it('场景4：父节点重命名后，子树路径全部更新', async () => {
+            const parent = await createNode('OldParent');
+            const child = await createNode('ChildA', parent.path);
+
+            try {
+                const oldChildPath = child.path;
+
+                // 重命名父节点
+                const renamedParent = await renameNode(parent.path, 'NewParent');
+                expect(renamedParent.name).toBe('NewParent');
+                expect(renamedParent.path).toContain('NewParent');
+
+                // 子节点路径应级联更新
+                const childDump = await queryNodeDump(oldChildPath);
+                expect(childDump).toBeNull(); // 旧路径失效
+
+                const newChildPath = `${renamedParent.path}/ChildA`;
+                const updatedChildDump = await queryNodeDump(newChildPath);
+                expect(updatedChildDump).not.toBeNull();
+
+                await deleteNode(newChildPath);
+            } finally {
+                try { await deleteNode(parent.path); } catch { /* */ }
+                try { await deleteNode('NewParent'); } catch { /* */ }
+            }
+        });
+
+        it('场景5：冲突重命名后，update 返回真实路径而非用户输入', async () => {
+            const nodeA = await createNode('Hero');
+            const nodeB = await createNode('Villain');
+
+            try {
+                // 通过 NodeProxy.update 重命名 B 为 "Hero"（冲突）
+                const result = await NodeProxy.update({ path: nodeB.path, name: 'Hero' });
+                // 返回的路径应该是系统分配的唯一路径，不能是 A 的路径
+                expect(result.path).not.toBe(nodeA.path);
+                // 路径应该包含去重后缀
+                expect(result.path).toBeTruthy();
+
+                // 通过返回的路径能查到节点
+                const queryResult = await NodeProxy.query({ path: result.path });
+                expect(queryResult).not.toBeNull();
+                // name 应该是用户输入的 "Hero"
+                expect(queryResult!.name).toBe('Hero');
+
+                await deleteNode(result.path);
+            } finally {
+                try { await deleteNode(nodeA.path); } catch { /* */ }
+                try { await deleteNode(nodeB.path); } catch { /* */ }
+            }
+        });
+
+        it('场景6：兄弟增删不影响已有路径', async () => {
+            const nodeA = await createNode('Item');
+            const nodeB = await createNode('Item'); // 会变成 Item_001
+            const nodeC = await createNode('Item'); // 会变成 Item_002
+
+            try {
+                const pathA = nodeA.path;
+                const pathB = nodeB.path;
+                const pathC = nodeC.path;
+
+                // 三个路径应各不相同
+                expect(new Set([pathA, pathB, pathC]).size).toBe(3);
+
+                // 删除 A
+                await deleteNode(pathA);
+
+                // B 和 C 的路径不应变化
+                const bDump = await queryNodeDump(pathB);
+                expect(bDump).not.toBeNull();
+
+                const cDump = await queryNodeDump(pathC);
+                expect(cDump).not.toBeNull();
+            } finally {
+                try { await deleteNode(nodeA.path); } catch { /* */ }
+                try { await deleteNode(nodeB.path); } catch { /* */ }
+                try { await deleteNode(nodeC.path); } catch { /* */ }
+            }
         });
     });
 });

--- a/src/core/scene/test/node-for-editor.testcase.ts
+++ b/src/core/scene/test/node-for-editor.testcase.ts
@@ -1014,5 +1014,23 @@ describe('Node ForEditor 接口测试', () => {
             await expect(createNode('Leaf', `${validPrefix}/A:B`)).rejects.toThrow(/illegal character/);
             expect(await queryNodeDump(validPrefix)).toBeNull();
         });
+
+        it('场景10：在第二个同名父节点的系统路径下自动创建中间层级', async () => {
+            const parentA = await createNode('DuplicateParent');
+            const parentB = await createNode('DuplicateParent');
+            const nestedParentPath = `${parentB.path}/Nested`;
+
+            try {
+                const leaf = await createNode('Leaf', nestedParentPath);
+
+                expect(parentB.path).not.toBe(parentA.path);
+                expect(leaf.path).toBe(`${nestedParentPath}/Leaf`);
+                expect(await queryNodeDump(leaf.path)).not.toBeNull();
+                expect(await queryNodeDump(`${parentA.path}/Nested`)).toBeNull();
+            } finally {
+                await deleteNode(parentB.path);
+                await deleteNode(parentA.path);
+            }
+        });
     });
 });

--- a/src/core/scene/test/node-for-editor.testcase.ts
+++ b/src/core/scene/test/node-for-editor.testcase.ts
@@ -985,5 +985,34 @@ describe('Node ForEditor 接口测试', () => {
                 try { await deleteNode(nodeC.path); } catch { /* */ }
             }
         });
+
+        it('场景7：创建重名节点后 display name 保持用户输入', async () => {
+            const nodeA = await createNode('Enemy');
+            const nodeB = await createNode('Enemy');
+
+            try {
+                // 路径唯一
+                expect(nodeA.path).not.toBe(nodeB.path);
+
+                // display name 都是用户输入的 "Enemy"，不应被系统路径后缀覆盖
+                const dumpA = await queryNodeDump(nodeA.path) as INode;
+                const dumpB = await queryNodeDump(nodeB.path) as INode;
+                expect(dumpA.name.value).toBe('Enemy');
+                expect(dumpB.name.value).toBe('Enemy');
+            } finally {
+                try { await deleteNode(nodeA.path); } catch { /* */ }
+                try { await deleteNode(nodeB.path); } catch { /* */ }
+            }
+        });
+
+        it('场景8：节点名含非法字符时创建报错', async () => {
+            await expect(createNode('A:B')).rejects.toThrow(/illegal character/);
+        });
+
+        it('场景9：路径段含非法字符时创建报错', async () => {
+            const validPrefix = `ValidationParent_${Date.now()}`;
+            await expect(createNode('Leaf', `${validPrefix}/A:B`)).rejects.toThrow(/illegal character/);
+            expect(await queryNodeDump(validPrefix)).toBeNull();
+        });
     });
 });

--- a/src/core/scene/test/node-proxy-rename-path.test.ts
+++ b/src/core/scene/test/node-proxy-rename-path.test.ts
@@ -59,4 +59,5 @@ describe('NodeProxy.update 重命名路径解析', () => {
         expect(result.path).toBe('Canvas/Enemy');
         expect(mockRequest).toHaveBeenCalledTimes(2);
     });
+
 });

--- a/src/core/scene/test/node-proxy-rename-path.test.ts
+++ b/src/core/scene/test/node-proxy-rename-path.test.ts
@@ -1,0 +1,62 @@
+const mockRequest = jest.fn();
+jest.mock('../main-process/rpc', () => ({
+    Rpc: {
+        getInstance: () => ({ request: mockRequest }),
+    },
+}));
+
+import { NodeProxy } from '../main-process/proxy/node-proxy';
+
+function makeDump(uuid?: string) {
+    return {
+        uuid: uuid !== undefined ? { value: uuid } : undefined,
+        name: { value: 'OldName', type: 'string' },
+    };
+}
+
+beforeEach(() => mockRequest.mockReset());
+
+describe('NodeProxy.update 重命名路径解析', () => {
+    it('重命名成功且 getPathByUuid 返回有效路径', async () => {
+        mockRequest
+            .mockResolvedValueOnce(makeDump('uuid-1'))
+            .mockResolvedValueOnce(undefined)
+            .mockResolvedValueOnce('Canvas/Enemy_001');
+
+        const result = await NodeProxy.update({ path: 'Canvas/Enemy', name: 'Enemy' });
+        expect(result.path).toBe('Canvas/Enemy_001');
+        expect(mockRequest).toHaveBeenCalledWith('Node', 'getPathByUuid', ['uuid-1']);
+    });
+
+    it('nodeDump 无 uuid 时抛错而非静默回退旧路径', async () => {
+        mockRequest
+            .mockResolvedValueOnce(makeDump(undefined))
+            .mockResolvedValueOnce(undefined);
+
+        await expect(
+            NodeProxy.update({ path: 'Canvas/Enemy', name: 'NewName' }),
+        ).rejects.toThrow('has no uuid');
+    });
+
+    it('getPathByUuid 返回空时抛错而非静默回退旧路径', async () => {
+        mockRequest
+            .mockResolvedValueOnce(makeDump('uuid-2'))
+            .mockResolvedValueOnce(undefined)
+            .mockResolvedValueOnce(null);
+
+        await expect(
+            NodeProxy.update({ path: 'Canvas/Enemy', name: 'NewName' }),
+        ).rejects.toThrow('Cannot resolve path');
+    });
+
+    it('不传 name 时不触发路径解析，直接返回原路径', async () => {
+        mockRequest.mockResolvedValueOnce({
+            ...makeDump('uuid-3'),
+            active: { value: true, type: 'boolean' },
+        }).mockResolvedValueOnce(undefined);
+
+        const result = await NodeProxy.update({ path: 'Canvas/Enemy', properties: { active: false } });
+        expect(result.path).toBe('Canvas/Enemy');
+        expect(mockRequest).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/core/scene/test/node-proxy.testcase.ts
+++ b/src/core/scene/test/node-proxy.testcase.ts
@@ -660,7 +660,7 @@ describe('Node Proxy 测试', () => {
 
             const node2 = await NodeProxy.createByType(params);
             expect(node2).toBeDefined();
-            expect(node2!.name).toBe('DupNode_001');
+            expect(node2!.name).toBe('DupNode');
             expect(node2!.path).toBe('DupNode_001');
             createdNodes.push(node2!);
         });
@@ -676,9 +676,9 @@ describe('Node Proxy 测试', () => {
                 };
                 const node = await NodeProxy.createByType(params);
                 expect(node).toBeDefined();
-                const expectedName = i === 0 ? baseName : `${baseName}_${String(i).padStart(3, '0')}`;
-                expect(node!.name).toBe(expectedName);
-                expect(node!.path).toBe(expectedName);
+                const expectedPath = i === 0 ? baseName : `${baseName}_${String(i).padStart(3, '0')}`;
+                expect(node!.name).toBe(baseName);
+                expect(node!.path).toBe(expectedPath);
                 createdNodes.push(node!);
             }
         });

--- a/src/core/scene/test/selection-prefab-path.test.ts
+++ b/src/core/scene/test/selection-prefab-path.test.ts
@@ -97,6 +97,67 @@ describe('SelectionService prefab path resolution', () => {
         }]);
     });
 
+    it('uses prefab system path segments when display names collide with generated suffixes', () => {
+        const generatedSuffixNode = { name: 'Child', uuid: 'generated-uuid', children: [], components: [] };
+        const literalSuffixNode = { name: 'Child_001', uuid: 'literal-uuid', children: [], components: [] };
+        const root = {
+            name: 'Node',
+            uuid: 'root-uuid',
+            children: [generatedSuffixNode, literalSuffixNode],
+            components: [],
+        };
+        (globalThis as any).EditorExtends = {
+            Node: {
+                getNodeUuidByPath: jest.fn(() => ''),
+                getNodeByPath: jest.fn(() => null),
+                getNodePath: jest.fn((node: any) => {
+                    if (node === root) return 'Node';
+                    if (node === generatedSuffixNode) return 'Node/Child_001';
+                    if (node === literalSuffixNode) return 'Node/Child_001_001';
+                    return '';
+                }),
+            },
+        };
+        mockService.Editor.getCurrentEditorType.mockReturnValue('prefab');
+        mockService.Editor.getRootNode.mockReturnValue(root);
+
+        const { SelectionService } = require('../scene-process/service/selection');
+        const selection = new SelectionService();
+        jest.spyOn(selection, 'broadcast').mockImplementation(() => undefined);
+
+        selection.select('Node/Child_001');
+
+        expect((selection as any)._selections).toEqual([{
+            path: 'Node/Child_001',
+            uuid: 'generated-uuid',
+        }]);
+    });
+
+    it('does not alias the prefab display root name when its system path segment differs', () => {
+        const child = { name: 'Child', uuid: 'child-uuid', children: [], components: [] };
+        const root = { name: 'Player', uuid: 'root-uuid', children: [child], components: [] };
+        (globalThis as any).EditorExtends = {
+            Node: {
+                getNodeUuidByPath: jest.fn(() => ''),
+                getNodeByPath: jest.fn(() => null),
+                getNodePath: jest.fn((node: any) => {
+                    if (node === root) return 'virtual-scene/should_hide_in_hierarchy/Player_001/';
+                    if (node === child) return 'virtual-scene/should_hide_in_hierarchy/Player_001/Child';
+                    return '';
+                }),
+            },
+        };
+        mockService.Editor.getCurrentEditorType.mockReturnValue('prefab');
+        mockService.Editor.getRootNode.mockReturnValue(root);
+
+        const { getEditorNodeUuidByPath } = require('../scene-process/service/gizmo/utils/editor-node');
+
+        expect(getEditorNodeUuidByPath('Player/Child')).toBe('');
+        expect(getEditorNodeUuidByPath('Player_001/Child')).toBe('child-uuid');
+        expect(getEditorNodeUuidByPath('should_hide_in_hierarchy/Player/Child')).toBe('');
+        expect(getEditorNodeUuidByPath('should_hide_in_hierarchy/Player_001/Child')).toBe('child-uuid');
+    });
+
     it('does not resolve stale prefab paths from a previous virtual scene', () => {
         const child = { name: 'Child', uuid: 'child-uuid', children: [], components: [] };
         const root = { name: 'Node', uuid: 'root-uuid', children: [child], components: [] };

--- a/src/core/scene/test/selection-prefab-path.test.ts
+++ b/src/core/scene/test/selection-prefab-path.test.ts
@@ -122,6 +122,7 @@ describe('SelectionService prefab path resolution', () => {
         mockService.Editor.getRootNode.mockReturnValue(root);
 
         const { SelectionService } = require('../scene-process/service/selection');
+        const { getEditorNodeByPath } = require('../scene-process/service/gizmo/utils/editor-node');
         const selection = new SelectionService();
         jest.spyOn(selection, 'broadcast').mockImplementation(() => undefined);
 
@@ -131,6 +132,8 @@ describe('SelectionService prefab path resolution', () => {
             path: 'Node/Child_001',
             uuid: 'generated-uuid',
         }]);
+        expect(getEditorNodeByPath('Node/Child_001')).toBe(generatedSuffixNode);
+        expect(getEditorNodeByPath('Node\\Child_001')).toBe(generatedSuffixNode);
     });
 
     it('does not alias the prefab display root name when its system path segment differs', () => {

--- a/src/core/scene/test/service-core/message-callsite.test.ts
+++ b/src/core/scene/test/service-core/message-callsite.test.ts
@@ -557,6 +557,29 @@ describe('ServiceEvents 事件发射集成测试', () => {
     // ── NodeService: setProperty(name) → ServiceEvents ──
 
     describe('NodeService (node.ts)', () => {
+        it('createByType 应在场景操作前拒绝非法节点名', async () => {
+            const { NodeType } = require('../../common');
+            const { NodeService } = require('../../scene-process/service/node');
+            const nodeService = new NodeService();
+
+            await expect(nodeService.createByType({
+                path: '',
+                name: 'A:B',
+                nodeType: NodeType.EMPTY,
+            })).rejects.toThrow(/illegal character/);
+        });
+
+        it('createByAsset 应在资源查询前拒绝含非法段的父路径', async () => {
+            const { NodeService } = require('../../scene-process/service/node');
+            const nodeService = new NodeService();
+
+            await expect(nodeService.createByAsset({
+                path: 'Parent/A:B',
+                dbURL: 'db://assets/Test.prefab',
+            })).rejects.toThrow(/illegal character/);
+            expect(mockRpcRequest).not.toHaveBeenCalledWith('assetManager', 'queryUUID', expect.anything());
+        });
+
         it('setProperty(name) 应 emit node:change 到 ServiceEvents', async () => {
             const listener = jest.fn();
             globalEventEmitter.on('node:change', listener);
@@ -588,6 +611,35 @@ describe('ServiceEvents 事件发射集成测试', () => {
             });
 
             expect(listener).toHaveBeenCalledWith(node, expect.objectContaining({ propPath: 'name' }));
+        });
+
+        it('setProperty(name) 应拒绝新的非法名称且不调用底层改名', async () => {
+            const { NodeService } = require('../../scene-process/service/node');
+            const nodeService = new NodeService();
+
+            const { Node: MockNode } = require('cc');
+            const node = new MockNode();
+            node.uuid = 'invalid-name-change';
+            node.name = 'OldName';
+
+            nodeService._undo = {
+                recordNodeSnapshot: jest.fn((_node: any, _opts: any, callback: any) => callback()),
+            };
+
+            const NodeMgr = (global as any).EditorExtends.Node;
+            NodeMgr.getNodeByPath = jest.fn(() => node);
+            NodeMgr.updateNodeName = jest.fn();
+            nodeService.emit = jest.fn();
+
+            await expect(nodeService.setProperty({
+                nodePath: '/TestNode',
+                path: 'name',
+                dump: { value: 'A:B' },
+            })).rejects.toThrow(/illegal character/);
+
+            expect(NodeMgr.updateNodeName).not.toHaveBeenCalled();
+            expect(nodeService.emit).not.toHaveBeenCalled();
+            expect(node.name).toBe('OldName');
         });
 
         it('setProperty(position) 成功后应 broadcast animation:property-committed', async () => {

--- a/src/core/scene/test/undo-redo.testcase.ts
+++ b/src/core/scene/test/undo-redo.testcase.ts
@@ -134,9 +134,13 @@ const Node = {
                 path: 'name',
                 dump: { ...nodeDump.name, value: params.name },
             }]);
-            const segments = currentPath.split('/');
-            segments[segments.length - 1] = params.name;
-            currentPath = segments.join('/');
+            const nodeUuid = nodeDump.uuid?.value;
+            if (nodeUuid) {
+                const realPath = await request<string>('Node', 'getPathByUuid', [nodeUuid]);
+                if (realPath) {
+                    currentPath = realPath;
+                }
+            }
         }
         return { path: currentPath };
     },
@@ -847,13 +851,14 @@ describe('Undo/Redo 集成测试', () => {
 
         it('update name, undo restores original name, redo reapplies', async () => {
             const updateParams: IUpdateNodeParams = { path, name: 'RenamedNode' };
-            await Node.update(updateParams);
-            const renamedPath = `${path.slice(0, path.lastIndexOf('/') + 1)}RenamedNode`;
+            const updateResult = await Node.update(updateParams);
+            const renamedPath = updateResult.path;
             expect(await queryNode(renamedPath)).not.toBeNull();
 
             await Undo.undo();
             expect(await queryNode(path)).not.toBeNull();
-            expect((await queryNode(path))!.name).toBe(path.split('/').pop());
+            const originalName = path.split('/').pop();
+            expect((await queryNode(path))!.name).toBe(originalName);
 
             await Undo.redo();
             expect(await queryNode(renamedPath)).not.toBeNull();

--- a/src/core/scene/test/undo-redo.testcase.ts
+++ b/src/core/scene/test/undo-redo.testcase.ts
@@ -863,6 +863,37 @@ describe('Undo/Redo 集成测试', () => {
             await Undo.redo();
             expect(await queryNode(renamedPath)).not.toBeNull();
         });
+
+        it('conflicting rename keeps the display name and restores the correct paths through undo/redo', async () => {
+            const conflictingPath = 'UndoConflictName';
+            let renamedPath = '';
+            await Node.createByType({ path: conflictingPath, nodeType: NodeType.EMPTY });
+            await Undo.clearHistory();
+
+            try {
+                const updateResult = await Node.update({ path, name: conflictingPath });
+                renamedPath = updateResult.path;
+
+                expect(renamedPath).not.toBe(conflictingPath);
+                expect((await queryNode(renamedPath))?.name).toBe(conflictingPath);
+                expect((await queryNode(conflictingPath))?.name).toBe(conflictingPath);
+
+                expectUndoSuccess(await Undo.undo());
+                expect((await queryNode(path))?.name).toBe(path);
+                expect(await queryNode(renamedPath)).toBeNull();
+                expect(await queryNode(conflictingPath)).not.toBeNull();
+
+                expectUndoSuccess(await Undo.redo());
+                expect((await queryNode(renamedPath))?.name).toBe(conflictingPath);
+                expect(await queryNode(path)).toBeNull();
+                expect(await queryNode(conflictingPath)).not.toBeNull();
+            } finally {
+                if (renamedPath) {
+                    await safeDelete(renamedPath);
+                }
+                await safeDelete(conflictingPath);
+            }
+        });
     });
 
     // ========================================================================

--- a/tests/asset-db-url-normalization-schema.test.ts
+++ b/tests/asset-db-url-normalization-schema.test.ts
@@ -91,15 +91,19 @@ describe('AssetDB URL normalization schemas', () => {
         expect(SchemaAssetDbUrlOrUUID.parse('123456781234123412341234567890ab')).toBe('12345678-1234-1234-1234-1234567890ab');
     });
 
-    it('rejects illegal node names before create or update reaches the scene process', () => {
-        expect(SchemaNodeCreateByAsset.safeParse({
-            path: '/',
-            name: 'A:B',
-            dbURL: 'db://assets/prefabs/Enemy.prefab',
-        }).success).toBe(false);
-        expect(SchemaNodeUpdate.safeParse({
-            path: 'Enemy',
-            name: 'A:B',
-        }).success).toBe(false);
-    });
+    it.each(['/', '\\', ':', '*', '?', '"', '<', '>', '|'])(
+        'rejects node names containing %p before create or update reaches the scene process',
+        (character) => {
+            const name = `A${character}B`;
+            expect(SchemaNodeCreateByAsset.safeParse({
+                path: '/',
+                name,
+                dbURL: 'db://assets/prefabs/Enemy.prefab',
+            }).success).toBe(false);
+            expect(SchemaNodeUpdate.safeParse({
+                path: 'Enemy',
+                name,
+            }).success).toBe(false);
+        },
+    );
 });

--- a/tests/asset-db-url-normalization-schema.test.ts
+++ b/tests/asset-db-url-normalization-schema.test.ts
@@ -14,7 +14,7 @@ jest.mock('../src/core/scene/common/editor/type', () => ({
 
 import { SchemaAssetDbUrl, SchemaAssetDbUrlOrUUID } from '../src/api/base/schema-asset-db-url';
 import { SchemaCreateOptions, SchemaOpenOptions } from '../src/api/scene/schema';
-import { SchemaNodeCreateByAsset, SchemaNodeQuery } from '../src/api/scene/node-schema';
+import { SchemaNodeCreateByAsset, SchemaNodeQuery, SchemaNodeUpdate } from '../src/api/scene/node-schema';
 import { SchemaCreatePrefabFromNodeOptions } from '../src/api/scene/prefab-schema';
 import { SchemaInsertTextAtLineInfo } from '../src/api/system/file-editor-schema';
 
@@ -89,5 +89,17 @@ describe('AssetDB URL normalization schemas', () => {
 
     it('keeps UUID support for mixed URL-or-UUID fields', () => {
         expect(SchemaAssetDbUrlOrUUID.parse('123456781234123412341234567890ab')).toBe('12345678-1234-1234-1234-1234567890ab');
+    });
+
+    it('rejects illegal node names before create or update reaches the scene process', () => {
+        expect(SchemaNodeCreateByAsset.safeParse({
+            path: '/',
+            name: 'A:B',
+            dbURL: 'db://assets/prefabs/Enemy.prefab',
+        }).success).toBe(false);
+        expect(SchemaNodeUpdate.safeParse({
+            path: 'Enemy',
+            name: 'A:B',
+        }).success).toBe(false);
     });
 });


### PR DESCRIPTION
## Background

After node name/path decoupling, `node.name` becomes a user-controlled display label that can duplicate among siblings, while the system path (managed by `NodePathManager`) remains unique with `_001`/`_002` suffixes. This creates two independent path namespaces:

- **System path**: `Enemy`, `Enemy_001`, `Enemy_002` — unique, used for node addressing
- **Engine name path**: `Enemy`, `Enemy`, `Enemy` — resolved by `getChildByPath` using `Array.find` (first match only)

The animation system builds track paths from `node.name` and resolves them via `getChildByPath`. Several code paths still assumed `name === path segment`, causing:

1. `property-curve.ts` string-slicing produced system path segments (e.g. `Enemy_001`) that `getChildByPath` cannot resolve
2. `property-value.ts` used `queryNodePath` which returns system paths, same mismatch
3. `node-proxy.ts` silently returned stale paths after rename failure
4. `node.ts` used `getChildByName` for path resolution, breaking when name differs from path segment
5. `_updateNameCount` operated on display names instead of path segments, corrupting the path allocation table

## Fix

**Animation path resolution** — Rewrite `resolveRelativeNodePath` (property-curve.ts) and `resolveOperationRelativeNodePath` (property-value.ts) to a UUID-first 3-step flow:
1. Resolve target node UUID (via `nodeUuid` directly, or via `getNodeByPath`/`getChildByPath` from `nodePath`)
2. Build name-based relative path via `findRelativeNodePathByUuid` (DFS using `child.name`), producing paths compatible with engine `getChildByPath`
3. Detect same-name sibling ambiguity via `hasSameNameSiblings` — reject create/update operations when any path level has duplicate names

**Node proxy** — Throw on failed path resolution after rename instead of silently returning the old (now invalid) path.

**Node manager** — Remove `_updateNameCount` entirely (path segment lifecycle managed by `NodePathManager`), remove path-segment writeback to `node.name` after move, fix `_ensurePathExists` to resolve by accumulated system path.

## Test Plan

### Scene editor
1. Open a scene with sibling nodes sharing the same name
2. Verify animation track creation is rejected with a console warning for any node that has same-name siblings
3. Rename a node to conflict with a sibling, verify the returned path uses the system suffix (e.g. `Enemy_001`) while `node.name` shows the user input
4. Verify animation keyframe create/update operations work normally for nodes without name conflicts

### Prefab editor
5. Open a prefab in the prefab editor, create multiple child nodes with the same name
6. Verify animation track creation is rejected for same-name sibling nodes (same behavior as scene editor)
7. Delete a same-name node, then undo — verify the node restores correctly and the system path remains consistent
8. Verify animation operations still work correctly after undo/redo cycles on same-name nodes
