### PR TITLE
[break][feat] queryAssetInfos lib entry pass through dataKeys parameter

### DIFF
--- a/src/lib/assets/assets.ts
+++ b/src/lib/assets/assets.ts
@@ -120,8 +120,8 @@ export async function queryCreateMap(): Promise<ICreateMenuInfo[]> {
 /**
  * Batch Query Asset Info // 批量查询资源信息
  */
-export async function queryAssetInfos(options?: QueryAssetsOption): Promise<IAssetInfo[]> {
-    return await assetManager.queryAssetInfos(options);
+export async function queryAssetInfos(options?: QueryAssetsOption, dataKeys?: (keyof IAssetInfo)[]): Promise<IAssetInfo[]> {
+    return await assetManager.queryAssetInfos(options, dataKeys);
 }
 
 /**


### PR DESCRIPTION
## Summary
- `queryAssetInfos` lib entry now accepts and forwards the `dataKeys` parameter to `assetManager.queryAssetInfos`
- Enables callers to specify which optional `IAssetInfo` fields to return, matching the existing `queryAssetInfo` (singular) pattern

## Test Plan

`dataKeys` controls which optional fields of `IAssetInfo` get populated in the result. Without it, only `subAssets` and `displayName` are returned by default.

Available optional fields: `isBundle`, `displayName`, `visible`, `subAssets`, `meta`, `parent`, `extends`, `mtime`, `depends`, `dependeds`, `temp`, `redirect`, `instantiation`, `readonly`

**Before (no dataKeys):**
```ts
const infos = await Editor.Assets.queryAssetInfos({ ccType: 'cc.SpriteFrame' });
// infos[0].meta => undefined
// infos[0].depends => undefined
// infos[0].subAssets => { ... }       // default included
// infos[0].displayName => 'xxx'       // default included
```

**After (with dataKeys):**
```ts
const infos = await Editor.Assets.queryAssetInfos(
  { ccType: 'cc.SpriteFrame' },
  ['meta', 'depends']
);
// infos[0].meta => { ver: '...', importer: '...', ... }
// infos[0].depends => ['uuid1', 'uuid2']
// infos[0].subAssets => undefined     // no longer included
// infos[0].displayName => undefined   // no longer included
```

> **Breaking change:** `dataKeys` is a full replacement, not additive. Passing `dataKeys` will **override** the defaults (`['subAssets', 'displayName']`). If callers still need these fields, they must explicitly include them:
> ```ts
> queryAssetInfos(options, ['subAssets', 'displayName', 'meta', 'depends'])
> ```

- [ ] Call `queryAssetInfos(options)` without `dataKeys` — result should contain default fields (`subAssets`, `displayName`)
- [ ] Call `queryAssetInfos(options, ['meta', 'depends'])` — result items should have `meta` and `depends` populated, but **not** `subAssets` or `displayName`
- [ ] Call `queryAssetInfos(options, ['subAssets', 'displayName', 'meta'])` — result items should have all three fields
- [ ] Call `queryAssetInfos(options, ['parent'])` — result items should have `parent` with `source`, `library`, `uuid`
- [ ] Verify existing callers (e.g. `asset-db.ts` uses `['meta', 'url', 'file', 'importer', 'type']`) still work correctly