### PR TITLE
[break] update asset query dts snapshot

### DIFF
--- a/.github/workflows/check-dts.yml
+++ b/.github/workflows/check-dts.yml
@@ -34,20 +34,9 @@ jobs:
         shell: bash
         run: |
           cp packages/engine/bin/.declarations/cc.d.ts packages/cocos-cli-types/cc.d.ts
+          npx jest --roots packages/cocos-cli-types --testPathPattern dts-snapshot --no-cache
           npx eslint --fix "./packages/cocos-cli-types/*.d.ts"
-          npx jest --roots packages/cocos-cli-types --testPathPattern dts-snapshot --no-cache -u
-          npx jest packages/cocos-cli-types --roots="<rootDir>/packages/cocos-cli-types"
-
-      - name: Check committed DTS snapshot
-        shell: bash
-        run: |
-          SNAP_FILE="packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap"
-          if ! git diff --quiet HEAD -- "$SNAP_FILE"; then
-            echo "::error::DTS snapshot is out of date. Run npm run generate:dts and commit the updated snapshot."
-            git diff -- "$SNAP_FILE"
-            exit 1
-          fi
-          echo "DTS snapshot is up to date."
+          npx jest packages/cocos-cli-types --roots="<rootDir>/packages/cocos-cli-types" --testPathIgnorePatterns dts-snapshot
 
       - name: Typecheck DTS declarations
         shell: bash

--- a/.github/workflows/check-dts.yml
+++ b/.github/workflows/check-dts.yml
@@ -38,6 +38,17 @@ jobs:
           npx jest --roots packages/cocos-cli-types --testPathPattern dts-snapshot --no-cache -u
           npx jest packages/cocos-cli-types --roots="<rootDir>/packages/cocos-cli-types"
 
+      - name: Check committed DTS snapshot
+        shell: bash
+        run: |
+          SNAP_FILE="packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap"
+          if ! git diff --quiet HEAD -- "$SNAP_FILE"; then
+            echo "::error::DTS snapshot is out of date. Run npm run generate:dts and commit the updated snapshot."
+            git diff -- "$SNAP_FILE"
+            exit 1
+          fi
+          echo "DTS snapshot is up to date."
+
       - name: Typecheck DTS declarations
         shell: bash
         run: |

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -776,7 +776,7 @@ export declare function queryAssetConfigMap(): Promise<Record<string, IAssetConf
 export declare function queryAssetDBInfos(): Promise<Record<string, IAssetDBInfo>>;
 export declare function queryAssetDependencies(uuidOrUrl: string, type?: QueryAssetType): Promise<string[]>;
 export declare function queryAssetInfo(urlOrUUIDOrPath: string, dataKeys?: string[] | undefined): Promise<IAssetInfo | null>;
-export declare function queryAssetInfos(options?: QueryAssetsOption): Promise<IAssetInfo[]>;
+export declare function queryAssetInfos(options?: QueryAssetsOption, dataKeys?: (keyof IAssetInfo)[]): Promise<IAssetInfo[]>;
 export declare function queryAssetMeta(urlOrUUIDOrPath: string): Promise<IAssetMeta<'unknown'> | null>;
 export declare interface QueryAssetsOption {
     ccType?: string | string[],
@@ -8889,7 +8889,7 @@ export declare function queryAssetConfigMap(): Promise<Record<string, IAssetConf
 export declare function queryAssetDBInfos(): Promise<Record<string, IAssetDBInfo>>;
 export declare function queryAssetDependencies(uuidOrUrl: string, type?: QueryAssetType): Promise<string[]>;
 export declare function queryAssetInfo(urlOrUUIDOrPath: string, dataKeys?: string[] | undefined): Promise<IAssetInfo | null>;
-export declare function queryAssetInfos(options?: QueryAssetsOption): Promise<IAssetInfo[]>;
+export declare function queryAssetInfos(options?: QueryAssetsOption, dataKeys?: (keyof IAssetInfo)[]): Promise<IAssetInfo[]>;
 export declare function queryAssetMeta(urlOrUUIDOrPath: string): Promise<IAssetMeta<'unknown'> | null>;
 export declare interface QueryAssetsOption {
     ccType?: string | string[],


### PR DESCRIPTION
## Summary

This updates the generated DTS snapshot for the `queryAssetInfos` API signature added in #810.

The snapshot now includes the optional `dataKeys` parameter so the type compatibility test matches the generated declarations.

This also adds a CI guard to fail `check-dts` when the snapshot is regenerated by the workflow but the updated `.snap` file was not committed. That prevents future DTS changes from landing without their generated snapshot updates.

## Validation

- `npx jest --roots packages/cocos-cli-types --testPathPattern dts-snapshot`
- Confirmed the new snapshot cleanliness check passes when the committed snapshot has no diff