### PR TITLE
[break] fix(scene): paste prefab nodes under editor root

### DIFF
--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -742,7 +742,7 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             }
 
             const beforeNodeUuids = this._collectSceneNodeUuidsForUndo();
-            const newUuids = nodeMgr.paste(parentUuid, copiedUuids, params.keepWorldTransform);
+            const newUuids = nodeMgr.paste(parentUuid || root.uuid, copiedUuids, params.keepWorldTransform);
             const newPaths = newUuids.map(uuid => this._getNodePathByUuid(uuid)).filter(Boolean);
             this._undo.recordCreateNodeCommand(beforeNodeUuids, newPaths);
             return newPaths;

--- a/src/core/scene/test/editor-proxy-prefab.testcase.ts
+++ b/src/core/scene/test/editor-proxy-prefab.testcase.ts
@@ -1,10 +1,31 @@
-import { IBaseIdentifier, INodeInfo, INodeIdentifier, IComponentIdentifier, NodeType, ReloadResult } from '../common';
+import {
+    IBaseIdentifier,
+    INodeInfo,
+    INodeIdentifier,
+    IComponentIdentifier,
+    NodeType,
+    ReloadResult,
+    ICopyParams,
+    IPasteParams,
+} from '../common';
 import { EditorProxy } from '../main-process/proxy/editor-proxy';
 import { SceneTestEnv } from './scene-test-env';
 import { NodeProxy } from '../main-process/proxy/node-proxy';
 import { readFileSync } from 'fs-extra';
 import { ComponentProxy } from '../main-process/proxy/component-proxy';
 import { assetManager } from '../../assets';
+import { Rpc } from '../main-process/rpc';
+
+const rpcRequest = (method: string, args?: any[]) =>
+    (Rpc.getInstance() as any).request('Node', method, args);
+
+function copy(params: ICopyParams): Promise<string[]> {
+    return rpcRequest('copy', [params]);
+}
+
+function paste(params: IPasteParams): Promise<string[]> {
+    return rpcRequest('paste', [params]);
+}
 
 describe('EditorProxy Prefab 测试', () => {
     describe('预制体操作', () => {
@@ -208,6 +229,25 @@ describe('EditorProxy Prefab 测试', () => {
 
             expect(result).not.toBeNull();
             expect(JSON.stringify(result)).toContain('current-prefab-test-node');
+        });
+
+        it('paste without parent path uses the opened prefab root as parent', async () => {
+            const current = await EditorProxy.queryCurrent() as INodeInfo;
+            expect(current).not.toBeNull();
+
+            const rootPath = current.path || current.name;
+            const source = await NodeProxy.createByType({
+                path: rootPath,
+                nodeType: NodeType.EMPTY,
+                name: 'prefab-paste-default-parent-source',
+            });
+            expect(source).not.toBeNull();
+
+            await copy({ paths: [source!.path] });
+            const result = await paste({});
+
+            expect(result).toHaveLength(1);
+            expect(result[0].startsWith(`${rootPath}/`)).toBe(true);
         });
 
         it('close - 不保存地关闭当前预制体', async () => {


### PR DESCRIPTION
## Summary
- Use the currently opened editor root as the default paste parent when no parent path is provided.
- Add a prefab editor regression test for copy/paste without an explicit target parent.

## Details
When editing a prefab, the runtime scene contains a virtual scene node and the actual prefab root is mounted under it. The copy/paste path passed no target parent to the lower-level node manager, so it fell back to `director.getScene()` and pasted nodes under the virtual scene. The cut/paste path already used the editor root as its default parent, so this change aligns copy/paste with that behavior.

## Verification
- `npx tsc -b --pretty false`
- `git diff --check`

The scene regression test was added but the local scene test runner is blocked by the existing native `gl` module ABI mismatch in this workspace.