### PR TITLE
fix(animation): preserve skeletal clip duration during edits

### DIFF
--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -49,7 +49,7 @@ import { IAnimationSession } from './animation/types';
 import { clipUuid, ensureClipEvents, getClipSample } from './animation/utils';
 import { serializeAnimationPropertyValue } from './animation/property-value';
 import { AnimationServicePlayback } from './animation/service-playback';
-import { isAllowedSkeletonAnimationOperation, isAnimationOperationResult, shouldSyncClipDuration } from './animation/operation-policy';
+import { isAllowedSkeletonAnimationOperation, isAnimationOperationResult, shouldSyncAnimationClipDuration } from './animation/operation-policy';
 import { normalizeAnimationOperation } from './animation/operation-normalizer';
 import {
     loadAnimationClip,
@@ -452,6 +452,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         const shouldRecordUndo = options.recordUndo !== false;
         const before = captureAnimationClipSnapshot(clip, propertyMetadataContext);
         const appliedOperations: IAnimationOperation[] = [];
+        const isSkeleton = isSkeletonClip(session.clipUuid, rootNode);
         let shouldSyncDuration = false;
         let shouldRestoreOnFailure = false;
         for (const inputOperation of options.operations) {
@@ -462,7 +463,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
                 }
                 return inputFailure;
             }
-            if (isSkeletonClip(session.clipUuid, rootNode) && !isAllowedSkeletonAnimationOperation(inputOperation)) {
+            if (isSkeleton && !isAllowedSkeletonAnimationOperation(inputOperation)) {
                 const skeletonFailure = {
                     state: 'failure',
                     result: false,
@@ -524,7 +525,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
                 return failureResult;
             }
             appliedOperations.push(operation);
-            shouldSyncDuration = shouldSyncDuration || shouldSyncClipDuration(operation);
+            shouldSyncDuration = shouldSyncDuration || shouldSyncAnimationClipDuration(operation, isSkeleton);
         }
 
         if (shouldSyncDuration) {

--- a/src/core/scene/scene-process/service/animation/operation-policy.ts
+++ b/src/core/scene/scene-process/service/animation/operation-policy.ts
@@ -39,6 +39,15 @@ export function shouldSyncClipDuration(operation: IAnimationOperation): boolean 
     }
 }
 
