### PR TITLE
Fix scene view mode restore

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -776,7 +776,7 @@ export declare function queryAssetConfigMap(): Promise<Record<string, IAssetConf
 export declare function queryAssetDBInfos(): Promise<Record<string, IAssetDBInfo>>;
 export declare function queryAssetDependencies(uuidOrUrl: string, type?: QueryAssetType): Promise<string[]>;
 export declare function queryAssetInfo(urlOrUUIDOrPath: string, dataKeys?: string[] | undefined): Promise<IAssetInfo | null>;
-export declare function queryAssetInfos(options?: QueryAssetsOption): Promise<IAssetInfo[]>;
+export declare function queryAssetInfos(options?: QueryAssetsOption, dataKeys?: (keyof IAssetInfo)[]): Promise<IAssetInfo[]>;
 export declare function queryAssetMeta(urlOrUUIDOrPath: string): Promise<IAssetMeta<'unknown'> | null>;
 export declare interface QueryAssetsOption {
     ccType?: string | string[],
@@ -8889,7 +8889,7 @@ export declare function queryAssetConfigMap(): Promise<Record<string, IAssetConf
 export declare function queryAssetDBInfos(): Promise<Record<string, IAssetDBInfo>>;
 export declare function queryAssetDependencies(uuidOrUrl: string, type?: QueryAssetType): Promise<string[]>;
 export declare function queryAssetInfo(urlOrUUIDOrPath: string, dataKeys?: string[] | undefined): Promise<IAssetInfo | null>;
-export declare function queryAssetInfos(options?: QueryAssetsOption): Promise<IAssetInfo[]>;
+export declare function queryAssetInfos(options?: QueryAssetsOption, dataKeys?: (keyof IAssetInfo)[]): Promise<IAssetInfo[]>;
 export declare function queryAssetMeta(urlOrUUIDOrPath: string): Promise<IAssetMeta<'unknown'> | null>;
 export declare interface QueryAssetsOption {
     ccType?: string | string[],

--- a/src/core/scene/scene-process/service/camera.ts
+++ b/src/core/scene/scene-process/service/camera.ts
@@ -100,9 +100,9 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
                     // view may not be ready
                 }
 
-                this.initFromConfig();
             }
 
+            const initConfigTask = this.initFromConfig();
             this.refresh();
 
             const uuid = this._getCurrentViewUuid();
@@ -112,16 +112,16 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
             }
 
             this._detachSceneCameras();
-            void this._restoreCameraView();
-
+            void this._restoreCameraView(initConfigTask);
         } catch (e) {
             console.warn('[Camera] onEditorOpened failed:', e);
         }
     }
 
