### PR TITLE
fix(assets): preserve metadata when copying assets

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -202,6 +202,7 @@ export declare interface BitmapFontAssetUserData {
     fontSize: number;
     textureUuid: string;
 }
+export declare function copyAsset(source: string, target: string, options?: AssetOperationOption): Promise<IAssetInfo>;
 export declare function createAsset(options: CreateAssetOptions): Promise<IAssetInfo>;
 export declare function createAssetByType(ccType: ISupportCreateType, dirOrUrl: string, baseName: string, options?: CreateAssetByTypeOptions): Promise<IAssetInfo>;
 export declare interface CreateAssetByTypeOptions extends AssetOperationOption {
@@ -7629,6 +7630,7 @@ export declare namespace Assets {
         createAssetByType,
         createAsset,
         importAsset,
+        copyAsset,
         reimportAsset,
         saveAsset,
         querySerializedData,
@@ -7827,6 +7829,7 @@ export declare namespace Configuration {
     }
 }
 export declare type ConfigurationScope = 'default' | 'project' | 'local';
+export declare function copyAsset(source: string, target: string, options?: AssetOperationOption): Promise<IAssetInfo>;
 export declare function createAsset(options: CreateAssetOptions): Promise<IAssetInfo>;
 export declare function createAssetByType(ccType: ISupportCreateType, dirOrUrl: string, baseName: string, options?: CreateAssetByTypeOptions): Promise<IAssetInfo>;
 export declare interface CreateAssetByTypeOptions extends AssetOperationOption {

--- a/src/api/assets/assets.ts
+++ b/src/api/assets/assets.ts
@@ -392,6 +392,34 @@ export class AssetsApi {
     }
 
     /**
+     * Copy Asset // 复制资源
+     */
+    @tool('assets-copy-asset')
+    @title('Copy Asset') // 复制资源
+    @description('Copy an existing main asset to a new location together with its complete metadata. The copied asset receives new UUIDs while preserving importer settings, userData, subMetas, and internal references. Supports overwrite or automatic rename on conflicts.') // 将现有主资源及其完整元数据复制到新位置。副本会获得新 UUID，同时保留导入设置、userData、subMetas 和内部引用。支持冲突时覆盖或自动重命名。
+    @result(SchemaAssetInfoResult)
+    async copyAsset(
+        @param(SchemaUrlOrUUIDOrPath) source: TUrlOrUUIDOrPath,
+        @param(SchemaTargetPath) target: TDirOrDbPath,
+        @param(SchemaAssetOperationOption) options?: TAssetOperationOption
+    ): Promise<CommonResultType<TAssetInfoResult>> {
+        const ret: CommonResultType<TAssetInfoResult> = {
+            code: COMMON_STATUS.SUCCESS,
+            data: null,
+        };
+
+        try {
+            ret.data = await assetManager.copyAsset(source, target, options);
+        } catch (e) {
+            ret.code = getCommonErrorStatus(e);
+            console.error('copy asset fail:', e instanceof Error ? e.message : String(e));
+            ret.reason = e instanceof Error ? e.message : String(e);
+        }
+
+        return ret;
+    }
+
+    /**
      * Reimport Asset // 重新导入资源
      */
     @tool('assets-reimport-asset')

--- a/src/core/assets/manager/asset-copy.ts
+++ b/src/core/assets/manager/asset-copy.ts
@@ -1,0 +1,363 @@
+import { existsSync, readdir, stat } from 'fs-extra';
+import { basename, dirname, extname, join, relative } from 'path';
+import type { AssetOperationOption } from '../@types/public';
+import utils from '../../base/utils';
+import { copyPath, deletePath, readPath, renamePath, writePath } from './filesystem';
+
+type JsonRecord = Record<string, unknown>;
+
+interface MetaCopyEntry {
+    relativePath: string | null;
+    meta: JsonRecord;
+}
+
+interface AssetContentCopyEntry {
+    relativePath: string | null;
+    content: string;
+}
+
+export interface AssetCopyTransaction {
+    finalize(): Promise<void>;
+    rollback(): Promise<void>;
+}
+
+const JSON_ASSET_EXTENSIONS = new Set([
+    '.json',
+    '.scene',
+    '.fire',
+    '.prefab',
+    '.mtl',
+    '.pmtl',
+    '.anim',
+    '.animgraph',
+    '.animgraphvari',
+    '.animask',
+    '.texture',
+    '.cubemap',
+    '.rt',
+    '.gltf',
+    '.pac',
+    '.labelatlas',
+    '.rpp',
+    '.stg',
+    '.flow',
+]);
+
+function isRecord(value: unknown): value is JsonRecord {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function collectMetaUuidMap(
+    meta: JsonRecord,
+    nextUuid: string,
+    uuidMap: Map<string, string>,
+): void {
+    if (typeof meta.uuid !== 'string' || !meta.uuid) {
+        throw new Error('Asset meta is missing a valid uuid');
+    }
+
+    uuidMap.set(meta.uuid, nextUuid);
+
+    if (!isRecord(meta.subMetas)) {
+        return;
+    }
+
+    for (const [key, value] of Object.entries(meta.subMetas)) {
+        if (!isRecord(value)) {
+            continue;
+        }
+        const subId = typeof value.id === 'string' && value.id ? value.id : key;
+        collectMetaUuidMap(value, `${nextUuid}@${subId}`, uuidMap);
+    }
+}
+
+function replaceMappedUuids(value: unknown, uuidMap: Map<string, string>): unknown {
+    if (typeof value === 'string') {
+        return uuidMap.get(value) ?? value;
+    }
+    if (Array.isArray(value)) {
+        return value.map((item) => replaceMappedUuids(item, uuidMap));
+    }
+    if (!isRecord(value)) {
+        return value;
+    }
+
+    const result: JsonRecord = {};
+    for (const [key, item] of Object.entries(value)) {
+        const mappedKey = uuidMap.get(key) ?? key;
+        result[mappedKey] = replaceMappedUuids(item, uuidMap);
+    }
+    return result;
+}
+
+function replaceMappedJsonStrings(content: string, uuidMap: Map<string, string>): string | null {
+    try {
+        JSON.parse(content);
+    } catch {
+        return null;
+    }
+
+    let rewritten = content;
+    let changed = false;
+    for (const [sourceUuid, targetUuid] of uuidMap) {
+        const sourceJsonString = JSON.stringify(sourceUuid);
+        if (!rewritten.includes(sourceJsonString)) {
+            continue;
+        }
+        rewritten = rewritten.split(sourceJsonString).join(JSON.stringify(targetUuid));
+        changed = true;
+    }
+    return changed ? rewritten : null;
+}
+
+async function collectNestedMetaPaths(directory: string, paths: string[]): Promise<void> {
+    for (const name of await readdir(directory)) {
+        const path = join(directory, name);
+        const pathStat = await stat(path);
+        if (pathStat.isDirectory()) {
+            await collectNestedMetaPaths(path, paths);
+        } else if (name.endsWith('.meta')) {
+            paths.push(path);
+        }
+    }
+}
+
+async function collectMetaCopyEntries(source: string): Promise<{ entries: MetaCopyEntry[]; paths: string[] }> {
+    const metaPaths: string[] = [];
+    const sourceMeta = `${source}.meta`;
+    if (!existsSync(sourceMeta)) {
+        throw new Error(`Cannot copy asset because its meta file does not exist: ${sourceMeta}`);
+    }
+    metaPaths.push(sourceMeta);
+
+    if ((await stat(source)).isDirectory()) {
+        await collectNestedMetaPaths(source, metaPaths);
+    }
+
+    const entries = await Promise.all(metaPaths.map(async (metaPath) => {
+        const content = await readPath(metaPath, 'utf8');
+        let meta: unknown;
+        try {
+            meta = JSON.parse(typeof content === 'string' ? content : content.toString('utf8'));
+        } catch (error) {
+            throw new Error(`Cannot copy asset because meta file is invalid: ${metaPath}`, { cause: error });
+        }
+        if (!isRecord(meta)) {
+            throw new Error(`Cannot copy asset because meta file is invalid: ${metaPath}`);
+        }
+
+        return {
+            relativePath: metaPath === sourceMeta ? null : relative(source, metaPath),
+            meta,
+        };
+    }));
+    return { entries, paths: metaPaths };
+}
+
+async function collectAssetContentCopyEntries(
+    source: string,
+    metaPaths: string[],
+    uuidMap: Map<string, string>,
+): Promise<AssetContentCopyEntry[]> {
+    const entries: AssetContentCopyEntry[] = [];
+    for (const metaPath of metaPaths) {
+        const assetPath = metaPath.slice(0, -'.meta'.length);
+        if (!existsSync(assetPath) || (await stat(assetPath)).isDirectory()) {
+            continue;
+        }
+        if (!JSON_ASSET_EXTENSIONS.has(extname(assetPath).toLowerCase())) {
+            continue;
+        }
+
+        const content = await readPath(assetPath, 'utf8');
+        const text = typeof content === 'string' ? content : content.toString('utf8');
+        const rewritten = replaceMappedJsonStrings(text, uuidMap);
+        if (rewritten === null) {
+            continue;
+        }
+        entries.push({
+            relativePath: assetPath === source ? null : relative(source, assetPath),
+            content: rewritten,
+        });
+    }
+    return entries;
+}
+
+function resolveMetaTarget(root: string, relativePath: string | null): string {
+    return relativePath === null ? `${root}.meta` : join(root, relativePath);
+}
+
+function resolveAssetTarget(root: string, relativePath: string | null): string {
+    return relativePath === null ? root : join(root, relativePath);
+}
+
+async function removePathIfExists(path: string): Promise<void> {
+    if (existsSync(path)) {
+        await deletePath(path, { useTrash: false });
+    }
+}
+
+async function runCleanupSteps(steps: Array<() => Promise<void>>, message: string): Promise<void> {
+    const errors: unknown[] = [];
+    for (const step of steps) {
+        try {
+            await step();
+        } catch (error) {
+            errors.push(error);
+        }
+    }
+    if (errors.length) {
+        const details = errors.map((error) => error instanceof Error ? error.message : String(error)).join('; ');
+        throw new Error(`${message}: ${details}`, { cause: errors[0] });
+    }
+}
+
+/**
+ * Copy an asset source into a hidden staging path, install it as one transaction,
+ * and rebuild UUIDs in both metadata and supported serialized asset files.
+ */
+export async function copyAssetSource(
+    source: string,
+    target: string,
+    options?: AssetOperationOption,
+): Promise<AssetCopyTransaction> {
+    const { entries: metaEntries, paths: metaPaths } = await collectMetaCopyEntries(source);
+    const uuidMap = new Map<string, string>();
+
+    for (const entry of metaEntries) {
+        collectMetaUuidMap(entry.meta, utils.UUID.generate(false), uuidMap);
+    }
+
+    const rewrittenMetas = metaEntries.map((entry) => ({
+        relativePath: entry.relativePath,
+        content: `${JSON.stringify(replaceMappedUuids(entry.meta, uuidMap), null, 2)}\n`,
+    }));
+    const rewrittenAssets = await collectAssetContentCopyEntries(source, metaPaths, uuidMap);
+
+    const transactionId = utils.UUID.generate(false);
+    const targetDirectory = dirname(target);
+    const targetName = basename(target);
+    const staging = join(targetDirectory, `.${targetName}.copy-asset-${transactionId}`);
+    const backup = join(targetDirectory, `.${targetName}.copy-backup-${transactionId}`);
+    const targetMeta = `${target}.meta`;
+    const stagingMeta = `${staging}.meta`;
+    const backupMeta = `${backup}.meta`;
+    const targetExists = existsSync(target);
+    const targetMetaExists = existsSync(targetMeta);
+
+    if ((targetExists || targetMetaExists) && !options?.overwrite) {
+        throw new Error(`file ${target} already exists, please use overwrite option to overwrite it.`);
+    }
+
+    try {
+        await copyPath(source, staging, { overwrite: false });
+        for (const entry of rewrittenMetas) {
+            await writePath(resolveMetaTarget(staging, entry.relativePath), entry.content);
+        }
+        for (const entry of rewrittenAssets) {
+            await writePath(resolveAssetTarget(staging, entry.relativePath), entry.content);
+        }
+    } catch (error) {
+        try {
+            await runCleanupSteps([
+                () => removePathIfExists(staging),
+                () => removePathIfExists(stagingMeta),
+            ], `Failed to clean staging copy ${staging} for ${target}`);
+        } catch (cleanupError) {
+            const cleanupMessage = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+            throw new Error(`Copy asset to ${target} failed and staging cleanup also failed: ${cleanupMessage}`, { cause: error });
+        }
+        throw error;
+    }
+
+    let backupMoved = false;
+    let backupMetaMoved = false;
+    let targetInstalled = false;
+    let targetMetaInstalled = false;
+
+    const restoreFailedCommit = async (): Promise<void> => {
+        await runCleanupSteps([
+            async () => {
+                if (targetInstalled) {
+                    await removePathIfExists(target);
+                }
+            },
+            async () => {
+                if (targetMetaInstalled) {
+                    await removePathIfExists(targetMeta);
+                }
+            },
+            async () => {
+                if (backupMetaMoved && existsSync(backupMeta)) {
+                    await renamePath(backupMeta, targetMeta, { overwrite: true });
+                }
+            },
+            async () => {
+                if (backupMoved && existsSync(backup)) {
+                    await renamePath(backup, target, { overwrite: true });
+                }
+            },
+            () => removePathIfExists(staging),
+            () => removePathIfExists(stagingMeta),
+        ], `Failed to roll back copy to ${target}`);
+    };
+
+    try {
+        if (targetMetaExists) {
+            await renamePath(targetMeta, backupMeta, { overwrite: false });
+            backupMetaMoved = true;
+        }
+        if (targetExists) {
+            await renamePath(target, backup, { overwrite: false });
+            backupMoved = true;
+        }
+        await renamePath(stagingMeta, targetMeta, { overwrite: false });
+        targetMetaInstalled = true;
+        await renamePath(staging, target, { overwrite: false });
+        targetInstalled = true;
+    } catch (error) {
+        try {
+            await restoreFailedCommit();
+        } catch (rollbackError) {
+            const rollbackMessage = rollbackError instanceof Error ? rollbackError.message : String(rollbackError);
+            throw new Error(`Copy asset to ${target} failed and rollback also failed: ${rollbackMessage}`, { cause: error });
+        }
+        throw error;
+    }
+
+    let active = true;
+    return {
+        async finalize(): Promise<void> {
+            if (!active) {
+                return;
+            }
+            await runCleanupSteps([
+                () => removePathIfExists(backup),
+                () => removePathIfExists(backupMeta),
+            ], `Failed to clean copy backup ${backup} for ${target}`);
+            active = false;
+        },
+        async rollback(): Promise<void> {
+            if (!active) {
+                return;
+            }
+            await runCleanupSteps([
+                () => removePathIfExists(target),
+                () => removePathIfExists(targetMeta),
+                async () => {
+                    if (backupMetaMoved && existsSync(backupMeta)) {
+                        await renamePath(backupMeta, targetMeta, { overwrite: true });
+                    }
+                },
+                async () => {
+                    if (backupMoved && existsSync(backup)) {
+                        await renamePath(backup, target, { overwrite: true });
+                    }
+                },
+                () => removePathIfExists(staging),
+                () => removePathIfExists(stagingMeta),
+            ], `Failed to roll back copy to ${target}`);
+            active = false;
+        },
+    };
+}

--- a/src/core/assets/manager/asset.ts
+++ b/src/core/assets/manager/asset.ts
@@ -37,6 +37,7 @@ class AssetManager extends EventEmitter {
     queryAssetMtime = assetQuery.queryAssetMtime.bind(assetQuery);
     // ---------- operation ---------
     importAsset = assetOperation.importAsset.bind(assetOperation);
+    copyAsset = assetOperation.copyAsset.bind(assetOperation);
     saveAssetMeta = assetOperation.saveAssetMeta.bind(assetOperation);
     saveAsset = assetOperation.saveAsset.bind(assetOperation);
     createAsset = assetOperation.createAsset.bind(assetOperation);
@@ -356,6 +357,7 @@ export interface TypedAssetManager extends EventEmitter {
     queryAssetMtime: typeof assetQuery.queryAssetMtime;
 
     importAsset: typeof assetOperation.importAsset;
+    copyAsset: typeof assetOperation.copyAsset;
     saveAssetMeta: typeof assetOperation.saveAssetMeta;
     saveAsset: typeof assetOperation.saveAsset;
     createAsset: typeof assetOperation.createAsset;

--- a/src/core/assets/manager/filesystem.ts
+++ b/src/core/assets/manager/filesystem.ts
@@ -97,7 +97,7 @@ export async function createDirectoryPath(path: string): Promise<void> {
     await Promise.resolve(provider.createDirectory!(path));
 }
 
-async function deletePath(path: string, options: DeleteAssetOptions = {}): Promise<void> {
+export async function deletePath(path: string, options: DeleteAssetOptions = {}): Promise<void> {
     await Promise.resolve(provider.delete!(path, options));
 }
 

--- a/src/core/assets/manager/operation.ts
+++ b/src/core/assets/manager/operation.ts
@@ -12,6 +12,7 @@ import assetConfig from '../asset-config';
 import { url2path, ensureOutputData, url2uuid, pathToDbUrlIfAssetDBPath, dirnameForDbUrlOrPath } from '../utils';
 import assetDBManager from './asset-db';
 import assetHandlerManager from './asset-handler';
+import { copyAssetSource } from './asset-copy';
 import { copyPath, moveAssetSource, removeAssetSource, renamePath } from './filesystem';
 import i18n from '../../base/i18n';
 import assetQuery from './query';
@@ -476,6 +477,63 @@ class AssetOperation extends EventEmitter {
         return assetQuery.queryAssetInfos({
             pattern: `${assetInfo.url}/**/*`
         });
+    }
+
+    /**
+     * Copy an existing main asset together with its complete meta information.
+     */
+    async copyAsset(source: string, target: string, options?: AssetOperationOption): Promise<IAssetInfo> {
+        return await assetDBManager.addTask(this._copyAsset.bind(this), [source, target, options]);
+    }
+
+    private async _copyAsset(source: string, target: string, options?: AssetOperationOption): Promise<IAssetInfo> {
+        const asset = assetQuery.queryAsset(source);
+        if (!asset) {
+            throw new Error(`asset in source file ${source} not exists`);
+        }
+        if (asset._parent) {
+            throw new Error('Sub-assets cannot be copied independently; copy their main asset instead.');
+        }
+
+        this.checkValidUrl(target);
+        source = asset.source;
+        this._checkExists(source);
+        if (target.startsWith('db://')) {
+            target = url2path(target);
+        }
+        target = this._checkOverwrite(target, options);
+
+        const targetIsAssetDBRoot = Object.values(assetDBManager.assetDBInfo).some((info) => (
+            utils.Path.contains(info.target, target) && utils.Path.contains(target, info.target)
+        ));
+        if (targetIsAssetDBRoot) {
+            throw new Error(`Cannot copy an asset over an AssetDB root.\ntarget: ${target}`);
+        }
+        if (utils.Path.contains(source, target) || utils.Path.contains(target, source)) {
+            throw new Error(`Cannot copy an asset into or over itself.\nsource: ${source}\ntarget: ${target}`);
+        }
+
+        const transaction = await copyAssetSource(source, target, options);
+        let copiedAsset: IAsset | null = null;
+        try {
+            await this._refreshAsset(target);
+            copiedAsset = assetQuery.queryAsset(target);
+            if (!copiedAsset || !copiedAsset.imported || copiedAsset.invalid) {
+                throw copiedAsset?.importError || new Error(`Copy asset from ${source} to ${target} failed`);
+            }
+        } catch (error) {
+            try {
+                await transaction.rollback();
+                await this._refreshAsset(dirname(target), false);
+            } catch (rollbackError) {
+                const rollbackMessage = rollbackError instanceof Error ? rollbackError.message : String(rollbackError);
+                throw new Error(`Copy asset from ${source} to ${target} failed and rollback also failed: ${rollbackMessage}`, { cause: error });
+            }
+            throw error;
+        }
+
+        await transaction.finalize();
+        return assetQuery.encodeAsset(copiedAsset);
     }
 
     /**

--- a/src/core/assets/test/asset-copy.test.ts
+++ b/src/core/assets/test/asset-copy.test.ts
@@ -1,0 +1,234 @@
+import { copy as fsCopy, ensureDir, existsSync, mkdtemp, outputFile, outputJson, readFile, readJson, remove } from 'fs-extra';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import type { IAssetFileSystemProvider } from '../@types/public';
+import { copyAssetSource } from '../manager/asset-copy';
+import { resetFileSystemProvider, setFileSystemProvider } from '../manager/filesystem';
+
+const CUBE_META = join(__dirname, '../../../../packages/engine/editor/assets/default_skybox/default_skybox.png.meta');
+const SPRITE_FRAME_META = join(__dirname, '../../../../tests/fixtures/projects/asset-operation/assets/default_btn_normal.png.meta');
+
+describe('copyAssetSource', () => {
+    let tempRoot: string;
+    let copy: jest.Mock;
+    let writeFile: jest.Mock;
+    let providerReadFile: jest.Mock;
+    let deleteFile: jest.Mock;
+
+    beforeEach(async () => {
+        tempRoot = await mkdtemp(join(tmpdir(), 'cocos-cli-copy-asset-'));
+        copy = jest.fn(async (source: string, target: string, options?: { overwrite?: boolean }) => {
+            await fsCopy(source, target, options?.overwrite === undefined ? undefined : { overwrite: options.overwrite });
+        });
+        writeFile = jest.fn(async (path: string, content: Buffer | string | Uint8Array) => {
+            await ensureDir(join(path, '..'));
+            await outputFile(path, content as any);
+        });
+        providerReadFile = jest.fn(async (path: string, encoding?: BufferEncoding) => {
+            return encoding ? await readFile(path, encoding) : await readFile(path);
+        });
+        deleteFile = jest.fn(async (path: string) => {
+            await remove(path);
+        });
+        setFileSystemProvider({
+            readFile: providerReadFile,
+            writeFile,
+            copy,
+            delete: deleteFile,
+        } as IAssetFileSystemProvider);
+    });
+
+    afterEach(async () => {
+        resetFileSystemProvider();
+        await remove(tempRoot);
+    });
+
+    async function prepareImage(metaFixture: string) {
+        const source = join(tempRoot, 'source.png');
+        const target = join(tempRoot, 'target.png');
+        await outputFile(source, 'image');
+        await fsCopy(metaFixture, `${source}.meta`);
+        return { source, target };
+    }
+
+    it('preserves texture cube metadata while rebuilding parent and nested subMeta UUIDs', async () => {
+        const { source, target } = await prepareImage(CUBE_META);
+        const sourceMeta = await readJson(`${source}.meta`);
+        const externalUuid = '11111111-2222-4333-8444-555555555555';
+        sourceMeta.userData.externalUuid = externalUuid;
+        sourceMeta.userData.partialUuid = `${sourceMeta.uuid}-suffix`;
+        await outputJson(`${source}.meta`, sourceMeta, { spaces: 2 });
+
+        const transaction = await copyAssetSource(source, target, { overwrite: true });
+        await transaction.finalize();
+
+        const targetMeta = await readJson(`${target}.meta`);
+        const cubeId = Object.keys(sourceMeta.subMetas)[0];
+        const sourceCube = sourceMeta.subMetas[cubeId];
+        const targetCube = targetMeta.subMetas[cubeId];
+
+        expect(targetMeta.userData.type).toBe('texture cube');
+        expect(targetMeta.uuid).not.toBe(sourceMeta.uuid);
+        expect(targetCube.uuid).toBe(`${targetMeta.uuid}@${cubeId}`);
+        expect(targetCube.userData.imageDatabaseUri).toBe(targetMeta.uuid);
+
+        for (const [faceId, sourceFace] of Object.entries<any>(sourceCube.subMetas)) {
+            const targetFace = targetCube.subMetas[faceId];
+            expect(targetFace.uuid).toBe(`${targetCube.uuid}@${faceId}`);
+            expect(targetFace.uuid).not.toBe(sourceFace.uuid);
+        }
+
+        expect(targetMeta.userData.externalUuid).toBe(externalUuid);
+        expect(targetMeta.userData.partialUuid).toBe(`${sourceMeta.uuid}-suffix`);
+        expect(copy).toHaveBeenCalledWith(
+            source,
+            expect.stringContaining('.target.png.copy-asset-'),
+            { overwrite: false },
+        );
+        expect(writeFile).toHaveBeenCalledWith(
+            expect.stringContaining('.target.png.copy-asset-'),
+            expect.any(String),
+            undefined,
+        );
+    });
+
+    it('preserves sprite-frame type and rewrites redirect and image references to the copy', async () => {
+        const { source, target } = await prepareImage(SPRITE_FRAME_META);
+        const sourceMeta = await readJson(`${source}.meta`);
+
+        const transaction = await copyAssetSource(source, target);
+        await transaction.finalize();
+
+        const targetMeta = await readJson(`${target}.meta`);
+        const textureId = '6c48a';
+        const spriteFrameId = 'f9941';
+        expect(targetMeta.userData.type).toBe('sprite-frame');
+        expect(targetMeta.uuid).not.toBe(sourceMeta.uuid);
+        expect(targetMeta.subMetas[textureId].userData.imageUuidOrDatabaseUri).toBe(targetMeta.uuid);
+        expect(targetMeta.subMetas[spriteFrameId].userData.imageUuidOrDatabaseUri).toBe(`${targetMeta.uuid}@${textureId}`);
+        expect(targetMeta.userData.redirect).toBe(`${targetMeta.uuid}@${textureId}`);
+    });
+
+    it('rewrites references between assets when copying a directory', async () => {
+        const source = join(tempRoot, 'source');
+        const target = join(tempRoot, 'target');
+        const directoryUuid = '00000000-0000-4000-8000-000000000001';
+        const imageUuid = '00000000-0000-4000-8000-000000000002';
+        const materialUuid = '00000000-0000-4000-8000-000000000003';
+        await ensureDir(source);
+        await outputFile(join(source, 'image.png'), 'image');
+        await outputJson(join(source, 'material.mtl'), {
+            effectAsset: { __uuid__: imageUuid },
+        });
+        await outputJson(`${source}.meta`, createMeta(directoryUuid));
+        await outputJson(join(source, 'image.png.meta'), createMeta(imageUuid));
+        await outputJson(join(source, 'material.mtl.meta'), createMeta(materialUuid, { image: imageUuid }));
+
+        const transaction = await copyAssetSource(source, target);
+        await transaction.finalize();
+
+        const targetDirectoryMeta = await readJson(`${target}.meta`);
+        const targetImageMeta = await readJson(join(target, 'image.png.meta'));
+        const targetMaterialMeta = await readJson(join(target, 'material.mtl.meta'));
+        const targetMaterial = await readJson(join(target, 'material.mtl'));
+        expect(targetDirectoryMeta.uuid).not.toBe(directoryUuid);
+        expect(targetImageMeta.uuid).not.toBe(imageUuid);
+        expect(targetMaterialMeta.uuid).not.toBe(materialUuid);
+        expect(targetMaterialMeta.userData.image).toBe(targetImageMeta.uuid);
+        expect(targetMaterial.effectAsset.__uuid__).toBe(targetImageMeta.uuid);
+    });
+
+    it('replaces an overwritten directory instead of retaining target-only assets', async () => {
+        const source = join(tempRoot, 'source');
+        const target = join(tempRoot, 'target');
+        await ensureDir(source);
+        await ensureDir(target);
+        await outputFile(join(source, 'source-only.txt'), 'source');
+        await outputJson(`${source}.meta`, createMeta('00000000-0000-4000-8000-000000000011'));
+        await outputJson(join(source, 'source-only.txt.meta'), createMeta('00000000-0000-4000-8000-000000000012'));
+        await outputFile(join(target, 'target-only.txt'), 'stale');
+        await outputJson(`${target}.meta`, createMeta('00000000-0000-4000-8000-000000000013'));
+        await outputJson(join(target, 'target-only.txt.meta'), createMeta('00000000-0000-4000-8000-000000000014'));
+
+        const transaction = await copyAssetSource(source, target, { overwrite: true });
+        await transaction.finalize();
+
+        expect(existsSync(join(target, 'source-only.txt'))).toBe(true);
+        expect(existsSync(join(target, 'target-only.txt'))).toBe(false);
+        expect(existsSync(join(target, 'target-only.txt.meta'))).toBe(false);
+    });
+
+    it('restores the previous target when a completed copy is rolled back', async () => {
+        const source = join(tempRoot, 'source.txt');
+        const target = join(tempRoot, 'target.txt');
+        const oldTargetUuid = '00000000-0000-4000-8000-000000000021';
+        await outputFile(source, 'source-content');
+        await outputJson(`${source}.meta`, createMeta('00000000-0000-4000-8000-000000000022'));
+        await outputFile(target, 'target-content');
+        await outputJson(`${target}.meta`, createMeta(oldTargetUuid));
+
+        const transaction = await copyAssetSource(source, target, { overwrite: true });
+        expect(await readFile(target, 'utf8')).toBe('source-content');
+
+        await transaction.rollback();
+
+        expect(await readFile(target, 'utf8')).toBe('target-content');
+        expect((await readJson(`${target}.meta`)).uuid).toBe(oldTargetUuid);
+    });
+
+    it('does not mutate an existing target when staging metadata fails', async () => {
+        const source = join(tempRoot, 'source.txt');
+        const target = join(tempRoot, 'target.txt');
+        const oldTargetUuid = '00000000-0000-4000-8000-000000000031';
+        await outputFile(source, 'source-content');
+        await outputJson(`${source}.meta`, createMeta('00000000-0000-4000-8000-000000000032'));
+        await outputFile(target, 'target-content');
+        await outputJson(`${target}.meta`, createMeta(oldTargetUuid));
+        writeFile.mockRejectedValueOnce(new Error('disk full'));
+
+        await expect(copyAssetSource(source, target, { overwrite: true })).rejects.toThrow('disk full');
+
+        expect(await readFile(target, 'utf8')).toBe('target-content');
+        expect((await readJson(`${target}.meta`)).uuid).toBe(oldTargetUuid);
+    });
+
+    it('does not decode binary instantiation assets as JSON while copying', async () => {
+        const source = join(tempRoot, 'source.mesh');
+        const target = join(tempRoot, 'target.mesh');
+        await outputFile(source, Buffer.from([0x50, 0x4b, 0x03, 0x04, 0xff, 0x00]));
+        await outputJson(`${source}.meta`, createMeta('00000000-0000-4000-8000-000000000041'));
+
+        const transaction = await copyAssetSource(source, target);
+        await transaction.finalize();
+
+        expect(providerReadFile).not.toHaveBeenCalledWith(source, 'utf8');
+        expect(await readFile(target)).toEqual(Buffer.from([0x50, 0x4b, 0x03, 0x04, 0xff, 0x00]));
+    });
+
+    it('reports backup cleanup failure instead of silently completing', async () => {
+        const source = join(tempRoot, 'source.txt');
+        const target = join(tempRoot, 'target.txt');
+        await outputFile(source, 'source-content');
+        await outputJson(`${source}.meta`, createMeta('00000000-0000-4000-8000-000000000051'));
+        await outputFile(target, 'target-content');
+        await outputJson(`${target}.meta`, createMeta('00000000-0000-4000-8000-000000000052'));
+
+        const transaction = await copyAssetSource(source, target, { overwrite: true });
+        deleteFile.mockRejectedValueOnce(new Error('cleanup denied'));
+
+        await expect(transaction.finalize()).rejects.toThrow('cleanup denied');
+        expect(await readFile(target, 'utf8')).toBe('source-content');
+    });
+});
+
+function createMeta(uuid: string, userData: Record<string, unknown> = {}) {
+    return {
+        ver: '1.0.0',
+        importer: 'unknown',
+        imported: true,
+        uuid,
+        files: [],
+        subMetas: {},
+        userData,
+    };
+}

--- a/src/core/assets/test/operation-filesystem-bridge.test.ts
+++ b/src/core/assets/test/operation-filesystem-bridge.test.ts
@@ -3,6 +3,13 @@ export {};
 const mockCopy = jest.fn();
 const mockExistsSync = jest.fn();
 const mockCopyPath = jest.fn();
+const mockCopyAssetSource = jest.fn();
+const mockFinalizeCopy = jest.fn();
+const mockRollbackCopy = jest.fn();
+const mockCopyTransaction = {
+    finalize: mockFinalizeCopy,
+    rollback: mockRollbackCopy,
+};
 const mockMoveAssetSource = jest.fn();
 const mockRenamePath = jest.fn();
 const mockQueryAsset = jest.fn();
@@ -77,6 +84,10 @@ jest.mock('../manager/filesystem', () => ({
     resetFileSystemProvider: jest.fn(),
 }));
 
+jest.mock('../manager/asset-copy', () => ({
+    copyAssetSource: (...args: any[]) => mockCopyAssetSource(...args),
+}));
+
 jest.mock('../manager/asset-db', () => ({
     __esModule: true,
     default: {
@@ -148,6 +159,9 @@ describe('asset operation filesystem bridge', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        mockCopyAssetSource.mockResolvedValue(mockCopyTransaction);
+        mockFinalizeCopy.mockResolvedValue(undefined);
+        mockRollbackCopy.mockResolvedValue(undefined);
         const assetDBManager = require('../manager/asset-db').default as typeof import('../manager/asset-db').default;
         Object.keys(assetDBManager.assetDBInfo).forEach((key) => delete assetDBManager.assetDBInfo[key]);
         mockAssetQueryUrl.mockImplementation((value: string) => {
@@ -321,6 +335,130 @@ describe('asset operation filesystem bridge', () => {
         expect(mockCopyPath).toHaveBeenCalledWith(source, target, { overwrite: true });
         expect(mockCopy).not.toHaveBeenCalled();
         expect(result).toEqual([assetInfo]);
+    });
+
+    it('copyAsset should delegate source and meta copying and return the imported copy', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const source = 'D:/project/assets/source.png';
+        const target = 'D:/project/assets/source-001.png';
+        const sourceAsset = {
+            source,
+            _parent: null,
+        };
+        const copiedAsset = {
+            source: target,
+            imported: true,
+            invalid: false,
+        };
+
+        setAssetDBInfo();
+        mockQueryAsset.mockImplementation((value: string) => value === target ? copiedAsset : sourceAsset);
+        mockExistsSync.mockImplementation((path: string) => path === source);
+        mockCopyAssetSource.mockResolvedValue(mockCopyTransaction);
+        jest.spyOn(assetOperation as any, '_refreshAsset').mockResolvedValue(0);
+
+        const result = await assetOperation.copyAsset(source, target, { overwrite: true });
+
+        expect(mockCopyAssetSource).toHaveBeenCalledWith(source, target, { overwrite: true });
+        expect(mockFinalizeCopy).toHaveBeenCalledTimes(1);
+        expect(mockRollbackCopy).not.toHaveBeenCalled();
+        expect(result).toEqual({ source: target });
+    });
+
+    it('copyAsset should resolve a rename conflict before copying metadata', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const source = 'D:/project/assets/source.png';
+        const requestedTarget = source;
+        const renamedTarget = 'D:/project/assets/source-001.png';
+        const sourceAsset = {
+            source,
+            _parent: null,
+        };
+        const copiedAsset = {
+            source: renamedTarget,
+            imported: true,
+            invalid: false,
+        };
+
+        setAssetDBInfo();
+        mockQueryAsset.mockImplementation((value: string) => value === renamedTarget ? copiedAsset : sourceAsset);
+        mockExistsSync.mockImplementation((path: string) => path === source);
+        mockCopyAssetSource.mockResolvedValue(mockCopyTransaction);
+        jest.spyOn(assetOperation as any, '_checkOverwrite').mockReturnValue(renamedTarget);
+        jest.spyOn(assetOperation as any, '_refreshAsset').mockResolvedValue(0);
+
+        await assetOperation.copyAsset(source, requestedTarget, { rename: true });
+
+        expect(mockCopyAssetSource).toHaveBeenCalledWith(source, renamedTarget, { rename: true });
+    });
+
+    it('copyAsset should reject replacing an AssetDB root', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const source = 'D:/project/internal/source.png';
+        const target = 'D:/project/assets';
+        mockQueryAsset.mockReturnValue({ source, _parent: null });
+        mockExistsSync.mockImplementation((path: string) => path === source || path === target);
+        setAssetDBInfo(target);
+
+        await expect(assetOperation.copyAsset(source, 'db://assets', { overwrite: true }))
+            .rejects.toThrow('Cannot copy an asset over an AssetDB root');
+
+        expect(mockCopyAssetSource).not.toHaveBeenCalled();
+    });
+
+    it('copyAsset should reject replacing an ancestor of the source asset', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const target = 'D:/project/assets/folder';
+        const source = `${target}/child/source.png`;
+        mockQueryAsset.mockReturnValue({ source, _parent: null });
+        mockExistsSync.mockImplementation((path: string) => path === source || path === target);
+        setAssetDBInfo();
+
+        await expect(assetOperation.copyAsset(source, target, { overwrite: true }))
+            .rejects.toThrow('Cannot copy an asset into or over itself');
+
+        expect(mockCopyAssetSource).not.toHaveBeenCalled();
+    });
+
+    it('copyAsset should roll back the filesystem transaction when refresh fails', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const source = 'D:/project/assets/source.png';
+        const target = 'D:/project/assets/source-001.png';
+        const sourceAsset = {
+            source,
+            _parent: null,
+        };
+
+        setAssetDBInfo();
+        mockQueryAsset.mockReturnValue(sourceAsset);
+        mockExistsSync.mockImplementation((path: string) => path === source);
+        const refresh = jest.spyOn(assetOperation as any, '_refreshAsset')
+            .mockRejectedValueOnce(new Error('refresh failed'))
+            .mockResolvedValueOnce(0);
+
+        await expect(assetOperation.copyAsset(source, target, { overwrite: true })).rejects.toThrow('refresh failed');
+
+        expect(mockRollbackCopy).toHaveBeenCalledTimes(1);
+        expect(mockFinalizeCopy).not.toHaveBeenCalled();
+        expect(refresh).toHaveBeenLastCalledWith(dirname(target), false);
+    });
+
+    it('copyAsset should report backup cleanup failures', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const source = 'D:/project/assets/source.png';
+        const target = 'D:/project/assets/source-001.png';
+        const sourceAsset = { source, _parent: null };
+        const copiedAsset = { source: target, imported: true, invalid: false };
+
+        setAssetDBInfo();
+        mockQueryAsset.mockImplementation((value: string) => value === target ? copiedAsset : sourceAsset);
+        mockExistsSync.mockImplementation((path: string) => path === source);
+        mockFinalizeCopy.mockRejectedValueOnce(new Error('cleanup denied'));
+        jest.spyOn(assetOperation as any, '_refreshAsset').mockResolvedValue(0);
+
+        await expect(assetOperation.copyAsset(source, target)).rejects.toThrow('cleanup denied');
+
+        expect(mockRollbackCopy).not.toHaveBeenCalled();
     });
 
     it('refreshAsset should normalize an absolute asset-db path before refreshing', async () => {

--- a/src/core/assets/test/operation.test.ts
+++ b/src/core/assets/test/operation.test.ts
@@ -123,6 +123,48 @@ describe('测试 db 的操作接口', function () {
         });
     });
 
+    describe('copy-asset', () => {
+        it('copies a texture cube image without falling back to sprite-frame', async function () {
+            const sourceUrl = 'db://internal/default_skybox/default_skybox.png';
+            const targetName = `${name}-copy-texture-cube.png`;
+            const targetUrl = `${TestGlobalEnv.testRootUrl}/${targetName}`;
+            const targetPath = join(databasePath, targetName);
+            const sourceMeta = readJSONSync(join(TestGlobalEnv.engineRoot, 'editor/assets/default_skybox/default_skybox.png.meta'));
+
+            const copiedAsset = await assetManager.copyAsset(sourceUrl, targetUrl);
+            const targetMeta = readJSONSync(`${targetPath}.meta`);
+            const cubeId = 'b47c0';
+
+            expect(copiedAsset.url).toBe(targetUrl);
+            expect(targetMeta.userData.type).toBe('texture cube');
+            expect(targetMeta.uuid).not.toBe(sourceMeta.uuid);
+            expect(targetMeta.subMetas[cubeId].uuid).toBe(`${targetMeta.uuid}@${cubeId}`);
+            expect(targetMeta.subMetas[cubeId].userData.imageDatabaseUri).toBe(targetMeta.uuid);
+            for (const faceId of Object.keys(sourceMeta.subMetas[cubeId].subMetas)) {
+                expect(targetMeta.subMetas[cubeId].subMetas[faceId].uuid).toBe(`${targetMeta.uuid}@${cubeId}@${faceId}`);
+            }
+        });
+
+        it('copies a sprite-frame image with new UUIDs and preserved metadata', async function () {
+            const sourceUrl = 'db://assets/default_btn_normal.png';
+            const targetName = `${name}-copy-sprite-frame.png`;
+            const targetUrl = `${TestGlobalEnv.testRootUrl}/${targetName}`;
+            const targetPath = join(databasePath, targetName);
+            const sourceMeta = readJSONSync(join(TestGlobalEnv.projectRoot, 'assets/default_btn_normal.png.meta'));
+
+            const copiedAsset = await assetManager.copyAsset(sourceUrl, targetUrl);
+            const targetMeta = readJSONSync(`${targetPath}.meta`);
+
+            expect(copiedAsset.url).toBe(targetUrl);
+            expect(targetMeta.userData.type).toBe('sprite-frame');
+            expect(targetMeta.uuid).not.toBe(sourceMeta.uuid);
+            expect(targetMeta.subMetas['6c48a'].uuid).toBe(`${targetMeta.uuid}@6c48a`);
+            expect(targetMeta.subMetas['f9941'].uuid).toBe(`${targetMeta.uuid}@f9941`);
+            expect(targetMeta.subMetas['f9941'].userData.imageUuidOrDatabaseUri).toBe(`${targetMeta.uuid}@6c48a`);
+            expect(targetMeta.userData.redirect).toBe(`${targetMeta.uuid}@6c48a`);
+        });
+    });
+
     // describe('copy-asset', () => {
     //     it('复制文件夹', async function() {
     //         await assetManager.copyAsset(

--- a/src/lib/assets/assets.ts
+++ b/src/lib/assets/assets.ts
@@ -164,6 +164,17 @@ export async function importAsset(
 }
 
 /**
+ * Copy Asset // 复制资源及其完整元数据
+ */
+export async function copyAsset(
+    source: string,
+    target: string,
+    options?: AssetOperationOption
+): Promise<IAssetInfo> {
+    return await assetManager.copyAsset(source, target, options);
+}
+
+/**
  * Reimport Asset // 重新导入资源
  */
 export async function reimportAsset(pathOrUrlOrUUID: string): Promise<IAssetInfo> {

--- a/tests/lib/assets-api.test.ts
+++ b/tests/lib/assets-api.test.ts
@@ -1,4 +1,5 @@
 const mockAssetManager = {
+    copyAsset: jest.fn(),
     updateUserData: jest.fn(),
     updateUserDataByPath: jest.fn(),
     querySerializedData: jest.fn(),
@@ -28,6 +29,22 @@ describe('lib assets api', () => {
 
     it('does not expose updateAssetMetaUserData from the public lib API', () => {
         expect((Assets as { updateAssetMetaUserData?: unknown }).updateAssetMetaUserData).toBeUndefined();
+    });
+
+    it('copyAsset delegates resource and metadata copying to assetManager', async () => {
+        const copiedAsset = { uuid: 'copied-uuid', url: 'db://assets/copied.png' };
+        mockAssetManager.copyAsset.mockResolvedValue(copiedAsset);
+
+        await expect(Assets.copyAsset(
+            'db://assets/source.png',
+            'db://assets/copied.png',
+            { rename: true },
+        )).resolves.toBe(copiedAsset);
+        expect(mockAssetManager.copyAsset).toHaveBeenCalledWith(
+            'db://assets/source.png',
+            'db://assets/copied.png',
+            { rename: true },
+        );
     });
 
     it('updateAssetUserData delegates complete userData replacement to assetManager', async () => {


### PR DESCRIPTION
## 修复说明

新增 `assets.copyAsset(source, target, options)`，复制资源时会保留完整父 meta、`userData.type` 和 `subMetas`，同时为副本重建父/子 UUID。

已验证：

- texture cube 复制后仍为 `texture cube`
- sprite-frame 复制后仍为 `sprite-frame`
- Build 通过
- 全量测试：138 suites、1649 tests 通过

## PinK 对接方式

PinK 必须升级并匹配包含 `copyAsset` 的新版 CLI SDK，不需要兼容旧 CLI。

当前 Duplicate 使用：

```ts
await assets.createAsset({
  target: `${targetDir}/${asset.name}`,
  template: asset.url,
  rename: true,
});
```

需要改为：
```ts
await assets.copyAsset(
  asset.url,
  `${targetDir}/${asset.name}`,
  { rename: true },
);
```
Paste Copy 同样需要从 createAsset({ template }) 切换为：
```ts
await assets.copyAsset(
  sourceAsset.url,
  `${targetDir}/${sourceAsset.name}`,
  { rename: true },
);
```
注意：
source 必须传图像主资源 URL，不要传带 @ 的 spriteFrame/textureCube 子资源 UUID。
target 传完整目标 db:// URL。
Ctrl/Cmd+D 使用 { rename: true } 自动生成副本名称。
不要继续使用 createAsset({ template }) 模拟复制；该接口只复制文件内容，不负责继承完整 meta/subMetas。

## 测试方法:
测试组无需关心本pr. pink部门对接好即可在pink那边完成验收.