### PR TITLE
fix: serialize file edits during asset reimport

### DIFF
--- a/src/api/assets/assets.ts
+++ b/src/api/assets/assets.ts
@@ -409,7 +409,7 @@ export class AssetsApi {
             const assetInfo = await assetManager.reimportAsset(pathOrUrlOrUUID);
             ret.data = assetInfo;
         } catch (e) {
-            ret.code = COMMON_STATUS.FAIL;
+            ret.code = getCommonErrorStatus(e);
             console.error(e);
             ret.reason = e instanceof Error ? e.message + e.stack : String(e);
         }

--- a/src/api/base/schema-base.ts
+++ b/src/api/base/schema-base.ts
@@ -78,7 +78,7 @@ export function getCommonErrorStatus(error: unknown): CommonStatus {
         return COMMON_STATUS.BAD_REQUEST;
     }
 
-    if (code === 'ENOENT' || /ENOENT|no such file or directory|not found|not exist|cannot find|can not find|can not be found/i.test(message)) {
+    if (code === 'ENOENT' || /ENOENT|no such file or directory|not found|not exist|cannot find|can not find|can not be found|无法找到资源/i.test(message)) {
         return COMMON_STATUS.NOT_FOUND;
     }
 

--- a/src/core/assets/manager/operation.ts
+++ b/src/core/assets/manager/operation.ts
@@ -20,6 +20,24 @@ import EventEmitter from 'events';
 import { mergeMeta } from '../asset-handler/utils';
 import * as lodash from 'lodash';
 
+const REIMPORT_BUSY_TIMEOUT_MS = 10_000;
+
+function waitForAssetInit(asset: IAsset, timeoutMs: number, pathOrUrlOrUUID: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+            reject(new Error(`Reimport asset ${pathOrUrlOrUUID} timed out waiting for the current import to finish`));
+        }, timeoutMs);
+
+        asset.waitInit().then(() => {
+            clearTimeout(timer);
+            resolve();
+        }, (error) => {
+            clearTimeout(timer);
+            reject(error);
+        });
+    });
+}
+
 function isScriptAsset(asset: IAsset) {
     const importer = asset.meta?.importer;
     return importer === 'typescript'
@@ -606,11 +624,27 @@ class AssetOperation extends EventEmitter {
         if (pathOrUrlOrUUID.startsWith('db://')) {
             pathOrUrlOrUUID = url2uuid(pathOrUrlOrUUID);
         }
-        const asset = await reimport(pathOrUrlOrUUID);
-        if (!asset) {
-            throw new Error(`无法找到资源 ${pathOrUrlOrUUID}, 请检查参数是否正确`);
+        let asset = await reimport(pathOrUrlOrUUID);
+        let busyDeadline = 0;
+        while (!asset) {
+            const existingAsset = assetQuery.queryAsset(pathOrUrlOrUUID);
+            if (!existingAsset) {
+                throw new Error(`无法找到资源 ${pathOrUrlOrUUID}, 请检查参数是否正确`);
+            }
+            busyDeadline ||= Date.now() + REIMPORT_BUSY_TIMEOUT_MS;
+            const remainingTime = busyDeadline - Date.now();
+            if (remainingTime <= 0) {
+                throw new Error(`Reimport asset ${pathOrUrlOrUUID} timed out waiting for the current import to finish`);
+            }
+            if (!existingAsset.init) {
+                await waitForAssetInit(existingAsset, remainingTime, pathOrUrlOrUUID);
+            }
+            if (Date.now() >= busyDeadline) {
+                throw new Error(`Reimport asset ${pathOrUrlOrUUID} timed out waiting for the current import to finish`);
+            }
+            asset = await reimport(pathOrUrlOrUUID);
         }
-        if (asset && (!asset.imported || asset.invalid)) {
+        if (!asset.imported || asset.invalid) {
             throw asset.importError || new Error(`Reimport asset ${asset.source} failed`);
         }
         return assetQuery.encodeAsset(asset);

--- a/src/core/assets/test/operation-filesystem-bridge.test.ts
+++ b/src/core/assets/test/operation-filesystem-bridge.test.ts
@@ -11,6 +11,7 @@ const mockQueryAssetInfos = jest.fn();
 const mockQueryUrl = jest.fn();
 const mockAssetQueryUrl = jest.fn();
 const mockRefresh = jest.fn(async (_pathOrUrlOrUUID: string) => 0);
+const mockReimport = jest.fn();
 const mockAddTask = jest.fn(async (func: Function, args: any[]) => await func(...args));
 const mockGetCreateMenuByName = jest.fn();
 const mockCreateAssetByHandler = jest.fn();
@@ -27,7 +28,7 @@ jest.mock('fs-extra', () => ({
 
 jest.mock('@cocos/asset-db', () => ({
     refresh: (pathOrUrlOrUUID: string) => mockRefresh(pathOrUrlOrUUID),
-    reimport: jest.fn(),
+    reimport: (...args: any[]) => mockReimport(...args),
     queryUrl: (...args: any[]) => mockQueryUrl(...args),
     Asset: class {},
 }));
@@ -199,6 +200,61 @@ describe('asset operation filesystem bridge', () => {
         expect(reimport).toHaveBeenCalledTimes(1);
         expect(reimport).toHaveBeenCalledWith('6fa5fbad-0d32-4b63-95d8-24507665775c@6c48a');
         expect(result).toBe(subAsset.meta.userData);
+    });
+
+    it('reimportAsset waits for a busy asset and retries the latest disk content', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const asset = {
+            init: false,
+            imported: true,
+            invalid: false,
+            source: 'D:/project/assets/Game.ts',
+            waitInit: jest.fn(async () => {
+                asset.init = true;
+            }),
+        };
+        mockReimport.mockResolvedValueOnce(null).mockResolvedValueOnce(asset);
+        mockQueryAsset.mockReturnValue(asset);
+
+        const result = await assetOperation.reimportAsset('game-script-uuid');
+
+        expect(mockReimport).toHaveBeenNthCalledWith(1, 'game-script-uuid');
+        expect(asset.waitInit).toHaveBeenCalledTimes(1);
+        expect(mockReimport).toHaveBeenNthCalledWith(2, 'game-script-uuid');
+        expect(result).toEqual({ source: asset.source });
+    });
+
+    it('reimportAsset still reports a genuinely missing asset', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        mockReimport.mockResolvedValue(null);
+        mockQueryAsset.mockReturnValue(null);
+
+        await expect(assetOperation.reimportAsset('missing-asset-uuid'))
+            .rejects.toThrow('无法找到资源 missing-asset-uuid');
+    });
+
+    it('reimportAsset times out instead of waiting forever for a busy asset', async () => {
+        jest.useFakeTimers();
+        try {
+            const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+            const asset = {
+                init: false,
+                waitInit: jest.fn(() => new Promise<void>(() => undefined)),
+            };
+            mockReimport.mockResolvedValue(null);
+            mockQueryAsset.mockReturnValue(asset);
+
+            const result = assetOperation.reimportAsset('busy-asset-uuid');
+            const rejection = expect(result).rejects.toThrow(
+                'Reimport asset busy-asset-uuid timed out waiting for the current import to finish'
+            );
+            await jest.advanceTimersByTimeAsync(10_000);
+
+            await rejection;
+            expect(asset.waitInit).toHaveBeenCalledTimes(1);
+        } finally {
+            jest.useRealTimers();
+        }
     });
 
     it('updateUserDataByPath updates sub asset userData through composite uuid with one reimport', async () => {

--- a/src/core/filesystem/file-edit.test.ts
+++ b/src/core/filesystem/file-edit.test.ts
@@ -1,0 +1,174 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const mockQueryPath = jest.fn();
+const mockReimportAsset = jest.fn();
+const mockResolveToRaw = jest.fn();
+const mockContains = jest.fn();
+
+jest.mock('@cocos/asset-db/libs/manager', () => ({
+    queryPath: (...args: unknown[]) => mockQueryPath(...args),
+}));
+
+jest.mock('../../core/assets', () => ({
+    assetManager: {
+        reimportAsset: (...args: unknown[]) => mockReimportAsset(...args),
+    },
+}));
+
+jest.mock('../base/utils/path', () => ({
+    resolveToRaw: (...args: unknown[]) => mockResolveToRaw(...args),
+    contains: (...args: unknown[]) => mockContains(...args),
+}));
+
+jest.mock('replace-in-file', () => ({
+    replaceInFile: async (options: {
+        files: string;
+        from: string | RegExp;
+        to: string;
+        countMatches?: boolean;
+        dry?: boolean;
+    }) => {
+        const nodeFs = require('fs') as typeof import('fs');
+        const content = nodeFs.readFileSync(options.files, 'utf8');
+        const matches = typeof options.from === 'string'
+            ? content.split(options.from).length - 1
+            : Array.from(content.matchAll(options.from)).length;
+        const replaced = content.replace(options.from, options.to);
+        if (!options.dry && replaced !== content) {
+            nodeFs.writeFileSync(options.files, replaced);
+        }
+        return [{
+            file: options.files,
+            hasChanged: replaced !== content,
+            numMatches: options.countMatches ? matches : undefined,
+        }];
+    },
+}));
+
+import { replaceTextInFile } from './file-edit';
+
+function createDeferred() {
+    let resolve!: () => void;
+    const promise = new Promise<void>((done) => {
+        resolve = done;
+    });
+    return { promise, resolve };
+}
+
+async function waitForMockCalls(mock: jest.Mock, expected: number) {
+    for (let attempt = 0; attempt < 20 && mock.mock.calls.length < expected; attempt++) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+    expect(mock).toHaveBeenCalledTimes(expected);
+}
+
+describe('file edit concurrency', () => {
+    let projectDir: string;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cocos-file-edit-'));
+        mockResolveToRaw.mockReturnValue(projectDir);
+        mockContains.mockImplementation((root: string, filename: string) => filename.startsWith(root));
+    });
+
+    afterEach(() => {
+        fs.rmSync(projectDir, { recursive: true, force: true });
+    });
+
+    it('serializes replacements for the same file through reimport', async () => {
+        const filename = path.join(projectDir, 'Game.ts');
+        fs.writeFileSync(filename, 'const first = 1;\nconst second = 2;\n');
+        mockQueryPath.mockReturnValue(filename);
+
+        const firstReimport = createDeferred();
+        mockReimportAsset
+            .mockImplementationOnce(() => firstReimport.promise)
+            .mockResolvedValueOnce({});
+
+        const first = replaceTextInFile('db://assets/Game.ts', 'ts', 'first = 1', 'first = 10', false);
+        await waitForMockCalls(mockReimportAsset, 1);
+        const second = replaceTextInFile('db://assets/Game.ts', 'ts', 'second = 2', 'second = 20', false);
+        await new Promise<void>((resolve) => setImmediate(resolve));
+
+        expect(mockReimportAsset).toHaveBeenCalledTimes(1);
+        firstReimport.resolve();
+        await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+        expect(fs.readFileSync(filename, 'utf8')).toBe('const first = 10;\nconst second = 20;\n');
+        expect(mockReimportAsset).toHaveBeenCalledTimes(2);
+    });
+
+    it('preserves the unique-match contract for duplicate concurrent replacements', async () => {
+        const filename = path.join(projectDir, 'Game.ts');
+        fs.writeFileSync(filename, 'const score = 0;\n');
+        mockQueryPath.mockReturnValue(filename);
+
+        const firstReimport = createDeferred();
+        mockReimportAsset.mockImplementationOnce(() => firstReimport.promise);
+
+        const first = replaceTextInFile('db://assets/Game.ts', 'ts', 'score = 0', 'score = 1', false);
+        await waitForMockCalls(mockReimportAsset, 1);
+        const second = replaceTextInFile('db://assets/Game.ts', 'ts', 'score = 0', 'score = 2', false);
+        firstReimport.resolve();
+
+        await expect(first).resolves.toBe(true);
+        await expect(second).rejects.toThrow('No replacement was performed');
+        expect(fs.readFileSync(filename, 'utf8')).toBe('const score = 1;\n');
+        expect(mockReimportAsset).toHaveBeenCalledTimes(1);
+    });
+
+    it('releases the file queue after an edit fails', async () => {
+        const filename = path.join(projectDir, 'Game.ts');
+        fs.writeFileSync(filename, 'const ready = false;\n');
+        mockQueryPath.mockReturnValue(filename);
+        mockReimportAsset.mockResolvedValue({});
+
+        const missing = replaceTextInFile('db://assets/Game.ts', 'ts', 'missing = true', 'missing = false', false);
+        const valid = replaceTextInFile('db://assets/Game.ts', 'ts', 'ready = false', 'ready = true', false);
+
+        await expect(missing).rejects.toThrow('No replacement was performed');
+        await expect(valid).resolves.toBe(true);
+        expect(fs.readFileSync(filename, 'utf8')).toBe('const ready = true;\n');
+    });
+
+    it('releases the file queue after reimport rejects', async () => {
+        const filename = path.join(projectDir, 'Game.ts');
+        fs.writeFileSync(filename, 'const first = 1;\nconst second = 2;\n');
+        mockQueryPath.mockReturnValue(filename);
+        mockReimportAsset
+            .mockRejectedValueOnce(new Error('Reimport asset timed out'))
+            .mockResolvedValueOnce({});
+
+        const first = replaceTextInFile('db://assets/Game.ts', 'ts', 'first = 1', 'first = 10', false);
+        const second = replaceTextInFile('db://assets/Game.ts', 'ts', 'second = 2', 'second = 20', false);
+
+        await expect(first).rejects.toThrow('Reimport asset timed out');
+        await expect(second).resolves.toBe(true);
+        expect(fs.readFileSync(filename, 'utf8')).toBe('const first = 10;\nconst second = 20;\n');
+        expect(mockReimportAsset).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not serialize edits to different files', async () => {
+        const firstFilename = path.join(projectDir, 'First.ts');
+        const secondFilename = path.join(projectDir, 'Second.ts');
+        fs.writeFileSync(firstFilename, 'const first = 1;\n');
+        fs.writeFileSync(secondFilename, 'const second = 2;\n');
+        mockQueryPath.mockImplementation((dbURL: string) => dbURL.includes('First') ? firstFilename : secondFilename);
+
+        const firstReimport = createDeferred();
+        const secondReimport = createDeferred();
+        mockReimportAsset
+            .mockImplementationOnce(() => firstReimport.promise)
+            .mockImplementationOnce(() => secondReimport.promise);
+
+        const first = replaceTextInFile('db://assets/First.ts', 'ts', 'first = 1', 'first = 10', false);
+        const second = replaceTextInFile('db://assets/Second.ts', 'ts', 'second = 2', 'second = 20', false);
+        await waitForMockCalls(mockReimportAsset, 2);
+
+        firstReimport.resolve();
+        secondReimport.resolve();
+        await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+    });
+});

--- a/src/core/filesystem/file-edit.ts
+++ b/src/core/filesystem/file-edit.ts
@@ -9,6 +9,33 @@ import { assetManager } from '../../core/assets';
 import { queryPath } from '@cocos/asset-db/libs/manager';
 
 const LF = '\n';
+const fileEditQueues = new Map<string, Promise<void>>();
+
+function getFileEditQueueKey(filename: string): string {
+    const resolved = path.resolve(filename);
+    return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
+async function withFileEditLock<T>(filename: string, operation: () => Promise<T>): Promise<T> {
+    const key = getFileEditQueueKey(filename);
+    const previous = fileEditQueues.get(key) ?? Promise.resolve();
+    let release!: () => void;
+    const turn = new Promise<void>((resolve) => {
+        release = resolve;
+    });
+    const tail = previous.catch(() => undefined).then(() => turn);
+    fileEditQueues.set(key, tail);
+
+    await previous.catch(() => undefined);
+    try {
+        return await operation();
+    } finally {
+        release();
+        if (fileEditQueues.get(key) === tail) {
+            fileEditQueues.delete(key);
+        }
+    }
+}
 
 function asyncWrite(stream: fs.WriteStream, chunk: string): Promise<void> {
     return new Promise((resolve, reject) => {
@@ -56,64 +83,66 @@ export async function insertTextAtLine(
     textToInsert = eol.auto(textToInsert);
 
     const filename = getScriptFilename(dbURL, fileType);
-    const tmpFilename = filename + '.tmp';
-    const fileStream = fs.createReadStream(filename);
+    return await withFileEditLock(filename, async () => {
+        const tmpFilename = filename + '.tmp';
+        const fileStream = fs.createReadStream(filename);
 
-    const rl = readline.createInterface({
-        input: fileStream,
-        crlfDelay: Infinity
-    });
+        const rl = readline.createInterface({
+            input: fileStream,
+            crlfDelay: Infinity
+        });
 
-    // Create a temporary write stream
-    const writeStream = fs.createWriteStream(tmpFilename);
+        // Create a temporary write stream
+        const writeStream = fs.createWriteStream(tmpFilename);
 
-    let currentLine = 0;
-    let modified = false;
-    let errorOccurred = false;
-    try {
-        for await (const line of rl) {
-            if (currentLine === lineNumber) { // Insert text before the current line
+        let currentLine = 0;
+        let modified = false;
+        let errorOccurred = false;
+        try {
+            for await (const line of rl) {
+                if (currentLine === lineNumber) { // Insert text before the current line
+                    await asyncWrite(writeStream, textToInsert);
+                    modified = true;
+                }
+                // Write the current line
+                await asyncWrite(writeStream, line);
+                ++currentLine;
+            }
+
+            if (!modified) { // If lineNumber is greater than total lines, append at the end
                 await asyncWrite(writeStream, textToInsert);
                 modified = true;
             }
-            // Write the current line
-            await asyncWrite(writeStream, line);
-            ++currentLine;
+        } catch (err) {
+            console.error('insertTextAtLine error:', err);
+            errorOccurred = true;
+        } finally {
+            rl.close();
+            fileStream.destroy();
+
+            await new Promise<void>((resolve, reject) => {
+                writeStream.on('finish', resolve);
+                writeStream.on('error', reject);
+                writeStream.end();
+            });
         }
 
-        if (!modified) { // If lineNumber is greater than total lines, append at the end
-            await asyncWrite(writeStream, textToInsert);
-            modified = true;
+        // If an error occurred, delete the temporary file
+        if (errorOccurred || !modified) {
+            if (fs.existsSync(tmpFilename)) {
+                fs.unlinkSync(tmpFilename);
+            }
+            throw new Error('Failed to insert text at the specified line.');
         }
-    } catch (err) {
-        console.error('insertTextAtLine error:', err);
-        errorOccurred = true;
-    } finally {
-        rl.close();
-        fileStream.destroy();
 
-        await new Promise<void>((resolve, reject) => {
-            writeStream.on('finish', resolve);
-            writeStream.on('error', reject);
-            writeStream.end();
-        });
-    }
+        // Replace the original file with the modified temporary file
+        fs.renameSync(tmpFilename, filename);
 
-    // If an error occurred, delete the temporary file
-    if (errorOccurred || !modified) {
-        if (fs.existsSync(tmpFilename)) {
-            fs.unlinkSync(tmpFilename);
-        }
-        throw new Error('Failed to insert text at the specified line.');
-    }
+        // Reimport script
+        await assetManager.reimportAsset(dbURL);
 
-    // Replace the original file with the modified temporary file
-    fs.renameSync(tmpFilename, filename);
-
-    // Reimport script
-    await assetManager.reimportAsset(dbURL);
-
-    return true;
+        return true;
+    });
 }
 
 // End line is inclusive
@@ -131,62 +160,64 @@ export async function eraseLinesInRange(
     }
 
     const filename = getScriptFilename(dbURL, fileType);
-    const tmpFilename = filename + '.tmp';
-    const fileStream = fs.createReadStream(filename);
-    const rl = readline.createInterface({
-        input: fileStream,
-        crlfDelay: Infinity
-    });
-    // Create a temporary write stream
-    const writeStream = fs.createWriteStream(tmpFilename);
-    let currentLine = 0;
-    let modified = false;
-    let errorOccurred = false;
-    try {
-        for await (const line of rl) {
-            if (currentLine < startLine || currentLine > endLine) {
-                // Write the current line if it's outside the range
-                await asyncWrite(writeStream, line);
-            } else {
-                modified = true; // Lines in range are skipped
-            }
-            ++currentLine;
-        }
-    } catch (err) {
-        console.error('eraseLinesInRange error:', err);
-        errorOccurred = true;
-    } finally {
-        rl.close();
-        fileStream.destroy();
-
-        await new Promise<void>((resolve, reject) => {
-            writeStream.on('finish', resolve);
-            writeStream.on('error', reject);
-            writeStream.end();
+    return await withFileEditLock(filename, async () => {
+        const tmpFilename = filename + '.tmp';
+        const fileStream = fs.createReadStream(filename);
+        const rl = readline.createInterface({
+            input: fileStream,
+            crlfDelay: Infinity
         });
-    }
+        // Create a temporary write stream
+        const writeStream = fs.createWriteStream(tmpFilename);
+        let currentLine = 0;
+        let modified = false;
+        let errorOccurred = false;
+        try {
+            for await (const line of rl) {
+                if (currentLine < startLine || currentLine > endLine) {
+                    // Write the current line if it's outside the range
+                    await asyncWrite(writeStream, line);
+                } else {
+                    modified = true; // Lines in range are skipped
+                }
+                ++currentLine;
+            }
+        } catch (err) {
+            console.error('eraseLinesInRange error:', err);
+            errorOccurred = true;
+        } finally {
+            rl.close();
+            fileStream.destroy();
 
-    // If an error occurred, delete the temporary file
-    if (errorOccurred) {
-        if (fs.existsSync(tmpFilename)) {
-            fs.unlinkSync(tmpFilename);
+            await new Promise<void>((resolve, reject) => {
+                writeStream.on('finish', resolve);
+                writeStream.on('error', reject);
+                writeStream.end();
+            });
         }
-        throw new Error('Failed to erase lines in the specified range.');
-    }
 
-    // Replace the original file with the modified temporary file
-    if (modified) {
-        fs.renameSync(tmpFilename, filename);
-
-        await assetManager.reimportAsset(dbURL);
-
-        return true;
-    } else {
-        if (fs.existsSync(tmpFilename)) {
-            fs.unlinkSync(tmpFilename);
+        // If an error occurred, delete the temporary file
+        if (errorOccurred) {
+            if (fs.existsSync(tmpFilename)) {
+                fs.unlinkSync(tmpFilename);
+            }
+            throw new Error('Failed to erase lines in the specified range.');
         }
-        throw new Error('No lines were erased. Please check the specified range.');
-    }
+
+        // Replace the original file with the modified temporary file
+        if (modified) {
+            fs.renameSync(tmpFilename, filename);
+
+            await assetManager.reimportAsset(dbURL);
+
+            return true;
+        } else {
+            if (fs.existsSync(tmpFilename)) {
+                fs.unlinkSync(tmpFilename);
+            }
+            throw new Error('No lines were erased. Please check the specified range.');
+        }
+    });
 }
 
 export function findTextOccurrencesInFile(
@@ -216,43 +247,45 @@ export async function replaceTextInFile(
     // Get filename
     const filename = getScriptFilename(dbURL, fileType);
 
-    let count = 0;
-    if (regex) {
-        // First, count occurrences
-        const results = await replaceInFile({
-            files: filename,
-            from: new RegExp(targetText1, 'g'), // Global replace
-            to: replacementText,
-            countMatches: true,
-            dry: true, // Dry run to count matches first
-        });
-        for (const result of results) {
-            if (result.numMatches) {
-                count += result.numMatches;
+    return await withFileEditLock(filename, async () => {
+        let count = 0;
+        if (regex) {
+            // First, count occurrences
+            const results = await replaceInFile({
+                files: filename,
+                from: new RegExp(targetText1, 'g'), // Global replace
+                to: replacementText,
+                countMatches: true,
+                dry: true, // Dry run to count matches first
+            });
+            for (const result of results) {
+                if (result.numMatches) {
+                    count += result.numMatches;
+                }
             }
+        } else {
+            count = findTextOccurrencesInFile(filename, targetText1);
         }
-    } else {
-        count = findTextOccurrencesInFile(filename, targetText1);
-    }
 
-    if (count > 1) {
-        throw new Error(`Multiple (${count}) occurrences found. File is not changed.`);
-    }
+        if (count > 1) {
+            throw new Error(`Multiple (${count}) occurrences found. File is not changed.`);
+        }
 
-    if (count == 1) {
-        const results = await replaceInFile({
-            files: filename,
-            from: regex
-                ? new RegExp(targetText1, 'g') // Global replace
-                : targetText1, // First occurrence
-            to: replacementText,
-        });
+        if (count == 1) {
+            const results = await replaceInFile({
+                files: filename,
+                from: regex
+                    ? new RegExp(targetText1, 'g') // Global replace
+                    : targetText1, // First occurrence
+                to: replacementText,
+            });
 
-        await assetManager.reimportAsset(dbURL);
+            await assetManager.reimportAsset(dbURL);
 
-        return results.some(result => result.hasChanged);
-    }
-    throw new Error(`No replacement was performed, TargetText ${targetText} did not appear verbatim in ${filename}.`);
+            return results.some(result => result.hasChanged);
+        }
+        throw new Error(`No replacement was performed, TargetText ${targetText} did not appear verbatim in ${filename}.`);
+    });
 }
 
 export async function queryLinesInFile(

--- a/tests/bug-497-api-error-status.test.ts
+++ b/tests/bug-497-api-error-status.test.ts
@@ -5,6 +5,7 @@ const mockCreateAsset = jest.fn();
 const mockCreateAssetByType = jest.fn();
 const mockImportAsset = jest.fn();
 const mockSaveAsset = jest.fn();
+const mockReimportAsset = jest.fn();
 const mockQueryPath = jest.fn();
 const mockQueryUrl = jest.fn();
 const mockQueryLinesInFile = jest.fn();
@@ -33,6 +34,7 @@ jest.mock('../src/core/assets', () => ({
         createAssetByType: (...args: unknown[]) => mockCreateAssetByType(...args),
         importAsset: (...args: unknown[]) => mockImportAsset(...args),
         saveAsset: (...args: unknown[]) => mockSaveAsset(...args),
+        reimportAsset: (...args: unknown[]) => mockReimportAsset(...args),
         queryPath: (...args: unknown[]) => mockQueryPath(...args),
         queryUrl: (...args: unknown[]) => mockQueryUrl(...args),
     },
@@ -86,6 +88,7 @@ describe('Bug #497 common API error status codes', () => {
         mockCreateAssetByType.mockReset();
         mockImportAsset.mockReset();
         mockSaveAsset.mockReset();
+        mockReimportAsset.mockReset();
         mockQueryPath.mockReset();
         mockQueryUrl.mockReset();
         mockQueryLinesInFile.mockReset();
@@ -106,6 +109,7 @@ describe('Bug #497 common API error status codes', () => {
         expect(getCommonErrorStatus(new Error('ENOENT: no such file or directory'))).toBe(COMMON_STATUS.NOT_FOUND);
         expect(getCommonErrorStatus(new Error('Asset can not be found: db://assets/missing.scene'))).toBe(COMMON_STATUS.NOT_FOUND);
         expect(getCommonErrorStatus(new Error('can not find asset d:\\cocos\\program\\snake2\\assets\\resources\\Image'))).toBe(COMMON_STATUS.NOT_FOUND);
+        expect(getCommonErrorStatus(new Error('无法找到资源 missing-asset-uuid, 请检查参数是否正确'))).toBe(COMMON_STATUS.NOT_FOUND);
         expect(getCommonErrorStatus(new Error('Invalid scene/prefab asset content: invalid JSON'))).toBe(COMMON_STATUS.BAD_REQUEST);
         expect(getCommonErrorStatus(Object.assign(new Error('Invalid asset reference for property spriteFrame'), {
             code: 'INVALID_ASSET_REFERENCE',
@@ -143,6 +147,16 @@ describe('Bug #497 common API error status codes', () => {
         expect(result.code).toBe(HTTP_STATUS.NOT_FOUND);
         expect(result.data).toBeNull();
         expect(result.reason).toContain('Asset not found');
+    });
+
+    it('returns 404 when reimporting a genuinely missing asset', async () => {
+        mockReimportAsset.mockRejectedValue(new Error('无法找到资源 missing-asset-uuid, 请检查参数是否正确'));
+
+        const result = await new AssetsApi().reimportAsset('missing-asset-uuid');
+
+        expect(result.code).toBe(HTTP_STATUS.NOT_FOUND);
+        expect(result.data).toBeNull();
+        expect(result.reason).toContain('无法找到资源 missing-asset-uuid');
     });
 
     it('returns 400 for asset query parameter errors', async () => {


### PR DESCRIPTION
## 修复说明

已修复 Pink 使用 GLM5.2 创建游戏时，文件编辑并发触发 AssetDB 重导入，误报“无法找到资源”的问题。

### 主要改动

- 同一文件的读取、写入和重导入串行执行，不同文件仍可并行。
- 资源正在导入时等待完成并重试。
- 增加 10 秒超时，防止请求和文件队列永久阻塞。
- 真实资源缺失统一返回 404。
- 补充并发编辑、超时、队列释放和错误码回归测试。

### 测试
- 偶先bug, 在pink中留意是否复现