### PR TITLE
fix(scene): filter prefab children before node deletion

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -6406,6 +6406,7 @@ export declare interface IPrefabService extends IServiceEvents {
     getPrefabInfo(params: IGetPrefabInfoParams): Promise<IPrefab | null>;
     unlinkPrefab(params: IUnlinkPrefabParams): Promise<boolean>;
     removePrefabInfoFromNode(node: Node_2, removeNested?: boolean): void;
+    filterChildOfPrefabAssetWhenRemoveNode(uuids: string | string[]): string[];
 }
 export declare interface IPrefabStateInfo {
     state: PrefabState;

--- a/src/core/scene/common/prefab/service.ts
+++ b/src/core/scene/common/prefab/service.ts
@@ -18,7 +18,7 @@ export interface IPrefabEvents {
 
 }
 
-export interface IPublicPrefabService extends Omit<IPrefabService, keyof IServiceEvents | 'removePrefabInfoFromNode'> {
+export interface IPublicPrefabService extends Omit<IPrefabService, keyof IServiceEvents | 'removePrefabInfoFromNode' | 'filterChildOfPrefabAssetWhenRemoveNode'> {
 }
 
 export interface IPrefabService extends IServiceEvents {
@@ -63,4 +63,9 @@ export interface IPrefabService extends IServiceEvents {
      * @param removeNested
      */
     removePrefabInfoFromNode(node: Node, removeNested?: boolean): void;
+
+    /**
+     * Filter out prefab asset children that cannot be removed from the current context.
+     */
+    filterChildOfPrefabAssetWhenRemoveNode(uuids: string | string[]): string[];
 }

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -282,6 +282,11 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
                 return null;
             }
 
+            const uuids = Service.Prefab.filterChildOfPrefabAssetWhenRemoveNode(node.uuid);
+            if (!uuids.length) {
+                return null;
+            }
+
             let command: RemoveNodeCommand | null = null;
             if (this._undo.shouldRecordStructureCommand()) {
                 command = RemoveNodeCommand.capture(node, params.keepWorldTransform);

--- a/src/core/scene/scene-process/service/prefab.ts
+++ b/src/core/scene/scene-process/service/prefab.ts
@@ -495,7 +495,7 @@ export class PrefabService extends BaseService<IPrefabEvents> implements IPrefab
             if (!prefabUtils.isPrefabInstanceRoot(node) && prefabUtils.isPartOfAssetInPrefabInstance(node)) {
                 console.warn(`Node [${node.name}] is a prefab child of prefabInstance [${node['_prefab']?.root?.name}], ${operationTips}`);
                 // 消除其它面板的等待操作，例如hierarchy操作节点时会先进入等待状态，如果没有node的change消息，就会一直处于等待状态。
-                ServiceEvents.broadcast('node:change', EditorExtends.Node.getNodePath(node));
+                ServiceEvents.emit('node:change', node);
                 continue;
             }
 
@@ -522,7 +522,7 @@ export class PrefabService extends BaseService<IPrefabEvents> implements IPrefab
             if (prefabUtils.isPartOfAssetInPrefabInstance(node)) {
                 console.warn(`Node [${node.name}] is part of prefabInstance [${node['_prefab']?.root?.name}], ${operationTips}`);
                 // 消除其它面板的等待操作，例如hierarchy操作节点时会先进入等待状态，如果没有node的change消息，就会一直处于等待状态。
-                ServiceEvents.broadcast('node:change', EditorExtends.Node.getNodePath(node));
+                ServiceEvents.emit('node:change', node);
                 continue;
             }
 
@@ -575,7 +575,7 @@ export class PrefabService extends BaseService<IPrefabEvents> implements IPrefab
                     console.warn(`Node [${child.name}] is a prefab child of prefabInstance [${child['_prefab'].root?.name}], \
                     it's not allowed to modify hierarchy in current context, you can modify it in it's prefabAsset or do it after unlink prefab from root node`);
                     // 消除其它面板的等待操作，例如hierarchy操作节点时会先进入等待状态，如果没有node的change消息，就会一直处于等待状态。
-                    ServiceEvents.broadcast('node:change', EditorExtends.Node.getNodePath(child));
+                    ServiceEvents.emit('node:change', child);
                     return false;
                 }
             }

--- a/src/core/scene/test/node-delete-prefab-filter.test.ts
+++ b/src/core/scene/test/node-delete-prefab-filter.test.ts
@@ -1,0 +1,129 @@
+const mockEditorNode = {
+    getNodeByPath: jest.fn(),
+};
+
+(global as any).EditorExtends = {
+    Node: mockEditorNode,
+};
+
+const mockService = {
+    Editor: {
+        lock: jest.fn(async () => undefined),
+        unlock: jest.fn(),
+        getRootNode: jest.fn(() => ({ uuid: 'scene-root' })),
+    },
+    Prefab: {
+        filterChildOfPrefabAssetWhenRemoveNode: jest.fn(),
+    },
+    Undo: {
+        push: jest.fn(),
+    },
+};
+
+const mockBaseRemoveNode = jest.fn();
+const mockCaptureRemoveNodeCommand = jest.fn(() => ({ type: 'remove-node' }));
+const mockShouldRecordStructureCommand = jest.fn(() => true);
+
+jest.mock('cc', () => ({
+    CCClass: {},
+    CCObject: {},
+    Component: class Component {},
+    Node: class Node {},
+    Prefab: class Prefab {},
+    Quat: class Quat {},
+    Vec3: class Vec3 {},
+}));
+
+jest.mock('../scene-process/service/core', () => ({
+    BaseService: class BaseService {},
+    register: () => () => undefined,
+    Service: mockService,
+}));
+
+jest.mock('../scene-process/service/node/index', () => ({
+    __esModule: true,
+    default: {
+        baseRemoveNode: mockBaseRemoveNode,
+    },
+}));
+
+jest.mock('../scene-process/service/node/node-create', () => ({
+    createNodeByAsset: jest.fn(),
+    loadAny: jest.fn(),
+}));
+
+jest.mock('../scene-process/service/node/node-utils', () => ({
+    getUICanvasNode: jest.fn(),
+    setLayer: jest.fn(),
+}));
+
+jest.mock('../scene-process/service/node/node-undo', () => ({
+    NodeUndoHelper: jest.fn().mockImplementation(() => ({
+        shouldRecordStructureCommand: mockShouldRecordStructureCommand,
+    })),
+}));
+
+jest.mock('../scene-process/service/prefab/utils', () => ({
+    prefabUtils: {},
+}));
+
+jest.mock('../scene-process/service/scene/utils', () => ({
+    sceneUtils: {},
+}));
+
+jest.mock('../scene-process/service/undo/commands/remove-node-command', () => ({
+    RemoveNodeCommand: {
+        capture: mockCaptureRemoveNodeCommand,
+    },
+}));
+
+jest.mock('../scene-process/service/undo/commands/remove-component-command', () => ({
+    RemoveComponentCommand: {},
+}));
+
+jest.mock('../scene-process/service/animation/property-commit-event', () => ({
+    broadcastAnimationPropertyCommitted: jest.fn(),
+}));
+
+describe('NodeService delete prefab filtering', () => {
+    const node = { uuid: 'child-uuid', name: 'Child' };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockEditorNode.getNodeByPath.mockReturnValue(node);
+        mockService.Editor.getRootNode.mockReturnValue({ uuid: 'scene-root' });
+        mockShouldRecordStructureCommand.mockReturnValue(true);
+    });
+
+    it('skips deletion when the target is filtered out as a prefab asset child', async () => {
+        mockService.Prefab.filterChildOfPrefabAssetWhenRemoveNode.mockReturnValue([]);
+
+        const { NodeService } = require('../scene-process/service/node');
+        const service = new NodeService();
+
+        await expect(service.delete({ path: '/Child' })).resolves.toBeNull();
+
+        expect(mockService.Prefab.filterChildOfPrefabAssetWhenRemoveNode).toHaveBeenCalledWith('child-uuid');
+        expect(mockBaseRemoveNode).not.toHaveBeenCalled();
+        expect(mockCaptureRemoveNodeCommand).not.toHaveBeenCalled();
+        expect(mockService.Undo.push).not.toHaveBeenCalled();
+        expect(mockService.Editor.unlock).toHaveBeenCalled();
+    });
+
+    it('continues deletion when the target is allowed by prefab filtering', async () => {
+        mockService.Prefab.filterChildOfPrefabAssetWhenRemoveNode.mockReturnValue(['child-uuid']);
+
+        const { NodeService } = require('../scene-process/service/node');
+        const service = new NodeService();
+
+        await expect(service.delete({ path: '/Child', keepWorldTransform: true })).resolves.toEqual({
+            path: '/Child',
+        });
+
+        expect(mockBaseRemoveNode).toHaveBeenCalledWith(node, true);
+        expect(mockCaptureRemoveNodeCommand).toHaveBeenCalledWith(node, true);
+        expect(mockService.Undo.push).toHaveBeenCalledWith({ type: 'remove-node' });
+    });
+});
+
+export {};

