### PR TITLE
Feature/scene clone subtree

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -6112,6 +6112,10 @@ export declare interface IClipboardState {
     type: 'cut' | 'copy' | 'none';
     paths: string[];
 }
+export declare interface ICloneNodeParams {
+    sourcePath: string;
+    targetParentPath?: string;
+}
 export declare interface ICloseOptions {
     urlOrUUID?: string;
     save?: boolean;
@@ -6341,6 +6345,7 @@ export declare interface INodeService extends IServiceEvents {
     copy(params: ICopyParams): Promise<string[]>;
     paste(params: IPasteParams): Promise<string[]>;
     duplicate(params: IDuplicateParams): Promise<string[]>;
+    clone(params: ICloneNodeParams): Promise<INode | null>;
     cut(params: ICutParams): Promise<string[]>;
     queryClipboardState(): Promise<IClipboardState>;
     moveArrayElement(params: IMoveArrayElementParams): Promise<boolean>;

--- a/src/api/scene/node-schema.ts
+++ b/src/api/scene/node-schema.ts
@@ -78,8 +78,8 @@ export const SchemaNodeDelete = z.object({
 }).describe('To configure options for node deletion, the Scene must be open first.'); // 删除节点的选项参数，需先打开场景
 
 export const SchemaNodeClone = z.object({
-    sourcePath: z.string().describe('Path of the source node subtree in the currently opened scene'),
-    targetParentPath: z.string().optional().describe('Path of the target parent node; defaults to the source node parent'),
+    sourcePath: z.string().min(1).describe('Path of the source node subtree in the currently opened scene'),
+    targetParentPath: z.string().min(1).optional().describe('Path of the target parent node; defaults to the source node parent'),
 }).describe('Clone one node subtree in the currently opened scene. Prefab editing and cross-scene cloning are not supported.');
 
 export const SchemaNodeCloneResult = SchemaNodeIdentifier;

--- a/src/api/scene/node-schema.ts
+++ b/src/api/scene/node-schema.ts
@@ -77,6 +77,13 @@ export const SchemaNodeDelete = z.object({
     keepWorldTransform: z.boolean().optional().describe('Keep world transform'), // 保持世界变换
 }).describe('To configure options for node deletion, the Scene must be open first.'); // 删除节点的选项参数，需先打开场景
 
+export const SchemaNodeClone = z.object({
+    sourcePath: z.string().describe('Path of the source node subtree in the currently opened scene'),
+    targetParentPath: z.string().optional().describe('Path of the target parent node; defaults to the source node parent'),
+}).describe('Clone one node subtree in the currently opened scene. Prefab editing and cross-scene cloning are not supported.');
+
+export const SchemaNodeCloneResult = SchemaNodeIdentifier;
+
 const SchemaNodeCreateBase = z.object({
     path: z.string().describe('Relative path of the created node, root node is scene node; This path is parent node path, full node path is parent path + node name, and root node path is "/"'), // 创建的节点相对路径，根节点是场景节点; 该路径为父节点路径,完整节点路径为父路径+节点名，根节点路径为 "/"
     name: z.string().optional().describe('Name of the node, if not passed, the system will default a name'), // 节点的名称，不传，系统会默认一个名字
@@ -96,6 +103,7 @@ export const SchemaNodeCreateByType = SchemaNodeCreateBase.extend({
 
 // 类型导出
 export type TDeleteNodeOptions = z.infer<typeof SchemaNodeDelete>;
+export type TCloneNodeOptions = z.infer<typeof SchemaNodeClone>;
 export type TUpdateNodeOptions = z.infer<typeof SchemaNodeUpdate>;
 export type TCreateNodeByAssetOptions = z.infer<typeof SchemaNodeCreateByAsset>;
 export type TCreateNodeByTypeOptions = z.infer<typeof SchemaNodeCreateByType>;
@@ -103,5 +111,6 @@ export type TQueryNodeOptions = z.infer<typeof SchemaNodeQuery>;
 export type TNodeDetail = z.infer<typeof SchemaNodeQueryResult>;
 export type TNodeUpdateResult = z.infer<typeof SchemaNodeUpdateResult>;
 export type TNodeDeleteResult = z.infer<typeof SchemaNodeDeleteResult>;
+export type TNodeCloneResult = z.infer<typeof SchemaNodeCloneResult>;
 export type TNode = z.infer<typeof SchemaNode>;
 export type TNodeIdentifier = z.infer<typeof SchemaNodeIdentifier>;

--- a/src/api/scene/node.ts
+++ b/src/api/scene/node.ts
@@ -15,12 +15,54 @@ import {
     SchemaNodeQueryResult,
     SchemaNodeDeleteResult,
     SchemaNodeUpdateResult,
+    SchemaNodeClone,
+    SchemaNodeCloneResult,
+    TCloneNodeOptions,
+    TNodeCloneResult,
 } from './node-schema';
 import { description, param, result, title, tool } from '../decorator/decorator.js';
 import { COMMON_STATUS, CommonResultType, getCommonErrorStatus } from '../base/schema-base';
-import { ICreateByNodeTypeParams, INodeInfo, Scene } from '../../core/scene';
+import { ICloneNodeParams, ICreateByNodeTypeParams, INodeInfo, Scene } from '../../core/scene';
+
+function getCloneNodeErrorStatus(error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (/scene is not opened|only supported in the scene editor|scene root node/i.test(message)) {
+        return COMMON_STATUS.BAD_REQUEST;
+    }
+    return getCommonErrorStatus(error);
+}
 
 export class NodeApi {
+
+    /**
+     * Clone Node Subtree // Clone a subtree without using clipboard state.
+     */
+    @tool('scene-clone-node')
+    @title('Clone Node Subtree')
+    @description('Deep-clone one node subtree in the currently opened scene. By default the clone is appended under the source parent; targetParentPath can select another parent in the same scene. Prefab editing and cross-scene cloning are not supported.')
+    @result(SchemaNodeCloneResult)
+    async cloneNode(@param(SchemaNodeClone) options: TCloneNodeOptions): Promise<CommonResultType<TNodeCloneResult>> {
+        try {
+            const resultNode = await Scene.Node.clone(options as ICloneNodeParams);
+            if (!resultNode) {
+                throw new Error(`Failed to clone node at path: ${options.sourcePath}`);
+            }
+            return {
+                code: COMMON_STATUS.SUCCESS,
+                data: {
+                    nodeId: resultNode.nodeId,
+                    path: resultNode.path,
+                    name: resultNode.name,
+                },
+            };
+        } catch (error) {
+            console.error('Failed to clone node:', error);
+            return {
+                code: getCloneNodeErrorStatus(error),
+                reason: error instanceof Error ? error.message : String(error),
+            };
+        }
+    }
 
     /**
      * Create Node // 创建节点

--- a/src/core/scene/common/node.ts
+++ b/src/core/scene/common/node.ts
@@ -192,6 +192,12 @@ export interface IDuplicateParams {
     paths: string[];
 }
 
+// Clone a single node subtree in the currently opened scene.
+export interface ICloneNodeParams {
+    sourcePath: string;
+    targetParentPath?: string;
+}
+
 // 节点剪切参数接口
 export interface ICutParams {
     paths: string[];
@@ -461,6 +467,7 @@ export interface INodeService extends IServiceEvents {
     copy(params: ICopyParams): Promise<string[]>;
     paste(params: IPasteParams): Promise<string[]>;
     duplicate(params: IDuplicateParams): Promise<string[]>;
+    clone(params: ICloneNodeParams): Promise<INode | null>;
     cut(params: ICutParams): Promise<string[]>;
     queryClipboardState(): Promise<IClipboardState>;
 

--- a/src/core/scene/main-process/proxy/node-proxy.ts
+++ b/src/core/scene/main-process/proxy/node-proxy.ts
@@ -6,6 +6,7 @@ import {
     IQueryNodeTreeParams,
     IDeleteNodeParams,
     IDeleteNodeResult,
+    ICloneNodeParams,
     IUpdateNodeParams,
     IUpdateNodeResult,
     IPublicNodeService,
@@ -14,10 +15,11 @@ import { INodeInfo } from '../../common/cli/node';
 import { Rpc } from '../rpc';
 import { DumpConverter } from './dump-converter';
 
-export interface INodeProxy extends Omit<IPublicNodeService, 'createByType' | 'createByAsset' | 'query' | 'getPathByUuid' | 'setParent' | 'reorder' | 'copy' | 'paste' | 'duplicate' | 'cut' | 'moveArrayElement' | 'removeArrayElement' | 'changeNodeLock'> {
+export interface INodeProxy extends Omit<IPublicNodeService, 'createByType' | 'createByAsset' | 'query' | 'clone' | 'getPathByUuid' | 'setParent' | 'reorder' | 'copy' | 'paste' | 'duplicate' | 'cut' | 'moveArrayElement' | 'removeArrayElement' | 'changeNodeLock'> {
     createByType(params: ICreateByNodeTypeParams): Promise<INodeInfo | null>;
     createByAsset(params: ICreateByAssetParams): Promise<INodeInfo | null>;
     query(params?: IQueryNodeParams): Promise<INodeInfo | null>;
+    clone(params: ICloneNodeParams): Promise<INodeInfo | null>;
     update(params: IUpdateNodeParams): Promise<IUpdateNodeResult>;
 }
 
@@ -28,6 +30,10 @@ export const NodeProxy: INodeProxy = {
     },
     async createByAsset(params: ICreateByAssetParams): Promise<INodeInfo | null> {
         const result: any = await Rpc.getInstance().request('Node', 'createByAsset', [params]);
+        return result ? DumpConverter.toNode(result) : null;
+    },
+    async clone(params: ICloneNodeParams): Promise<INodeInfo | null> {
+        const result: any = await Rpc.getInstance().request('Node', 'clone', [params]);
         return result ? DumpConverter.toNode(result) : null;
     },
     delete(params: IDeleteNodeParams): Promise<IDeleteNodeResult | null> {

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -15,6 +15,7 @@ import {
     type ICopyParams,
     type IPasteParams,
     type IDuplicateParams,
+    type ICloneNodeParams,
     type ICutParams,
     type IClipboardState,
     type IMoveArrayElementParams,
@@ -773,6 +774,53 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             const newPaths = newUuids.map(uuid => this._getNodePathByUuid(uuid)).filter(Boolean);
             this._undo.recordCreateNodeCommand(beforeNodeUuids, newPaths);
             return newPaths;
+        } catch (error) {
+            console.error(error);
+            throw error;
+        } finally {
+            Service.Editor.unlock();
+        }
+    }
+
+    async clone(params: ICloneNodeParams): Promise<INode | null> {
+        try {
+            await Service.Editor.lock();
+            const root = Service.Editor.getRootNode();
+            if (!root) {
+                throw new Error('Failed to clone node: the scene is not opened.');
+            }
+            if (Service.Editor.getCurrentEditorType() !== 'scene') {
+                throw new Error('Failed to clone node: cloning is only supported in the scene editor.');
+            }
+
+            const sourceNode = NodeMgr.getNodeByPath(params.sourcePath);
+            if (!sourceNode) {
+                throw new Error(`Source node not found at path: ${params.sourcePath}`);
+            }
+            if (sourceNode === root || !sourceNode.parent) {
+                throw new Error('Cannot clone the scene root node.');
+            }
+
+            const targetParent = params.targetParentPath
+                ? NodeMgr.getNodeByPath(params.targetParentPath)
+                : sourceNode.parent;
+            if (!targetParent) {
+                throw new Error(`Target parent node not found at path: ${params.targetParentPath}`);
+            }
+
+            const beforeNodeUuids = this._collectSceneNodeUuidsForUndo();
+            const newUuid = nodeMgr.clone(sourceNode.uuid, targetParent.uuid);
+            if (!newUuid) {
+                throw new Error(`Failed to clone node at path: ${params.sourcePath}`);
+            }
+
+            const newNode = NodeMgr.getNode(newUuid) as Node | null;
+            if (!newNode?.isValid) {
+                throw new Error(`Failed to resolve cloned node: ${newUuid}`);
+            }
+            const newPath = this._getNodePathByUuid(newUuid);
+            this._undo.recordCreateNodeCommand(beforeNodeUuids, newPath ? [newPath] : []);
+            return sceneUtils.generateNodeDump(newNode) as INode;
         } catch (error) {
             console.error(error);
             throw error;

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -783,6 +783,7 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
     }
 
     async clone(params: ICloneNodeParams): Promise<INode | null> {
+        let clonedNode: Node | null = null;
         try {
             await Service.Editor.lock();
             const root = Service.Editor.getRootNode();
@@ -801,7 +802,7 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
                 throw new Error('Cannot clone the scene root node.');
             }
 
-            const targetParent = params.targetParentPath
+            const targetParent = params.targetParentPath !== undefined
                 ? NodeMgr.getNodeByPath(params.targetParentPath)
                 : sourceNode.parent;
             if (!targetParent) {
@@ -814,14 +815,25 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
                 throw new Error(`Failed to clone node at path: ${params.sourcePath}`);
             }
 
-            const newNode = NodeMgr.getNode(newUuid) as Node | null;
-            if (!newNode?.isValid) {
+            clonedNode = NodeMgr.getNode(newUuid) as Node | null;
+            if (!clonedNode?.isValid) {
                 throw new Error(`Failed to resolve cloned node: ${newUuid}`);
             }
             const newPath = this._getNodePathByUuid(newUuid);
-            this._undo.recordCreateNodeCommand(beforeNodeUuids, newPath ? [newPath] : []);
-            return sceneUtils.generateNodeDump(newNode) as INode;
+            if (!newPath) {
+                throw new Error(`Failed to resolve cloned node path: ${newUuid}`);
+            }
+            const result = sceneUtils.generateNodeDump(clonedNode) as INode;
+            this._undo.recordCreateNodeCommand(beforeNodeUuids, [newPath]);
+            return result;
         } catch (error) {
+            if (clonedNode?.isValid) {
+                try {
+                    nodeMgr.baseRemoveNode(clonedNode, false);
+                } catch (rollbackError) {
+                    console.error('Failed to roll back cloned node:', rollbackError);
+                }
+            }
             console.error(error);
             throw error;
         } finally {

--- a/src/core/scene/scene-process/service/node/index.ts
+++ b/src/core/scene/scene-process/service/node/index.ts
@@ -930,12 +930,29 @@ export class NodeManager {
 
     clone(sourceUuid: string, targetParentUuid: string): string | undefined {
         const oldStashInstants = stashInstants;
+        const beforeNodeUuids = new Set(Object.keys(NodeMgr.getNodes()));
         try {
             const [copiedUuid] = this.copy(sourceUuid);
             if (!copiedUuid) {
                 return;
             }
             return this.createNodeFromStash(targetParentUuid, null, copiedUuid, false, true);
+        } catch (error) {
+            const nodeMap = NodeMgr.getNodes();
+            const newNodes = Object.keys(nodeMap)
+                .filter(uuid => !beforeNodeUuids.has(uuid))
+                .map(uuid => nodeMap[uuid] as Node | null)
+                .filter((node): node is Node => !!node?.isValid);
+            const newNodeUuids = new Set(newNodes.map(node => node.uuid));
+            const newRootNodes = newNodes.filter(node => !node.parent || !newNodeUuids.has(node.parent.uuid));
+            for (const node of newRootNodes) {
+                try {
+                    this.baseRemoveNode(node, false);
+                } catch (rollbackError) {
+                    console.error('Failed to roll back cloned node:', rollbackError);
+                }
+            }
+            throw error;
         } finally {
             stashInstants = oldStashInstants;
         }
@@ -1017,7 +1034,7 @@ export class NodeManager {
 
     /**
      * 实时获取新节点在一个父节点下的有效名称
-     * 规则是 Node 同名时为 Node-001
+     * 规则是 Node 同名时为 Node_001
      * @param name 名称
      * @param parentUuid 父节点 uuid
      */

--- a/src/core/scene/scene-process/service/node/index.ts
+++ b/src/core/scene/scene-process/service/node/index.ts
@@ -928,6 +928,19 @@ export class NodeManager {
         return newUuids.filter(Boolean);
     }
 
+    clone(sourceUuid: string, targetParentUuid: string): string | undefined {
+        const oldStashInstants = stashInstants;
+        try {
+            const [copiedUuid] = this.copy(sourceUuid);
+            if (!copiedUuid) {
+                return;
+            }
+            return this.createNodeFromStash(targetParentUuid, null, copiedUuid, false, true);
+        } finally {
+            stashInstants = oldStashInstants;
+        }
+    }
+
     paste(target: string | null | undefined, uuids: string | string[], keepWorldTransform = false) {
         if (!Array.isArray(uuids)) {
             uuids = [uuids];

--- a/src/core/scene/scene-process/service/node/node-utils.ts
+++ b/src/core/scene/scene-process/service/node/node-utils.ts
@@ -1,4 +1,5 @@
 import { Node, Canvas, UITransformComponent, Scene, director, Layers, CCObject } from 'cc';
+import { formatUniqueName } from '../../../../engine/editor-extends/manager/path-utils';
 
 
 /**
@@ -95,7 +96,7 @@ export function hasOneKindOfComponent(node: Node | Scene, kind: any) {
 }
 
 /**
- * 生成一个 node-001 格式的可用节点名称
+ * 生成一个 node_001 格式的可用节点名称
  * @param name 被检查的名称
  * @param parent 父级节点
  * @returns {string} path 可用名称的文件路径
@@ -107,19 +108,18 @@ export function getNodeName(name: string, parent: Node) {
 
     const names = parent.children.map((child: Node) => (child && child.name) || '');
 
-    while (names.includes(name)) {
-        if (/(\d+)$/.test(name)) {
-            name = name.replace(/(\d+)$/, (strA: string, strB: string) => {
-                let num = parseInt(strB, 10);
-                num += 1;
-                return num.toString().padStart(strB.length, '0');
-            });
-        } else {
-            name += '-001';
-        }
+    if (!names.includes(name)) {
+        return name;
     }
 
-    return name;
+    let counter = 1;
+    let availableName = formatUniqueName(name, counter);
+    while (names.includes(availableName)) {
+        counter++;
+        availableName = formatUniqueName(name, counter);
+    }
+
+    return availableName;
 }
 
 /**

--- a/src/core/scene/test/editor-proxy-prefab.testcase.ts
+++ b/src/core/scene/test/editor-proxy-prefab.testcase.ts
@@ -7,6 +7,7 @@ import {
     ReloadResult,
     ICopyParams,
     IPasteParams,
+    ICloneNodeParams,
 } from '../common';
 import { EditorProxy } from '../main-process/proxy/editor-proxy';
 import { SceneTestEnv } from './scene-test-env';
@@ -25,6 +26,10 @@ function copy(params: ICopyParams): Promise<string[]> {
 
 function paste(params: IPasteParams): Promise<string[]> {
     return rpcRequest('paste', [params]);
+}
+
+function clone(params: ICloneNodeParams): Promise<INodeInfo | null> {
+    return NodeProxy.clone(params);
 }
 
 describe('EditorProxy Prefab 测试', () => {
@@ -248,6 +253,20 @@ describe('EditorProxy Prefab 测试', () => {
 
             expect(result).toHaveLength(1);
             expect(result[0].startsWith(`${rootPath}/`)).toBe(true);
+        });
+
+        it('rejects subtree clone while a prefab is being edited', async () => {
+            const current = await EditorProxy.queryCurrent() as INodeInfo;
+            const rootPath = current.path || current.name;
+            const source = await NodeProxy.createByType({
+                path: rootPath,
+                nodeType: NodeType.EMPTY,
+                name: 'prefab-clone-rejected-source',
+            });
+
+            await expect(clone({ sourcePath: source!.path })).rejects.toThrow(
+                'cloning is only supported in the scene editor',
+            );
         });
 
         it('close - 不保存地关闭当前预制体', async () => {

--- a/src/core/scene/test/node-hierarchy.testcase.ts
+++ b/src/core/scene/test/node-hierarchy.testcase.ts
@@ -484,10 +484,10 @@ describe('Node 层级操作测试', () => {
             const result = await clone({ sourcePath: source!.path });
 
             expect(result).not.toBeNull();
-            expect(result!.path).toBe(`${parent!.path}/CloneSource-001`);
-            expect(result!.name).toBe('CloneSource-001');
+            expect(result!.path).toBe(`${parent!.path}/CloneSource_001`);
+            expect(result!.name).toBe('CloneSource_001');
             expect(result!.nodeId).not.toBe(source!.nodeId);
-            expect(await getChildNames(parent!.path)).toEqual([...childrenBefore, 'CloneSource-001']);
+            expect(await getChildNames(parent!.path)).toEqual([...childrenBefore, 'CloneSource_001']);
 
             const clonedRoot = await NodeProxy.query({ path: result!.path });
             expect(clonedRoot?.properties.position).toEqual({ x: 12, y: 34, z: 5 });

--- a/src/core/scene/test/node-hierarchy.testcase.ts
+++ b/src/core/scene/test/node-hierarchy.testcase.ts
@@ -7,6 +7,7 @@ import {
     type ICopyParams,
     type IPasteParams,
     type IDuplicateParams,
+    type ICloneNodeParams,
     type ICutParams,
     type IClipboardState,
     NodeType,
@@ -15,6 +16,7 @@ import { NodeProxy } from '../main-process/proxy/node-proxy';
 import { EditorProxy } from '../main-process/proxy/editor-proxy';
 import { Rpc } from '../main-process/rpc';
 import { SceneTestEnv } from './scene-test-env';
+import { ComponentProxy } from '../main-process/proxy/component-proxy';
 
 const rpcRequest = (method: string, args?: any[]) =>
     (Rpc.getInstance() as any).request('Node', method, args);
@@ -37,6 +39,10 @@ function paste(params: IPasteParams): Promise<string[]> {
 
 function duplicate(params: IDuplicateParams): Promise<string[]> {
     return rpcRequest('duplicate', [params]);
+}
+
+function clone(params: ICloneNodeParams): Promise<INodeInfo | null> {
+    return NodeProxy.clone(params);
 }
 
 function cut(params: ICutParams): Promise<string[]> {
@@ -427,6 +433,96 @@ describe('Node 层级操作测试', () => {
 
             // 清理：paste 掉 cut 的节点
             await paste({ parentPath: parent!.path });
+        });
+    });
+
+    describe('7. clone - clone a single subtree without changing clipboard state', () => {
+        let parent: INodeInfo | null = null;
+        let targetParent: INodeInfo | null = null;
+        let source: INodeInfo | null = null;
+
+        beforeAll(async () => {
+            parent = await NodeProxy.createByType({ path: '/', name: 'CloneParent', nodeType: NodeType.EMPTY });
+            targetParent = await NodeProxy.createByType({ path: '/', name: 'CloneTarget', nodeType: NodeType.EMPTY });
+            source = await NodeProxy.createByType({
+                path: parent!.path,
+                name: 'CloneSource',
+                nodeType: NodeType.EMPTY,
+            });
+            await NodeProxy.update({
+                path: source!.path,
+                properties: {
+                    position: { x: 12, y: 34, z: 5 },
+                    active: false,
+                },
+            });
+            await NodeProxy.createByType({
+                path: source!.path,
+                name: 'CloneChild',
+                nodeType: NodeType.EMPTY,
+            });
+            const component = await ComponentProxy.add({
+                nodePath: source!.path,
+                component: 'cc.Label',
+            });
+            await ComponentProxy.setProperty({
+                componentPath: component.path,
+                properties: { string: 'clone-subtree-value' },
+            });
+        });
+
+        afterAll(async () => {
+            await NodeProxy.delete({ path: parent!.path, keepWorldTransform: false }).catch(() => {});
+            await NodeProxy.delete({ path: targetParent!.path, keepWorldTransform: false }).catch(() => {});
+        });
+
+        it('deep-clones under the source parent, appends the root, and preserves copy state', async () => {
+            await copy({ paths: [source!.path] });
+            const clipboardBefore = await queryClipboardState();
+            const childrenBefore = await getChildNames(parent!.path);
+
+            const result = await clone({ sourcePath: source!.path });
+
+            expect(result).not.toBeNull();
+            expect(result!.path).toBe(`${parent!.path}/CloneSource-001`);
+            expect(result!.name).toBe('CloneSource-001');
+            expect(result!.nodeId).not.toBe(source!.nodeId);
+            expect(await getChildNames(parent!.path)).toEqual([...childrenBefore, 'CloneSource-001']);
+
+            const clonedRoot = await NodeProxy.query({ path: result!.path });
+            expect(clonedRoot?.properties.position).toEqual({ x: 12, y: 34, z: 5 });
+            expect(clonedRoot?.properties.active).toBe(false);
+
+            const clonedChild = await NodeProxy.query({ path: `${result!.path}/CloneChild` });
+            const sourceChild = await NodeProxy.query({ path: `${source!.path}/CloneChild` });
+            expect(clonedChild).not.toBeNull();
+            expect(clonedChild!.nodeId).not.toBe(sourceChild!.nodeId);
+
+            const clonedComponent = await ComponentProxy.query({ path: `${result!.path}/cc.Label` });
+            expect(clonedComponent?.properties.string.value).toBe('clone-subtree-value');
+            expect(await queryClipboardState()).toEqual(clipboardBefore);
+            expect(await NodeProxy.query({ path: source!.path })).not.toBeNull();
+        });
+
+        it('clones under an explicit target parent, keeps local transform, and preserves cut state', async () => {
+            await cut({ paths: [source!.path] });
+            const clipboardBefore = await queryClipboardState();
+
+            const result = await clone({
+                sourcePath: source!.path,
+                targetParentPath: targetParent!.path,
+            });
+
+            expect(result?.path).toBe(`${targetParent!.path}/CloneSource`);
+            expect(result?.properties.position).toEqual({ x: 12, y: 34, z: 5 });
+            expect(await NodeProxy.query({ path: `${result!.path}/CloneChild` })).not.toBeNull();
+            expect(await queryClipboardState()).toEqual(clipboardBefore);
+
+            await copy({ paths: [source!.path] });
+        });
+
+        it('rejects cloning the scene root', async () => {
+            await expect(clone({ sourcePath: '/' })).rejects.toThrow('Cannot clone the scene root node');
         });
     });
 });

--- a/src/core/scene/test/service-core/event-dedup.test.ts
+++ b/src/core/scene/test/service-core/event-dedup.test.ts
@@ -725,7 +725,7 @@ describe('场景事件契约测试', () => {
             });
 
             it('baseRemoveNode 应 emit node:before-remove、node:remove 各 1 次，before-change 最多 1 次', () => {
-                const body = extractMethodBody(source, /baseRemoveNode\(/);
+                const body = extractMethodBody(source, /public baseRemoveNode\(/);
                 expect(countEmitCalls(body, 'node:before-remove')).toBe(1);
                 expect(countEmitCalls(body, 'node:remove')).toBe(1);
                 expect(countEmitCalls(body, 'node:before-change')).toBeLessThanOrEqual(1);

--- a/src/core/scene/test/service-core/message-callsite.test.ts
+++ b/src/core/scene/test/service-core/message-callsite.test.ts
@@ -322,6 +322,45 @@ describe('ServiceEvents 事件发射集成测试', () => {
 
             expect(listener).toHaveBeenCalledWith(node, expect.objectContaining({ type: expect.any(String) }));
         });
+
+        it('clone rolls back the newly created subtree when restoring the stash fails', () => {
+            const nodeMgr = new NodeManager();
+            const source = createMockNode('clone-source');
+            const targetParent = createMockNode('clone-target-parent');
+            const clonedRoot = createMockNode('cloned-root');
+            const clonedChild = createMockNode('cloned-child');
+            clonedRoot.parent = targetParent;
+            clonedRoot.children = [clonedChild];
+            clonedChild.parent = clonedRoot;
+
+            let nodes: Record<string, any> = {
+                [source.uuid]: source,
+                [targetParent.uuid]: targetParent,
+            };
+            const NodeMgr = (global as any).EditorExtends.Node;
+            const originalGetNodes = NodeMgr.getNodes;
+            NodeMgr.getNodes = jest.fn(() => nodes);
+
+            const failure = new Error('restore failed');
+            jest.spyOn(nodeMgr, 'copy').mockReturnValue([source.uuid]);
+            jest.spyOn(nodeMgr, 'createNodeFromStash').mockImplementation(() => {
+                nodes = {
+                    ...nodes,
+                    [clonedRoot.uuid]: clonedRoot,
+                    [clonedChild.uuid]: clonedChild,
+                };
+                throw failure;
+            });
+            const rollbackSpy = jest.spyOn(nodeMgr, 'baseRemoveNode').mockImplementation(() => undefined);
+
+            try {
+                expect(() => nodeMgr.clone(source.uuid, targetParent.uuid)).toThrow(failure);
+                expect(rollbackSpy).toHaveBeenCalledTimes(1);
+                expect(rollbackSpy).toHaveBeenCalledWith(clonedRoot, false);
+            } finally {
+                NodeMgr.getNodes = originalGetNodes;
+            }
+        });
     });
 
     // ── CompManager: add / remove → ServiceEvents ──
@@ -632,6 +671,72 @@ describe('ServiceEvents 事件发射集成测试', () => {
     // ── NodeService: setProperty(name) → ServiceEvents ──
 
     describe('NodeService (node.ts)', () => {
+        it('clone rolls back the created node when generating its dump fails', async () => {
+            const { NodeService } = require('../../scene-process/service/node');
+            const nodeService = new NodeService();
+            const nodeMgr = require('../../scene-process/service/node/index').default;
+            const { sceneUtils } = require('../../scene-process/service/scene/utils');
+            const { Service } = require('../../scene-process/service/core');
+            const { Node: MockNode } = require('cc');
+
+            const root = new MockNode();
+            root.uuid = 'scene-root';
+            const source = new MockNode();
+            source.uuid = 'clone-source';
+            source.parent = root;
+            const clonedNode = new MockNode();
+            clonedNode.uuid = 'cloned-node';
+            clonedNode.parent = root;
+
+            const NodeMgr = (global as any).EditorExtends.Node;
+            const originalEditorMethods = {
+                lock: Service.Editor.lock,
+                unlock: Service.Editor.unlock,
+                getRootNode: Service.Editor.getRootNode,
+                getCurrentEditorType: Service.Editor.getCurrentEditorType,
+            };
+            const originalNodeMethods = {
+                getNodeByPath: NodeMgr.getNodeByPath,
+                getNode: NodeMgr.getNode,
+                getNodePath: NodeMgr.getNodePath,
+            };
+            const originalGenerateNodeDump = sceneUtils.generateNodeDump;
+
+            Service.Editor.lock = jest.fn().mockResolvedValue(undefined);
+            Service.Editor.unlock = jest.fn();
+            Service.Editor.getRootNode = jest.fn(() => root);
+            Service.Editor.getCurrentEditorType = jest.fn(() => 'scene');
+            NodeMgr.getNodeByPath = jest.fn(() => source);
+            NodeMgr.getNode = jest.fn(() => clonedNode);
+            NodeMgr.getNodePath = jest.fn(() => '/CloneSource_001');
+            nodeService._undo = {
+                shouldRecordStructureCommand: jest.fn(() => false),
+                recordCreateNodeCommand: jest.fn(),
+            };
+
+            const cloneSpy = jest.spyOn(nodeMgr, 'clone').mockReturnValue(clonedNode.uuid);
+            const querySpy = jest.spyOn(nodeMgr, 'query').mockReturnValue(clonedNode);
+            const rollbackSpy = jest.spyOn(nodeMgr, 'baseRemoveNode').mockImplementation(() => undefined);
+            const failure = new Error('dump failed');
+            sceneUtils.generateNodeDump = jest.fn(() => {
+                throw failure;
+            });
+
+            try {
+                await expect(nodeService.clone({ sourcePath: '/CloneSource' })).rejects.toThrow(failure);
+                expect(rollbackSpy).toHaveBeenCalledTimes(1);
+                expect(rollbackSpy).toHaveBeenCalledWith(clonedNode, false);
+                expect(Service.Editor.unlock).toHaveBeenCalledTimes(1);
+            } finally {
+                cloneSpy.mockRestore();
+                querySpy.mockRestore();
+                rollbackSpy.mockRestore();
+                Object.assign(Service.Editor, originalEditorMethods);
+                Object.assign(NodeMgr, originalNodeMethods);
+                sceneUtils.generateNodeDump = originalGenerateNodeDump;
+            }
+        });
+
         it('setProperty(name) 应 emit node:change 到 ServiceEvents', async () => {
             const listener = jest.fn();
             globalEventEmitter.on('node:change', listener);

--- a/src/core/scene/test/undo-redo.testcase.ts
+++ b/src/core/scene/test/undo-redo.testcase.ts
@@ -155,6 +155,10 @@ const Node = {
     copy: (params: { paths: string[] }) => request<string[]>('Node', 'copy', [params]),
     paste: (params: { parentPath?: string; keepWorldTransform?: boolean }) => request<string[]>('Node', 'paste', [params]),
     duplicate: (params: { paths: string[] }) => request<string[]>('Node', 'duplicate', [params]),
+    async clone(params: { sourcePath: string; targetParentPath?: string }): Promise<INodeInfo | null> {
+        const result = await request<any>('Node', 'clone', [params]);
+        return result ? toNodeInfo(result) : null;
+    },
     cut: (params: { paths: string[] }) => request<string[]>('Node', 'cut', [params]),
     moveArrayElement: (params: { nodePath: string; path: string; target: number; offset: number }) => request<boolean>('Node', 'moveArrayElement', [params]),
     removeArrayElement: (params: { nodePath: string; path: string; index: number }) => request<boolean>('Node', 'removeArrayElement', [params]),
@@ -1122,6 +1126,27 @@ describe('Undo/Redo 集成测试', () => {
             const redoResult = await Undo.redo();
             expectUndoSuccess(redoResult);
             expect(await queryNode(duplicatedPath)).not.toBeNull();
+        });
+
+        it('clone creates one subtree and supports undo/redo as one command', async () => {
+            await Node.createByType({ path: childA, name: 'CloneUndoChild', nodeType: NodeType.EMPTY });
+            const cloned = await Node.clone({ sourcePath: childA, targetParentPath });
+            const clonedPath = cloned!.path;
+            const clonedChildPath = `${clonedPath}/CloneUndoChild`;
+
+            expect(await queryNode(clonedPath)).not.toBeNull();
+            expect(await queryNode(clonedChildPath)).not.toBeNull();
+            expect(await Undo.canUndo()).toBe(true);
+
+            const undoResult = await Undo.undo();
+            expectUndoSuccess(undoResult);
+            expect(await queryNode(clonedPath)).toBeNull();
+            expect(await queryNode(clonedChildPath)).toBeNull();
+
+            const redoResult = await Undo.redo();
+            expectUndoSuccess(redoResult);
+            expect(await queryNode(clonedPath)).not.toBeNull();
+            expect(await queryNode(clonedChildPath)).not.toBeNull();
         });
 
         it('copy paste creates nodes and supports undo/redo', async () => {

--- a/tests/scene-clone-node-api.test.ts
+++ b/tests/scene-clone-node-api.test.ts
@@ -47,20 +47,20 @@ describe('scene-clone-node API', () => {
         });
         expect(SchemaNodeCloneResult.parse({
             nodeId: 'node-uuid',
-            path: 'Canvas/Panel-001',
-            name: 'Panel-001',
+            path: 'Canvas/Panel_001',
+            name: 'Panel_001',
         })).toEqual({
             nodeId: 'node-uuid',
-            path: 'Canvas/Panel-001',
-            name: 'Panel-001',
+            path: 'Canvas/Panel_001',
+            name: 'Panel_001',
         });
     });
 
     it('returns the cloned node identifier', async () => {
         mockCloneNode.mockResolvedValue({
             nodeId: 'clone-uuid',
-            path: 'Canvas/Panel-001',
-            name: 'Panel-001',
+            path: 'Canvas/Panel_001',
+            name: 'Panel_001',
             properties: {},
             prefab: null,
         });
@@ -72,10 +72,15 @@ describe('scene-clone-node API', () => {
             code: COMMON_STATUS.SUCCESS,
             data: {
                 nodeId: 'clone-uuid',
-                path: 'Canvas/Panel-001',
-                name: 'Panel-001',
+                path: 'Canvas/Panel_001',
+                name: 'Panel_001',
             },
         });
+    });
+
+    it('rejects empty source and target paths', () => {
+        expect(SchemaNodeClone.safeParse({ sourcePath: '' }).success).toBe(false);
+        expect(SchemaNodeClone.safeParse({ sourcePath: 'Canvas/Panel', targetParentPath: '' }).success).toBe(false);
     });
 
     it.each([

--- a/tests/scene-clone-node-api.test.ts
+++ b/tests/scene-clone-node-api.test.ts
@@ -1,0 +1,114 @@
+const mockCloneNode = jest.fn();
+
+jest.mock('../src/api/decorator/decorator.js', () => ({
+    description: () => jest.fn(),
+    param: () => jest.fn(),
+    result: () => jest.fn(),
+    title: () => jest.fn(),
+    tool: () => jest.fn(),
+}), { virtual: true });
+
+jest.mock('../src/core/scene', () => ({
+    NodeType: {
+        EMPTY: 'Empty',
+        SPRITE: 'Sprite',
+    },
+    Scene: {
+        Node: {
+            clone: (...args: unknown[]) => mockCloneNode(...args),
+        },
+    },
+}));
+
+import { NodeApi } from '../src/api/scene/node';
+import { SchemaNodeClone, SchemaNodeCloneResult } from '../src/api/scene/node-schema';
+import { COMMON_STATUS } from '../src/api/base/schema-base';
+
+describe('scene-clone-node API', () => {
+    beforeEach(() => {
+        mockCloneNode.mockReset();
+        jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('validates request and result schemas', () => {
+        expect(SchemaNodeClone.parse({ sourcePath: 'Canvas/Panel' })).toEqual({
+            sourcePath: 'Canvas/Panel',
+        });
+        expect(SchemaNodeClone.parse({
+            sourcePath: 'Canvas/Panel',
+            targetParentPath: 'Canvas/Container',
+        })).toEqual({
+            sourcePath: 'Canvas/Panel',
+            targetParentPath: 'Canvas/Container',
+        });
+        expect(SchemaNodeCloneResult.parse({
+            nodeId: 'node-uuid',
+            path: 'Canvas/Panel-001',
+            name: 'Panel-001',
+        })).toEqual({
+            nodeId: 'node-uuid',
+            path: 'Canvas/Panel-001',
+            name: 'Panel-001',
+        });
+    });
+
+    it('returns the cloned node identifier', async () => {
+        mockCloneNode.mockResolvedValue({
+            nodeId: 'clone-uuid',
+            path: 'Canvas/Panel-001',
+            name: 'Panel-001',
+            properties: {},
+            prefab: null,
+        });
+
+        const result = await new NodeApi().cloneNode({ sourcePath: 'Canvas/Panel' });
+
+        expect(mockCloneNode).toHaveBeenCalledWith({ sourcePath: 'Canvas/Panel' });
+        expect(result).toEqual({
+            code: COMMON_STATUS.SUCCESS,
+            data: {
+                nodeId: 'clone-uuid',
+                path: 'Canvas/Panel-001',
+                name: 'Panel-001',
+            },
+        });
+    });
+
+    it.each([
+        'Source node not found at path: Canvas/Missing',
+        'Target parent node not found at path: Canvas/MissingParent',
+    ])('returns 404 for missing nodes: %s', async (message) => {
+        mockCloneNode.mockRejectedValue(new Error(message));
+
+        const result = await new NodeApi().cloneNode({ sourcePath: 'Canvas/Panel' });
+
+        expect(result.code).toBe(COMMON_STATUS.NOT_FOUND);
+        expect(result.reason).toBe(message);
+    });
+
+    it.each([
+        'Failed to clone node: the scene is not opened.',
+        'Failed to clone node: cloning is only supported in the scene editor.',
+        'Cannot clone the scene root node.',
+    ])('returns 400 for unsupported clone requests: %s', async (message) => {
+        mockCloneNode.mockRejectedValue(new Error(message));
+
+        const result = await new NodeApi().cloneNode({ sourcePath: '/' });
+
+        expect(result.code).toBe(COMMON_STATUS.BAD_REQUEST);
+        expect(result.reason).toBe(message);
+    });
+
+    it('keeps unknown failures as 500', async () => {
+        mockCloneNode.mockRejectedValue(new Error('unexpected clone failure'));
+
+        const result = await new NodeApi().cloneNode({ sourcePath: 'Canvas/Panel' });
+
+        expect(result.code).toBe(COMMON_STATUS.FAIL);
+        expect(result.reason).toBe('unexpected clone failure');
+    });
+});


### PR DESCRIPTION
新增 `scene-clone-node`，用于深复制当前打开 Scene 中的单个节点子树。

## 测试方法:
{
  "sourcePath": "Canvas/Parent/Source",
  "targetParentPath": "Canvas/Target"
}
类似这样的参数来测试

