### PR TITLE
fix(scene): report whether animation mutations record undo history

### DIFF
--- a/src/core/scene/common/animation.ts
+++ b/src/core/scene/common/animation.ts
@@ -500,6 +500,8 @@ export interface IAnimationOperationOptions {
 export interface IAnimationOperationResult {
     state: 'success' | 'failure';
     result: boolean;
+    /** 成功操作是否创建了 animation scoped Undo 历史；失败时省略。 */
+    undoRecorded?: boolean;
     reason?: string;
 }
 

--- a/src/core/scene/scene-process/service/animation.ts
+++ b/src/core/scene/scene-process/service/animation.ts
@@ -535,7 +535,8 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         this._animationStates.create(session.clipUuid, clip);
         await this.setTime({ time: this._curEditTime });
         const after = shouldRecordUndo ? captureAnimationClipSnapshot(clip, propertyMetadataContext) : null;
-        if (before && after && !animationClipSnapshotsEqual(before, after)) {
+        const undoRecorded = Boolean(before && after && !animationClipSnapshotsEqual(before, after));
+        if (undoRecorded && before && after) {
             const undoCommand = new AnimationClipSnapshotCommand({
                 clipUuid: session.clipUuid,
                 before,
@@ -565,6 +566,7 @@ export class AnimationService extends BaseService<Record<string, any>> implement
         return {
             state: 'success',
             result: true,
+            undoRecorded,
         };
     }
 

--- a/src/core/scene/test/animation-service.testcase.ts
+++ b/src/core/scene/test/animation-service.testcase.ts
@@ -473,7 +473,7 @@ describe('Animation Service 场景进程测试', () => {
         const event = await eventPromise;
         const dump = await request('queryClip', [{ clipUuid }]);
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(event).toMatchObject({
             reason: 'operation',
             rootPath: nodePath,
@@ -501,7 +501,7 @@ describe('Animation Service 场景进程测试', () => {
         const afterCreate = await request('queryClip', [{ clipUuid }]);
         const positionCurve = afterCreate.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'position');
 
-        expect(createResult).toEqual({ state: 'success', result: true });
+        expect(createResult).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(positionCurve).toMatchObject({
             nodePath: '',
             key: 'position',
@@ -537,7 +537,7 @@ describe('Animation Service 场景进程测试', () => {
         const afterRemove = await request('queryClip', [{ clipUuid }]);
         const removedCurve = afterRemove.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'position');
 
-        expect(removeResult).toEqual({ state: 'success', result: true });
+        expect(removeResult).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(removedCurve.keyframes).toEqual([
             { frame: 30, dump: { value: { x: 8, y: 9, z: 10 }, type: 'cc.Vec3' } },
         ]);
@@ -562,7 +562,7 @@ describe('Animation Service 场景进程测试', () => {
         const saveResult = await request('save');
         const afterSave = await request('queryClip', [{ clipUuid: emptyClipUuid }]);
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(afterCreate.duration).toBe(1);
         expect(Math.round(afterCreate.duration * afterCreate.sample)).toBe(30);
         expect(time).toBe(1);
@@ -595,7 +595,7 @@ describe('Animation Service 场景进程测试', () => {
         const time = await request<number>('queryTime', [{ clipUuid: childClipUuid }]);
         const childNode = await NodeProxy.query({ path: childTrackNodePath, includeChildren: false, includeComponents: false }) as any;
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: false });
         expect(Math.round(dump.duration * dump.sample)).toBe(60);
         expect(dump.curves.find((curve: any) => curve.nodePath === 'AnimationServiceChildSamplingChild' && curve.key === 'position')).toBeDefined();
         expect(time).toBe(1);
@@ -624,7 +624,7 @@ describe('Animation Service 场景进程测试', () => {
         const afterEdit = await request('queryClip', [{ rootPath: rootEditNodePath, clipUuid: rootEditClipUuid }]);
         const positionCurve = afterEdit.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'position');
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(Math.round(afterEdit.duration * afterEdit.sample)).toBe(90);
         expect(positionCurve.keyframes).toEqual([
             { frame: 0, dump: { value: { x: 0, y: 0, z: 0 }, type: 'cc.Vec3' } },
@@ -675,7 +675,7 @@ describe('Animation Service 场景进程测试', () => {
         const dump = await request('queryClip', [{ clipUuid }]);
         const scaleCurve = dump.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'scale');
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(scaleCurve.partKeys).toEqual(['x', 'y', 'z']);
         expect(scaleCurve.keyframes).toEqual([
             { frame: 0, dump: { value: { x: 1, y: 1, z: 1 }, type: 'cc.Vec3' } },
@@ -718,7 +718,7 @@ describe('Animation Service 场景进程测试', () => {
         const brokenScaleCurve = afterBroken.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'scale');
         const brokenKey = brokenScaleCurve.channels.find((channel: any) => channel.key === 'y').keyframes.find((keyframe: any) => keyframe.frame === 21);
 
-        expect(createResult).toEqual({ state: 'success', result: true });
+        expect(createResult).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(brokenKey.broken).toBe(true);
 
         const updateResult = await request('applyOperations', [{
@@ -730,7 +730,7 @@ describe('Animation Service 场景进程测试', () => {
         const linkedScaleCurve = afterLinked.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'scale');
         const linkedKey = linkedScaleCurve.channels.find((channel: any) => channel.key === 'y').keyframes.find((keyframe: any) => keyframe.frame === 21);
 
-        expect(updateResult).toEqual({ state: 'success', result: true });
+        expect(updateResult).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(linkedKey.broken).toBe(false);
 
         expectUndoSuccess(await Undo.undo());
@@ -770,7 +770,7 @@ describe('Animation Service 场景进程测试', () => {
         }]);
         const afterUpdateKey = await queryPositionXKey();
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(afterUpdateKey).toMatchObject({
             frame: 60,
             dump: { value: 80, type: 'cc.Number' },
@@ -795,7 +795,7 @@ describe('Animation Service 场景进程测试', () => {
             operations: [
                 { type: 'updatePropertyKey', clipUuid: keyDataClipUuid, propKey: 'position', channel: 'x', frame: 60, keyData: { broken: false } },
             ],
-        }])).toEqual({ state: 'success', result: true });
+        }])).toEqual({ state: 'success', result: true, undoRecorded: true });
         const afterBrokenFalseKey = await queryPositionXKey();
         expect(afterBrokenFalseKey).toMatchObject({
             frame: 60,
@@ -878,7 +878,7 @@ describe('Animation Service 场景进程测试', () => {
         }]);
         const key = await queryEulerYKey();
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(key).toMatchObject({
             frame: 84,
             dump: { value: 84, type: 'cc.Number' },
@@ -924,7 +924,7 @@ describe('Animation Service 场景进程测试', () => {
                 { type: 'createPropertyKey', clipUuid: keyDataClipUuid, propKey: 'eulerAngles', channel: 'x', frame: 36, value: 1 },
             ],
         }]);
-        expect(createResult).toEqual({ state: 'success', result: true });
+        expect(createResult).toEqual({ state: 'success', result: true, undoRecorded: true });
 
         const before = await request('queryClip', [{ rootPath: keyDataNodePath, clipUuid: keyDataClipUuid }]);
         const result = await request('applyOperations', [{
@@ -962,7 +962,7 @@ describe('Animation Service 场景进程测试', () => {
         const dump = await request('queryClip', [{ clipUuid }]);
 
         expect(properties.map((item: any) => item.key)).toEqual(expect.arrayContaining(['rotation', 'active']));
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(dump.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'rotation')).toMatchObject({
             type: { value: 'cc.Quat' },
             keyframes: [
@@ -1013,7 +1013,7 @@ describe('Animation Service 场景进程测试', () => {
             frame: 30,
         }]);
 
-        expect(createResult).toEqual({ state: 'success', result: true });
+        expect(createResult).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(Math.round(afterCreate.duration * afterCreate.sample)).toBe(31);
         expect(spriteFrameCurve).toMatchObject({
             type: { value: 'cc.SpriteFrame' },
@@ -1065,7 +1065,7 @@ describe('Animation Service 场景进程测试', () => {
             frame: 0,
         }]);
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: false });
         expect(sampled).toMatchObject({ r: 32, g: 64, b: 128, a: 255 });
     });
 
@@ -1102,7 +1102,7 @@ describe('Animation Service 场景进程测试', () => {
             frame: 30,
         }]);
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: false });
         expect(sampled).toMatchObject({ x: 7, y: 8, z: 9 });
     });
 
@@ -1123,7 +1123,7 @@ describe('Animation Service 场景进程测试', () => {
         const dump = await request('queryClip', [{ clipUuid }]);
         const positionCurve = dump.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'position');
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(positionCurve).toMatchObject({
             preExtrap: 1,
             postExtrap: 2,
@@ -1148,7 +1148,7 @@ describe('Animation Service 场景进程测试', () => {
         }]);
         const dump = await request('queryClip', [{ rootPath: emptyNodePath, clipUuid: emptyClipUuid }]);
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: false });
         expect(dump.curves.map((curve: any) => curve.key)).toEqual([
             'position',
             'cc.Sprite.color',
@@ -1169,7 +1169,7 @@ describe('Animation Service 场景进程测试', () => {
         const afterClear = await request('queryClip', [{ rootPath: emptyNodePath, clipUuid: emptyClipUuid }]);
         const scaleCurveAfterClear = afterClear.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'scale');
 
-        expect(clearResult).toEqual({ state: 'success', result: true });
+        expect(clearResult).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(scaleCurveAfterClear).toBeDefined();
         expect(scaleCurveAfterClear.keyframes).toEqual([]);
         expect(scaleCurveAfterClear.channels.every((channel: any) => channel.keyframes.length === 0)).toBe(true);
@@ -1181,7 +1181,7 @@ describe('Animation Service 场景进程测试', () => {
         }]);
         const afterRemove = await request('queryClip', [{ rootPath: emptyNodePath, clipUuid: emptyClipUuid }]);
 
-        expect(removeResult).toEqual({ state: 'success', result: true });
+        expect(removeResult).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(afterRemove.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'scale')).toBeUndefined();
     });
 
@@ -1203,7 +1203,7 @@ describe('Animation Service 场景进程测试', () => {
         const dump = await request('queryClip', [{ clipUuid }]);
         const positionCurve = dump.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'position');
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(positionCurve.keyframes).toEqual(expect.arrayContaining([
             { frame: 6, dump: { value: sampled, type: 'cc.Vec3' } },
         ]));
@@ -1257,7 +1257,7 @@ describe('Animation Service 场景进程测试', () => {
         }]);
         const dump = await request('queryClip', [{ clipUuid }]);
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(dump.embeddedPlayerGroups).toEqual([
             { key: 'particle-track', name: 'Particle Track', type: 'particle-system' },
         ]);
@@ -1302,7 +1302,7 @@ describe('Animation Service 场景进程测试', () => {
         }]);
         const dump = await request('queryClip', [{ clipUuid: embeddedClipUuid }]);
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: false });
         expect(dump.embeddedPlayers).toEqual([secondPlayer]);
     });
 
@@ -1318,7 +1318,7 @@ describe('Animation Service 场景进程测试', () => {
         }]);
         const dump = await request('queryClip', [{ clipUuid }]);
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(dump.auxiliaryCurves.BlendWeight.keyframes).toEqual([
             { frame: 0, value: 0.25 },
             { frame: 60, value: 0.75 },
@@ -1341,7 +1341,7 @@ describe('Animation Service 场景进程测试', () => {
         const sampled = await request('queryAuxiliaryCurveValueAtFrame', [{ clipUuid, name: 'CurveWeight', frame: 15 }]);
         const sampledEnd = await request('queryAuxiliaryCurveValueAtFrame', [{ clipUuid, name: 'CurveWeight', frame: 30 }]);
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(dump.auxiliaryCurves.CurveWeight.keyframes).toEqual([
             { frame: 0, value: 0, interpMode: 1 },
             { frame: 30, value: 1, broken: true, outTangent: 0.5 },
@@ -1365,7 +1365,7 @@ describe('Animation Service 场景进程测试', () => {
         }]);
         const dump = await request('queryClip', [{ clipUuid: emptyClipUuid }]);
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: false });
         expect(Math.round(dump.duration * dump.sample)).toBeGreaterThanOrEqual(90);
     });
 
@@ -1383,7 +1383,7 @@ describe('Animation Service 场景进程测试', () => {
         }]);
         const after = await request('queryClip', [{ clipUuid }]);
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(await Undo.isDirty()).toBe(true);
         expect(await Undo.canUndo()).toBe(true);
         expect(await Undo.canRedo()).toBe(false);
@@ -1577,7 +1577,7 @@ describe('Animation Service 场景进程测试', () => {
         }]);
         const after = await request('queryClip', [{ clipUuid: addCurveClipUuid }]);
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(after.curves.some((curve: any) => curve.nodePath === '' && curve.key === 'position')).toBe(true);
         expect(await Undo.isDirty()).toBe(true);
         expect(await Undo.canUndo()).toBe(true);
@@ -1617,7 +1617,7 @@ describe('Animation Service 场景进程测试', () => {
         }]);
         const after = await request('queryClip', [{ rootPath: childRootNodePath, clipUuid: childClipUuid }]);
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(after.curves.some((curve: any) => curve.nodePath === childRelativePath && curve.key === 'position')).toBe(true);
         expect(await Undo.isDirty()).toBe(true);
         expect(await Undo.canUndo()).toBe(true);
@@ -1644,7 +1644,7 @@ describe('Animation Service 场景进程测试', () => {
         }]);
         const afterAdd = await request('queryClip', [{ rootPath: childRootNodePath, clipUuid: childClipUuid }]);
 
-        expect(addResult).toEqual({ state: 'success', result: true });
+        expect(addResult).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(afterAdd.curves.some((curve: any) => curve.nodePath === childRelativePath && curve.key === 'active')).toBe(true);
 
         const removeResult = await request('applyOperations', [{
@@ -1654,7 +1654,7 @@ describe('Animation Service 场景进程测试', () => {
         }]);
         const afterRemove = await request('queryClip', [{ rootPath: childRootNodePath, clipUuid: childClipUuid }]);
 
-        expect(removeResult).toEqual({ state: 'success', result: true });
+        expect(removeResult).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(afterRemove.curves.some((curve: any) => curve.nodePath === childRelativePath && curve.key === 'active')).toBe(false);
     });
 
@@ -1680,7 +1680,7 @@ describe('Animation Service 场景进程测试', () => {
         const after = await request('queryClip', [{ rootPath: emptyNodePath, clipUuid: emptyClipUuid }]);
         const positionCurve = after.curves.find((curve: any) => curve.nodePath === '' && curve.key === 'position');
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(positionCurve.keyframes).toEqual([
             { frame: 0, dump: { value: { x: 0, y: 0, z: 0 }, type: 'cc.Vec3' } },
             { frame: 30, dump: { value: { x: 123, y: 0, z: 0 }, type: 'cc.Vec3' } },
@@ -1738,7 +1738,7 @@ describe('Animation Service 场景进程测试', () => {
             absorbPreviousScenePropertyUndo: true,
         }]);
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(await Undo.canUndoInAnimationScope()).toBe(true);
 
         expectUndoSuccess(await Undo.undoInAnimationScope());
@@ -1772,7 +1772,7 @@ describe('Animation Service 场景进程测试', () => {
             absorbPreviousScenePropertyUndo: true,
         }]);
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(await Undo.canUndoInAnimationScope()).toBe(true);
 
         expectUndoSuccess(await Undo.undoInAnimationScope());
@@ -1813,7 +1813,7 @@ describe('Animation Service 场景进程测试', () => {
             absorbPreviousScenePropertyUndo: true,
         }]);
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(await Undo.canUndoInAnimationScope()).toBe(true);
 
         expectUndoSuccess(await Undo.undoInAnimationScope());
@@ -1844,7 +1844,7 @@ describe('Animation Service 场景进程测试', () => {
             absorbPreviousScenePropertyUndo: true,
         }]);
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect(await Undo.canUndoInAnimationScope()).toBe(true);
 
         expectUndoSuccess(await Undo.undoInAnimationScope());
@@ -1906,7 +1906,7 @@ describe('Animation Service 场景进程测试', () => {
                 { type: 'createPropertyKey', clipUuid: emptyClipUuid, propKey: 'position', frame: 30, value: { x: 30, y: 0, z: 0 } },
             ],
         }]);
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: true });
         expect((await request('queryState')).dirty).toBe(true);
 
         await request('exit', [{ save: false, restoreSelection: false }]);
@@ -1915,6 +1915,24 @@ describe('Animation Service 场景进程测试', () => {
 
         expect(afterDiscard.curves).toEqual(before.curves);
         expect((await request('queryState')).dirty).toBe(false);
+    });
+
+    it('applyOperations 无实际变更时不写入 undo 栈', async () => {
+        await ensureAnimationSession(nodePath, clipUuid);
+        await Undo.clearHistory();
+        await Undo.markSaved();
+
+        const before = await request('queryClip', [{ clipUuid }]);
+        const result = await request('applyOperations', [{
+            operations: [
+                { type: 'changeSpeed', clipUuid, speed: before.speed },
+            ],
+        }]);
+
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: false });
+        expect(await Undo.isDirty()).toBe(false);
+        expect(await Undo.canUndo()).toBe(false);
+        expect(await Undo.canRedo()).toBe(false);
     });
 
     it('applyOperations recordUndo 为 false 时不写入 undo 栈', async () => {
@@ -1931,7 +1949,7 @@ describe('Animation Service 场景进程测试', () => {
         }]);
         const after = await request('queryClip', [{ clipUuid }]);
 
-        expect(result).toEqual({ state: 'success', result: true });
+        expect(result).toEqual({ state: 'success', result: true, undoRecorded: false });
         expect(after.speed).toBe(before.speed + 0.125);
         expect(await Undo.isDirty()).toBe(false);
         expect(await Undo.canUndo()).toBe(false);


### PR DESCRIPTION
## 📌 Background

Successful animation operations do not always push an animation-scoped Undo entry. Without the scene-process outcome, a following Undo or Redo can be routed as though a new history entry exists and consume older history.

## ✨ Changes

- Return whether a successful animation operation recorded Undo history.
- Set `undoRecorded` only when the animation clip snapshot changes and an Undo command is pushed.
- Cover both history-producing and no-history operation outcomes.

## 💡 Design Notes

The scene process is the source of truth for Undo history creation. Consumers use the explicit outcome instead of inferring it from operation success.

## 🧪 QA Steps

N/A — this is a Cocos CLI scene-process contract. Product validation is performed through the PinK Animation Editor integration flow.

## ⚠️ Risks

- The focused Jest suite could not start in this worktree because `jest` is not installed; source test execution remains pending in a dependency-complete CLI checkout.
