### PR TITLE
fix(scene): validate component asset references

### DIFF
--- a/src/api/assets/assets.ts
+++ b/src/api/assets/assets.ts
@@ -178,7 +178,7 @@ export class AssetsApi {
      */
     @tool('assets-query-asset-info')
     @title('Query Detailed Asset Info') // 查询资源详细信息
-    @description('Query detailed information of an asset based on its URL, UUID, or file path. You can specify the fields to query via the dataKeys parameter to optimize performance. Returned information includes asset name, type, path, UUID, import status, etc.') // 根据资源的 URL、UUID 或文件路径查询资源的详细信息。可以通过 dataKeys 参数指定需要查询的字段，以优化性能。返回的信息包括资源名称、类型、路径、UUID、导入状态等。
+    @description('Query detailed asset information by URL, UUID, or file path. By default the result includes subAssets; use each sub-asset type (for example type === "cc.SpriteFrame") to select the UUID required by a component property. Specify dataKeys, including "subAssets" and "extends", when an explicit field list is needed.') // 根据 URL、UUID 或文件路径查询资源详情；默认包含子资源，可按 type 选择组件属性所需的子资源 UUID
     @result(SchemaAssetInfoResult)
     async queryAssetInfo(
         @param(SchemaUrlOrUUIDOrPath) urlOrUUIDOrPath: TUrlOrUUIDOrPath,
@@ -792,7 +792,7 @@ export class AssetsApi {
      */
     @tool('assets-query-uuid')
     @title('Query Asset UUID') // 查询资源 UUID
-    @description('Query the unique identifier UUID of an asset based on its URL or file path. Supports db:// protocol paths and file system paths.') // 根据资源的 URL 或文件路径查询资源的唯一标识符 UUID。支持 db:// 协议路径和文件系统路径。
+    @description('Query the UUID of the exact asset addressed by a URL or file path. This does not automatically choose a typed sub-asset: querying an image URL returns its parent ImageAsset UUID. Use assets-query-asset-info and inspect subAssets when a component requires cc.SpriteFrame or another specific Asset type.') // 查询 URL 或路径直接指向资源的 UUID；不会自动选择 SpriteFrame 等子资源
     @result(SchemaUUIDResult)
     async queryUUID(@param(SchemaUrlOrPath) urlOrPath: TUrlOrPath): Promise<CommonResultType<TUUIDResult>> {
         const code: HttpStatusCode = COMMON_STATUS.SUCCESS;

--- a/src/api/base/schema-base.ts
+++ b/src/api/base/schema-base.ts
@@ -74,6 +74,10 @@ export function getCommonErrorStatus(error: unknown): CommonStatus {
         return COMMON_STATUS.BAD_REQUEST;
     }
 
+    if (code === 'INVALID_ASSET_REFERENCE' || /invalid asset reference/i.test(message)) {
+        return COMMON_STATUS.BAD_REQUEST;
+    }
+
     if (code === 'ENOENT' || /ENOENT|no such file or directory|not found|not exist|cannot find|can not find|can not be found/i.test(message)) {
         return COMMON_STATUS.NOT_FOUND;
     }

--- a/src/api/scene/component.ts
+++ b/src/api/scene/component.ts
@@ -96,7 +96,7 @@ export class ComponentApi {
      */
     @tool('scene-set-component-property')
     @title('Set component property') // 设置组件属性
-    @description('Set component property. Input component path (unique index of component), property name, property value to modify corresponding property info. Property types can be queried via scene-query-component') // 设置组件属性，输入组件path（唯一索引的组件）、属性名称、属性值，修改对应属性的信息，属性的类型可以通过 scene-query-component 查询到
+    @description('Set component properties. Query scene-query-component first and match each Asset reference to the returned property type. Asset values use { uuid: "..." }; uuid may be an exact UUID or db:// URL. If a parent asset has exactly one compatible sub-asset, it is normalized automatically; incompatible or ambiguous references return 400 without modifying the component.') // 设置组件属性前先查询属性类型；Asset 引用必须匹配类型，唯一兼容子资源会自动规范化，失配或歧义时不修改组件并返回 400
     @result(SchemaBooleanResult)
     async setProperty(@param(SchemaSetPropertyOptions) setPropertyOptions?: TSetPropertyOptions): Promise<CommonResultType<boolean>> {
         try {

--- a/src/api/scene/scene.ts
+++ b/src/api/scene/scene.ts
@@ -17,7 +17,7 @@ import {
     TSaveResult,
 } from './schema';
 import { description, param, result, title, tool } from '../decorator/decorator.js';
-import { COMMON_STATUS, CommonResultType } from '../base/schema-base';
+import { COMMON_STATUS, CommonResultType, getCommonErrorStatus } from '../base/schema-base';
 import { Scene, TSceneTemplateType } from '../../core/scene';
 import { ComponentApi } from './component';
 import { NodeApi } from './node';
@@ -51,7 +51,7 @@ export class SceneApi {
                 (result as any).reason = 'No scene is currently open.';
             }
             return result;
-        } catch (e) { 
+        } catch (e) {
             console.error(e);
             return {
                 code: COMMON_STATUS.FAIL,
@@ -74,7 +74,7 @@ export class SceneApi {
         } catch (e) {
             console.error(e);
             return {
-                code: COMMON_STATUS.FAIL,
+                code: getCommonErrorStatus(e),
                 reason: e instanceof Error ? e.message : String(e)
             };
         }

--- a/src/core/scene/main-process/proxy/asset-reference-resolver.ts
+++ b/src/core/scene/main-process/proxy/asset-reference-resolver.ts
@@ -1,0 +1,128 @@
+const ASSET_BASE_TYPE = 'cc.Asset';
+
+export interface IAssetReferenceInfo {
+    uuid: string;
+    type: string;
+    name?: string;
+    url?: string;
+    imported?: boolean;
+    invalid?: boolean;
+    extends?: string[];
+    subAssets?: Record<string, IAssetReferenceInfo>;
+}
+
+export type AssetReferenceInfoQuery = (
+    urlOrUuid: string,
+) => IAssetReferenceInfo | null | Promise<IAssetReferenceInfo | null>;
+
+export class AssetReferenceValidationError extends Error {
+    readonly code = 'INVALID_ASSET_REFERENCE';
+
+    constructor(message: string) {
+        super(message);
+        this.name = 'AssetReferenceValidationError';
+    }
+}
+
+export function getExpectedAssetType(propertyDump: any): string | null {
+    const typeDump = propertyDump?.isArray ? propertyDump.elementTypeData : propertyDump;
+    if (!typeDump || typeof typeDump.type !== 'string') {
+        return null;
+    }
+
+    const inheritance = Array.isArray(typeDump.extends) ? typeDump.extends : [];
+    return typeDump.type === ASSET_BASE_TYPE || inheritance.includes(ASSET_BASE_TYPE)
+        ? typeDump.type
+        : null;
+}
+
+export async function resolveAssetReference(
+    value: unknown,
+    expectedType: string,
+    propertyName: string,
+    queryAssetInfo: AssetReferenceInfoQuery,
+): Promise<unknown> {
+    if (!isAssetReferenceValue(value)) {
+        return value;
+    }
+
+    const requestedReference = value.uuid;
+    if (!requestedReference || requestedReference.startsWith('ui-')) {
+        return value;
+    }
+
+    const assetInfo = await queryAssetInfo(requestedReference);
+    if (!assetInfo) {
+        // Historical UUIDs must continue through the shared dump decoder so its
+        // existing placeholder behavior remains unchanged. db:// is a new CLI
+        // convenience syntax and must resolve before it is sent to the decoder.
+        if (requestedReference.startsWith('db://')) {
+            throw new AssetReferenceValidationError(
+                `Invalid asset reference for property '${propertyName}': '${requestedReference}' cannot be resolved. ` +
+                'Refresh the asset database and try again.',
+            );
+        }
+        return value;
+    }
+
+    if (isTypeCompatible(assetInfo, expectedType)) {
+        return requestedReference === assetInfo.uuid
+            ? value
+            : { ...value, uuid: assetInfo.uuid };
+    }
+
+    const subAssets = collectSubAssets(assetInfo);
+    const compatibleSubAssets = subAssets.filter((candidate) => isTypeCompatible(candidate, expectedType));
+    if (compatibleSubAssets.length === 1) {
+        return { ...value, uuid: compatibleSubAssets[0].uuid };
+    }
+
+    const compatibleDescription = compatibleSubAssets.length > 0
+        ? compatibleSubAssets.map(describeAsset).join(', ')
+        : 'none';
+    const availableDescription = subAssets.length > 0
+        ? subAssets.map(describeAsset).join(', ')
+        : 'none';
+    throw new AssetReferenceValidationError(
+        `Invalid asset reference for property '${propertyName}': expected ${expectedType}, ` +
+        `but '${requestedReference}' is ${assetInfo.type}. Compatible sub-assets: ${compatibleDescription}. ` +
+        `Available sub-assets: ${availableDescription}.`,
+    );
+}
+
+function isAssetReferenceValue(value: unknown): value is { uuid: string; [key: string]: unknown } {
+    return Boolean(
+        value &&
+        typeof value === 'object' &&
+        !Array.isArray(value) &&
+        typeof (value as { uuid?: unknown }).uuid === 'string',
+    );
+}
+
+function isTypeCompatible(assetInfo: IAssetReferenceInfo, expectedType: string): boolean {
+    return assetInfo.type === expectedType || Boolean(assetInfo.extends?.includes(expectedType));
+}
+
+function collectSubAssets(assetInfo: IAssetReferenceInfo): IAssetReferenceInfo[] {
+    const result: IAssetReferenceInfo[] = [];
+    const seen = new Set<string>();
+
+    const visit = (subAssets?: Record<string, IAssetReferenceInfo>) => {
+        for (const child of Object.values(subAssets ?? {})) {
+            if (!child?.uuid || seen.has(child.uuid)) {
+                continue;
+            }
+            seen.add(child.uuid);
+            result.push(child);
+            visit(child.subAssets);
+        }
+    };
+
+    visit(assetInfo.subAssets);
+    return result;
+}
+
+function describeAsset(assetInfo: IAssetReferenceInfo): string {
+    const label = assetInfo.url || assetInfo.name || assetInfo.uuid;
+    return `${label} (uuid: ${assetInfo.uuid}, type: ${assetInfo.type})`;
+}

--- a/src/core/scene/main-process/proxy/component-proxy.ts
+++ b/src/core/scene/main-process/proxy/component-proxy.ts
@@ -6,9 +6,12 @@ import {
 } from '../../common';
 import { IComponentInfo } from '../../common/cli/component';
 import { ISetPropertyOptionsInfo } from '../../common/cli/component';
+import type { IAssetInfo } from '../../../assets/@types/public';
+import { assetManager } from '../../../assets';
 
 import { Rpc } from '../rpc';
 import { DumpConverter } from './dump-converter';
+import { getExpectedAssetType, resolveAssetReference } from './asset-reference-resolver';
 
 export interface IComponentProxy extends Omit<IPublicComponentService, 'add' | 'query' | 'setProperty' | 'getPathByUuid'> {
     add(params: IAddComponentOptions): Promise<IComponentInfo>;
@@ -55,6 +58,17 @@ export const ComponentProxy: IComponentProxy = {
             throw new Error(`Component index not found: ${params.componentPath}`);
         }
 
+        const assetInfoCache = new Map<string, Promise<IAssetInfo | null>>();
+        const queryAssetInfo = (urlOrUuid: string): Promise<IAssetInfo | null> => {
+            let pending = assetInfoCache.get(urlOrUuid);
+            if (!pending) {
+                pending = Promise.resolve(assetManager.queryAssetInfo(urlOrUuid, ['subAssets', 'extends']));
+                assetInfoCache.set(urlOrUuid, pending);
+            }
+            return pending;
+        };
+        const pendingUpdates: Array<{ key: string; propDef: any; dumpValue: any }> = [];
+
         for (const [key, value] of Object.entries(params.properties)) {
             const propDef = compDump.value?.[key];
             if (!propDef) {
@@ -62,14 +76,25 @@ export const ComponentProxy: IComponentProxy = {
             }
             let dumpValue: any;
             if (propDef.isArray && propDef.elementTypeData && Array.isArray(value)) {
-                dumpValue = (value as any[]).map((item, i) => ({
+                const expectedAssetType = getExpectedAssetType(propDef);
+                const resolvedItems = expectedAssetType
+                    ? await Promise.all(value.map((item) => resolveAssetReference(item, expectedAssetType, key, queryAssetInfo)))
+                    : value;
+                dumpValue = resolvedItems.map((item, i) => ({
                     ...propDef.elementTypeData,
                     name: String(i),
                     value: item,
                 }));
             } else {
-                dumpValue = value;
+                const expectedAssetType = getExpectedAssetType(propDef);
+                dumpValue = expectedAssetType
+                    ? await resolveAssetReference(value, expectedAssetType, key, queryAssetInfo)
+                    : value;
             }
+            pendingUpdates.push({ key, propDef, dumpValue });
+        }
+
+        for (const { key, propDef, dumpValue } of pendingUpdates) {
             await Rpc.getInstance().request('Component', 'setProperty', [{
                 nodePath,
                 path: `__comps__.${compIndex}.${key}`,

--- a/src/core/scene/scene-process/service/error-utils.ts
+++ b/src/core/scene/scene-process/service/error-utils.ts
@@ -8,7 +8,7 @@ export async function enrichMissingDependencyError(
 ): Promise<string> {
     const result = DOWNLOAD_FAILED_RE.exec(errInfo);
     if (!result) {
-        return `The asset ${ownerAsset} cannot be loaded because a dependent asset is missing. Detail: ${errInfo}`;
+        return `The asset ${ownerAsset} cannot be loaded. Detail: ${errInfo}`;
     }
     const missingUuid = result[1];
     let assetDesc = missingUuid;

--- a/src/core/scene/test/asset-reference-resolver.test.ts
+++ b/src/core/scene/test/asset-reference-resolver.test.ts
@@ -1,0 +1,155 @@
+import {
+    AssetReferenceValidationError,
+    getExpectedAssetType,
+    IAssetReferenceInfo,
+    resolveAssetReference,
+} from '../main-process/proxy/asset-reference-resolver';
+
+const SPRITE_UUID = '11111111-1111-4111-8111-111111111111@f9941';
+const TEXTURE_UUID = '11111111-1111-4111-8111-111111111111@6c48a';
+const PARENT_UUID = '11111111-1111-4111-8111-111111111111';
+
+function spriteFrame(uuid = SPRITE_UUID): IAssetReferenceInfo {
+    return {
+        uuid,
+        name: 'spriteFrame',
+        url: `db://assets/coin.png/${uuid.split('@')[1]}`,
+        type: 'cc.SpriteFrame',
+        extends: ['cc.Asset'],
+    };
+}
+
+function imageAsset(subAssets: Record<string, IAssetReferenceInfo> = {}): IAssetReferenceInfo {
+    return {
+        uuid: PARENT_UUID,
+        name: 'coin.png',
+        url: 'db://assets/coin.png',
+        type: 'cc.ImageAsset',
+        extends: ['cc.Asset'],
+        subAssets,
+    };
+}
+
+describe('asset reference resolver', () => {
+    it('detects Asset types for scalar and array property dumps', () => {
+        expect(getExpectedAssetType({ type: 'cc.SpriteFrame', extends: ['cc.Asset'] })).toBe('cc.SpriteFrame');
+        expect(getExpectedAssetType({
+            type: 'Array',
+            isArray: true,
+            elementTypeData: { type: 'cc.AnimationClip', extends: ['cc.Asset'] },
+        })).toBe('cc.AnimationClip');
+        expect(getExpectedAssetType({ type: 'cc.Color', extends: ['cc.ValueType'] })).toBeNull();
+    });
+
+    it('passes through an already compatible exact UUID', async () => {
+        const value = { uuid: SPRITE_UUID };
+        const query = jest.fn().mockResolvedValue(spriteFrame());
+
+        await expect(resolveAssetReference(value, 'cc.SpriteFrame', 'spriteFrame', query)).resolves.toBe(value);
+    });
+
+    it('normalizes a db URL to the resolved exact UUID', async () => {
+        const value = { uuid: 'db://assets/coin.png/spriteFrame' };
+        const query = jest.fn().mockResolvedValue(spriteFrame());
+
+        await expect(resolveAssetReference(value, 'cc.SpriteFrame', 'spriteFrame', query)).resolves.toEqual({
+            uuid: SPRITE_UUID,
+        });
+    });
+
+    it('normalizes an incompatible parent to its only compatible sub-asset', async () => {
+        const query = jest.fn().mockResolvedValue(imageAsset({
+            texture: {
+                uuid: TEXTURE_UUID,
+                type: 'cc.Texture2D',
+                extends: ['cc.Asset'],
+            },
+            spriteFrame: spriteFrame(),
+        }));
+
+        await expect(resolveAssetReference(
+            { uuid: PARENT_UUID, tag: 'preserved' },
+            'cc.SpriteFrame',
+            'spriteFrame',
+            query,
+        )).resolves.toEqual({ uuid: SPRITE_UUID, tag: 'preserved' });
+    });
+
+    it('accepts a subclass when the property expects cc.Asset', async () => {
+        const query = jest.fn().mockResolvedValue(spriteFrame());
+
+        await expect(resolveAssetReference(
+            { uuid: SPRITE_UUID },
+            'cc.Asset',
+            'asset',
+            query,
+        )).resolves.toEqual({ uuid: SPRITE_UUID });
+    });
+
+    it('rejects a resolved asset when no compatible sub-asset exists', async () => {
+        const query = jest.fn().mockResolvedValue(imageAsset({
+            texture: {
+                uuid: TEXTURE_UUID,
+                type: 'cc.Texture2D',
+                extends: ['cc.Asset'],
+            },
+        }));
+
+        await expect(resolveAssetReference(
+            { uuid: PARENT_UUID },
+            'cc.AnimationClip',
+            'clips',
+            query,
+        )).rejects.toThrow(AssetReferenceValidationError);
+        await expect(resolveAssetReference(
+            { uuid: PARENT_UUID },
+            'cc.AnimationClip',
+            'clips',
+            query,
+        )).rejects.toThrow('expected cc.AnimationClip');
+    });
+
+    it('rejects ambiguous compatible sub-assets and reports every candidate', async () => {
+        const secondUuid = '11111111-1111-4111-8111-111111111111@aaaaa';
+        const query = jest.fn().mockResolvedValue(imageAsset({
+            first: spriteFrame(),
+            second: spriteFrame(secondUuid),
+        }));
+
+        await expect(resolveAssetReference(
+            { uuid: PARENT_UUID },
+            'cc.SpriteFrame',
+            'spriteFrame',
+            query,
+        )).rejects.toThrow(secondUuid);
+    });
+
+    it('preserves unresolved historical UUIDs for the existing placeholder path', async () => {
+        const value = { uuid: '22222222-2222-4222-8222-222222222222' };
+        const query = jest.fn().mockResolvedValue(null);
+
+        await expect(resolveAssetReference(value, 'cc.SpriteFrame', 'spriteFrame', query)).resolves.toBe(value);
+    });
+
+    it('requires the new db URL convenience syntax to resolve', async () => {
+        const query = jest.fn().mockResolvedValue(null);
+
+        await expect(resolveAssetReference(
+            { uuid: 'db://assets/missing.png' },
+            'cc.SpriteFrame',
+            'spriteFrame',
+            query,
+        )).rejects.toThrow('cannot be resolved');
+    });
+
+    it.each([
+        null,
+        { uuid: '' },
+        { uuid: 'ui-sprite-material' },
+    ])('does not query or change legacy empty/internal value %#', async (value) => {
+        const query = jest.fn();
+
+        await expect(resolveAssetReference(value, 'cc.SpriteFrame', 'spriteFrame', query)).resolves.toBe(value);
+        expect(query).not.toHaveBeenCalled();
+    });
+});

--- a/src/core/scene/test/component-proxy-asset-validation.test.ts
+++ b/src/core/scene/test/component-proxy-asset-validation.test.ts
@@ -1,0 +1,138 @@
+const mockQueryAssetInfo = jest.fn();
+const mockRequest = jest.fn();
+
+jest.mock('../../assets', () => ({
+    assetManager: {
+        queryAssetInfo: (...args: unknown[]) => mockQueryAssetInfo(...args),
+    },
+}));
+
+jest.mock('../main-process/rpc', () => ({
+    Rpc: {
+        getInstance: () => ({ request: (...args: unknown[]) => mockRequest(...args) }),
+    },
+}));
+
+import { ComponentProxy } from '../main-process/proxy/component-proxy';
+
+const PARENT_UUID = '11111111-1111-4111-8111-111111111111';
+const SPRITE_UUID = `${PARENT_UUID}@f9941`;
+
+const componentDump = {
+    value: {
+        uuid: { value: 'component-uuid' },
+        label: { type: 'String', value: '', path: 'label' },
+        spriteFrame: {
+            type: 'cc.SpriteFrame',
+            extends: ['cc.Asset'],
+            value: { uuid: '' },
+            path: 'spriteFrame',
+        },
+        clips: {
+            type: 'Array',
+            isArray: true,
+            value: [],
+            path: 'clips',
+            elementTypeData: {
+                type: 'cc.AnimationClip',
+                extends: ['cc.Asset'],
+                value: { uuid: '' },
+                path: '',
+            },
+        },
+    },
+};
+
+function setPropertyRequests() {
+    return mockRequest.mock.calls.filter(([service, method]) => service === 'Component' && method === 'setProperty');
+}
+
+describe('ComponentProxy Asset validation', () => {
+    beforeEach(() => {
+        mockQueryAssetInfo.mockReset();
+        mockRequest.mockReset();
+        mockRequest.mockImplementation((service: string, method: string) => {
+            if (service === 'Component' && method === 'query') {
+                return componentDump;
+            }
+            if (service === 'Node' && method === 'queryNodeTree') {
+                return { components: [{ value: 'component-uuid' }] };
+            }
+            if (service === 'Component' && method === 'setProperty') {
+                return true;
+            }
+            throw new Error(`Unexpected RPC request: ${service}.${method}`);
+        });
+    });
+
+    it('normalizes a parent UUID before sending the scene write RPC', async () => {
+        mockQueryAssetInfo.mockReturnValue({
+            uuid: PARENT_UUID,
+            type: 'cc.ImageAsset',
+            extends: ['cc.Asset'],
+            subAssets: {
+                spriteFrame: {
+                    uuid: SPRITE_UUID,
+                    type: 'cc.SpriteFrame',
+                    extends: ['cc.Asset'],
+                },
+            },
+        });
+
+        await expect(ComponentProxy.setProperty({
+            componentPath: 'Canvas/Coin/cc.Sprite',
+            properties: { spriteFrame: { uuid: PARENT_UUID } },
+        })).resolves.toBe(true);
+
+        expect(mockQueryAssetInfo).toHaveBeenCalledWith(PARENT_UUID, ['subAssets', 'extends']);
+        expect(setPropertyRequests()).toHaveLength(1);
+        expect(setPropertyRequests()[0][2][0].dump.value).toEqual({ uuid: SPRITE_UUID });
+    });
+
+    it('validates every property before sending any write RPC', async () => {
+        mockQueryAssetInfo.mockReturnValue({
+            uuid: PARENT_UUID,
+            type: 'cc.ImageAsset',
+            extends: ['cc.Asset'],
+            subAssets: {},
+        });
+
+        await expect(ComponentProxy.setProperty({
+            componentPath: 'Canvas/Coin/cc.Sprite',
+            properties: {
+                label: 'would-have-been-written-first',
+                spriteFrame: { uuid: PARENT_UUID },
+            },
+        })).rejects.toThrow('Invalid asset reference');
+
+        expect(setPropertyRequests()).toHaveLength(0);
+    });
+
+    it('preserves unresolved UUIDs so the shared decoder can create placeholders', async () => {
+        const missingUuid = '22222222-2222-4222-8222-222222222222';
+        mockQueryAssetInfo.mockReturnValue(null);
+
+        await ComponentProxy.setProperty({
+            componentPath: 'Canvas/Coin/cc.Sprite',
+            properties: { spriteFrame: { uuid: missingUuid } },
+        });
+
+        expect(setPropertyRequests()).toHaveLength(1);
+        expect(setPropertyRequests()[0][2][0].dump.value).toEqual({ uuid: missingUuid });
+    });
+
+    it('validates Asset arrays transactionally', async () => {
+        mockQueryAssetInfo.mockImplementation((uuid: string) => uuid === 'valid-clip'
+            ? { uuid, type: 'cc.AnimationClip', extends: ['cc.Asset'] }
+            : { uuid, type: 'cc.ImageAsset', extends: ['cc.Asset'], subAssets: {} });
+
+        await expect(ComponentProxy.setProperty({
+            componentPath: 'Canvas/Coin/cc.Sprite',
+            properties: {
+                clips: [{ uuid: 'valid-clip' }, { uuid: 'wrong-clip' }],
+            },
+        })).rejects.toThrow('expected cc.AnimationClip');
+
+        expect(setPropertyRequests()).toHaveLength(0);
+    });
+});

--- a/src/core/scene/test/component-proxy.testcase.ts
+++ b/src/core/scene/test/component-proxy.testcase.ts
@@ -679,7 +679,7 @@ describe('Component Proxy 测试', () => {
         });
         it('setProperty - 设置组件属性 - 设置SpriteFrame', async () => {
             try {
-                // 对错误的值 类型 会修改失败，但是返回还是true
+                // 正确的 SpriteFrame 子资源 UUID 应原样写入
                 const setComponentProperty: ISetPropertyOptionsInfo = {
                     componentPath: componentPath,
                     properties: {
@@ -697,6 +697,33 @@ describe('Component Proxy 测试', () => {
                 console.log(`setComponentProperty test error:  ${e}`);
                 throw e;
             }
+        });
+        it('setProperty - 设置组件属性 - 图片父UUID自动规范化为SpriteFrame', async () => {
+            const result = await ComponentProxy.setProperty({
+                componentPath,
+                properties: {
+                    spriteFrame: {
+                        uuid: '20835ba4-6145-4fbc-a58a-051ce700aa3e'
+                    }
+                }
+            });
+
+            expect(result).toBe(true);
+            componentInfo = await ComponentProxy.query(queryComponent) as IComponentInfo;
+            expect(componentInfo?.properties['spriteFrame'].value.uuid).toBe('20835ba4-6145-4fbc-a58a-051ce700aa3e@f9941');
+        });
+        it('setProperty - 设置组件属性 - 未解析UUID保持历史placeholder行为', async () => {
+            const missingUuid = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+            const result = await ComponentProxy.setProperty({
+                componentPath,
+                properties: {
+                    spriteFrame: { uuid: missingUuid }
+                }
+            });
+
+            expect(result).toBe(true);
+            componentInfo = await ComponentProxy.query(queryComponent) as IComponentInfo;
+            expect(componentInfo?.properties['spriteFrame'].value.uuid).toBe(missingUuid);
         });
     });
 

--- a/src/core/scene/test/enrich-missing-dependency-error.test.ts
+++ b/src/core/scene/test/enrich-missing-dependency-error.test.ts
@@ -100,11 +100,13 @@ describe('enrichMissingDependencyError', () => {
         const msg = await enrichMissingDependencyError(errInfo, OWNER);
         expect(msg).toContain('Detail: some unexpected error format');
         expect(msg).toContain(OWNER);
+        expect(msg).not.toContain('dependent asset is missing');
     });
 
     it('handles empty error message', async () => {
         const msg = await enrichMissingDependencyError('', OWNER);
         expect(msg).toContain('Detail:');
         expect(msg).toContain(OWNER);
+        expect(msg).not.toContain('dependent asset is missing');
     });
 });

--- a/tests/asset-reference-tool-guidance.test.ts
+++ b/tests/asset-reference-tool-guidance.test.ts
@@ -1,0 +1,51 @@
+import 'reflect-metadata';
+
+jest.mock('../src/core/assets', () => ({
+    assetDBManager: {},
+    assetManager: {},
+}));
+
+jest.mock('../src/core/scene', () => ({
+    Scene: {},
+}));
+
+jest.mock('../src/api/decorator/decorator.js', () => ({
+    description: (desc: string) => (target: object, propertyKey: string | symbol) => {
+        Reflect.defineMetadata(`tool:description:${propertyKey.toString()}`, desc, target);
+    },
+    param: () => jest.fn(),
+    result: () => jest.fn(),
+    title: () => jest.fn(),
+    tool: () => jest.fn(),
+}), { virtual: true });
+
+import { AssetsApi } from '../src/api/assets/assets';
+import { ComponentApi } from '../src/api/scene/component';
+
+describe('Asset reference tool guidance', () => {
+    it('explains component Asset type validation and unique sub-asset normalization', () => {
+        const description = Reflect.getOwnMetadata('tool:description:setProperty', ComponentApi.prototype);
+
+        expect(description).toContain('scene-query-component');
+        expect(description).toContain('Asset reference');
+        expect(description).toContain('exactly one compatible sub-asset');
+        expect(description).toContain('return 400 without modifying');
+    });
+
+    it('explains that query UUID returns the exact parent resource', () => {
+        const description = Reflect.getOwnMetadata('tool:description:queryUUID', AssetsApi.prototype);
+
+        expect(description).toContain('exact asset');
+        expect(description).toContain('parent ImageAsset UUID');
+        expect(description).toContain('assets-query-asset-info');
+        expect(description).toContain('subAssets');
+    });
+
+    it('explains how to select typed sub-assets from detailed asset info', () => {
+        const description = Reflect.getOwnMetadata('tool:description:queryAssetInfo', AssetsApi.prototype);
+
+        expect(description).toContain('By default the result includes subAssets');
+        expect(description).toContain('type === "cc.SpriteFrame"');
+        expect(description).toContain('"extends"');
+    });
+});

--- a/tests/bug-497-api-error-status.test.ts
+++ b/tests/bug-497-api-error-status.test.ts
@@ -13,6 +13,7 @@ const mockReplaceTextInFile = jest.fn();
 const mockNodeQuery = jest.fn();
 const mockNodeDelete = jest.fn();
 const mockComponentQuery = jest.fn();
+const mockComponentSetProperty = jest.fn();
 
 jest.mock('../src/api/decorator/decorator.js', () => ({
     description: () => jest.fn(),
@@ -55,6 +56,7 @@ jest.mock('../src/core/scene', () => ({
         },
         Component: {
             query: (...args: unknown[]) => mockComponentQuery(...args),
+            setProperty: (...args: unknown[]) => mockComponentSetProperty(...args),
         },
     },
 }));
@@ -92,6 +94,7 @@ describe('Bug #497 common API error status codes', () => {
         mockNodeQuery.mockReset();
         mockNodeDelete.mockReset();
         mockComponentQuery.mockReset();
+        mockComponentSetProperty.mockReset();
     });
 
     it('allows client-side business error codes in common results', () => {
@@ -104,6 +107,9 @@ describe('Bug #497 common API error status codes', () => {
         expect(getCommonErrorStatus(new Error('Asset can not be found: db://assets/missing.scene'))).toBe(COMMON_STATUS.NOT_FOUND);
         expect(getCommonErrorStatus(new Error('can not find asset d:\\cocos\\program\\snake2\\assets\\resources\\Image'))).toBe(COMMON_STATUS.NOT_FOUND);
         expect(getCommonErrorStatus(new Error('Invalid scene/prefab asset content: invalid JSON'))).toBe(COMMON_STATUS.BAD_REQUEST);
+        expect(getCommonErrorStatus(Object.assign(new Error('Invalid asset reference for property spriteFrame'), {
+            code: 'INVALID_ASSET_REFERENCE',
+        }))).toBe(COMMON_STATUS.BAD_REQUEST);
         expect(getCommonErrorStatus(new Error('Filename cannot be empty.'))).toBe(COMMON_STATUS.BAD_REQUEST);
         expect(getCommonErrorStatus(new Error('parameter error'))).toBe(COMMON_STATUS.BAD_REQUEST);
         expect(getCommonErrorStatus(new Error('file GameManager.ts already exists, please use overwrite option'))).toBe(COMMON_STATUS.BAD_REQUEST);
@@ -371,5 +377,20 @@ describe('Bug #497 common API error status codes', () => {
 
         expect(result.code).toBe(HTTP_STATUS.NOT_FOUND);
         expect(result.reason).toBe('component not found: Canvas/Missing/cc.Label');
+    });
+
+    it('returns 400 when a component Asset reference fails semantic validation', async () => {
+        mockComponentSetProperty.mockRejectedValue(Object.assign(
+            new Error("Invalid asset reference for property 'spriteFrame': expected cc.SpriteFrame"),
+            { code: 'INVALID_ASSET_REFERENCE' },
+        ));
+
+        const result = await new ComponentApi().setProperty({
+            componentPath: 'Canvas/Coin/cc.Sprite',
+            properties: { spriteFrame: { uuid: 'bad-parent-uuid' } },
+        });
+
+        expect(result.code).toBe(HTTP_STATUS.BAD_REQUEST);
+        expect(result.reason).toContain('expected cc.SpriteFrame');
     });
 });

--- a/tests/scene-open-error-status.test.ts
+++ b/tests/scene-open-error-status.test.ts
@@ -1,0 +1,59 @@
+const mockSceneOpen = jest.fn();
+
+jest.mock('../src/api/decorator/decorator.js', () => ({
+    description: () => jest.fn(),
+    param: () => jest.fn(),
+    result: () => jest.fn(),
+    title: () => jest.fn(),
+    tool: () => jest.fn(),
+}), { virtual: true });
+
+jest.mock('../src/core/scene', () => ({
+    NodeType: {
+        EMPTY: 'Node',
+        SPRITE: 'Sprite',
+    },
+    Scene: {
+        open: (...args: unknown[]) => mockSceneOpen(...args),
+    },
+}));
+
+import { SceneApi } from '../src/api/scene/scene';
+import { COMMON_STATUS } from '../src/api/base/schema-base';
+
+describe('scene-open error status', () => {
+    beforeEach(() => {
+        mockSceneOpen.mockReset();
+        jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('returns 400 for known invalid scene or prefab content', async () => {
+        mockSceneOpen.mockRejectedValue(new Error('Invalid scene/prefab asset content: invalid JSON'));
+
+        const result = await new SceneApi().open({
+            dbURLOrUUID: 'db://assets/broken.prefab',
+            includeChildren: true,
+            includeComponents: false,
+        });
+
+        expect(result.code).toBe(COMMON_STATUS.BAD_REQUEST);
+        expect(result.reason).toContain('Invalid scene/prefab asset content');
+    });
+
+    it('keeps unknown internal failures as 500', async () => {
+        mockSceneOpen.mockRejectedValue(new TypeError("Cannot read properties of undefined (reading '0')"));
+
+        const result = await new SceneApi().open({
+            dbURLOrUUID: 'db://assets/broken.prefab',
+            includeChildren: true,
+            includeComponents: false,
+        });
+
+        expect(result.code).toBe(COMMON_STATUS.FAIL);
+        expect(result.reason).toContain('Cannot read properties');
+    });
+});


### PR DESCRIPTION
## 修复说明

组件 Asset 属性写入前增加类型校验：

- 父资源仅有一个兼容子资源时，自动替换为正确的子资源 UUID。
- 类型不兼容或存在多个候选资源时返回 400，并保证组件不会被部分修改。
- 保持历史 placeholder、空引用、数组空引用及 `ui-*` 行为不变。
- 自动修正发生在写入前，不依赖后续大模型再次发现并修复。

## 测试组验证步骤
偶发bug, 继续留意观察是否还出现