--- a/src/core/scene/test/service-core/message-callsite.test.ts
+++ b/src/core/scene/test/service-core/message-callsite.test.ts
@@ -953,7 +953,7 @@ describe('ServiceEvents 事件发射集成测试', () => {
 
             prefabService.canModifySibling('parent', 0, 1);
 
-            expect(listener).toHaveBeenCalledWith('/PrefabChild');
+            expect(listener).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'prefab-child' }));
         });
     });
 });

--- a/src/core/scene/test/service-core/message-callsite.test.ts
+++ b/src/core/scene/test/service-core/message-callsite.test.ts
@@ -888,7 +888,7 @@ describe('ServiceEvents 事件发射集成测试', () => {
 
             prefabService.filterChildOfAssetOfPrefabInstance(['child-uuid-1'], 'test operation');
 
-            expect(listener).toHaveBeenCalledWith('/Node-child-uuid-1');
+            expect(listener).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'child-uuid-1' }));
         });
 
         it('filterChildOfAssetOfPrefabInstance 中非 prefab 子节点不应 emit node:change', () => {
@@ -913,7 +913,7 @@ describe('ServiceEvents 事件发射集成测试', () => {
 
             prefabService.filterPartOfPrefabAsset(['part-uuid'], 'test operation');
 
-            expect(listener).toHaveBeenCalledWith('/Node-part-uuid');
+            expect(listener).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'part-uuid' }));
         });
 
         it('filterPartOfPrefabAsset 中非 prefab 部件不应 emit node:change', () => {


### PR DESCRIPTION
## Summary
- call the prefab child removal filter before deleting nodes from NodeService
- skip remove and undo recording when the target belongs to a prefab asset child
- emit local node:change with the Node instance instead of a path string from prefab filters
- add coverage for the allowed and filtered delete paths

## Details
The prefab service already had the Creator-style filter, but NodeService.delete did not call it before baseRemoveNode. Deleting a prefab asset child could continue through the removal path and leave later listeners handling removed or invalid nodes.

The prefab filter also used a path string for local node:change broadcasts. CLI service listeners such as AssetService and GizmoService expect a Node instance, so this could trigger errors while the delete operation was being blocked.

## Tests
- npx jest src/core/scene/test/node-delete-prefab-filter.test.ts --no-cache
- npx jest src/core/scene/test/service-core/message-callsite.test.ts --testNamePattern filterChildOfAssetOfPrefabInstance|filterPartOfPrefabAsset --no-cache
- npx tsc -p tsconfig.json --noEmit --pretty false