### PR TITLE
fix: prevent deletion of prefab template children

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -774,7 +774,7 @@ export declare function queryAssetConfigMap(): Promise<Record<string, IAssetConf
 export declare function queryAssetDBInfos(): Promise<Record<string, IAssetDBInfo>>;
 export declare function queryAssetDependencies(uuidOrUrl: string, type?: QueryAssetType): Promise<string[]>;
 export declare function queryAssetInfo(urlOrUUIDOrPath: string, dataKeys?: string[] | undefined): Promise<IAssetInfo | null>;
-export declare function queryAssetInfos(options?: QueryAssetsOption): Promise<IAssetInfo[]>;
+export declare function queryAssetInfos(options?: QueryAssetsOption, dataKeys?: (keyof IAssetInfo)[]): Promise<IAssetInfo[]>;
 export declare function queryAssetMeta(urlOrUUIDOrPath: string): Promise<IAssetMeta<'unknown'> | null>;
 export declare interface QueryAssetsOption {
     ccType?: string | string[],
@@ -6403,6 +6403,7 @@ export declare interface IPrefabService extends IServiceEvents {
     isPrefabInstance(params: IIsPrefabInstanceParams): Promise<boolean>;
     getPrefabInfo(params: IGetPrefabInfoParams): Promise<IPrefab | null>;
     unlinkPrefab(params: IUnlinkPrefabParams): Promise<boolean>;
+    filterChildOfPrefabAssetWhenRemoveNode(uuids: string | string[]): string[];
     removePrefabInfoFromNode(node: Node_2, removeNested?: boolean): void;
 }
 export declare interface IPrefabStateInfo {
@@ -8908,7 +8909,7 @@ export declare function queryAssetConfigMap(): Promise<Record<string, IAssetConf
 export declare function queryAssetDBInfos(): Promise<Record<string, IAssetDBInfo>>;
 export declare function queryAssetDependencies(uuidOrUrl: string, type?: QueryAssetType): Promise<string[]>;
 export declare function queryAssetInfo(urlOrUUIDOrPath: string, dataKeys?: string[] | undefined): Promise<IAssetInfo | null>;
-export declare function queryAssetInfos(options?: QueryAssetsOption): Promise<IAssetInfo[]>;
+export declare function queryAssetInfos(options?: QueryAssetsOption, dataKeys?: (keyof IAssetInfo)[]): Promise<IAssetInfo[]>;
 export declare function queryAssetMeta(urlOrUUIDOrPath: string): Promise<IAssetMeta<'unknown'> | null>;
 export declare interface QueryAssetsOption {
     ccType?: string | string[],

--- a/src/core/scene/common/prefab/service.ts
+++ b/src/core/scene/common/prefab/service.ts
@@ -18,7 +18,7 @@ export interface IPrefabEvents {
 
 }
 
-export interface IPublicPrefabService extends Omit<IPrefabService, keyof IServiceEvents | 'removePrefabInfoFromNode'> {
+export interface IPublicPrefabService extends Omit<IPrefabService, keyof IServiceEvents | 'removePrefabInfoFromNode' | 'filterChildOfPrefabAssetWhenRemoveNode'> {
 }
 
 export interface IPrefabService extends IServiceEvents {
@@ -56,6 +56,12 @@ export interface IPrefabService extends IServiceEvents {
      * 解绑预制体实例，使其成为普通节点
      */
     unlinkPrefab(params: IUnlinkPrefabParams): Promise<boolean>;
+
+    /**
+     * Filters template-owned children of prefab instances before node deletion.
+     * @internal
+     */
+    filterChildOfPrefabAssetWhenRemoveNode(uuids: string | string[]): string[];
 
     /**
      * 移除 prefab info

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -282,6 +282,11 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
                 return null;
             }
 
+            const removableUuids = Service.Prefab.filterChildOfPrefabAssetWhenRemoveNode(node.uuid);
+            if (removableUuids.length === 0) {
+                return null;
+            }
+
             let command: RemoveNodeCommand | null = null;
             if (this._undo.shouldRecordStructureCommand()) {
                 command = RemoveNodeCommand.capture(node, params.keepWorldTransform);

--- a/src/core/scene/test/prefab-proxy.testcase.ts
+++ b/src/core/scene/test/prefab-proxy.testcase.ts
@@ -93,6 +93,17 @@ describe('Prefab Proxy In Scene 测试', () => {
             }
         });
 
+        it('createPrefabFromNode - creates a template child for delete protection', async () => {
+            const templateChild = await NodeProxy.createByType({
+                path: testNodePath,
+                name: 'TemplateChild',
+                nodeType: NodeType.EMPTY,
+            });
+
+            expect(templateChild).toBeTruthy();
+            expect(templateChild?.path).toBe(testNodePath + '/TemplateChild');
+        });
+
         it('createPrefabFromNode - 参数验证测试', async () => {
             // 测试空节点路径
             const invalidParams1: ICreatePrefabFromNodeParams = {
@@ -149,6 +160,28 @@ describe('Prefab Proxy In Scene 测试', () => {
             expect(prefabInstanceNode?.prefab).toBeDefined();
             expect(prefabInstanceNode?.prefab?.asset).toBeDefined();
             expect(prefabInstanceNode?.name).toBe('PrefabInstanceNode-CreatePrefabFromNode');
+        });
+
+        it('delete - prevents deleting a prefab template child from an instance', async () => {
+            const prefabInstance = await NodeProxy.createByAsset({
+                dbURL: prefabAssetURL,
+                path: '',
+                name: 'PrefabInstanceNode-DeleteGuard',
+            });
+
+            expect(prefabInstance).toBeTruthy();
+            if (!prefabInstance) return;
+
+            const templateChildPath = prefabInstance.path + '/TemplateChild';
+            expect(await NodeProxy.query({ path: templateChildPath })).toBeTruthy();
+
+            const deleteChildResult = await NodeProxy.delete({ path: templateChildPath });
+            expect(deleteChildResult).toBeNull();
+            expect(await NodeProxy.query({ path: templateChildPath })).toBeTruthy();
+
+            const deleteRootResult = await NodeProxy.delete({ path: prefabInstance.path });
+            expect(deleteRootResult).toEqual({ path: prefabInstance.path });
+            expect(await NodeProxy.query({ path: prefabInstance.path })).toBeNull();
         });
 
         it('isPrefabInstance - 检查节点是否为预制体实例', async () => {

--- a/src/core/scene/test/service-core/message-callsite.test.ts
+++ b/src/core/scene/test/service-core/message-callsite.test.ts
@@ -665,6 +665,63 @@ describe('ServiceEvents 事件发射集成测试', () => {
             expect(listener).toHaveBeenCalledWith(node, expect.objectContaining({ propPath: 'name' }));
         });
 
+        it('delete preserves one node:change broadcast when rejecting a prefab template child', async () => {
+            require('../../scene-process/service/editor');
+            require('../../scene-process/service/undo');
+            require('../../scene-process/service/prefab');
+
+            const { Service } = require('../../scene-process/service/core');
+            const { NodeService } = require('../../scene-process/service/node');
+            const nodeMgr = require('../../scene-process/service/node/index').default;
+            const { RemoveNodeCommand } = require('../../scene-process/service/undo/commands/remove-node-command');
+            const { prefabUtils } = require('../../scene-process/service/prefab/utils');
+            const { Node: MockNode } = require('cc');
+            const node = new MockNode();
+            node.uuid = 'prefab-child';
+            node.name = 'PrefabChild';
+
+            const listener = jest.fn();
+            globalEventEmitter.on('node:change', listener);
+
+            const NodeMgr = (global as any).EditorExtends.Node;
+            NodeMgr.getNodeByPath = jest.fn(() => node);
+            NodeMgr.getNode = jest.fn(() => node);
+            NodeMgr.getNodePath = jest.fn(() => '/PrefabChild');
+
+            const originalLock = Service.Editor.lock;
+            const originalUnlock = Service.Editor.unlock;
+            const originalGetRootNode = Service.Editor.getRootNode;
+            const removeNodeSpy = jest.spyOn(nodeMgr, 'baseRemoveNode');
+            const captureSpy = jest.spyOn(RemoveNodeCommand, 'capture');
+
+            try {
+                Service.Editor.lock = jest.fn().mockResolvedValue(undefined);
+                Service.Editor.unlock = jest.fn();
+                Service.Editor.getRootNode = jest.fn(() => ({}));
+                prefabUtils.isOutmostPrefabInstanceMountedChildren.mockReturnValue(false);
+                prefabUtils.isPrefabInstanceRoot.mockReturnValue(false);
+                prefabUtils.isPartOfAssetInPrefabInstance.mockReturnValue(true);
+
+                const nodeService = new NodeService();
+                nodeService._undo = { shouldRecordStructureCommand: jest.fn(() => true) };
+
+                await expect(nodeService.delete({ path: '/PrefabChild' })).resolves.toBeNull();
+                expect(listener).toHaveBeenCalledTimes(1);
+                expect(listener).toHaveBeenCalledWith('/PrefabChild');
+                expect(captureSpy).not.toHaveBeenCalled();
+                expect(removeNodeSpy).not.toHaveBeenCalled();
+            } finally {
+                Service.Editor.lock = originalLock;
+                Service.Editor.unlock = originalUnlock;
+                Service.Editor.getRootNode = originalGetRootNode;
+                prefabUtils.isOutmostPrefabInstanceMountedChildren.mockReturnValue(false);
+                prefabUtils.isPrefabInstanceRoot.mockReturnValue(false);
+                prefabUtils.isPartOfAssetInPrefabInstance.mockReturnValue(false);
+                captureSpy.mockRestore();
+                removeNodeSpy.mockRestore();
+            }
+        });
+
         it('setProperty(position) 成功后应 broadcast animation:property-committed', async () => {
             const listener = jest.fn();
             globalEventEmitter.on('animation:property-committed', listener);


### PR DESCRIPTION
## Summary

- Filter template-owned children of prefab instances before `removeNode` deletes a node.
  - Prevent direct deletion of a prefab template child from an instance.
  - Preserve the existing ability to delete the prefab instance root.
  - Skip Undo command capture and low-level node removal when deletion is rejected.

Migrate Creator behavior below:
<img width="1128" height="342" alt="image" src="https://github.com/user-attachments/assets/aaead691-4565-4dba-aec1-9164138434ac"/>

## Test Plan

- Add prefab proxy coverage.
  - Verify that a template child cannot be deleted and remains queryable.
  - Verify that the prefab instance root can still be deleted.
- Add message call-site coverage.
  - Verify that a rejected deletion still emits exactly one `node:change` notification.
  - Verify that no `RemoveNodeCommand` is captured and low-level node removal is not called.

## References

- Creator Legacy
  - https://github.com/cocos/cocos-editor/blob/v3.8.9/app/builtin/scene/source/script/3d/facade/general-scene-facade.ts#L563
  - https://github.com/cocos/cocos-editor/blob/v3.8.9/app/builtin/scene/source/script/3d/manager/prefab/index.ts

## Known Issue

- Some `onNodeChanged` warnings logged at runtime.

<img width="676" height="634" alt="image" src="https://github.com/user-attachments/assets/d1b3654a-bf9b-43dd-9e67-46316fa3973f"/>