-    private async _restoreCameraView(): Promise<void> {
+    private async _restoreCameraView(initConfigTask?: Promise<void>): Promise<void> {
         const uuid = this._currentUuid;
         try {
+            await initConfigTask;
             await this.loadCameraInfos();
             if (uuid !== this._currentUuid) {
                 return;
@@ -167,6 +167,7 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
             }
             const gizmoConfig = await rpc.request('sceneConfigInstance', 'get', ['gizmo', 'local']) as Partial<IGizmoConfig> | undefined;
             if (gizmoConfig) {
+                this._applyGizmoViewMode(gizmoConfig);
                 this._applyGizmoDisplay(gizmoConfig);
             }
         } catch {
@@ -196,6 +197,12 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
         if (config.originAxis2D !== undefined) this.setOriginAxes2D(config.originAxis2D);
         if (config.originAxis3D !== undefined) this.setOriginAxes3D(config.originAxis3D);
         Service.Engine.repaintInEditMode();
+    }
+
+    private _applyGizmoViewMode(config: Partial<IGizmoConfig>): void {
+        if (config.is2D !== undefined && this.is2D !== config.is2D) {
+            this.is2D = config.is2D;
+        }
     }
 
     setGridColor(color: number[]): void {

--- a/src/core/scene/test/camera-view-mode-config.test.ts
+++ b/src/core/scene/test/camera-view-mode-config.test.ts
@@ -1,0 +1,175 @@
+const mockRpcRequest = jest.fn();
+
+const mockService: any = {
+    Editor: {
+        getRootNode: jest.fn(() => null),
+    },
+    Engine: {
+        repaintInEditMode: jest.fn(),
+    },
+    Gizmo: {
+        backgroundNode: { name: 'background' },
+        transformToolData: { is2D: false },
+    },
+    Operation: {
+        addListener: jest.fn(),
+        dispatch: jest.fn(),
+    },
+};
+
+class MockColor {
+    constructor(
+        public r = 0,
+        public g = 0,
+        public b = 0,
+        public a = 255,
+    ) {}
+}
+
+class MockController {
+    activeValues: boolean[] = [];
+    init = jest.fn();
+    on = jest.fn();
+    updateGrid = jest.fn();
+    refresh = jest.fn();
+    focus = jest.fn();
+    showGrid = jest.fn();
+    isGridVisible = true;
+    lineColor: any;
+
+    private _active = false;
+
+    set active(value: boolean) {
+        this._active = value;
+        this.activeValues.push(value);
+    }
+
+    get active() {
+        return this._active;
+    }
+}
+
+jest.mock('cc', () => ({
+    Camera: class {},
+    Canvas: class {},
+    Color: MockColor,
+    Layers: { Enum: { EDITOR: 1, IGNORE_RAYCAST: 2 } },
+    Vec3: class {},
+    gfx: {},
+}));
+
+jest.mock('../scene-process/service/core/decorator', () => ({
+    register: () => () => undefined,
+    Service: mockService,
+}));
+
+jest.mock('../scene-process/rpc', () => ({
+    Rpc: {
+        getInstance: () => ({ request: mockRpcRequest }),
+    },
+}));
+
+jest.mock('../scene-process/service/camera/camera-controller-2d', () => ({
+    CameraController2D: MockController,
+}));
+
+jest.mock('../scene-process/service/camera/camera-controller-3d', () => ({
+    CameraController3D: MockController,
+}));
+
+jest.mock('../scene-process/service/camera/utils', () => ({
+    CameraMoveMode: { IDLE: 0 },
+    CameraUtils: {
+        createCamera: jest.fn(() => ({
+            camera: { update: jest.fn() },
+            clearColor: new MockColor(48, 48, 48, 255),
+            far: 10000,
+            fov: 45,
+            near: 0.01,
+            node: {},
+        })),
+    },
+}));
+
+jest.mock('../scene-process/service/camera/editor-camera-component', () => ({
+    __esModule: true,
+    default: class EditorCameraComponent {},
+}));
+
+describe('CameraService view mode config', () => {
+    async function flushConfigRestore() {
+        await Promise.resolve();
+        await Promise.resolve();
+    }
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockService.Gizmo.transformToolData.is2D = false;
+        mockRpcRequest.mockImplementation((_service, _method, args) => {
+            const [key] = args;
+            if (key === 'gizmo') return Promise.resolve({ is2D: true });
+            return Promise.resolve(undefined);
+        });
+        (global as any).cc = {
+            director: {
+                getScene: jest.fn(() => ({ uuid: 'scene-uuid' })),
+            },
+            view: { on: jest.fn() },
+        };
+    });
+
+    afterEach(() => {
+        delete (global as any).cc;
+    });
+
+    it('restores the saved 2D view when the scene editor is reopened', async () => {
+        const { CameraService } = require('../scene-process/service/camera');
+        const camera = new CameraService();
+        camera.init();
+
+        camera.onEditorOpened();
+        await flushConfigRestore();
+
+        expect(camera.is2D).toBe(true);
+        expect(mockService.Gizmo.transformToolData.is2D).toBe(true);
+
+        camera.is2D = false;
+        expect(camera.is2D).toBe(false);
+
+        camera.onEditorOpened();
+        await flushConfigRestore();
+
+        expect(camera.is2D).toBe(true);
+        expect(mockService.Gizmo.transformToolData.is2D).toBe(true);
+    });
+
+    it('waits for view mode config before running deferred focus', async () => {
+        let resolveGizmoConfig!: (value: { is2D: boolean }) => void;
+        const gizmoConfig = new Promise<{ is2D: boolean }>((resolve) => {
+            resolveGizmoConfig = resolve;
+        });
+
+        mockRpcRequest.mockImplementation((_service, _method, args) => {
+            const [key] = args;
+            if (key === 'gizmo') return gizmoConfig;
+            return Promise.resolve(undefined);
+        });
+
+        const { CameraService } = require('../scene-process/service/camera');
+        const camera = new CameraService();
+        camera.init();
+        const defaultFocus = jest.spyOn(camera, 'defaultFocus');
+
+        camera.onEditorOpened();
+        await Promise.resolve();
+
+        expect(defaultFocus).not.toHaveBeenCalled();
+
+        resolveGizmoConfig({ is2D: true });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(camera.is2D).toBe(true);
+        expect(defaultFocus).toHaveBeenCalledWith('scene-uuid');
+    });
+});

--- a/src/core/scene/test/camera-view-mode-config.test.ts
+++ b/src/core/scene/test/camera-view-mode-config.test.ts
@@ -173,3 +173,5 @@ describe('CameraService view mode config', () => {
         expect(defaultFocus).toHaveBeenCalledWith('scene-uuid');
     });
 });
+
+export {};


### PR DESCRIPTION
## Summary
- Restore the saved 2D/3D scene view mode every time the scene editor opens.
- Wait for view mode config to finish loading before restoring the camera view.
- Add coverage for reopening the editor with a saved 2D view.

## Tests
- npx jest src/core/scene/test/camera-view-mode-config.test.ts --runInBand
- npx tsc -b --pretty false