### PR TITLE
fix(assets): normalize Windows save-as paths

### DIFF
--- a/src/core/assets/manager/query.ts
+++ b/src/core/assets/manager/query.ts
@@ -790,6 +790,14 @@ class AssetQueryManager {
             throw new Error('parameter error');
         }
 
+        const normalizedUrl = pathToDbUrlIfAssetDBPath(uuidOrPath, assetDBManager.assetDBInfo);
+        if (!uuidOrPath.startsWith('db://') && normalizedUrl.startsWith('db://')) {
+            const dbName = normalizedUrl.slice('db://'.length).split('/', 1)[0];
+            if (assetDBManager.assetDBMap[dbName]) {
+                return normalizedUrl;
+            }
+        }
+
         // 根路径 /assets, /internal 对应的 url 模拟数据
         const name = uuidOrPath.substr(assetConfig.data.root.length + 1);
         if (assetDBManager.assetDBMap[name]) {

--- a/src/core/assets/test/operation-filesystem-bridge.test.ts
+++ b/src/core/assets/test/operation-filesystem-bridge.test.ts
@@ -156,6 +156,12 @@ describe('asset operation filesystem bridge', () => {
             state: 'none',
             preImportExtList: [],
         };
+        assetDBManager.assetDBMap.assets = {
+            options: {
+                name: 'assets',
+                target,
+            },
+        } as any;
     }
 
     beforeEach(() => {
@@ -165,15 +171,14 @@ describe('asset operation filesystem bridge', () => {
         mockRollbackCopy.mockResolvedValue(undefined);
         const assetDBManager = require('../manager/asset-db').default as typeof import('../manager/asset-db').default;
         Object.keys(assetDBManager.assetDBInfo).forEach((key) => delete assetDBManager.assetDBInfo[key]);
+        Object.keys(assetDBManager.assetDBMap).forEach((key) => delete assetDBManager.assetDBMap[key]);
+        const { pathToDbUrlIfAssetDBPath } = jest.requireActual('../asset-db-url') as typeof import('../asset-db-url');
         mockAssetQueryUrl.mockImplementation((value: string) => {
-            const normalized = value.replace(/\\/g, '/');
-            if (normalized.startsWith('D:/project/assets/')) {
-                return `db://assets/${normalized.slice('D:/project/assets/'.length)}`;
-            }
-            if (normalized === 'D:/project/assets') {
-                return 'db://assets';
-            }
-            return '';
+            const normalizedUrl = pathToDbUrlIfAssetDBPath(value, assetDBManager.assetDBInfo);
+            const dbName = normalizedUrl.startsWith('db://')
+                ? normalizedUrl.slice('db://'.length).split('/', 1)[0]
+                : '';
+            return dbName && assetDBManager.assetDBMap[dbName] ? normalizedUrl : '';
         });
     });
 
@@ -573,6 +578,31 @@ describe('asset operation filesystem bridge', () => {
         expect(mockRefresh).toHaveBeenCalledWith('db://assets/resources/Image/snake_head.png');
         expect(mockQueryAssetInfo).toHaveBeenCalledWith('db://assets/resources/Image/snake_head.png');
         expect(result).toEqual([assetInfo]);
+    });
+
+    it('createAsset should accept a Windows asset path after queryUrl normalizes its drive-letter case', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const target = 'g:\\test\\PinK-Animation-Editor-QA\\assets\\extended\\clip-settings\\baseline.scene';
+        const template = 'db://assets/extended/clip-settings/source.scene';
+        const createdAsset = {
+            source: target,
+            imported: true,
+            invalid: false,
+        };
+
+        setAssetDBInfo('G:\\test\\PinK-Animation-Editor-QA\\assets');
+        mockCreateAssetByHandler.mockResolvedValue(target);
+        mockQueryAsset.mockReturnValue(createdAsset);
+        jest.spyOn(assetOperation, 'refreshAsset').mockResolvedValue(0);
+
+        const result = await assetOperation.createAsset({ target, template });
+
+        expect(mockAssetQueryUrl).toHaveBeenCalledWith(target);
+        expect(mockCreateAssetByHandler).toHaveBeenCalledWith(expect.objectContaining({
+            target,
+            template,
+        }));
+        expect(result).toEqual({ source: target });
     });
 
     it('createAssetByType should resolve a database-name relative directory before creating', async () => {

--- a/src/core/assets/test/query-path-normalization.test.ts
+++ b/src/core/assets/test/query-path-normalization.test.ts
@@ -3,6 +3,8 @@ export {};
 const mockQueryUUID = jest.fn();
 const mockQueryAsset = jest.fn();
 const mockQueryPath = jest.fn();
+const mockQueryUrl = jest.fn();
+const mockAssetDBMap: Record<string, any> = {};
 
 jest.mock('@cocos/asset-db', () => ({
     queryUUID: (...args: any[]) => mockQueryUUID(...args),
@@ -12,7 +14,7 @@ jest.mock('@cocos/asset-db', () => ({
     Asset: class {},
     forEach: jest.fn(),
     queryPath: (...args: any[]) => mockQueryPath(...args),
-    queryUrl: jest.fn(),
+    queryUrl: (...args: any[]) => mockQueryUrl(...args),
 }));
 
 jest.mock('@cocos/asset-db/index', () => ({
@@ -22,6 +24,7 @@ jest.mock('@cocos/asset-db/index', () => ({
         nameToId: (value: string) => value,
     },
     queryPath: (...args: any[]) => mockQueryPath(...args),
+    queryUrl: (...args: any[]) => mockQueryUrl(...args),
     Asset: class {},
     VirtualAsset: class {},
 }));
@@ -44,7 +47,7 @@ jest.mock('../manager/asset-db', () => ({
                 preImportExtList: [],
             },
         },
-        assetDBMap: {},
+        assetDBMap: mockAssetDBMap,
         path2url: jest.fn(),
     },
 }));
@@ -82,6 +85,13 @@ jest.mock('../../base/i18n', () => ({
 describe('asset query path normalization', () => {
     beforeEach(() => {
         jest.resetAllMocks();
+        Object.keys(mockAssetDBMap).forEach((key) => delete mockAssetDBMap[key]);
+        mockAssetDBMap.assets = {
+            options: {
+                name: 'assets',
+                target: 'D:/project/assets',
+            },
+        };
     });
 
     afterEach(() => {
@@ -123,5 +133,53 @@ describe('asset query path normalization', () => {
         expect(mockQueryUUID).toHaveBeenCalledWith('db://assets/resources/Image/gem_red.png');
         expect(mockQueryPath).toHaveBeenCalledWith('gem-red-uuid');
         expect(result).toBe('D:/project/assets/resources/Image/gem_red.png');
+    });
+
+    it('queryUrl should normalize a Windows absolute asset path with a differently cased drive letter', () => {
+        const assetQuery = require('../manager/query').default as typeof import('../manager/query').default;
+
+        const result = assetQuery.queryUrl('d:\\project\\assets\\extended\\clip-settings\\baseline.scene');
+
+        expect(result).toBe('db://assets/extended/clip-settings/baseline.scene');
+        expect(mockQueryUrl).not.toHaveBeenCalled();
+    });
+
+    it('queryUrl should normalize mixed separators in an absolute asset path', () => {
+        const assetQuery = require('../manager/query').default as typeof import('../manager/query').default;
+
+        const result = assetQuery.queryUrl('d:/project/assets\\extended/clip-settings\\baseline.scene');
+
+        expect(result).toBe('db://assets/extended/clip-settings/baseline.scene');
+        expect(mockQueryUrl).not.toHaveBeenCalled();
+    });
+
+    it('queryUrl should not resolve a path for a database that is configured but not registered', () => {
+        const assetQuery = require('../manager/query').default as typeof import('../manager/query').default;
+        const target = 'd:\\project\\assets\\extended\\clip-settings\\baseline.scene';
+
+        delete mockAssetDBMap.assets;
+        mockQueryUrl.mockReturnValue('');
+
+        expect(assetQuery.queryUrl(target)).toBe('');
+        expect(mockQueryUrl).toHaveBeenCalledWith(target);
+    });
+
+    it('queryUrl should not treat a similarly prefixed external directory as part of the asset database', () => {
+        const assetQuery = require('../manager/query').default as typeof import('../manager/query').default;
+        const externalPath = 'D:\\project\\assets-copy\\baseline.scene';
+
+        mockQueryUrl.mockReturnValue('');
+
+        expect(assetQuery.queryUrl(externalPath)).toBe('');
+        expect(mockQueryUrl).toHaveBeenCalledWith(externalPath);
+    });
+
+    it('queryUrl should preserve the existing UUID fallback', () => {
+        const assetQuery = require('../manager/query').default as typeof import('../manager/query').default;
+
+        mockQueryUrl.mockReturnValue('db://assets/scenes/Game.scene');
+
+        expect(assetQuery.queryUrl('scene-uuid')).toBe('db://assets/scenes/Game.scene');
+        expect(mockQueryUrl).toHaveBeenCalledWith('scene-uuid');
     });
 });

--- a/tests/bug-497-api-error-status.test.ts
+++ b/tests/bug-497-api-error-status.test.ts
@@ -184,7 +184,7 @@ describe('Bug #497 common API error status codes', () => {
         mockCreateAsset.mockRejectedValue(new Error('Invalid URL: input URL must be a string and start with db:// \n  url:'));
 
         const result = await new AssetsApi().createAsset({
-            target: 'd:\\cocos\\program\\snake2\\assets\\resources',
+            target: 'd:\\outside\\resources',
         });
 
         expect(result.code).toBe(HTTP_STATUS.BAD_REQUEST);


### PR DESCRIPTION
## 修复说明

修复 PinK 在 Windows 下执行 Save As 时，因盘符大小写及路径分隔符差异导致资源路径无法转换为 `db://` 的问题。

### 改动

- Windows 绝对路径统一转换为 AssetDB URL。
- 兼容盘符大小写和混合路径分隔符。
- 仅解析已注册的 AssetDB，避免误识别外部目录。
- 保留原有 UUID 查询回退逻辑。
- 补充 Save As、外部路径及未注册数据库测试。

### 测试方法:
https://zentao.sud.center/index.php?m=bug&f=view&bugID=833, 在windows上save as, 如果另存为场景成功没有报错就是符合预期