### PR TITLE
fix(build): restore nan patch for Electron 42 on Windows

### DIFF
--- a/patches/nan+2.28.0.patch
+++ b/patches/nan+2.28.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/nan/nan_typedarray_contents.h b/node_modules/nan/nan_typedarray_contents.h
+index f2650ed..850760e 100644
+--- a/node_modules/nan/nan_typedarray_contents.h
++++ b/node_modules/nan/nan_typedarray_contents.h
+@@ -34,7 +34,7 @@ class TypedArrayContents {
+ // Actually it's 7.9 here but this would lead to ABI issues with Node.js 13
+ // using 7.8 till 13.2.0.
+ #if (V8_MAJOR_VERSION >= 8)
+-      data = static_cast<char*>(buffer->GetBackingStore()->Data()) + byte_offset;
++      data = static_cast<char*>(buffer->Data()) + byte_offset;
+ #else
+       data = static_cast<char*>(buffer->GetContents().Data()) + byte_offset;
+ #endif


### PR DESCRIPTION
## Background

  After upgrading to Electron 42.3.0 and `nan@2.28.0`, `@electron/rebuild` fails on Windows with:

  ```text
  LNK2019: unresolved external symbol v8::ArrayBuffer::GetBackingStore()
  ```

  The call originates from `Nan::TypedArrayContents`. The previously removed NAN patch was required for this
  Windows compatibility issue.

  ## Changes

  - Restore the NAN TypedArray compatibility patch for `nan@2.28.0`.
  - Replace `GetBackingStore()->Data()` with `Data()`.
  - Preserve the existing TypedArray offset and length handling.

  ## Validation

  - `patch-package` applies successfully:
    - `gl@9.0.0-rc.10 ✔`
    - `nan@2.28.0 ✔`
  - Electron 42.3.0 rebuild succeeds locally.
  - `git diff --check` passes.
  - Windows rebuild will be verified by PR CI.