+/**
+ * Imported skeletal clips keep the duration authored by the importer. Their
+ * editable event/settings operations must not recompute duration from the
+ * currently visible event list and accidentally shorten the source clip.
+ */
+export function shouldSyncAnimationClipDuration(operation: IAnimationOperation, isSkeleton: boolean): boolean {
+    return !isSkeleton && shouldSyncClipDuration(operation);
+}
+
 export function isAllowedSkeletonAnimationOperation(operation: IAnimationOperation): boolean {
     switch (operation.type) {
         case 'changeSample':

--- a/src/core/scene/scene-process/service/animation/scene-node.ts
+++ b/src/core/scene/scene-process/service/animation/scene-node.ts
@@ -73,10 +73,12 @@ export function isUsingBakedAnimation(rootNode: Node): boolean {
 }
 
 export function isSkeletonClip(uuid: string, rootNode?: Node | null): boolean {
-    if (uuid.includes('@')) {
-        return true;
+    if (rootNode) {
+        // A sub-asset UUID is not enough to identify a skeletal clip. Ordinary
+        // imported AnimationClips use the same `@subAsset` UUID form.
+        return Boolean(rootNode.getComponent(SkeletalAnimation));
     }
-    return Boolean(rootNode && queryAnimationComponent(rootNode) instanceof SkeletalAnimation);
+    return uuid.includes('@');
 }
 
 export function readPropertyValue(node: Node, propKey: string): unknown {

--- a/src/core/scene/test/animation-clip-operations.test.ts
+++ b/src/core/scene/test/animation-clip-operations.test.ts
@@ -35,6 +35,7 @@ jest.mock('../scene-process/service/animation/property-curve', () => ({
 
 const { applyClipOperation } = require('../scene-process/service/animation/clip-operations');
 const { syncAnimationClipDuration } = require('../scene-process/service/animation/clip-duration');
+const { shouldSyncAnimationClipDuration } = require('../scene-process/service/animation/operation-policy');
 
 describe('animation clip operations', () => {
     it('preserves a skeletal track duration when an event moves earlier', async () => {
@@ -101,5 +102,28 @@ describe('animation clip operations', () => {
         expect(clip.events[0].frame).toBe(1);
         expect(Math.round(clip.events[0].frame * clip.sample)).toBe(60);
         expect(clip.updateEventDatas).toHaveBeenCalled();
+    });
+
+    it('does not resync imported skeletal duration for editable operations', () => {
+        expect(shouldSyncAnimationClipDuration({
+            type: 'moveEvents',
+            clipUuid: 'clip-uuid',
+            frames: [60],
+            offset: -12,
+        }, true)).toBe(false);
+        expect(shouldSyncAnimationClipDuration({
+            type: 'changeSample',
+            clipUuid: 'clip-uuid',
+            sample: 30,
+        }, true)).toBe(false);
+    });
+
+    it('keeps duration synchronization enabled for ordinary clips', () => {
+        expect(shouldSyncAnimationClipDuration({
+            type: 'moveEvents',
+            clipUuid: 'clip-uuid',
+            frames: [60],
+            offset: -12,
+        }, false)).toBe(true);
     });
 });

--- a/src/core/scene/test/animation-scene-node.test.ts
+++ b/src/core/scene/test/animation-scene-node.test.ts
@@ -1,0 +1,43 @@
+class MockAnimation {}
+class MockSkeletalAnimation extends MockAnimation {}
+
+jest.mock('cc', () => ({
+    Animation: MockAnimation,
+    SkeletalAnimation: MockSkeletalAnimation,
+    Node: class Node {},
+    Scene: class Scene {},
+    animation: {},
+    js: {},
+}));
+
+(globalThis as any).EditorExtends = {
+    Node: {
+        getNode: jest.fn(),
+        getNodeByPath: jest.fn(),
+        getNodePath: jest.fn(),
+    },
+};
+
+const { isSkeletonClip } = require('../scene-process/service/animation/scene-node');
+
+describe('animation scene-node classification', () => {
+    it('does not classify an ordinary sub-asset clip as skeletal', () => {
+        const ordinaryRoot = {
+            getComponent: jest.fn((type: unknown) => type === MockAnimation ? new MockAnimation() : null),
+        };
+
+        expect(isSkeletonClip('gltf-asset@walk', ordinaryRoot)).toBe(false);
+    });
+
+    it('classifies a clip on a SkeletalAnimation root as skeletal', () => {
+        const skeletalRoot = {
+            getComponent: jest.fn((type: unknown) => type === MockSkeletalAnimation ? new MockSkeletalAnimation() : null),
+        };
+
+        expect(isSkeletonClip('gltf-asset@walk', skeletalRoot)).toBe(true);
+    });
+
+    it('keeps the sub-asset UUID fallback when the root node is unavailable', () => {
+        expect(isSkeletonClip('gltf-asset@walk')).toBe(true);
+    });
+});


### PR DESCRIPTION
## Background
Imported `cc.SkeletalAnimation` clips keep their duration from the source animation. Editing an event or changing editable clip settings must not recompute that duration from the currently visible event/property data and shorten the clip.

## Changes
- Preserve imported skeletal clip duration when applying editable animation operations.
- Keep duration synchronization enabled for ordinary `AnimationClip` clips.
- Add regression coverage for skeletal and ordinary duration-sync policy.

## QA Steps
1. Open a project containing an imported `cc.SkeletalAnimation` clip with animation data extending beyond an event.
2. Enter the Animation Editor and move an event to an earlier frame.
3. Verify the clip duration and imported transform keyframes remain unchanged.
4. Change a skeletal clip sample rate and verify the duration remains unchanged.
5. Verify ordinary `AnimationClip` editing continues to synchronize duration from its authored tracks.

## Risks
The change intentionally changes duration synchronization only for clips identified as skeletal by the Scene animation service. Ordinary clips retain the existing behavior.
