### PR TITLE
Fix builder configuration value cloning

### DIFF
--- a/src/core/builder/index.ts
+++ b/src/core/builder/index.ts
@@ -2,7 +2,7 @@ import { readJSONSync } from 'fs-extra';
 import i18n from '../base/i18n';
 import { BuildExitCode, BuildStageProgressCallback, IBuildCommandOption, IBuildResultData, IBuildStageOptions, IBuildTaskOption, IBundleBuildOptions, IPreviewSettingsResult, Platform } from './@types/private';
 import { pluginManager } from './manager/plugin';
-import { formatMSTime } from './share/utils';
+import { cloneConfigValue, formatMSTime } from './share/utils';
 import { newConsole } from '../base/console';
 import { basename, extname, isAbsolute, join } from 'path';
 import assetManager from '../assets/manager/asset';
@@ -351,5 +351,5 @@ export function getRegisteredPlatforms() {
 }
 
 export async function queryDefaultBuildConfigByPlatform(platform: Platform) {
-    return await pluginManager.getOptionsByPlatform(platform);
+    return cloneConfigValue(await pluginManager.getOptionsByPlatform(platform));
 }

--- a/src/core/builder/manager/plugin.ts
+++ b/src/core/builder/manager/plugin.ts
@@ -3,7 +3,7 @@ import { basename, join } from 'path';
 import { checkBuildCommonOptionsByKey, checkBundleCompressionSetting } from '../share/common-options-validator';
 import { NATIVE_PLATFORM, PLATFORMS } from '../share/platforms-options';
 import { validator, validatorManager } from '../share/validator-manager';
-import { checkConfigDefault, defaultMerge, defaultsDeep, getOptionsDefault, resolveToRaw } from '../share/utils';
+import { checkConfigDefault, cloneConfigValue, defaultMerge, defaultsDeep, getOptionsDefault, resolveToRaw } from '../share/utils';
 import { Platform, IDisplayOptions, IBuildTaskOption, IConsoleType, TextureCompressRenderConfig, TextureCompressFullRenderConfig } from '../@types';
 import { IInternalBuildPluginConfig, IPlatformBuildPluginConfig, PlatformBundleConfig, BundleQueryConfig, IBuildStageItem, BuildCheckResult, BuildTemplateConfig, IConfigGroupsInfo, IPlatformConfig, ITextureCompressConfig, IBuildHooksInfo, IBuildCommandOption, MakeRequired, IBuilderConfigItem, IPlatformRegisterInfo, IPluginRegisterInfo, IPackageRegisterInfo, IBuilderRegisterInfo, PlatformBuildSchema, PlatformConfigItem } from '../@types/protected';
 import Utils from '../../base/utils';
@@ -815,11 +815,11 @@ export class PluginManager extends EventEmitter {
      * @param platform
      */
     public async getOptionsByPlatform<P extends Platform | string>(platform: P): Promise<IBuildTaskOption> {
-        const options = await builderConfig.getProject<IBuildTaskOption>(`platforms.${platform}`);
-        const commonOptions = await builderConfig.getProject<IBuildCommandOption>(`common`);
+        const options = cloneConfigValue(await builderConfig.getProject<IBuildTaskOption>(`platforms.${platform}`));
+        const commonOptions = cloneConfigValue(await builderConfig.getProject<IBuildCommandOption>(`common`));
         commonOptions.platform = platform;
         commonOptions.outputName = platform;
-        return Object.assign(commonOptions, options);
+        return Object.assign({}, commonOptions, options);
     }
 
     public getTexturePlatformConfigs(): Record<string, ITextureCompressConfig> {

--- a/src/core/builder/share/common-options-validator.ts
+++ b/src/core/builder/share/common-options-validator.ts
@@ -13,6 +13,7 @@ import Utils from '../../base/utils';
 import assetManager from '../../assets/manager/asset';
 import { Engine } from '../../engine';
 import builderConfig from './builder-config';
+import { cloneConfigValue } from './utils';
 import { validatorManager } from './validator-manager';
 interface ModuleConfig {
     match: (module: string) => boolean;
@@ -368,7 +369,7 @@ export function checkBundleCompressionSetting(value: BundleCompressionType, supp
  */
 export function handleOverwriteProjectSettings(options: IBuildTaskOption) {
     const overwriteModules = options.overwriteProjectSettings?.includeModules;
-    let includeModules = options.includeModules;
+    let includeModules = options.includeModules ? [...options.includeModules] : options.includeModules;
     if (includeModules && overwriteModules && includeModules.length) {
         for (const module in overwriteModules) {
             if (overwriteModules[module] !== 'inherit-project-setting') {
@@ -434,25 +435,26 @@ export async function fillIncludeModulesFromProjectConfig(
     }
 }
 
-export async function checkProjectSetting(options: IInternalBuildOptions | IInternalBundleBuildOptions) {    options.engineInfo = options.engineInfo || Engine.getInfo();
+export async function checkProjectSetting(options: IInternalBuildOptions | IInternalBundleBuildOptions) {
+    options.engineInfo = options.engineInfo || cloneConfigValue(Engine.getInfo());
 
     const engineConfig = Engine.getConfig();
     const { designResolution, renderPipeline, physicsConfig, customLayers, sortingLayers, macroConfig } = engineConfig;
     // 默认 Canvas 设置
     if (!options.designResolution) {
-        options.designResolution = designResolution;
+        options.designResolution = cloneConfigValue(designResolution);
     }
 
     // renderPipeline
     if (!options.renderPipeline) {
         if (renderPipeline) {
-            options.renderPipeline = renderPipeline;
+            options.renderPipeline = cloneConfigValue(renderPipeline);
         }
     }
 
     // physicsConfig
     if (!options.physicsConfig) {
-        options.physicsConfig = physicsConfig;
+        options.physicsConfig = cloneConfigValue(physicsConfig);
         if (!options.physicsConfig.defaultMaterial) {
             options.physicsConfig.defaultMaterial = 'ba21476f-2866-4f81-9c4d-6e359316e448';
         }
@@ -460,20 +462,20 @@ export async function checkProjectSetting(options: IInternalBuildOptions | IInte
 
     // customLayers
     if (!options.customLayers) {
-        options.customLayers = customLayers;
+        options.customLayers = cloneConfigValue(customLayers);
     }
 
     // sortingLayers
     if (!options.sortingLayers) {
         if (sortingLayers) {
-            options.sortingLayers = sortingLayers;
+            options.sortingLayers = cloneConfigValue(sortingLayers);
         }
     }
 
     // macro 配置
     if (!options.macroConfig) {
         if (macroConfig) {
-            options.macroConfig = macroConfig;
+            options.macroConfig = cloneConfigValue(macroConfig);
         }
     }
 
@@ -497,7 +499,7 @@ export async function checkProjectSetting(options: IInternalBuildOptions | IInte
     }
 
     if (!options.splashScreen) {
-        options.splashScreen = Engine.getConfig().splashScreen;
+        options.splashScreen = cloneConfigValue(engineConfig.splashScreen);
     }
 
 }

--- a/src/core/builder/share/utils.ts
+++ b/src/core/builder/share/utils.ts
@@ -11,6 +11,10 @@ export function compareNumeric(lhs: string, rhs: string): number {
 
 export { compareNumeric as compareUUID };
 
+export function cloneConfigValue<T>(value: T): T {
+    return value === undefined || value === null ? value : JSON.parse(JSON.stringify(value));
+}
+
 /**
  * 解析配置 options 内的默认值
  * @param options

--- a/src/core/builder/test/common-options-validator.spec.ts
+++ b/src/core/builder/test/common-options-validator.spec.ts
@@ -122,5 +122,57 @@ describe('common-options-validator', () => {
 
             await expect(checkProjectSetting(options)).rejects.toThrow('Invalid engineModulesConfigKey: missing');
         });
+
+        it('does not mutate objects from Engine config when filling project settings', async () => {
+            const engineConfig = createEngineConfig({
+                designResolution: { width: 1280, height: 720 },
+                physicsConfig: { defaultMaterial: '' },
+                customLayers: [{ name: 'LayerA', value: 1 }],
+                sortingLayers: [{ id: 1, name: 'SortingA' }],
+                macroConfig: { ENABLE_FOO: true },
+                splashScreen: { totalTime: 1000 },
+            });
+            mockGetConfig.mockReturnValue(engineConfig);
+
+            const { checkProjectSetting } = await import('../share/common-options-validator');
+            const options = {} as any;
+
+            await checkProjectSetting(options);
+
+            options.designResolution.width = 1;
+            options.physicsConfig.defaultMaterial = 'changed';
+            options.customLayers[0].name = 'ChangedLayer';
+            options.sortingLayers[0].name = 'ChangedSorting';
+            options.macroConfig.ENABLE_FOO = false;
+            options.splashScreen.totalTime = 1;
+
+            expect(engineConfig.designResolution).toEqual({ width: 1280, height: 720 });
+            expect(engineConfig.physicsConfig).toEqual({ defaultMaterial: '' });
+            expect(engineConfig.customLayers).toEqual([{ name: 'LayerA', value: 1 }]);
+            expect(engineConfig.sortingLayers).toEqual([{ id: 1, name: 'SortingA' }]);
+            expect(engineConfig.macroConfig).toEqual({ ENABLE_FOO: true });
+            expect(engineConfig.splashScreen).toEqual({ totalTime: 1000 });
+        });
+    });
+
+    describe('handleOverwriteProjectSettings', () => {
+        it('does not mutate the original includeModules array while applying overwrites', async () => {
+            const { handleOverwriteProjectSettings } = await import('../share/common-options-validator');
+            const includeModules = ['base', 'physics-builtin'];
+            const options = {
+                includeModules,
+                overwriteProjectSettings: {
+                    includeModules: {
+                        webview: 'on',
+                        physics: 'physics-physx',
+                    },
+                },
+            } as any;
+
+            handleOverwriteProjectSettings(options);
+
+            expect(includeModules).toEqual(['base', 'physics-builtin']);
+            expect(options.includeModules).toEqual(['base', 'physics-physx', 'webview']);
+        });
     });
 });

--- a/src/core/builder/test/plugin-get-options.spec.ts
+++ b/src/core/builder/test/plugin-get-options.spec.ts
@@ -1,0 +1,45 @@
+import { PluginManager } from '../manager/plugin';
+import builderConfig from '../share/builder-config';
+
+describe('PluginManager.getOptionsByPlatform', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('returns a cloned merge of common and platform options', async () => {
+        const commonOptions: any = {
+            name: 'game',
+            nested: {
+                fromCommon: true,
+            },
+        };
+        const platformOptions: any = {
+            nested: {
+                fromPlatform: true,
+            },
+            packages: {
+                web: {
+                    enabled: true,
+                },
+            },
+        };
+        jest.spyOn(builderConfig, 'getProject').mockImplementation(async (key?: string) => {
+            if (key === 'common') {
+                return commonOptions;
+            }
+            if (key === 'platforms.web-mobile') {
+                return platformOptions;
+            }
+            return undefined as any;
+        });
+
+        const options = await new PluginManager().getOptionsByPlatform('web-mobile');
+
+        (options.packages as any).web.enabled = false;
+        expect(options.platform).toBe('web-mobile');
+        expect(options.outputName).toBe('web-mobile');
+        expect(platformOptions.packages.web.enabled).toBe(true);
+        expect((commonOptions as any).platform).toBeUndefined();
+        expect((commonOptions as any).outputName).toBeUndefined();
+    });
+});

--- a/src/core/builder/test/project-options.spec.ts
+++ b/src/core/builder/test/project-options.spec.ts
@@ -1,0 +1,82 @@
+describe('project-options', () => {
+    describe('getSplashSettings', () => {
+        it('does not mutate splash screen config inputs', async () => {
+            const { getSplashSettings } = await import('../worker/builder/tasks/setting-task/utils/project-options');
+            const defaultSplashScreen = {
+                totalTime: 1200,
+                background: {
+                    type: 'default',
+                    image: 'db://internal/default-background.png',
+                },
+            } as any;
+            const splashScreen = {
+                logo: {
+                    type: 'none',
+                    image: 'db://assets/logo.png',
+                },
+            } as any;
+
+            const result = await getSplashSettings(true, false, defaultSplashScreen, splashScreen);
+
+            expect(result.logo).toEqual({ type: 'none' });
+            expect(defaultSplashScreen).toEqual({
+                totalTime: 1200,
+                background: {
+                    type: 'default',
+                    image: 'db://internal/default-background.png',
+                },
+            });
+            expect(splashScreen).toEqual({
+                logo: {
+                    type: 'none',
+                    image: 'db://assets/logo.png',
+                },
+            });
+        });
+
+        it('does not mutate default splash screen config when disabled', async () => {
+            const { getSplashSettings } = await import('../worker/builder/tasks/setting-task/utils/project-options');
+            const defaultSplashScreen = {
+                totalTime: 1200,
+                background: {
+                    type: 'default',
+                    image: 'db://internal/default-background.png',
+                },
+            } as any;
+
+            const result = await getSplashSettings(false, false, defaultSplashScreen, {} as any);
+
+            expect(result.totalTime).toBe(0);
+            expect(result.background).toBeUndefined();
+            expect(defaultSplashScreen).toEqual({
+                totalTime: 1200,
+                background: {
+                    type: 'default',
+                    image: 'db://internal/default-background.png',
+                },
+            });
+        });
+    });
+
+    describe('getPhysicsConfig', () => {
+        it('does not mutate physics config input', async () => {
+            const { getPhysicsConfig } = await import('../worker/builder/tasks/setting-task/utils/project-options');
+            const physicsConfig = {
+                defaultMaterial: 'material',
+                gravity: { x: 0, y: -10, z: 0 },
+            } as any;
+
+            const result = await getPhysicsConfig(['physics-physx'], physicsConfig);
+
+            result.gravity.y = -1;
+            expect(result).toMatchObject({
+                physicsEngine: 'physics-physx',
+                defaultMaterial: 'material',
+            });
+            expect(physicsConfig).toEqual({
+                defaultMaterial: 'material',
+                gravity: { x: 0, y: -10, z: 0 },
+            });
+        });
+    });
+});

--- a/src/core/builder/worker/builder/tasks/setting-task/utils/project-options.ts
+++ b/src/core/builder/worker/builder/tasks/setting-task/utils/project-options.ts
@@ -12,6 +12,7 @@ import { resolveCustomJointTextureLayouts } from '../../../../../../engine/joint
 import { configurationManager } from '../../../../../../configuration';
 import { ISplashSetting } from '../../../../../../engine/@types/config';
 import { GlobalPaths } from '../../../../../../../global';
+import { cloneConfigValue } from '../../../../../share/utils';
 
 const layerMask: number[] = [];
 for (let i = 0; i <= 19; i++) {
@@ -58,17 +59,17 @@ export async function patchOptionsToSettings(options: IInternalBuildOptions, set
 export async function getSplashSettings(useSplashScreen: boolean, preview: boolean, defaultSplashScreen: ISplashSetting, splashScreen: ISplashSetting): Promise<ISplashSetting> {
     if (useSplashScreen !== false || preview) {
         try {
-            splashScreen = Object.assign({}, defaultSplashScreen, splashScreen);
+            splashScreen = cloneConfigValue(Object.assign({}, defaultSplashScreen, splashScreen));
             return formatSplashScreen(splashScreen);
         } catch (error) {
             console.error(error);
             console.error(i18n.t('builder.error.missing_splash_tips', {
                 splashScreen: JSON.stringify(splashScreen),
             }));
-            return formatSplashScreen(defaultSplashScreen!);
+            return formatSplashScreen(cloneConfigValue(defaultSplashScreen!));
         }
     } else {
-        const defaultSplashSettings = formatSplashScreen(defaultSplashScreen!);
+        const defaultSplashSettings = formatSplashScreen(cloneConfigValue(defaultSplashScreen!));
         defaultSplashSettings.totalTime = 0;
         delete defaultSplashSettings.logo;
         delete defaultSplashSettings.background;
@@ -88,7 +89,7 @@ export async function getPhysicsConfig(includeModules: string[], physicsConfig: 
     }
 
     // 不论引擎对物理模块的剔除情况，物理配置都输出
-    return Object.assign({ physicsEngine }, physicsConfig);
+    return Object.assign({ physicsEngine }, cloneConfigValue(physicsConfig));
 }
 
 export function formatSplashScreen(splashScreen: ISplashSetting) {


### PR DESCRIPTION
Summary:
- Clone builder configuration values before assigning them to build options.
- Avoid mutating shared project/default configuration objects while applying project settings, splash settings, physics settings, and platform defaults.
- Add regression coverage for cloned builder options and configuration-derived settings.

Validation:
- `npx jest src/core/builder/test/plugin-get-options.spec.ts src/core/builder/test/common-options-validator.spec.ts src/core/builder/test/project-options.spec.ts --runInBand`

Note:
- Jest still reports an existing open handle from `@cocos/ccbuild`, but all targeted tests pass.