### PR TITLE
Fix canvas creation for requested UI node creation

### DIFF
--- a/e2e/scripts/check-coverage.ts
+++ b/e2e/scripts/check-coverage.ts
@@ -1,7 +1,7 @@
 /**
  * 检查 E2E 测试覆盖率
  * 
- * 通过 toolRegistry 扫描所有已注册的 MCP 工具和 E2E 测试文件，检查哪些 API 缺少 E2E 测试。
+ * 通过 API 源码扫描 MCP 工具定义和 E2E 测试文件，检查哪些 API 缺少 E2E 测试。
  * 
  * 用法：
  *   npx tsx e2e/scripts/check-coverage.ts
@@ -10,7 +10,7 @@
 import * as fs from 'fs';
 import * as glob from 'glob';
 import * as path from 'path';
-import { scanToolsFromRegistry, extendToolInfo } from './tool-utils';
+import { scanToolsFromSource, extendToolInfo } from './tool-utils';
 
 interface ApiTool {
     name: string;
@@ -30,14 +30,13 @@ interface TestReference {
 const E2E_TEST_DIRS = ['e2e'];
 
 /**
- * 扫描所有 MCP 工具定义 (通过 toolRegistry)
+ * 扫描所有 MCP 工具定义 (通过 API 源码)
  * 
- * 这个方法与 mcp.middleware.ts 中的实现保持一致，
- * 确保统计的工具数量与实际注册的 MCP 工具一致。
+ * 覆盖率统计只需要工具名、方法名和描述信息，不需要启动运行时服务。
  */
 async function scanApiTools(): Promise<ApiTool[]> {
     // 使用共享的工具扫描函数
-    const baseTools = await scanToolsFromRegistry();
+    const baseTools = scanToolsFromSource();
 
     // 转换为 ApiTool 格式，添加类别字段
     return baseTools.map(tool => {
@@ -698,7 +697,7 @@ async function main() {
     const outputJson = args.includes('--json');
     const shouldSaveReport = args.includes('--save') || args.includes('--report') || args.includes('--html');
 
-    console.log('🔍 扫描 MCP API 工具定义 (通过 toolRegistry)...\n');
+    console.log('🔍 扫描 MCP API 工具定义 (通过 API 源码)...\n');
     const tools = await scanApiTools();
     console.log(`✅ 找到 ${tools.length} 个 MCP 工具\n`);
 

--- a/e2e/scripts/tool-utils.ts
+++ b/e2e/scripts/tool-utils.ts
@@ -2,7 +2,7 @@
  * MCP 工具扫描共享工具函数
  * 
  * 用于 check-coverage.ts 和 generate-mcp-types.ts 等脚本
- * 完全基于运行时数据，不读取源码
+ * 覆盖率检查使用源码扫描，类型生成仍使用运行时注册表
  */
 
 
@@ -35,6 +35,89 @@ export function inferToolCategory(target: any): string {
         return className.replace(/Api$/, '');
     }
     return 'Unknown';
+}
+
+/**
+ * 通过源码扫描覆盖率检查所需的工具信息。
+ *
+ * 覆盖率统计只需要工具名、方法名、标题、描述和分类，不需要启动运行时服务。
+ */
+export function scanToolsFromSource(apiRoot = 'src/api'): ExtendedToolInfo[] {
+    const fs = require('fs') as typeof import('fs');
+    const glob = require('glob') as typeof import('glob');
+    const normalizedRoot = apiRoot.replace(/\\/g, '/');
+    const files = glob.sync(`${normalizedRoot}/**/*.ts`, {
+        ignore: [
+            `${normalizedRoot}/**/*.d.ts`,
+            `${normalizedRoot}/decorator/**`,
+        ],
+    });
+    const tools: ExtendedToolInfo[] = [];
+
+    for (const file of files) {
+        const content = fs.readFileSync(file, 'utf-8');
+        const lines = content.split(/\r?\n/);
+        let currentClass = 'Unknown';
+        let pending: Partial<ExtendedToolInfo> = {};
+
+        for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed || trimmed.startsWith('//')) {
+                continue;
+            }
+
+            const classMatch = trimmed.match(/(?:export\s+)?class\s+(\w+Api)\b/);
+            if (classMatch) {
+                currentClass = classMatch[1].replace(/Api$/, '');
+                pending = {};
+                continue;
+            }
+
+            const toolName = matchDecoratorValue(trimmed, 'tool');
+            if (toolName) {
+                pending = {
+                    toolName,
+                    category: currentClass,
+                };
+                continue;
+            }
+
+            if (!pending.toolName) {
+                continue;
+            }
+
+            const title = matchDecoratorValue(trimmed, 'title');
+            if (title) {
+                pending.title = title;
+                continue;
+            }
+
+            const description = matchDecoratorValue(trimmed, 'description');
+            if (description) {
+                pending.description = description;
+                continue;
+            }
+
+            const methodMatch = trimmed.match(/^(?:public\s+|private\s+|protected\s+)?(?:async\s+)?(\w+)\s*\(/);
+            if (methodMatch) {
+                tools.push({
+                    toolName: pending.toolName,
+                    methodName: methodMatch[1],
+                    title: pending.title,
+                    description: pending.description,
+                    category: pending.category || currentClass,
+                });
+                pending = {};
+            }
+        }
+    }
+
+    return tools.sort((a, b) => a.toolName.localeCompare(b.toolName));
+}
+
+function matchDecoratorValue(line: string, decorator: string): string | undefined {
+    const match = line.match(new RegExp(`^@${decorator}\\((['"\`])([\\s\\S]*?)\\1\\)`));
+    return match?.[2];
 }
 
 /**

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -6092,10 +6092,6 @@ export declare interface ICameraService {
     setOriginAxes3D(config: IOriginAxesConfig): void;
     onUpdate(deltaTime: number): void;
 }
-export declare interface ICanvasContext {
-    canvas: INodeIdentifier | null;
-    uiTransform: INodeIdentifier | null;
-}
 export declare interface IChangeNodeLockParams {
     paths: string[];
     locked: boolean;
@@ -6162,6 +6158,12 @@ export declare interface ICreateByAssetParams extends IBaseCreateNodeParams {
 }
 export declare interface ICreateByNodeTypeParams extends IBaseCreateNodeParams {
     nodeType: NodeType;
+}
+export declare interface ICreateNodePreflightResult {
+    action: 'create' | 'choose-prefab-canvas-handling';
+    canvasRequired: boolean;
+    canvasPath: string | null;
+    uiTransformPath: string | null;
 }
 export declare interface ICreateOptions {
     type: ICreateType;
@@ -6325,17 +6327,12 @@ export declare interface INodeDumpOptions {
     includeChildren?: boolean;
     includeComponents?: boolean;
 }
-export declare interface INodeIdentifier {
-    nodeId: string;
-    path: string;
-    name: string;
-}
 export declare interface INodeService extends IServiceEvents {
     createByType(params: ICreateByNodeTypeParams): Promise<INode | null>;
     createByAsset(params: ICreateByAssetParams): Promise<INode | null>;
+    preflightCreate(params: ICreateByNodeTypeParams | ICreateByAssetParams): Promise<ICreateNodePreflightResult>;
     delete(params: IDeleteNodeParams): Promise<IDeleteNodeResult | null>;
     query(params?: IQueryNodeParams): Promise<INode | IScene | null>;
-    queryCanvasContext(path: string): Promise<ICanvasContext>;
     queryNodeTree(params: IQueryNodeTreeParams): Promise<INodeTreeItem | null>;
     queryNodesByAssetUuid(uuid: string): string[];
     queryNodesMissAsset(): Promise<string[]>;

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -6092,6 +6092,10 @@ export declare interface ICameraService {
     setOriginAxes3D(config: IOriginAxesConfig): void;
     onUpdate(deltaTime: number): void;
 }
+export declare interface ICanvasContext {
+    canvas: INodeIdentifier | null;
+    uiTransform: INodeIdentifier | null;
+}
 export declare interface IChangeNodeLockParams {
     paths: string[];
     locked: boolean;
@@ -6321,11 +6325,17 @@ export declare interface INodeDumpOptions {
     includeChildren?: boolean;
     includeComponents?: boolean;
 }
+export declare interface INodeIdentifier {
+    nodeId: string;
+    path: string;
+    name: string;
+}
 export declare interface INodeService extends IServiceEvents {
     createByType(params: ICreateByNodeTypeParams): Promise<INode | null>;
     createByAsset(params: ICreateByAssetParams): Promise<INode | null>;
     delete(params: IDeleteNodeParams): Promise<IDeleteNodeResult | null>;
     query(params?: IQueryNodeParams): Promise<INode | IScene | null>;
+    queryCanvasContext(path: string): Promise<ICanvasContext>;
     queryNodeTree(params: IQueryNodeTreeParams): Promise<INodeTreeItem | null>;
     queryNodesByAssetUuid(uuid: string): string[];
     queryNodesMissAsset(): Promise<string[]>;

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -6043,6 +6043,7 @@ export declare interface IBaseCreateNodeParams {
     position?: IVec3;
     keepWorldTransform?: boolean;
     canvasRequired?: boolean;
+    prefabCanvasHandling?: PrefabCanvasHandling;
     unlinkPrefab?: boolean;
 }
 export declare interface IBaseIdentifier {
@@ -6974,6 +6975,7 @@ export declare interface PrefabAssetUserData {
     persistent?: boolean;
     syncNodeName?: string;
 }
+export declare type PrefabCanvasHandling = 'add-root-ui-transform' | 'create-canvas' | 'cancel';
 export declare enum PrefabState {
     NotAPrefab = 0,
     PrefabChild = 1,

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -6975,7 +6975,7 @@ export declare interface PrefabAssetUserData {
     persistent?: boolean;
     syncNodeName?: string;
 }
-export declare type PrefabCanvasHandling = 'add-root-ui-transform' | 'create-canvas' | 'cancel';
+export declare type PrefabCanvasHandling = 'add-root-ui-transform' | 'create-canvas';
 export declare enum PrefabState {
     NotAPrefab = 0,
     PrefabChild = 1,

--- a/src/api/scene/node-schema.ts
+++ b/src/api/scene/node-schema.ts
@@ -92,11 +92,15 @@ const SchemaNodeCreateBase = z.object({
     ].join(' ')), // prefab 模式中 canvasRequired 为 true 时的 Canvas 处理
 }).describe('To configure options for node creation, the Scene must be open first.'); // 创建节点的选项参数, 需先打开场景;
 
-export const SchemaNodeCreateByAsset = SchemaNodeCreateBase.extend({
+const SchemaNodeCreateWithPreflight = SchemaNodeCreateBase.extend({
+    preflightToken: z.string().optional().describe('Opaque token returned by preflightCreate. Pass it to the matching create request to reject stale Canvas decisions.'),
+});
+
+export const SchemaNodeCreateByAsset = SchemaNodeCreateWithPreflight.extend({
     dbURL: SchemaAssetDbUrl.describe('Prefab asset path, if created from a prefab, please pass this parameter, format is custom db path e.g. db://assets/abc.prefab'), // 预制体资源路径，如果是从某个预制体创建，请传入这个参数，格式为自定义的db 路径比如 db://assets/abc.prefab
 });
 
-export const SchemaNodeCreateByType = SchemaNodeCreateBase.extend({
+export const SchemaNodeCreateByType = SchemaNodeCreateWithPreflight.extend({
     nodeType: z.enum(Object.values(NodeType) as [string, ...string[]]).describe('Node type'), // 节点类型
 });
 

--- a/src/api/scene/node-schema.ts
+++ b/src/api/scene/node-schema.ts
@@ -84,6 +84,12 @@ const SchemaNodeCreateBase = z.object({
     keepWorldTransform: z.boolean().optional().describe('Keep world transform'), // 保持世界变换
     position: SchemaVec3.optional().describe('Node position'), // 节点位置
     canvasRequired: z.boolean().optional().describe('Whether Canvas is required'), // 是否需要 Canvas
+    prefabCanvasHandling: z.enum(['add-root-ui-transform', 'create-canvas', 'cancel']).optional().describe([
+        'Prefab Canvas handling when canvasRequired is true and the parent has no Canvas or UITransform ancestor.',
+        'add-root-ui-transform adds UITransform to the prefab root and creates a hidden preview Canvas if needed.',
+        'create-canvas creates a Canvas parent for the new node.',
+        'cancel skips Canvas creation.',
+    ].join(' ')), // prefab 模式中 canvasRequired 为 true 时的 Canvas 处理
 }).describe('To configure options for node creation, the Scene must be open first.'); // 创建节点的选项参数, 需先打开场景;
 
 export const SchemaNodeCreateByAsset = SchemaNodeCreateBase.extend({

--- a/src/api/scene/node-schema.ts
+++ b/src/api/scene/node-schema.ts
@@ -84,11 +84,11 @@ const SchemaNodeCreateBase = z.object({
     keepWorldTransform: z.boolean().optional().describe('Keep world transform'), // 保持世界变换
     position: SchemaVec3.optional().describe('Node position'), // 节点位置
     canvasRequired: z.boolean().optional().describe('Whether Canvas is required'), // 是否需要 Canvas
-    prefabCanvasHandling: z.enum(['add-root-ui-transform', 'create-canvas', 'cancel']).optional().describe([
+    prefabCanvasHandling: z.enum(['add-root-ui-transform', 'create-canvas']).optional().describe([
         'Prefab Canvas handling when canvasRequired is true and the parent has no Canvas or UITransform ancestor.',
         'add-root-ui-transform adds UITransform to the prefab root and creates a hidden preview Canvas if needed.',
         'create-canvas creates a Canvas parent for the new node.',
-        'cancel skips Canvas creation.',
+        'Omit this option to skip Canvas creation when the host cancels the prefab Canvas prompt.',
     ].join(' ')), // prefab 模式中 canvasRequired 为 true 时的 Canvas 处理
 }).describe('To configure options for node creation, the Scene must be open first.'); // 创建节点的选项参数, 需先打开场景;
 

--- a/src/core/builder/platforms/types/pink.internal-platform.d.ts
+++ b/src/core/builder/platforms/types/pink.internal-platform.d.ts
@@ -5447,6 +5447,8 @@ declare module 'pink' {
 			canvasRequired?: boolean;
 			/** prefab 模式下需要 Canvas 处理时，使用外部 UI 选择的处理方式 */
 			prefabCanvasHandling?: 'add-root-ui-transform' | 'create-canvas';
+			/** preflightCreate 返回的 token，用于验证 Canvas 决策仍然有效 */
+			preflightToken?: string;
 		}
 
 		/** 创建节点的参数 */

--- a/src/core/builder/platforms/types/pink.internal-platform.d.ts
+++ b/src/core/builder/platforms/types/pink.internal-platform.d.ts
@@ -5445,6 +5445,8 @@ declare module 'pink' {
 			keepWorldTransform?: boolean;
 			/** 是否需要 Canvas（2D UI 节点自动创建 Canvas） */
 			canvasRequired?: boolean;
+			/** prefab 模式下需要 Canvas 处理时，使用外部 UI 选择的处理方式 */
+			prefabCanvasHandling?: 'add-root-ui-transform' | 'create-canvas' | 'cancel';
 		}
 
 		/** 创建节点的参数 */

--- a/src/core/builder/platforms/types/pink.internal-platform.d.ts
+++ b/src/core/builder/platforms/types/pink.internal-platform.d.ts
@@ -5446,7 +5446,7 @@ declare module 'pink' {
 			/** 是否需要 Canvas（2D UI 节点自动创建 Canvas） */
 			canvasRequired?: boolean;
 			/** prefab 模式下需要 Canvas 处理时，使用外部 UI 选择的处理方式 */
-			prefabCanvasHandling?: 'add-root-ui-transform' | 'create-canvas' | 'cancel';
+			prefabCanvasHandling?: 'add-root-ui-transform' | 'create-canvas';
 		}
 
 		/** 创建节点的参数 */

--- a/src/core/builder/platforms/types/pink.internal.d.ts
+++ b/src/core/builder/platforms/types/pink.internal.d.ts
@@ -6247,6 +6247,8 @@ declare module 'pink' {
 			canvasRequired?: boolean;
 			/** prefab 模式下需要 Canvas 处理时，使用外部 UI 选择的处理方式 */
 			prefabCanvasHandling?: 'add-root-ui-transform' | 'create-canvas';
+			/** preflightCreate 返回的 token，用于验证 Canvas 决策仍然有效 */
+			preflightToken?: string;
 		}
 
 		/** 创建节点的参数 */

--- a/src/core/builder/platforms/types/pink.internal.d.ts
+++ b/src/core/builder/platforms/types/pink.internal.d.ts
@@ -6246,7 +6246,7 @@ declare module 'pink' {
 			/** 是否需要 Canvas（2D UI 节点自动创建 Canvas） */
 			canvasRequired?: boolean;
 			/** prefab 模式下需要 Canvas 处理时，使用外部 UI 选择的处理方式 */
-			prefabCanvasHandling?: 'add-root-ui-transform' | 'create-canvas' | 'cancel';
+			prefabCanvasHandling?: 'add-root-ui-transform' | 'create-canvas';
 		}
 
 		/** 创建节点的参数 */

--- a/src/core/builder/platforms/types/pink.internal.d.ts
+++ b/src/core/builder/platforms/types/pink.internal.d.ts
@@ -6245,6 +6245,8 @@ declare module 'pink' {
 			keepWorldTransform?: boolean;
 			/** 是否需要 Canvas（2D UI 节点自动创建 Canvas） */
 			canvasRequired?: boolean;
+			/** prefab 模式下需要 Canvas 处理时，使用外部 UI 选择的处理方式 */
+			prefabCanvasHandling?: 'add-root-ui-transform' | 'create-canvas' | 'cancel';
 		}
 
 		/** 创建节点的参数 */

--- a/src/core/scene/common/node.ts
+++ b/src/core/scene/common/node.ts
@@ -5,7 +5,6 @@ import { IServiceEvents } from '../scene-process/service/core';
 import { IPrefabStateInfo, ITargetOverrideInfo } from './prefab';
 import type { IProperty } from '../@types/public';
 import type { IScene } from './editor/scene';
-import type { INodeIdentifier } from './cli/node';
 
 // ====== Hierarchy tree types (for queryNodeTree) ======
 
@@ -99,6 +98,13 @@ export enum MobilityMode {
 
 export type PrefabCanvasHandling = 'add-root-ui-transform' | 'create-canvas';
 
+export interface ICreateNodePreflightResult {
+    action: 'create' | 'choose-prefab-canvas-handling';
+    canvasRequired: boolean;
+    canvasPath: string | null;
+    uiTransformPath: string | null;
+}
+
 // generateNodeDump / encode / open 共用的选项
 export interface INodeDumpOptions {
     includeChildren?: boolean; // true: children 以 INodeIdentifier[] 返回，false/undefined: undefined
@@ -108,11 +114,6 @@ export interface INodeDumpOptions {
 // 节点查询参数接口
 export interface IQueryNodeParams extends INodeDumpOptions {
     path: string; // 查询的节点路径
-}
-
-export interface ICanvasContext {
-    canvas: INodeIdentifier | null;
-    uiTransform: INodeIdentifier | null;
 }
 
 export interface IPrefab {
@@ -287,7 +288,7 @@ export type IPublicNodeService = Omit<INodeService, keyof IServiceEvents |
     'paste' |
     'duplicate' |
     'cut' |
-    'queryCanvasContext' |
+    'preflightCreate' |
     'queryClipboardState' |
     'moveArrayElement' |
     'removeArrayElement' |
@@ -311,6 +312,11 @@ export interface INodeService extends IServiceEvents {
      * @param params
      */
     createByAsset(params: ICreateByAssetParams): Promise<INode | null>;
+
+    /**
+     * Resolve Canvas handling for a node creation request without modifying the scene.
+     */
+    preflightCreate(params: ICreateByNodeTypeParams | ICreateByAssetParams): Promise<ICreateNodePreflightResult>;
     /**
      * 删除节点
      * @param params
@@ -323,11 +329,6 @@ export interface INodeService extends IServiceEvents {
      * @returns 查询到的节点信息，未找到返回 null
      */
     query(params?: IQueryNodeParams): Promise<INode | IScene | null>;
-
-    /**
-     * Query the nearest Canvas and UITransform on this node or its ancestors.
-     */
-    queryCanvasContext(path: string): Promise<ICanvasContext>;
 
     /**
      * 查询节点树（层级管理器格式）

--- a/src/core/scene/common/node.ts
+++ b/src/core/scene/common/node.ts
@@ -103,6 +103,11 @@ export interface ICreateNodePreflightResult {
     canvasRequired: boolean;
     canvasPath: string | null;
     uiTransformPath: string | null;
+    /**
+     * Opaque token for the matching create request. Passing it back prevents a
+     * stale preflight result from silently skipping required Canvas handling.
+     */
+    preflightToken: string;
 }
 
 // generateNodeDump / encode / open 共用的选项
@@ -236,6 +241,8 @@ interface IBaseCreateNodeParams {
     keepWorldTransform?: boolean;
     canvasRequired?: boolean;
     prefabCanvasHandling?: PrefabCanvasHandling;
+    /** Opaque token returned by preflightCreate for this creation request. */
+    preflightToken?: string;
     unlinkPrefab?: boolean;
 }
 

--- a/src/core/scene/common/node.ts
+++ b/src/core/scene/common/node.ts
@@ -5,6 +5,7 @@ import { IServiceEvents } from '../scene-process/service/core';
 import { IPrefabStateInfo, ITargetOverrideInfo } from './prefab';
 import type { IProperty } from '../@types/public';
 import type { IScene } from './editor/scene';
+import type { INodeIdentifier } from './cli/node';
 
 // ====== Hierarchy tree types (for queryNodeTree) ======
 
@@ -107,6 +108,11 @@ export interface INodeDumpOptions {
 // 节点查询参数接口
 export interface IQueryNodeParams extends INodeDumpOptions {
     path: string; // 查询的节点路径
+}
+
+export interface ICanvasContext {
+    canvas: INodeIdentifier | null;
+    uiTransform: INodeIdentifier | null;
 }
 
 export interface IPrefab {
@@ -281,6 +287,7 @@ export type IPublicNodeService = Omit<INodeService, keyof IServiceEvents |
     'paste' |
     'duplicate' |
     'cut' |
+    'queryCanvasContext' |
     'queryClipboardState' |
     'moveArrayElement' |
     'removeArrayElement' |
@@ -316,6 +323,11 @@ export interface INodeService extends IServiceEvents {
      * @returns 查询到的节点信息，未找到返回 null
      */
     query(params?: IQueryNodeParams): Promise<INode | IScene | null>;
+
+    /**
+     * Query the nearest Canvas and UITransform on this node or its ancestors.
+     */
+    queryCanvasContext(path: string): Promise<ICanvasContext>;
 
     /**
      * 查询节点树（层级管理器格式）

--- a/src/core/scene/common/node.ts
+++ b/src/core/scene/common/node.ts
@@ -96,6 +96,8 @@ export enum MobilityMode {
     Movable = 2
 }
 
+export type PrefabCanvasHandling = 'add-root-ui-transform' | 'create-canvas' | 'cancel';
+
 // generateNodeDump / encode / open 共用的选项
 export interface INodeDumpOptions {
     includeChildren?: boolean; // true: children 以 INodeIdentifier[] 返回，false/undefined: undefined
@@ -226,6 +228,7 @@ interface IBaseCreateNodeParams {
     position?: IVec3;
     keepWorldTransform?: boolean;
     canvasRequired?: boolean;
+    prefabCanvasHandling?: PrefabCanvasHandling;
     unlinkPrefab?: boolean;
 }
 

--- a/src/core/scene/common/node.ts
+++ b/src/core/scene/common/node.ts
@@ -96,7 +96,7 @@ export enum MobilityMode {
     Movable = 2
 }
 
-export type PrefabCanvasHandling = 'add-root-ui-transform' | 'create-canvas' | 'cancel';
+export type PrefabCanvasHandling = 'add-root-ui-transform' | 'create-canvas';
 
 // generateNodeDump / encode / open 共用的选项
 export interface INodeDumpOptions {

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -6,6 +6,7 @@ import {
     type IDeleteNodeResult,
     type INode,
     type INodeService,
+    type ICanvasContext,
     type IQueryNodeParams,
     type IQueryNodeTreeParams,
     type INodeTreeItem,
@@ -353,6 +354,51 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             }
             if (!node) return null;
             return sceneUtils.generateNodeDump(node, params);
+        } catch (error) {
+            console.error(error);
+            throw error;
+        } finally {
+            Service.Editor.unlock();
+        }
+    }
+
+    async queryCanvasContext(path: string): Promise<ICanvasContext> {
+        try {
+            await Service.Editor.lock();
+            const root = Service.Editor.getRootNode();
+            if (!root) {
+                throw new Error('Failed to query canvas context: the scene is not opened.');
+            }
+
+            const node = path === '/' ? root : NodeMgr.getNodeByPath(path);
+            if (!node) {
+                return { canvas: null, uiTransform: null };
+            }
+
+            const stopAtRoot = Service.Editor.getCurrentEditorType() === 'prefab'
+                ? root
+                : director.getScene() ?? root;
+            let current: Node | null = node;
+            let canvas: Node | null = null;
+            let uiTransform: Node | null = null;
+
+            while (current) {
+                if (!canvas && hasOneKindOfComponent(current, Canvas)) {
+                    canvas = current;
+                }
+                if (!uiTransform && hasOneKindOfComponent(current, UITransform)) {
+                    uiTransform = current;
+                }
+                if ((canvas && uiTransform) || current === stopAtRoot) {
+                    break;
+                }
+                current = current.parent;
+            }
+
+            return {
+                canvas: canvas ? sceneUtils.generateNodeIdentifier(canvas) : null,
+                uiTransform: uiTransform ? sceneUtils.generateNodeIdentifier(uiTransform) : null,
+            };
         } catch (error) {
             console.error(error);
             throw error;

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -197,6 +197,17 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         materializesUITransform: boolean;
         canvasRequired: boolean;
     } {
+        if (path) {
+            try {
+                const existingParent = NodeMgr.getNodeByPath(path);
+                if (existingParent) {
+                    return { parent: existingParent, materializesUITransform: false, canvasRequired: false };
+                }
+            } catch (error) {
+                console.error(error);
+            }
+        }
+
         const pathParts = path?.split('/').filter(part => part.trim() !== '') ?? [];
         let parent = currentScene;
 

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -55,6 +55,12 @@ interface IPrefabCanvasUndoRecord {
     workMode: string;
 }
 
+interface ICreatePreflightToken {
+    requestKey: string;
+    action: ICreateNodePreflightResult['action'];
+    canvasRequired: boolean;
+}
+
 /**
  * 子进程节点处理器
  * 在子进程中处理所有节点相关操作
@@ -64,6 +70,8 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
     private readonly _undo = new NodeUndoHelper((event, ...args) => this.emit(event as any, ...args));
     private _prefabCanvasUndoRecords: IPrefabCanvasUndoRecord[] | null = null;
     private _prefabCanvasUndoBeforeNodeUuids: Set<string> | null = null;
+    private readonly _preflightTokens = new Map<string, ICreatePreflightToken>();
+    private _preflightTokenSequence = 0;
 
     async createByType(params: ICreateByNodeTypeParams): Promise<INode | null> {
         try {
@@ -71,6 +79,7 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             const beforeNodeUuids = this._collectSceneNodeUuidsForUndo();
             const createRootPath = this._getCreateRootPathForUndo(beforeNodeUuids, params.path);
             const { assetUuid, canvasRequired: canvasNeeded } = this._resolveTypeCreateOptions(params);
+            this._validatePreflightToken(params);
             const prefabCanvasUndoRecords = this._beginPrefabCanvasUndoCapture(beforeNodeUuids);
             let result: INode | null;
             try {
@@ -107,6 +116,7 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             }
             const assetInfo = await Rpc.getInstance().request('assetManager', 'queryAssetInfo', [assetUuid]);
             const canvasNeeded = params.canvasRequired || false;
+            this._validatePreflightToken(params);
             const prefabCanvasUndoRecords = this._beginPrefabCanvasUndoCapture(beforeNodeUuids);
             let result: INode | null;
             try {
@@ -149,28 +159,10 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
                 canvasRequired = Boolean(params.canvasRequired || assetCanvasRequired);
             }
 
-            const pathPlan = this._getCreatePathPreflight(params.path, currentScene);
-            if (pathPlan.materializesUITransform) {
-                return {
-                    action: 'create',
-                    canvasRequired,
-                    canvasPath: null,
-                    uiTransformPath: null,
-                };
-            }
-
-            canvasRequired = canvasRequired || pathPlan.canvasRequired;
-            const context = this._getCanvasContext(pathPlan.parent);
-            const requiresPrefabCanvasHandling = canvasRequired
-                && Service.Editor.getCurrentEditorType() === 'prefab'
-                && !context.hasCanvasContext
-                && !context.uiTransformNode;
-
+            const result = this._resolveCreatePreflight(params, canvasRequired, currentScene);
             return {
-                action: requiresPrefabCanvasHandling ? 'choose-prefab-canvas-handling' : 'create',
-                canvasRequired,
-                canvasPath: context.canvasNode ? NodeMgr.getNodePath(context.canvasNode) ?? null : null,
-                uiTransformPath: context.uiTransformNode ? NodeMgr.getNodePath(context.uiTransformNode) ?? null : null,
+                ...result,
+                preflightToken: this._createPreflightToken(params, result),
             };
         } catch (error) {
             console.error(error);
@@ -236,35 +228,99 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         const uiTransformNode = getUITransformParentNode(parent);
         return {
             hasCanvasContext: Boolean(canvasContextNode),
-            canvasNode: canvasContextNode ? this._findCanvasNode(parent) : null,
+            canvasNode: canvasContextNode,
             uiTransformNode,
         };
     }
 
-    private _findCanvasNode(parent: Node): Node | null {
-        if (hasOneKindOfComponent(parent, Canvas)) {
-            return parent;
+    private _resolveCreatePreflight(
+        params: ICreateByNodeTypeParams | ICreateByAssetParams,
+        canvasRequired: boolean,
+        currentScene: Node,
+    ): Omit<ICreateNodePreflightResult, 'preflightToken'> {
+        const pathPlan = this._getCreatePathPreflight(params.path, currentScene);
+        if (pathPlan.materializesUITransform) {
+            return {
+                action: 'create',
+                canvasRequired,
+                canvasPath: null,
+                uiTransformPath: null,
+            };
         }
 
-        let ancestor = parent.parent;
-        while (ancestor) {
-            if (hasOneKindOfComponent(ancestor, Canvas)) {
-                return ancestor;
+        const effectiveCanvasRequired = canvasRequired || pathPlan.canvasRequired;
+        const context = this._getCanvasContext(pathPlan.parent);
+        const requiresPrefabCanvasHandling = effectiveCanvasRequired
+            && Service.Editor.getCurrentEditorType() === 'prefab'
+            && !context.hasCanvasContext
+            && !context.uiTransformNode;
+
+        return {
+            action: requiresPrefabCanvasHandling ? 'choose-prefab-canvas-handling' : 'create',
+            canvasRequired: effectiveCanvasRequired,
+            canvasPath: context.canvasNode ? NodeMgr.getNodePath(context.canvasNode) ?? null : null,
+            uiTransformPath: context.uiTransformNode ? NodeMgr.getNodePath(context.uiTransformNode) ?? null : null,
+        };
+    }
+
+    private _createPreflightToken(
+        params: ICreateByNodeTypeParams | ICreateByAssetParams,
+        result: Omit<ICreateNodePreflightResult, 'preflightToken'>,
+    ): string {
+        const token = `node-create-${Date.now().toString(36)}-${(++this._preflightTokenSequence).toString(36)}`;
+        if (this._preflightTokens.size >= 128) {
+            const oldestToken = this._preflightTokens.keys().next().value;
+            if (oldestToken) {
+                this._preflightTokens.delete(oldestToken);
             }
-            if (ancestor === director.getScene()) {
-                break;
-            }
-            ancestor = ancestor.parent;
+        }
+        this._preflightTokens.set(token, {
+            requestKey: this._getPreflightRequestKey(params),
+            action: result.action,
+            canvasRequired: result.canvasRequired,
+        });
+        return token;
+    }
+
+    private _validatePreflightToken(params: ICreateByNodeTypeParams | ICreateByAssetParams): void {
+        if (!params.preflightToken) {
+            return;
         }
 
-        for (let index = parent.children.length - 1; index >= 0; index--) {
-            const child = parent.children[index];
-            if (hasOneKindOfComponent(child, Canvas)) {
-                return child;
-            }
+        const record = this._preflightTokens.get(params.preflightToken);
+        this._preflightTokens.delete(params.preflightToken);
+        if (!record || record.requestKey !== this._getPreflightRequestKey(params)) {
+            throw new Error('The node creation preflight token is invalid or does not match the request. Run preflightCreate again.');
         }
 
-        return null;
+        if (record.action !== 'create') {
+            return;
+        }
+
+        const currentScene = Service.Editor.getRootNode();
+        if (!currentScene) {
+            throw new Error('Failed to create node: the scene is not opened.');
+        }
+        const currentResult = this._resolveCreatePreflight(params, record.canvasRequired, currentScene);
+        if (currentResult.action !== 'create') {
+            throw new Error('Canvas context changed after preflight. Run preflightCreate again before creating the node.');
+        }
+    }
+
+    private _getPreflightRequestKey(params: ICreateByNodeTypeParams | ICreateByAssetParams): string {
+        return JSON.stringify('nodeType' in params ? {
+            kind: 'type',
+            path: params.path,
+            nodeType: params.nodeType,
+            workMode: params.workMode ?? '2d',
+            canvasRequired: Boolean(params.canvasRequired),
+        } : {
+            kind: 'asset',
+            path: params.path,
+            dbURL: params.dbURL,
+            workMode: params.workMode ?? '2d',
+            canvasRequired: Boolean(params.canvasRequired),
+        });
     }
 
     async _createNode(assetUuid: string | null, canvasNeeded: boolean, checkUITransform: boolean, params: ICreateByNodeTypeParams | ICreateByAssetParams, assetType?: string): Promise<INode | null> {

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -2,11 +2,11 @@ import { register, BaseService, Service } from './core';
 import {
     type ICreateByAssetParams,
     type ICreateByNodeTypeParams,
+    type ICreateNodePreflightResult,
     type IDeleteNodeParams,
     type IDeleteNodeResult,
     type INode,
     type INodeService,
-    type ICanvasContext,
     type IQueryNodeParams,
     type IQueryNodeTreeParams,
     type INodeTreeItem,
@@ -29,7 +29,7 @@ import {
 import { type IScene } from '../../common/editor/scene';
 import { Rpc } from '../rpc';
 import { Canvas, CCClass, CCObject, Component, director, Node, Prefab, Quat, UITransform, Vec3 } from 'cc';
-import { createNodeByAsset, createShouldHideInHierarchyCanvasNode, loadAny } from './node/node-create';
+import { createNodeByAsset, createShouldHideInHierarchyCanvasNode, loadAny, queryCanvasRequiredByAsset } from './node/node-create';
 import { getUICanvasNode, getUITransformParentNode, hasOneKindOfComponent, setLayer } from './node/node-utils';
 import { NodeUndoHelper } from './node/node-undo';
 import { isUndoApplying } from './undo/applying-state';
@@ -70,21 +70,7 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             await Service.Editor.lock();
             const beforeNodeUuids = this._collectSceneNodeUuidsForUndo();
             const createRootPath = this._getCreateRootPathForUndo(beforeNodeUuids, params.path);
-            const explicitCanvasRequired = Boolean(params.canvasRequired);
-            let canvasNeeded = explicitCanvasRequired;
-            const nodeType = params.nodeType as string;
-            const paramsArray = NodeConfig[nodeType];
-            if (!paramsArray || paramsArray.length < 0) {
-                throw new Error(`Node type '${nodeType}' is not implemented`);
-            }
-            let assetUuid = paramsArray[0].assetUuid || null;
-            canvasNeeded = explicitCanvasRequired || Boolean(paramsArray[0].canvasRequired);
-            const projectType = paramsArray[0]['project-type'];
-            const workMode = params.workMode;
-            if (projectType && workMode && projectType !== workMode.toLowerCase() && paramsArray.length > 1) {
-                assetUuid = paramsArray[1]['assetUuid'] || null;
-                canvasNeeded = explicitCanvasRequired || Boolean(paramsArray[1].canvasRequired);
-            }
+            const { assetUuid, canvasRequired: canvasNeeded } = this._resolveTypeCreateOptions(params);
             const prefabCanvasUndoRecords = this._beginPrefabCanvasUndoCapture(beforeNodeUuids);
             let result: INode | null;
             try {
@@ -138,6 +124,149 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         }
     }
 
+    async preflightCreate(params: ICreateByNodeTypeParams | ICreateByAssetParams): Promise<ICreateNodePreflightResult> {
+        try {
+            await Service.Editor.lock();
+            const currentScene = Service.Editor.getRootNode();
+            if (!currentScene) {
+                throw new Error('Failed to preflight node creation: the scene is not opened.');
+            }
+
+            let canvasRequired: boolean;
+            if ('nodeType' in params) {
+                canvasRequired = this._resolveTypeCreateOptions(params).canvasRequired;
+            } else {
+                const assetUuid = await Rpc.getInstance().request('assetManager', 'queryUUID', [params.dbURL]);
+                if (!assetUuid) {
+                    throw new Error(`Asset not found for dbURL: ${params.dbURL}`);
+                }
+                const assetInfo = await Rpc.getInstance().request('assetManager', 'queryAssetInfo', [assetUuid]);
+                const assetCanvasRequired = await queryCanvasRequiredByAsset({
+                    uuid: assetUuid,
+                    type: assetInfo?.type,
+                    workMode: params.workMode || '2d',
+                });
+                canvasRequired = Boolean(params.canvasRequired || assetCanvasRequired);
+            }
+
+            const pathPlan = this._getCreatePathPreflight(params.path, currentScene);
+            if (pathPlan.materializesUITransform) {
+                return {
+                    action: 'create',
+                    canvasRequired,
+                    canvasPath: null,
+                    uiTransformPath: null,
+                };
+            }
+
+            canvasRequired = canvasRequired || pathPlan.canvasRequired;
+            const context = this._getCanvasContext(pathPlan.parent);
+            const requiresPrefabCanvasHandling = canvasRequired
+                && Service.Editor.getCurrentEditorType() === 'prefab'
+                && !context.hasCanvasContext
+                && !context.uiTransformNode;
+
+            return {
+                action: requiresPrefabCanvasHandling ? 'choose-prefab-canvas-handling' : 'create',
+                canvasRequired,
+                canvasPath: context.canvasNode ? NodeMgr.getNodePath(context.canvasNode) ?? null : null,
+                uiTransformPath: context.uiTransformNode ? NodeMgr.getNodePath(context.uiTransformNode) ?? null : null,
+            };
+        } catch (error) {
+            console.error(error);
+            throw error;
+        } finally {
+            Service.Editor.unlock();
+        }
+    }
+
+    private _resolveTypeCreateOptions(params: ICreateByNodeTypeParams): { assetUuid: string | null; canvasRequired: boolean } {
+        const explicitCanvasRequired = Boolean(params.canvasRequired);
+        const nodeType = params.nodeType as string;
+        const paramsArray = NodeConfig[nodeType];
+        if (!paramsArray || paramsArray.length === 0) {
+            throw new Error(`Node type '${nodeType}' is not implemented`);
+        }
+
+        let config = paramsArray[0];
+        const projectType = config['project-type'];
+        if (projectType && params.workMode && projectType !== params.workMode.toLowerCase() && paramsArray.length > 1) {
+            config = paramsArray[1];
+        }
+
+        return {
+            assetUuid: config.assetUuid || null,
+            canvasRequired: explicitCanvasRequired || Boolean(config.canvasRequired),
+        };
+    }
+
+    private _getCreatePathPreflight(path: string | undefined, currentScene: Node): {
+        parent: Node;
+        materializesUITransform: boolean;
+        canvasRequired: boolean;
+    } {
+        const pathParts = path?.split('/').filter(part => part.trim() !== '') ?? [];
+        let parent = currentScene;
+
+        for (const pathPart of pathParts) {
+            const child = parent.getChildByName(pathPart);
+            if (child) {
+                parent = child;
+                continue;
+            }
+
+            if (pathPart === 'Canvas') {
+                return { parent, materializesUITransform: false, canvasRequired: true };
+            }
+
+            // _ensurePathExists() adds UITransform to the first missing ordinary path segment.
+            return { parent, materializesUITransform: true, canvasRequired: false };
+        }
+
+        return { parent, materializesUITransform: false, canvasRequired: false };
+    }
+
+    private _getCanvasContext(parent: Node): {
+        hasCanvasContext: boolean;
+        canvasNode: Node | null;
+        uiTransformNode: Node | null;
+    } {
+        const isPrefabMode = Service.Editor.getCurrentEditorType() === 'prefab';
+        const canvasContextNode = getUICanvasNode(parent, !isPrefabMode);
+        const uiTransformNode = getUITransformParentNode(parent);
+        return {
+            hasCanvasContext: Boolean(canvasContextNode),
+            canvasNode: canvasContextNode ? this._findCanvasNode(parent) : null,
+            uiTransformNode,
+        };
+    }
+
+    private _findCanvasNode(parent: Node): Node | null {
+        if (hasOneKindOfComponent(parent, Canvas)) {
+            return parent;
+        }
+
+        let ancestor = parent.parent;
+        while (ancestor) {
+            if (hasOneKindOfComponent(ancestor, Canvas)) {
+                return ancestor;
+            }
+            if (ancestor === director.getScene()) {
+                break;
+            }
+            ancestor = ancestor.parent;
+        }
+
+        for (let index = parent.children.length - 1; index >= 0; index--) {
+            const child = parent.children[index];
+            if (hasOneKindOfComponent(child, Canvas)) {
+                return child;
+            }
+        }
+
+        return null;
+    }
+
     async _createNode(assetUuid: string | null, canvasNeeded: boolean, checkUITransform: boolean, params: ICreateByNodeTypeParams | ICreateByAssetParams, assetType?: string): Promise<INode | null> {
         const currentScene = Service.Editor.getRootNode();
         if (!currentScene) {
@@ -146,7 +275,7 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
 
         const workMode = params.workMode || '2d';
         // 使用增强的路径处理方法
-        let parent = await this._getOrCreateNodeByPath(params.path, currentScene);
+        let parent = await this._getOrCreateNodeByPath(params.path, currentScene, params.prefabCanvasHandling);
         if (!parent) {
             parent = currentScene;
         }
@@ -231,7 +360,7 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
     /**
      * 获取或创建路径节点
      */
-    private async _getOrCreateNodeByPath(path: string | undefined, currentScene: Node): Promise<Node | null> {
+    private async _getOrCreateNodeByPath(path: string | undefined, currentScene: Node, prefabCanvasHandling?: PrefabCanvasHandling): Promise<Node | null> {
         if (!path) {
             return null;
         }
@@ -248,13 +377,13 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
 
 
         // 如果不存在，则创建路径
-        return await this._ensurePathExists(path, currentScene);
+        return await this._ensurePathExists(path, currentScene, prefabCanvasHandling);
     }
 
     /**
      * 确保路径存在，如果不存在则创建空节点
      */
-    private async _ensurePathExists(path: string | undefined, currentScene: Node): Promise<Node | null> {
+    private async _ensurePathExists(path: string | undefined, currentScene: Node, prefabCanvasHandling?: PrefabCanvasHandling): Promise<Node | null> {
         if (!path) {
             return null;
         }
@@ -278,7 +407,7 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
 
             if (!nextNode) {
                 if (pathPart === 'Canvas') {
-                    nextNode = await this.checkCanvasRequired('2d', true, currentParent, undefined);
+                    nextNode = await this.checkCanvasRequired('2d', true, currentParent, undefined, prefabCanvasHandling);
                 } else {
                     // 创建空节点
                     nextNode = new Node(pathPart);
@@ -354,51 +483,6 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             }
             if (!node) return null;
             return sceneUtils.generateNodeDump(node, params);
-        } catch (error) {
-            console.error(error);
-            throw error;
-        } finally {
-            Service.Editor.unlock();
-        }
-    }
-
-    async queryCanvasContext(path: string): Promise<ICanvasContext> {
-        try {
-            await Service.Editor.lock();
-            const root = Service.Editor.getRootNode();
-            if (!root) {
-                throw new Error('Failed to query canvas context: the scene is not opened.');
-            }
-
-            const node = path === '/' ? root : NodeMgr.getNodeByPath(path);
-            if (!node) {
-                return { canvas: null, uiTransform: null };
-            }
-
-            const stopAtRoot = Service.Editor.getCurrentEditorType() === 'prefab'
-                ? root
-                : director.getScene() ?? root;
-            let current: Node | null = node;
-            let canvas: Node | null = null;
-            let uiTransform: Node | null = null;
-
-            while (current) {
-                if (!canvas && hasOneKindOfComponent(current, Canvas)) {
-                    canvas = current;
-                }
-                if (!uiTransform && hasOneKindOfComponent(current, UITransform)) {
-                    uiTransform = current;
-                }
-                if ((canvas && uiTransform) || current === stopAtRoot) {
-                    break;
-                }
-                current = current.parent;
-            }
-
-            return {
-                canvas: canvas ? sceneUtils.generateNodeIdentifier(canvas) : null,
-                uiTransform: uiTransform ? sceneUtils.generateNodeIdentifier(uiTransform) : null,
-            };
         } catch (error) {
             console.error(error);
             throw error;

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -20,15 +20,16 @@ import {
     type IMoveArrayElementParams,
     type IRemoveArrayElementParams,
     type IChangeNodeLockParams,
+    type PrefabCanvasHandling,
     NodeType,
     NodeEventType,
     ISetPropertyOptions,
 } from '../../common';
 import { type IScene } from '../../common/editor/scene';
 import { Rpc } from '../rpc';
-import { CCClass, CCObject, Component, Node, Prefab, Quat, Vec3 } from 'cc';
-import { createNodeByAsset, loadAny } from './node/node-create';
-import { getUICanvasNode, setLayer } from './node/node-utils';
+import { Canvas, CCClass, CCObject, Component, director, Node, Prefab, Quat, UITransform, Vec3 } from 'cc';
+import { createNodeByAsset, createShouldHideInHierarchyCanvasNode, loadAny } from './node/node-create';
+import { getUICanvasNode, getUITransformParentNode, hasOneKindOfComponent, setLayer } from './node/node-utils';
 import { NodeUndoHelper } from './node/node-undo';
 import { isUndoApplying } from './undo/applying-state';
 import { prefabUtils } from './prefab/utils';
@@ -54,19 +55,20 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             await Service.Editor.lock();
             const beforeNodeUuids = this._collectSceneNodeUuidsForUndo();
             const createRootPath = this._getCreateRootPathForUndo(beforeNodeUuids, params.path);
-            let canvasNeeded = params.canvasRequired || false;
+            const explicitCanvasRequired = Boolean(params.canvasRequired);
+            let canvasNeeded = explicitCanvasRequired;
             const nodeType = params.nodeType as string;
             const paramsArray = NodeConfig[nodeType];
             if (!paramsArray || paramsArray.length < 0) {
                 throw new Error(`Node type '${nodeType}' is not implemented`);
             }
             let assetUuid = paramsArray[0].assetUuid || null;
-            canvasNeeded = Boolean(paramsArray[0].canvasRequired);
+            canvasNeeded = explicitCanvasRequired || Boolean(paramsArray[0].canvasRequired);
             const projectType = paramsArray[0]['project-type'];
             const workMode = params.workMode;
             if (projectType && workMode && projectType !== workMode.toLowerCase() && paramsArray.length > 1) {
                 assetUuid = paramsArray[1]['assetUuid'] || null;
-                canvasNeeded = Boolean(paramsArray[1].canvasRequired);
+                canvasNeeded = explicitCanvasRequired || Boolean(paramsArray[1].canvasRequired);
             }
             const result = await this._createNode(assetUuid, canvasNeeded, params.nodeType == NodeType.EMPTY, params);
             this._undo.recordCreateNodeCommand(beforeNodeUuids, [createRootPath, result?.path].filter(Boolean) as string[]);
@@ -123,15 +125,16 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         }
 
         let resultNode;
+        let canvasRequired = canvasNeeded;
         if (assetUuid) {
-            const { node, canvasRequired } = await createNodeByAsset({
+            const createResult = await createNodeByAsset({
                 uuid: assetUuid,
                 canvasRequired: canvasNeeded,
                 type: assetType,
                 workMode: workMode,
             });
-            resultNode = node;
-            parent = await this.checkCanvasRequired(workMode.toLowerCase(), Boolean(canvasRequired), parent, params.position as Vec3) as Node;
+            resultNode = createResult.node;
+            canvasRequired = Boolean(canvasNeeded || createResult.canvasRequired);
         }
         if (!resultNode) {
             resultNode = new cc.Node();
@@ -140,6 +143,12 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         if (!resultNode) {
             return null;
         }
+
+        if (checkUITransform) {
+            nodeMgr.ensureUITransformComponent(resultNode);
+        }
+
+        parent = await this.checkCanvasRequired(workMode.toLowerCase(), Boolean(canvasRequired), parent, params.position as Vec3, params.prefabCanvasHandling) as Node;
 
         /**
          * 默认创建节点是从 prefab 模板，所以初始是 prefab 节点
@@ -186,10 +195,6 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         if (shouldUnlinkPrefab && Service.Editor.getCurrentEditorType() !== 'prefab') {
             Service.Prefab.removePrefabInfoFromNode(resultNode, true);
         }
-        if (checkUITransform) {
-            nodeMgr.ensureUITransformComponent(resultNode);
-        }
-
         // 发送添加节点事件，添加节点中的根节点
         this.emit('node:add', resultNode);
 
@@ -414,26 +419,51 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
      * @param position
      * @returns
      */
-    async checkCanvasRequired(workMode: string, canvasRequiredParam: boolean | undefined, parent: Node | null, position: Vec3 | undefined): Promise<Node | null> {
+    async checkCanvasRequired(
+        workMode: string,
+        canvasRequiredParam: boolean | undefined,
+        parent: Node | null,
+        position: Vec3 | undefined,
+        prefabCanvasHandling?: PrefabCanvasHandling,
+    ): Promise<Node | null> {
 
         if (canvasRequiredParam && parent?.isValid) {
             let canvasNode: Node | null;
+            const isPrefabMode = Service.Editor.getCurrentEditorType() === 'prefab';
 
-            canvasNode = getUICanvasNode(parent);
-            if (canvasNode) {
-                parent = canvasNode;
+            if (isPrefabMode) {
+                const rootNode = Service.Editor.getRootNode();
+                if (parent === director.getScene() && rootNode) {
+                    parent = rootNode;
+                }
+                canvasNode = getUICanvasNode(parent, false);
+                const uiTransformParentNode = getUITransformParentNode(parent);
+
+                if (!canvasNode) {
+                    if (uiTransformParentNode) {
+                        canvasNode = uiTransformParentNode;
+                    } else if (prefabCanvasHandling === 'add-root-ui-transform') {
+                        canvasNode = await this.ensurePrefabRootUITransform(workMode);
+                    } else if (prefabCanvasHandling === 'cancel' || !prefabCanvasHandling) {
+                        canvasNode = new Node();
+                    }
+                } else if (canvasNode.parent !== director.getScene()) {
+                    parent = canvasNode;
+                }
+            } else {
+                canvasNode = getUICanvasNode(parent);
+                if (canvasNode) {
+                    parent = canvasNode;
+                }
             }
 
             // 自动创建一个 canvas 节点
             if (!canvasNode) {
-                // TODO 这里会导致如果在 3D 场景下创建 2d canvas 摄像机的优先级跟主摄像机一样，
-                //  导致显示不出 UI 来，先都用 ui canvas
-                const canvasAssetUuid = 'f773db21-62b8-4540-956a-29bacf5ddbf5';
+                let canvasAssetUuid = 'f773db21-62b8-4540-956a-29bacf5ddbf5';
 
-                // // 2d 项目创建的 ui 节点，canvas 下的 camera 的 visibility 默认勾上 default
-                // if (workMode === '2d') {
-                //     canvasAssetUuid = '4c33600e-9ca9-483b-b734-946008261697';
-                // }
+                if (workMode === '2d') {
+                    canvasAssetUuid = '4c33600e-9ca9-483b-b734-946008261697';
+                }
 
                 const canvasAsset = await loadAny<Prefab>(canvasAssetUuid);
                 canvasNode = cc.instantiate(canvasAsset) as Node;
@@ -451,6 +481,25 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             }
         }
         return parent;
+    }
+
+    private async ensurePrefabRootUITransform(workMode: string): Promise<Node | null> {
+        const rootNode = Service.Editor.getRootNode();
+        if (!rootNode?.isValid) {
+            return null;
+        }
+
+        if (!hasOneKindOfComponent(rootNode, UITransform)) {
+            rootNode.addComponent('cc.UITransform');
+        }
+
+        if (rootNode.parent && !hasOneKindOfComponent(rootNode.parent, Canvas)) {
+            const canvasNode = await createShouldHideInHierarchyCanvasNode(director.getScene()!, workMode);
+            rootNode.parent = canvasNode;
+            return canvasNode;
+        }
+
+        return rootNode;
     }
 
     public onEditorOpened() {

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -38,9 +38,21 @@ import nodeMgr from './node/index';
 import NodeConfig from './node/node-type-config';
 import { RemoveNodeCommand } from './undo/commands/remove-node-command';
 import { RemoveComponentCommand } from './undo/commands/remove-component-command';
+import { PrefabPreviewCanvasCommand } from './undo/commands/prefab-preview-canvas-command';
 import { broadcastAnimationPropertyCommitted } from './animation/property-commit-event';
 
 const NodeMgr = EditorExtends.Node;
+
+interface IPrefabCanvasUndoRecord {
+    rootNode: Node;
+    rootParentUuid: string | null;
+    rootParentPath: string;
+    rootSiblingIndex: number;
+    addedUITransform: Component | null;
+    previewCanvasNode: Node | null;
+    previewCanvasCreated: boolean;
+    workMode: string;
+}
 
 /**
  * 子进程节点处理器
@@ -49,6 +61,8 @@ const NodeMgr = EditorExtends.Node;
 @register('Node')
 export class NodeService extends BaseService<INodeEvents> implements INodeService {
     private readonly _undo = new NodeUndoHelper((event, ...args) => this.emit(event as any, ...args));
+    private _prefabCanvasUndoRecords: IPrefabCanvasUndoRecord[] | null = null;
+    private _prefabCanvasUndoBeforeNodeUuids: Set<string> | null = null;
 
     async createByType(params: ICreateByNodeTypeParams): Promise<INode | null> {
         try {
@@ -70,8 +84,14 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
                 assetUuid = paramsArray[1]['assetUuid'] || null;
                 canvasNeeded = explicitCanvasRequired || Boolean(paramsArray[1].canvasRequired);
             }
-            const result = await this._createNode(assetUuid, canvasNeeded, params.nodeType == NodeType.EMPTY, params);
-            this._undo.recordCreateNodeCommand(beforeNodeUuids, [createRootPath, result?.path].filter(Boolean) as string[]);
+            const prefabCanvasUndoRecords = this._beginPrefabCanvasUndoCapture(beforeNodeUuids);
+            let result: INode | null;
+            try {
+                result = await this._createNode(assetUuid, canvasNeeded, params.nodeType == NodeType.EMPTY, params);
+            } finally {
+                this._endPrefabCanvasUndoCapture();
+            }
+            this._recordCreateNodeCommand(beforeNodeUuids, [createRootPath, result?.path].filter(Boolean) as string[], prefabCanvasUndoRecords);
             return result;
         } catch (error) {
             console.error(error);
@@ -100,8 +120,14 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             }
             const assetInfo = await Rpc.getInstance().request('assetManager', 'queryAssetInfo', [assetUuid]);
             const canvasNeeded = params.canvasRequired || false;
-            const result = await this._createNode(assetUuid, canvasNeeded, false, params, assetInfo?.type);
-            this._undo.recordCreateNodeCommand(beforeNodeUuids, [createRootPath, result?.path].filter(Boolean) as string[]);
+            const prefabCanvasUndoRecords = this._beginPrefabCanvasUndoCapture(beforeNodeUuids);
+            let result: INode | null;
+            try {
+                result = await this._createNode(assetUuid, canvasNeeded, false, params, assetInfo?.type);
+            } finally {
+                this._endPrefabCanvasUndoCapture();
+            }
+            this._recordCreateNodeCommand(beforeNodeUuids, [createRootPath, result?.path].filter(Boolean) as string[], prefabCanvasUndoRecords);
             return result;
         } catch (error) {
             console.error(error);
@@ -444,7 +470,7 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
                         canvasNode = uiTransformParentNode;
                     } else if (prefabCanvasHandling === 'add-root-ui-transform') {
                         canvasNode = await this.ensurePrefabRootUITransform(workMode);
-                    } else if (prefabCanvasHandling === 'cancel' || !prefabCanvasHandling) {
+                    } else if (!prefabCanvasHandling) {
                         canvasNode = new Node();
                     }
                 } else if (canvasNode.parent !== director.getScene()) {
@@ -489,17 +515,46 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             return null;
         }
 
+        const undoRecord = this._createPrefabCanvasUndoRecord(rootNode, workMode);
         if (!hasOneKindOfComponent(rootNode, UITransform)) {
-            rootNode.addComponent('cc.UITransform');
+            undoRecord.addedUITransform = rootNode.addComponent('cc.UITransform') as Component;
         }
 
         if (rootNode.parent && !hasOneKindOfComponent(rootNode.parent, Canvas)) {
             const canvasNode = await createShouldHideInHierarchyCanvasNode(director.getScene()!, workMode);
+            undoRecord.previewCanvasNode = canvasNode;
+            undoRecord.previewCanvasCreated = !this._prefabCanvasUndoBeforeNodeUuids?.has(canvasNode.uuid);
             rootNode.parent = canvasNode;
+            this._pushPrefabCanvasUndoRecord(undoRecord);
             return canvasNode;
         }
 
+        this._pushPrefabCanvasUndoRecord(undoRecord);
         return rootNode;
+    }
+
+    private _createPrefabCanvasUndoRecord(rootNode: Node, workMode: string): IPrefabCanvasUndoRecord {
+        const rootParent = rootNode.parent as Node | null;
+        return {
+            rootNode,
+            rootParentUuid: rootParent?.uuid ?? null,
+            rootParentPath: rootParent ? (NodeMgr.getNodePath(rootParent) ?? '/') : '/',
+            rootSiblingIndex: rootNode.getSiblingIndex(),
+            addedUITransform: null,
+            previewCanvasNode: null,
+            previewCanvasCreated: false,
+            workMode,
+        };
+    }
+
+    private _pushPrefabCanvasUndoRecord(record: IPrefabCanvasUndoRecord): void {
+        if (!this._prefabCanvasUndoRecords) {
+            return;
+        }
+        if (!record.addedUITransform && !record.previewCanvasNode) {
+            return;
+        }
+        this._prefabCanvasUndoRecords.push(record);
     }
 
     public onEditorOpened() {
@@ -601,6 +656,77 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             return null;
         }
         return this._undo.getCreateRootPath(path);
+    }
+
+    private _beginPrefabCanvasUndoCapture(beforeNodeUuids: Set<string> | null): IPrefabCanvasUndoRecord[] | null {
+        if (!beforeNodeUuids) {
+            return null;
+        }
+        const records: IPrefabCanvasUndoRecord[] = [];
+        this._prefabCanvasUndoRecords = records;
+        this._prefabCanvasUndoBeforeNodeUuids = beforeNodeUuids;
+        return records;
+    }
+
+    private _endPrefabCanvasUndoCapture(): void {
+        this._prefabCanvasUndoRecords = null;
+        this._prefabCanvasUndoBeforeNodeUuids = null;
+    }
+
+    private _recordCreateNodeCommand(
+        beforeNodeUuids: Set<string> | null,
+        preferredRootPaths: string[],
+        prefabCanvasUndoRecords: IPrefabCanvasUndoRecord[] | null,
+    ): void {
+        if (!prefabCanvasUndoRecords?.length) {
+            this._undo.recordCreateNodeCommand(beforeNodeUuids, preferredRootPaths);
+            return;
+        }
+
+        const ownsGroup = !Service.Undo?.isGroupActive?.();
+        const groupId = ownsGroup ? Service.Undo?.beginGroup?.({ label: 'Create Node' }) : null;
+        try {
+            this._recordPrefabCanvasUndoCommands(prefabCanvasUndoRecords);
+            this._undo.recordCreateNodeCommand(beforeNodeUuids, preferredRootPaths);
+            if (groupId) {
+                Service.Undo?.endGroup?.(groupId);
+            }
+        } catch (error) {
+            if (groupId) {
+                Service.Undo?.cancelGroup?.(groupId);
+            }
+            throw error;
+        }
+    }
+
+    private _recordPrefabCanvasUndoCommands(records: IPrefabCanvasUndoRecord[]): void {
+        for (const record of records) {
+            if (record.addedUITransform?.isValid) {
+                const command = this._captureAddComponentCommand(record.addedUITransform);
+                if (command) {
+                    Service.Undo?.push(command);
+                }
+            }
+
+            if (record.previewCanvasNode?.isValid) {
+                Service.Undo?.push(new PrefabPreviewCanvasCommand({
+                    rootUuid: record.rootNode.uuid,
+                    rootPath: NodeMgr.getNodePath(record.rootNode) ?? '',
+                    rootParentUuid: record.rootParentUuid,
+                    rootParentPath: record.rootParentPath,
+                    rootSiblingIndex: record.rootSiblingIndex,
+                    previewCanvasUuid: record.previewCanvasNode.uuid,
+                    previewCanvasPath: NodeMgr.getNodePath(record.previewCanvasNode) ?? '',
+                    removePreviewCanvasOnUndo: record.previewCanvasCreated,
+                    workMode: record.workMode,
+                }));
+            }
+        }
+    }
+
+    private _captureAddComponentCommand(component: Component) {
+        const { AddComponentCommand } = require('./undo/commands/add-component-command') as typeof import('./undo/commands/add-component-command');
+        return AddComponentCommand.capture(component);
     }
 
     private _captureReparentSnapshotsForUndo(nodes: Node[]) {

--- a/src/core/scene/scene-process/service/node/node-create.ts
+++ b/src/core/scene/scene-process/service/node/node-create.ts
@@ -12,6 +12,7 @@ import {
     Canvas,
     UITransform,
     Scene,
+    director,
     instantiate,
     CCObject,
 } from 'cc';
@@ -50,7 +51,7 @@ export async function createNodeByAsset(info: {
 
     let asset;
     let node;
-    let newCanvasRequired = canvasRequired ?? false;
+    let newCanvasRequired = Boolean(canvasRequired) || getCanvasRequiredByAssetType(type, workMode);
 
     switch (type) {
         case 'cc.AnimationClip':
@@ -127,11 +128,7 @@ export async function createNodeByAsset(info: {
             {
                 asset = await loadAny<Prefab>(uuid);
                 node = cc.instantiate(asset);
-                if (node) {
-                    if (node.getComponentsInChildren(UITransform).length > 0) {
-                        newCanvasRequired = node.getComponentsInChildren(Canvas).length === 0;
-                    }
-                }
+                newCanvasRequired = newCanvasRequired || Boolean(node && getPrefabCanvasRequired(node));
             }
             break;
         case 'cc.Script':
@@ -154,12 +151,7 @@ export async function createNodeByAsset(info: {
             {
                 asset = await loadAny<SpriteFrame>(uuid);
 
-                let useSpriteRenderer = false;
-                if (workMode === '3d') {
-                    const scene = cc.director.getScene();
-                    const hasCanvas = scene && scene.getComponentsInChildren(Canvas).length > 0;
-                    useSpriteRenderer = !hasCanvas;
-                }
+                const useSpriteRenderer = shouldUseSpriteRenderer(workMode);
 
                 const spritePrefabUuid = '9db8cd0b-cbe4-42e7-96a9-a239620c0a9d';
                 const spriteRendererPrefabUuid = '279ed042-5a65-4efe-9afb-2fc23c61e15a';
@@ -171,7 +163,6 @@ export async function createNodeByAsset(info: {
                 node.name = asset.name;
 
                 if (useSpriteRenderer) {
-                    newCanvasRequired = false;
                     const sprite: any = node.getComponent(cc.SpriteRenderer);
                     if (sprite) {
                         sprite.spriteFrame = asset;
@@ -293,6 +284,62 @@ export async function createNodeByAsset(info: {
         node,
         canvasRequired: newCanvasRequired,
     };
+}
+
+/**
+ * Resolve the Canvas requirement of an asset without attaching a node to the scene.
+ */
+export async function queryCanvasRequiredByAsset(info: {
+    uuid: string,
+    type?: string,
+    workMode?: string,
+}): Promise<boolean> {
+    if (info.type === 'cc.Prefab') {
+        const prefab = await loadAny<Prefab>(info.uuid);
+        const node = cc.instantiate(prefab) as Node;
+        try {
+            return getPrefabCanvasRequired(node);
+        } finally {
+            node.destroy();
+        }
+    }
+
+    return getCanvasRequiredByAssetType(info.type, info.workMode);
+}
+
+function getPrefabCanvasRequired(node: Node): boolean {
+    return node.getComponentsInChildren(UITransform).length > 0
+        && node.getComponentsInChildren(Canvas).length === 0;
+}
+
+function getCanvasRequiredByAssetType(type: string | undefined, workMode: string | undefined): boolean {
+    switch (type) {
+        case 'cc.BitmapFont':
+        case 'cc.LabelAtlas':
+        case 'cc.ParticleAsset':
+        case 'cc.TTFFont':
+        case 'cc.TiledMapAsset':
+        case 'cc.VideoClip':
+            return true;
+        case 'cc.SpriteFrame':
+            return !shouldUseSpriteRenderer(workMode);
+        case 'dragonBones.DragonBonesAsset':
+        case 'dragonBones.DragonBonesAtlasAsset':
+            return Boolean(cc.dragonBones);
+        case 'sp.SkeletonData':
+            return Boolean(cc.sp);
+        default:
+            return false;
+    }
+}
+
+function shouldUseSpriteRenderer(workMode: string | undefined): boolean {
+    if (workMode !== '3d') {
+        return false;
+    }
+
+    const scene = director.getScene();
+    return !scene || scene.getComponentsInChildren(Canvas).length === 0;
 }
 
 // 防止多次调用

--- a/src/core/scene/scene-process/service/node/node-create.ts
+++ b/src/core/scene/scene-process/service/node/node-create.ts
@@ -40,6 +40,23 @@ export async function loadAny<TAsset extends Asset>(uuid: string): Promise<TAsse
     });
 }
 
+async function loadCachedOrAny<TAsset extends Asset>(uuid: string): Promise<TAsset> {
+    const cached = assetManager.assets.get(uuid) as TAsset | undefined;
+    if (cached) {
+        return cached;
+    }
+
+    return new Promise<TAsset>((resolve, reject) => {
+        assetManager.loadAny<TAsset>(uuid, (error, asset) => {
+            if (error) {
+                reject(error);
+            } else {
+                resolve(asset);
+            }
+        });
+    });
+}
+
 export async function createNodeByAsset(info: {
     uuid: string,
     canvasRequired?: boolean,
@@ -295,7 +312,7 @@ export async function queryCanvasRequiredByAsset(info: {
     workMode?: string,
 }): Promise<boolean> {
     if (info.type === 'cc.Prefab') {
-        const prefab = await loadAny<Prefab>(info.uuid);
+        const prefab = await loadCachedOrAny<Prefab>(info.uuid);
         const node = cc.instantiate(prefab) as Node;
         try {
             return getPrefabCanvasRequired(node);

--- a/src/core/scene/scene-process/service/node/node-create.ts
+++ b/src/core/scene/scene-process/service/node/node-create.ts
@@ -317,13 +317,10 @@ export async function createShouldHideInHierarchyCanvasNode(scene: Scene, workMo
     }
 
     const creationPromise = (async () => {
-        const canvasAssetUuid = 'f773db21-62b8-4540-956a-29bacf5ddbf5';
-        // TODO 这里的需要知道当前场景是 2D 还是 3D，如果使用了 2D 的 canvas，
-        //  它的 camera 的优先级是为 0，会导致 3D 场景创建了 canvas 运行显示不出 UI 节点
-        //  目前先改注释掉，后续场景有 2D/3D 才去做判断
-        // if (workMode === '2d') {
-        //     canvasAssetUuid = '4c33600e-9ca9-483b-b734-946008261697';
-        // }
+        let canvasAssetUuid = 'f773db21-62b8-4540-956a-29bacf5ddbf5';
+        if (workMode === '2d') {
+            canvasAssetUuid = '4c33600e-9ca9-483b-b734-946008261697';
+        }
 
         const canvasAsset = await loadAny<Prefab>(canvasAssetUuid);
         // 实例化后是一个 prefab, 需要继续 unlink prefab

--- a/src/core/scene/scene-process/service/node/node-undo.ts
+++ b/src/core/scene/scene-process/service/node/node-undo.ts
@@ -336,6 +336,7 @@ export class NodeUndoHelper {
             .filter((node): node is Node => !!node?.isValid)
             .map(node => ({ node, path: NodeMgr.getNodePath(node) }))
             .filter(target => !!target.path)
+            .filter(target => !this._containsExistingNode(target.node, beforeNodeUuids))
             .filter(target => !target.node.parent || !newUuids.has(target.node.parent.uuid))
             .sort((a, b) => a.node.getSiblingIndex() - b.node.getSiblingIndex());
     }
@@ -347,6 +348,15 @@ export class NodeUndoHelper {
             }
             return !targets.some(other => other.node !== target.node && target.node.isChildOf(other.node));
         });
+    }
+
+    private _containsExistingNode(node: Node, beforeNodeUuids: Set<string>): boolean {
+        for (const child of node.children ?? []) {
+            if (beforeNodeUuids.has(child.uuid) || this._containsExistingNode(child as Node, beforeNodeUuids)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private _captureChildOrderSnapshot(parent: Node): Map<string, INodeChildOrderSnapshot> {

--- a/src/core/scene/scene-process/service/undo/commands/prefab-preview-canvas-command.ts
+++ b/src/core/scene/scene-process/service/undo/commands/prefab-preview-canvas-command.ts
@@ -1,0 +1,160 @@
+import { director, Node, Scene } from 'cc';
+import type { IUndoCommand, IUndoCommandMeta, IUndoRedoResult } from '../../../../common';
+import nodeMgr from '../../node/index';
+import { createShouldHideInHierarchyCanvasNode } from '../../node/node-create';
+import {
+    createUndoId,
+    failure,
+    getEditorExtends,
+    getEditorNodeManager,
+    getNodePath,
+    isNodeInCurrentScene,
+    success,
+} from './command-utils-shared';
+
+export interface IPrefabPreviewCanvasCommandOptions {
+    rootUuid: string;
+    rootPath: string;
+    rootParentUuid: string | null;
+    rootParentPath: string;
+    rootSiblingIndex: number;
+    previewCanvasUuid: string;
+    previewCanvasPath: string;
+    removePreviewCanvasOnUndo: boolean;
+    workMode: string;
+}
+
+export class PrefabPreviewCanvasCommand implements IUndoCommand {
+    meta: IUndoCommandMeta;
+    private _previewCanvasUuid: string;
+    private _previewCanvasPath: string;
+
+    constructor(private readonly _options: IPrefabPreviewCanvasCommandOptions) {
+        this.meta = {
+            id: createUndoId('prefab-preview-canvas'),
+            label: 'Update Prefab Preview Canvas',
+            type: 'prefab:preview-canvas',
+            scope: { editorType: 'scene' },
+            timestamp: Date.now(),
+        };
+        this._previewCanvasUuid = _options.previewCanvasUuid;
+        this._previewCanvasPath = _options.previewCanvasPath;
+    }
+
+    async undo(): Promise<IUndoRedoResult> {
+        const root = this._findRoot();
+        if (!root) {
+            return failure(this.meta, `Prefab root not found: ${this._options.rootPath || this._options.rootUuid}`);
+        }
+
+        const parent = this._findOriginalParent();
+        if (!parent) {
+            return failure(this.meta, `Prefab root parent not found: ${this._options.rootParentPath || this._options.rootParentUuid || '/'}`);
+        }
+
+        try {
+            if (root.parent !== parent) {
+                parent.addChild(root);
+            }
+            if (this._options.rootSiblingIndex >= 0) {
+                root.setSiblingIndex(this._options.rootSiblingIndex);
+            }
+
+            const previewCanvas = this._findPreviewCanvas();
+            if (this._options.removePreviewCanvasOnUndo && previewCanvas?.isValid && root.parent !== previewCanvas) {
+                nodeMgr.baseRemoveNode(previewCanvas);
+                this._unregisterNodeTree(previewCanvas);
+            }
+
+            return success(this.meta);
+        } catch (error) {
+            return failure(this.meta, error instanceof Error ? error.message : String(error));
+        }
+    }
+
+    async redo(): Promise<IUndoRedoResult> {
+        const root = this._findRoot();
+        if (!root) {
+            return failure(this.meta, `Prefab root not found: ${this._options.rootPath || this._options.rootUuid}`);
+        }
+
+        try {
+            let previewCanvas = this._findPreviewCanvas();
+            if (!previewCanvas) {
+                const scene = director.getScene() as Scene | null;
+                if (!scene) {
+                    return failure(this.meta, 'Scene not found');
+                }
+                previewCanvas = await createShouldHideInHierarchyCanvasNode(scene, this._options.workMode);
+                this._previewCanvasUuid = previewCanvas.uuid;
+                this._previewCanvasPath = getNodePath(previewCanvas);
+            }
+
+            if (root.parent !== previewCanvas) {
+                previewCanvas.addChild(root);
+            }
+            return success(this.meta);
+        } catch (error) {
+            return failure(this.meta, error instanceof Error ? error.message : String(error));
+        }
+    }
+
+    private _findRoot(): Node | null {
+        return this._findNode(this._options.rootUuid, this._options.rootPath);
+    }
+
+    private _findPreviewCanvas(): Node | null {
+        return this._findNode(this._previewCanvasUuid, this._previewCanvasPath);
+    }
+
+    private _findOriginalParent(): Node | null {
+        if (this._options.rootParentUuid || this._options.rootParentPath) {
+            const parent = this._findNode(this._options.rootParentUuid, this._options.rootParentPath);
+            if (parent) {
+                return parent;
+            }
+        }
+        return director.getScene() as Node | null;
+    }
+
+    private _findNode(uuid: string | null, path: string): Node | null {
+        const editorNode = getEditorNodeManager();
+        if (uuid) {
+            const byUuid = editorNode?.getNode?.(uuid) as Node | null;
+            if (isNodeInCurrentScene(byUuid)) {
+                return byUuid;
+            }
+        }
+
+        if (!path || path === '/') {
+            const scene = director.getScene() as Node | null;
+            return isNodeInCurrentScene(scene) ? scene : null;
+        }
+
+        try {
+            const byPath = editorNode?.getNodeByPath?.(path) as Node | null;
+            return isNodeInCurrentScene(byPath) ? byPath : null;
+        } catch (_error) {
+            return null;
+        }
+    }
+
+    private _unregisterNodeTree(node: Node): void {
+        const editorNode = getEditorNodeManager();
+        const editorComponent = getEditorExtends()?.Component;
+
+        for (const component of node.components ?? []) {
+            if (component?.uuid) {
+                editorComponent?.remove?.(component.uuid);
+            }
+        }
+
+        for (const child of node.children ?? []) {
+            this._unregisterNodeTree(child);
+        }
+
+        if (node.uuid) {
+            editorNode?.remove?.(node.uuid);
+        }
+    }
+}

--- a/src/core/scene/test/service-core/component-prefab-ui-handling.test.ts
+++ b/src/core/scene/test/service-core/component-prefab-ui-handling.test.ts
@@ -1,0 +1,219 @@
+const mockLock = jest.fn(async () => undefined);
+const mockUnlock = jest.fn();
+const mockGetRootNode = jest.fn();
+const mockGetNodeByPath = jest.fn();
+const mockCreateShouldHideInHierarchyCanvasNode = jest.fn();
+const mockOnComponentAddedFromEditor = jest.fn();
+const mockDumpComponent = jest.fn(() => ({ value: {} }));
+const mockCaptureMany = jest.fn(() => null);
+const mockGetClassById = jest.fn(() => null);
+const mockGetClassByName = jest.fn((name: string) => name === 'cc.UITransform' ? MockUITransform : null);
+const mockIsChildClassOf = jest.fn(() => true);
+const mockScene = { name: 'Scene' };
+
+class MockCanvas {}
+class MockComponent {
+    uuid = `component-${Math.random()}`;
+}
+class MockUITransform extends MockComponent {}
+
+class MockNode {
+    uuid: string;
+    name: string;
+    parent: MockNode | null = null;
+    children: MockNode[] = [];
+    components: any[] = [];
+    addComponent = jest.fn((component: any) => {
+        const instance = component === 'cc.UITransform' ? new MockUITransform() : new component();
+        this.components.push(instance);
+        return instance;
+    });
+    getComponent = jest.fn((component: any) => this.components.find((item) => item instanceof component) || null);
+
+    constructor(name = 'Node') {
+        this.name = name;
+        this.uuid = `${name}-uuid`;
+    }
+}
+
+(global as any).cc = {
+    js: {
+        getClassById: mockGetClassById,
+        getClassByName: mockGetClassByName,
+        isChildClassOf: mockIsChildClassOf,
+    },
+};
+
+(global as any).EditorExtends = {
+    Node: {
+        getNodeByPath: mockGetNodeByPath,
+    },
+};
+
+jest.mock('cc', () => ({
+    Animation: class Animation {},
+    animation: { AnimationController: class AnimationController {} },
+    Canvas: MockCanvas,
+    Collider: class Collider {},
+    Component: MockComponent,
+    Constructor: Function,
+    director: { getScene: jest.fn(() => mockScene) },
+    ERigidBodyType: {},
+    EColliderType: {},
+    MeshCollider: class MeshCollider {},
+    Node: MockNode,
+    RigidBody: class RigidBody {},
+    UITransform: MockUITransform,
+    js: {
+        getClassById: mockGetClassById,
+        getClassByName: mockGetClassByName,
+        isChildClassOf: mockIsChildClassOf,
+    },
+}));
+
+jest.mock('../../scene-process/service/core', () => ({
+    BaseService: class BaseService {
+        emit = jest.fn();
+    },
+    register: () => () => undefined,
+    Service: {
+        Editor: {
+            lock: mockLock,
+            unlock: mockUnlock,
+            getRootNode: mockGetRootNode,
+        },
+        Script: {
+            queryScriptCid: jest.fn(),
+            isCustomComponent: jest.fn(() => false),
+        },
+        Undo: {
+            push: jest.fn(),
+            isApplying: jest.fn(() => false),
+        },
+    },
+}));
+
+jest.mock('../../scene-process/rpc', () => ({
+    Rpc: { getInstance: () => ({ request: jest.fn() }) },
+}));
+
+jest.mock('../../scene-process/service/dump', () => ({
+    __esModule: true,
+    default: { dumpComponent: mockDumpComponent },
+}));
+
+jest.mock('../../scene-process/service/component/index', () => ({
+    __esModule: true,
+    default: { onComponentAddedFromEditor: mockOnComponentAddedFromEditor },
+}));
+
+jest.mock('../../scene-process/service/component/utils', () => ({
+    __esModule: true,
+    default: { isUUID: jest.fn(() => false) },
+}));
+
+jest.mock('../../scene-process/service/component/get-component-function-of-node', () => jest.fn());
+
+jest.mock('../../scene-process/service/node/node-utils', () => ({
+    hasOneKindOfComponent: (node: MockNode, kind: any) => node.components.some((component) => component instanceof kind),
+    isEditorNode: jest.fn(() => false),
+}));
+
+jest.mock('../../scene-process/service/node/node-create', () => ({
+    createShouldHideInHierarchyCanvasNode: mockCreateShouldHideInHierarchyCanvasNode,
+}));
+
+jest.mock('../../scene-process/service/prefab', () => ({
+    __esModule: true,
+    default: {
+        onRemoveComponentInGeneralMode: jest.fn(),
+        onComponentRemovedInGeneralMode: jest.fn(),
+    },
+}));
+
+jest.mock('../../scene-process/service/undo/commands/add-component-command', () => ({
+    AddComponentCommand: { captureMany: mockCaptureMany },
+}));
+
+jest.mock('../../scene-process/service/undo/commands/remove-component-command', () => ({
+    RemoveComponentCommand: {},
+}));
+
+jest.mock('../../scene-process/service/undo/commands/snapshot-command', () => ({
+    SnapshotCommand: {},
+}));
+
+jest.mock('../../scene-process/service/undo/commands/command-utils-shared', () => ({
+    createUndoId: jest.fn(() => 'undo-id'),
+    restoreComponentSnapshotDump: jest.fn(),
+    snapshotMapsEqual: jest.fn(() => true),
+}));
+
+jest.mock('../../scene-process/service/undo/applying-state', () => ({
+    isUndoApplying: jest.fn(() => false),
+}));
+
+jest.mock('../../scene-process/service/animation/property-commit-event', () => ({
+    broadcastAnimationPropertyCommitted: jest.fn(),
+}));
+
+describe('ComponentService prefab UI handling', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        const root = new MockNode('PrefabRoot');
+        root.parent = new MockNode('Scene');
+        mockGetRootNode.mockReturnValue(root);
+        mockGetNodeByPath.mockReturnValue(new MockNode('Target'));
+        mockCreateShouldHideInHierarchyCanvasNode.mockResolvedValue(new MockNode('PreviewCanvas'));
+    });
+
+    async function addUITransform(params: Record<string, unknown> = {}) {
+        const { ComponentService } = require('../../scene-process/service/component');
+        const service = new ComponentService();
+        service.modeName = 'prefab';
+        await service.add({
+            nodePath: '/Target',
+            component: 'cc.UITransform',
+            ...params,
+        });
+        return service;
+    }
+
+    it('creates a hidden Canvas parent for prefab UI components', async () => {
+        const root = mockGetRootNode();
+
+        await addUITransform();
+
+        expect(root.addComponent).not.toHaveBeenCalledWith('cc.UITransform');
+        expect(mockCreateShouldHideInHierarchyCanvasNode).toHaveBeenCalledWith(mockScene);
+        expect(root.parent?.name).toBe('PreviewCanvas');
+        expect(mockOnComponentAddedFromEditor).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not create a hidden Canvas when the prefab root already has Canvas', async () => {
+        const root = mockGetRootNode();
+
+        root.addComponent(MockCanvas);
+
+        await addUITransform();
+
+        expect(root.addComponent).not.toHaveBeenCalledWith('cc.UITransform');
+        expect(mockCreateShouldHideInHierarchyCanvasNode).not.toHaveBeenCalled();
+        expect(root.parent?.name).toBe('Scene');
+    });
+
+    it('keeps prefab UI component handling when adding component arrays', async () => {
+        const root = mockGetRootNode();
+        const { ComponentService } = require('../../scene-process/service/component');
+        const service = new ComponentService();
+        service.modeName = 'prefab';
+
+        await service.add({
+            nodePath: '/Target',
+            component: ['cc.UITransform', 'cc.UITransform'],
+        });
+
+        expect(mockCreateShouldHideInHierarchyCanvasNode).toHaveBeenCalledTimes(2);
+        expect(root.addComponent).not.toHaveBeenCalledWith('cc.UITransform');
+    });
+});

--- a/src/core/scene/test/service-core/node-create-canvas-required.test.ts
+++ b/src/core/scene/test/service-core/node-create-canvas-required.test.ts
@@ -37,7 +37,9 @@ class MockNode {
     setParent = jest.fn((parent: MockNode | null) => {
         this.parent = parent;
     });
-    getChildByName = jest.fn((name: string) => this.children.find(child => child.name === name) ?? null);
+    getChildByName: (name: string) => MockNode | null = jest.fn((name: string): MockNode | null => (
+        this.children.find((child: MockNode): boolean => child.name === name) ?? null
+    ));
     getSiblingIndex = jest.fn(() => this.parent?.children.indexOf(this) ?? 0);
 
     constructor(name = 'Node') {
@@ -267,11 +269,12 @@ describe('NodeService Canvas requirement handling', () => {
             path: '/',
             nodeType: NodeType.BUTTON,
             workMode: '2d',
-        })).resolves.toEqual({
+        })).resolves.toMatchObject({
             action: 'choose-prefab-canvas-handling',
             canvasRequired: true,
             canvasPath: null,
             uiTransformPath: null,
+            preflightToken: expect.any(String),
         });
     });
 
@@ -287,11 +290,12 @@ describe('NodeService Canvas requirement handling', () => {
             path: '/',
             nodeType: NodeType.BUTTON,
             workMode: '2d',
-        })).resolves.toEqual({
+        })).resolves.toMatchObject({
             action: 'create',
             canvasRequired: true,
             canvasPath: null,
             uiTransformPath: '/PrefabRoot',
+            preflightToken: expect.any(String),
         });
     });
 
@@ -307,11 +311,33 @@ describe('NodeService Canvas requirement handling', () => {
             path: '/',
             nodeType: NodeType.BUTTON,
             workMode: '2d',
-        })).resolves.toEqual({
+        })).resolves.toMatchObject({
             action: 'create',
             canvasRequired: true,
             canvasPath: '/PrefabRoot',
             uiTransformPath: null,
+            preflightToken: expect.any(String),
+        });
+    });
+
+    it('reports the same Canvas node used by the creation context', async () => {
+        mockGetCurrentEditorType.mockReturnValue('prefab');
+        const root = new MockNode('PrefabRoot');
+        const canvasContext = new MockNode('ReusableCanvas');
+        mockGetRootNode.mockReturnValue(root);
+        mockGetUICanvasNode.mockReturnValue(canvasContext);
+        const { NodeService } = require('../../scene-process/service/node');
+
+        await expect(new NodeService().preflightCreate({
+            path: '/',
+            nodeType: NodeType.BUTTON,
+            workMode: '2d',
+        })).resolves.toMatchObject({
+            action: 'create',
+            canvasRequired: true,
+            canvasPath: '/ReusableCanvas',
+            uiTransformPath: null,
+            preflightToken: expect.any(String),
         });
     });
 
@@ -325,11 +351,12 @@ describe('NodeService Canvas requirement handling', () => {
             path: '/PrefabRoot/NewParent',
             nodeType: NodeType.BUTTON,
             workMode: '2d',
-        })).resolves.toEqual({
+        })).resolves.toMatchObject({
             action: 'create',
             canvasRequired: true,
             canvasPath: null,
             uiTransformPath: null,
+            preflightToken: expect.any(String),
         });
     });
 
@@ -348,17 +375,44 @@ describe('NodeService Canvas requirement handling', () => {
             path: '/',
             dbURL: 'db://assets/font.fnt',
             workMode: '2d',
-        })).resolves.toEqual({
+        })).resolves.toMatchObject({
             action: 'choose-prefab-canvas-handling',
             canvasRequired: true,
             canvasPath: null,
             uiTransformPath: null,
+            preflightToken: expect.any(String),
         });
         expect(mockQueryCanvasRequiredByAsset).toHaveBeenCalledWith({
             uuid: 'asset-uuid',
             type: 'cc.BitmapFont',
             workMode: '2d',
         });
+    });
+
+    it('rejects a stale direct-create preflight token when prefab Canvas handling becomes required', async () => {
+        const root = new MockNode('PrefabRoot');
+        mockGetRootNode.mockReturnValue(root);
+        const { NodeService } = require('../../scene-process/service/node');
+        const service = new NodeService();
+        service._createNode = jest.fn().mockResolvedValue({ path: '/Node' });
+
+        const preflight = await service.preflightCreate({
+            path: '/',
+            nodeType: NodeType.BUTTON,
+            workMode: '2d',
+        });
+        expect(preflight.action).toBe('create');
+
+        mockGetCurrentEditorType.mockReturnValue('prefab');
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        await expect(service.createByType({
+            path: '/',
+            nodeType: NodeType.BUTTON,
+            workMode: '2d',
+            preflightToken: preflight.preflightToken,
+        })).rejects.toThrow('Canvas context changed after preflight');
+        consoleError.mockRestore();
+        expect(service._createNode).not.toHaveBeenCalled();
     });
 
 });

--- a/src/core/scene/test/service-core/node-create-canvas-required.test.ts
+++ b/src/core/scene/test/service-core/node-create-canvas-required.test.ts
@@ -131,7 +131,14 @@ jest.mock('../../scene-process/service/prefab/utils', () => ({
 }));
 
 jest.mock('../../scene-process/service/scene/utils', () => ({
-    sceneUtils: { generateNodeDump: jest.fn((node: MockNode) => ({ path: `/${node.name}` })) },
+    sceneUtils: {
+        generateNodeDump: jest.fn((node: MockNode) => ({ path: `/${node.name}` })),
+        generateNodeIdentifier: jest.fn((node: MockNode) => ({
+            nodeId: node.uuid,
+            path: `/${node.name}`,
+            name: node.name,
+        })),
+    },
 }));
 
 jest.mock('../../scene-process/service/undo/commands/remove-node-command', () => ({
@@ -247,5 +254,42 @@ describe('NodeService Canvas requirement handling', () => {
 
         expect(mockLoadAny).not.toHaveBeenCalled();
         expect(mockInstantiate).not.toHaveBeenCalled();
+    });
+
+    it('queries the nearest Canvas and UITransform ancestors independently', async () => {
+        const canvasRoot = new MockNode('CanvasRoot');
+        const uiParent = new MockNode('UIParent');
+        const target = new MockNode('Target');
+        canvasRoot.components.push(new MockCanvas(), new MockUITransform());
+        uiParent.components.push(new MockUITransform());
+        canvasRoot.addChild(uiParent);
+        uiParent.addChild(target);
+        mockGetRootNode.mockReturnValue(canvasRoot);
+        (global as any).EditorExtends.Node.getNodeByPath.mockReturnValue(target);
+
+        const { NodeService } = require('../../scene-process/service/node');
+        const result = await new NodeService().queryCanvasContext('/CanvasRoot/UIParent/Target');
+
+        expect(result).toEqual({
+            canvas: { nodeId: 'CanvasRoot-uuid', path: '/CanvasRoot', name: 'CanvasRoot' },
+            uiTransform: { nodeId: 'UIParent-uuid', path: '/UIParent', name: 'UIParent' },
+        });
+    });
+
+    it('does not search above the prefab root', async () => {
+        mockGetCurrentEditorType.mockReturnValue('prefab');
+        const sceneCanvas = new MockNode('SceneCanvas');
+        const prefabRoot = new MockNode('PrefabRoot');
+        const target = new MockNode('Target');
+        sceneCanvas.components.push(new MockCanvas(), new MockUITransform());
+        sceneCanvas.addChild(prefabRoot);
+        prefabRoot.addChild(target);
+        mockGetRootNode.mockReturnValue(prefabRoot);
+        (global as any).EditorExtends.Node.getNodeByPath.mockReturnValue(target);
+
+        const { NodeService } = require('../../scene-process/service/node');
+        const result = await new NodeService().queryCanvasContext('/PrefabRoot/Target');
+
+        expect(result).toEqual({ canvas: null, uiTransform: null });
     });
 });

--- a/src/core/scene/test/service-core/node-create-canvas-required.test.ts
+++ b/src/core/scene/test/service-core/node-create-canvas-required.test.ts
@@ -167,6 +167,7 @@ describe('NodeService Canvas requirement handling', () => {
         mockInstantiate.mockImplementation(() => new MockNode('Canvas'));
         mockQueryCanvasRequiredByAsset.mockResolvedValue(false);
         mockRpcRequest.mockReset();
+        (global as any).EditorExtends.Node.getNodeByPath.mockReturnValue(null);
     });
 
     it('keeps empty nodes plain unless Canvas is explicitly requested', async () => {
@@ -267,6 +268,26 @@ describe('NodeService Canvas requirement handling', () => {
 
         await expect(new NodeService().preflightCreate({
             path: '/',
+            nodeType: NodeType.BUTTON,
+            workMode: '2d',
+        })).resolves.toMatchObject({
+            action: 'choose-prefab-canvas-handling',
+            canvasRequired: true,
+            canvasPath: null,
+            uiTransformPath: null,
+            preflightToken: expect.any(String),
+        });
+    });
+
+    it('resolves an existing Prefab root path before predicting missing path materialization', async () => {
+        mockGetCurrentEditorType.mockReturnValue('prefab');
+        const root = new MockNode('Node');
+        mockGetRootNode.mockReturnValue(root);
+        (global as any).EditorExtends.Node.getNodeByPath.mockReturnValue(root);
+        const { NodeService } = require('../../scene-process/service/node');
+
+        await expect(new NodeService().preflightCreate({
+            path: 'Node',
             nodeType: NodeType.BUTTON,
             workMode: '2d',
         })).resolves.toMatchObject({

--- a/src/core/scene/test/service-core/node-create-canvas-required.test.ts
+++ b/src/core/scene/test/service-core/node-create-canvas-required.test.ts
@@ -6,6 +6,8 @@ const mockRemovePrefabInfoFromNode = jest.fn();
 const mockCreateNodeByAsset = jest.fn();
 const mockCreateShouldHideInHierarchyCanvasNode = jest.fn();
 const mockLoadAny = jest.fn();
+const mockQueryCanvasRequiredByAsset = jest.fn();
+const mockRpcRequest = jest.fn();
 const mockGetUICanvasNode = jest.fn();
 const mockGetUITransformParentNode = jest.fn();
 const mockInstantiate = jest.fn();
@@ -35,6 +37,7 @@ class MockNode {
     setParent = jest.fn((parent: MockNode | null) => {
         this.parent = parent;
     });
+    getChildByName = jest.fn((name: string) => this.children.find(child => child.name === name) ?? null);
     getSiblingIndex = jest.fn(() => this.parent?.children.indexOf(this) ?? 0);
 
     constructor(name = 'Node') {
@@ -94,13 +97,14 @@ jest.mock('../../scene-process/service/core', () => ({
 }));
 
 jest.mock('../../scene-process/rpc', () => ({
-    Rpc: { getInstance: () => ({ request: jest.fn() }) },
+    Rpc: { getInstance: () => ({ request: mockRpcRequest }) },
 }));
 
 jest.mock('../../scene-process/service/node/node-create', () => ({
     createNodeByAsset: mockCreateNodeByAsset,
     createShouldHideInHierarchyCanvasNode: mockCreateShouldHideInHierarchyCanvasNode,
     loadAny: mockLoadAny,
+    queryCanvasRequiredByAsset: mockQueryCanvasRequiredByAsset,
 }));
 
 jest.mock('../../scene-process/service/node/node-utils', () => ({
@@ -133,11 +137,6 @@ jest.mock('../../scene-process/service/prefab/utils', () => ({
 jest.mock('../../scene-process/service/scene/utils', () => ({
     sceneUtils: {
         generateNodeDump: jest.fn((node: MockNode) => ({ path: `/${node.name}` })),
-        generateNodeIdentifier: jest.fn((node: MockNode) => ({
-            nodeId: node.uuid,
-            path: `/${node.name}`,
-            name: node.name,
-        })),
     },
 }));
 
@@ -164,6 +163,8 @@ describe('NodeService Canvas requirement handling', () => {
         mockGetUITransformParentNode.mockReturnValue(null);
         mockLoadAny.mockResolvedValue({});
         mockInstantiate.mockImplementation(() => new MockNode('Canvas'));
+        mockQueryCanvasRequiredByAsset.mockResolvedValue(false);
+        mockRpcRequest.mockReset();
     });
 
     it('keeps empty nodes plain unless Canvas is explicitly requested', async () => {
@@ -256,40 +257,108 @@ describe('NodeService Canvas requirement handling', () => {
         expect(mockInstantiate).not.toHaveBeenCalled();
     });
 
-    it('queries the nearest Canvas and UITransform ancestors independently', async () => {
-        const canvasRoot = new MockNode('CanvasRoot');
-        const uiParent = new MockNode('UIParent');
-        const target = new MockNode('Target');
-        canvasRoot.components.push(new MockCanvas(), new MockUITransform());
-        uiParent.components.push(new MockUITransform());
-        canvasRoot.addChild(uiParent);
-        uiParent.addChild(target);
-        mockGetRootNode.mockReturnValue(canvasRoot);
-        (global as any).EditorExtends.Node.getNodeByPath.mockReturnValue(target);
-
+    it('asks the host to choose prefab Canvas handling only when creation needs it', async () => {
+        mockGetCurrentEditorType.mockReturnValue('prefab');
+        const root = new MockNode('PrefabRoot');
+        mockGetRootNode.mockReturnValue(root);
         const { NodeService } = require('../../scene-process/service/node');
-        const result = await new NodeService().queryCanvasContext('/CanvasRoot/UIParent/Target');
 
-        expect(result).toEqual({
-            canvas: { nodeId: 'CanvasRoot-uuid', path: '/CanvasRoot', name: 'CanvasRoot' },
-            uiTransform: { nodeId: 'UIParent-uuid', path: '/UIParent', name: 'UIParent' },
+        await expect(new NodeService().preflightCreate({
+            path: '/',
+            nodeType: NodeType.BUTTON,
+            workMode: '2d',
+        })).resolves.toEqual({
+            action: 'choose-prefab-canvas-handling',
+            canvasRequired: true,
+            canvasPath: null,
+            uiTransformPath: null,
         });
     });
 
-    it('does not search above the prefab root', async () => {
+    it('returns existing UI context paths when creation can proceed directly', async () => {
         mockGetCurrentEditorType.mockReturnValue('prefab');
-        const sceneCanvas = new MockNode('SceneCanvas');
-        const prefabRoot = new MockNode('PrefabRoot');
-        const target = new MockNode('Target');
-        sceneCanvas.components.push(new MockCanvas(), new MockUITransform());
-        sceneCanvas.addChild(prefabRoot);
-        prefabRoot.addChild(target);
-        mockGetRootNode.mockReturnValue(prefabRoot);
-        (global as any).EditorExtends.Node.getNodeByPath.mockReturnValue(target);
-
+        const root = new MockNode('PrefabRoot');
+        root.components.push(new MockUITransform());
+        mockGetRootNode.mockReturnValue(root);
+        mockGetUITransformParentNode.mockReturnValue(root);
         const { NodeService } = require('../../scene-process/service/node');
-        const result = await new NodeService().queryCanvasContext('/PrefabRoot/Target');
 
-        expect(result).toEqual({ canvas: null, uiTransform: null });
+        await expect(new NodeService().preflightCreate({
+            path: '/',
+            nodeType: NodeType.BUTTON,
+            workMode: '2d',
+        })).resolves.toEqual({
+            action: 'create',
+            canvasRequired: true,
+            canvasPath: null,
+            uiTransformPath: '/PrefabRoot',
+        });
     });
+
+    it('returns the reusable Canvas path when Canvas context exists', async () => {
+        mockGetCurrentEditorType.mockReturnValue('prefab');
+        const root = new MockNode('PrefabRoot');
+        root.components.push(new MockCanvas());
+        mockGetRootNode.mockReturnValue(root);
+        mockGetUICanvasNode.mockReturnValue(root);
+        const { NodeService } = require('../../scene-process/service/node');
+
+        await expect(new NodeService().preflightCreate({
+            path: '/',
+            nodeType: NodeType.BUTTON,
+            workMode: '2d',
+        })).resolves.toEqual({
+            action: 'create',
+            canvasRequired: true,
+            canvasPath: '/PrefabRoot',
+            uiTransformPath: null,
+        });
+    });
+
+    it('does not prompt when a missing ordinary parent path will create UITransform', async () => {
+        mockGetCurrentEditorType.mockReturnValue('prefab');
+        const root = new MockNode('PrefabRoot');
+        mockGetRootNode.mockReturnValue(root);
+        const { NodeService } = require('../../scene-process/service/node');
+
+        await expect(new NodeService().preflightCreate({
+            path: '/PrefabRoot/NewParent',
+            nodeType: NodeType.BUTTON,
+            workMode: '2d',
+        })).resolves.toEqual({
+            action: 'create',
+            canvasRequired: true,
+            canvasPath: null,
+            uiTransformPath: null,
+        });
+    });
+
+    it('derives Canvas requirements from assets during preflight', async () => {
+        mockGetCurrentEditorType.mockReturnValue('prefab');
+        mockGetRootNode.mockReturnValue(new MockNode('PrefabRoot'));
+        mockRpcRequest.mockImplementation((_service: string, method: string) => {
+            if (method === 'queryUUID') return 'asset-uuid';
+            if (method === 'queryAssetInfo') return { type: 'cc.BitmapFont' };
+            return null;
+        });
+        mockQueryCanvasRequiredByAsset.mockResolvedValue(true);
+        const { NodeService } = require('../../scene-process/service/node');
+
+        await expect(new NodeService().preflightCreate({
+            path: '/',
+            dbURL: 'db://assets/font.fnt',
+            workMode: '2d',
+        })).resolves.toEqual({
+            action: 'choose-prefab-canvas-handling',
+            canvasRequired: true,
+            canvasPath: null,
+            uiTransformPath: null,
+        });
+        expect(mockQueryCanvasRequiredByAsset).toHaveBeenCalledWith({
+            uuid: 'asset-uuid',
+            type: 'cc.BitmapFont',
+            workMode: '2d',
+        });
+    });
+
 });

--- a/src/core/scene/test/service-core/node-create-canvas-required.test.ts
+++ b/src/core/scene/test/service-core/node-create-canvas-required.test.ts
@@ -35,6 +35,7 @@ class MockNode {
     setParent = jest.fn((parent: MockNode | null) => {
         this.parent = parent;
     });
+    getSiblingIndex = jest.fn(() => this.parent?.children.indexOf(this) ?? 0);
 
     constructor(name = 'Node') {
         this.name = name;

--- a/src/core/scene/test/service-core/node-create-canvas-required.test.ts
+++ b/src/core/scene/test/service-core/node-create-canvas-required.test.ts
@@ -1,0 +1,250 @@
+const mockLock = jest.fn(async () => undefined);
+const mockUnlock = jest.fn();
+const mockGetCurrentEditorType = jest.fn(() => 'scene');
+const mockGetRootNode = jest.fn();
+const mockRemovePrefabInfoFromNode = jest.fn();
+const mockCreateNodeByAsset = jest.fn();
+const mockCreateShouldHideInHierarchyCanvasNode = jest.fn();
+const mockLoadAny = jest.fn();
+const mockGetUICanvasNode = jest.fn();
+const mockGetUITransformParentNode = jest.fn();
+const mockInstantiate = jest.fn();
+const mockScene = { name: 'Scene' };
+
+class MockCanvas {}
+class MockUITransform {}
+
+class MockNode {
+    uuid: string;
+    name: string;
+    parent: MockNode | null = null;
+    children: MockNode[] = [];
+    components: any[] = [];
+    layer = 0;
+    position = { z: 0 };
+    addChild = jest.fn((node: MockNode) => {
+        this.children.push(node);
+        node.parent = this;
+    });
+    addComponent = jest.fn((component: any) => {
+        const instance = component === 'cc.UITransform' ? new MockUITransform() : new component();
+        this.components.push(instance);
+        return instance;
+    });
+    setPosition = jest.fn();
+    setParent = jest.fn((parent: MockNode | null) => {
+        this.parent = parent;
+    });
+
+    constructor(name = 'Node') {
+        this.name = name;
+        this.uuid = `${name}-uuid`;
+    }
+
+    get isValid() {
+        return true;
+    }
+}
+
+(global as any).EditorExtends = {
+    Node: {
+        getNodeByPath: jest.fn(),
+        getNodePath: jest.fn((node: MockNode) => `/${node.name}`),
+    },
+};
+
+(global as any).cc = {
+    instantiate: mockInstantiate,
+    UITransform: MockUITransform,
+};
+
+jest.mock('cc', () => ({
+    Canvas: MockCanvas,
+    CCClass: { getInheritanceChain: jest.fn(() => []) },
+    CCObject: { Flags: { HideInHierarchy: 1, LockedInEditor: 2 } },
+    Component: class Component {},
+    director: { getScene: jest.fn(() => mockScene) },
+    Node: MockNode,
+    Prefab: class Prefab {},
+    Quat: class Quat {},
+    UITransform: MockUITransform,
+    Vec3: class Vec3 {},
+}));
+
+jest.mock('../../scene-process/service/core', () => ({
+    BaseService: class BaseService {
+        emit = jest.fn();
+    },
+    register: () => () => undefined,
+    Service: {
+        Editor: {
+            lock: mockLock,
+            unlock: mockUnlock,
+            getCurrentEditorType: mockGetCurrentEditorType,
+            getRootNode: mockGetRootNode,
+        },
+        Prefab: {
+            removePrefabInfoFromNode: mockRemovePrefabInfoFromNode,
+        },
+        Undo: {
+            push: jest.fn(),
+        },
+    },
+}));
+
+jest.mock('../../scene-process/rpc', () => ({
+    Rpc: { getInstance: () => ({ request: jest.fn() }) },
+}));
+
+jest.mock('../../scene-process/service/node/node-create', () => ({
+    createNodeByAsset: mockCreateNodeByAsset,
+    createShouldHideInHierarchyCanvasNode: mockCreateShouldHideInHierarchyCanvasNode,
+    loadAny: mockLoadAny,
+}));
+
+jest.mock('../../scene-process/service/node/node-utils', () => ({
+    getUICanvasNode: mockGetUICanvasNode,
+    getUITransformParentNode: mockGetUITransformParentNode,
+    hasOneKindOfComponent: (node: MockNode, kind: any) => node.components.some((component) => component instanceof kind),
+    setLayer: jest.fn(),
+}));
+
+jest.mock('../../scene-process/service/node/node-undo', () => ({
+    NodeUndoHelper: jest.fn().mockImplementation(() => ({
+        shouldRecordStructureCommand: jest.fn(() => false),
+        collectSceneNodeUuids: jest.fn(() => new Set()),
+        getCreateRootPath: jest.fn(() => null),
+        recordCreateNodeCommand: jest.fn(),
+    })),
+}));
+
+jest.mock('../../scene-process/service/node/index', () => ({
+    __esModule: true,
+    default: {
+        ensureUITransformComponent: jest.fn((node: MockNode) => node.addComponent('cc.UITransform')),
+    },
+}));
+
+jest.mock('../../scene-process/service/prefab/utils', () => ({
+    prefabUtils: { getPrefabStateInfo: jest.fn(() => ({})) },
+}));
+
+jest.mock('../../scene-process/service/scene/utils', () => ({
+    sceneUtils: { generateNodeDump: jest.fn((node: MockNode) => ({ path: `/${node.name}` })) },
+}));
+
+jest.mock('../../scene-process/service/undo/commands/remove-node-command', () => ({
+    RemoveNodeCommand: {},
+}));
+
+jest.mock('../../scene-process/service/undo/commands/remove-component-command', () => ({
+    RemoveComponentCommand: {},
+}));
+
+jest.mock('../../scene-process/service/animation/property-commit-event', () => ({
+    broadcastAnimationPropertyCommitted: jest.fn(),
+}));
+
+import { NodeType } from '../../common';
+
+describe('NodeService Canvas requirement handling', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockGetCurrentEditorType.mockReturnValue('scene');
+        mockGetRootNode.mockReturnValue(new MockNode('Root'));
+        mockGetUICanvasNode.mockReturnValue(null);
+        mockGetUITransformParentNode.mockReturnValue(null);
+        mockLoadAny.mockResolvedValue({});
+        mockInstantiate.mockImplementation(() => new MockNode('Canvas'));
+    });
+
+    it('keeps empty nodes plain unless Canvas is explicitly requested', async () => {
+        const { NodeService } = require('../../scene-process/service/node');
+        const service = new NodeService();
+        service._createNode = jest.fn().mockResolvedValue({ path: '/Node' });
+
+        await service.createByType({ path: '/', nodeType: NodeType.EMPTY, workMode: '2d' });
+
+        expect(service._createNode).toHaveBeenCalledWith(null, false, true, expect.objectContaining({
+            nodeType: NodeType.EMPTY,
+            workMode: '2d',
+        }));
+    });
+
+    it('honors explicit Canvas requests when creating empty nodes', async () => {
+        const { NodeService } = require('../../scene-process/service/node');
+        const service = new NodeService();
+        service._createNode = jest.fn().mockResolvedValue({ path: '/Node' });
+
+        await service.createByType({ path: '/', nodeType: NodeType.EMPTY, workMode: '2d', canvasRequired: true });
+
+        expect(service._createNode).toHaveBeenCalledWith(null, true, true, expect.objectContaining({
+            nodeType: NodeType.EMPTY,
+            workMode: '2d',
+            canvasRequired: true,
+        }));
+    });
+
+    it('does not create a Canvas when prefab handling is cancelled or omitted', async () => {
+        mockGetCurrentEditorType.mockReturnValue('prefab');
+        const parent = new MockNode('PrefabRoot');
+        const { NodeService } = require('../../scene-process/service/node');
+        const service = new NodeService();
+
+        await expect(service.checkCanvasRequired('2d', true, parent, undefined)).resolves.toBe(parent);
+
+        expect(mockLoadAny).not.toHaveBeenCalled();
+        expect(mockInstantiate).not.toHaveBeenCalled();
+        expect(mockCreateShouldHideInHierarchyCanvasNode).not.toHaveBeenCalled();
+    });
+
+    it('creates a Canvas parent when the host selects the create-canvas prefab branch', async () => {
+        mockGetCurrentEditorType.mockReturnValue('prefab');
+        const parent = new MockNode('PrefabRoot');
+        const canvas = new MockNode('Canvas');
+        mockInstantiate.mockReturnValue(canvas);
+        const { NodeService } = require('../../scene-process/service/node');
+        const service = new NodeService();
+
+        await expect(service.checkCanvasRequired('2d', true, parent, undefined, 'create-canvas')).resolves.toBe(canvas);
+
+        expect(mockLoadAny).toHaveBeenCalledTimes(1);
+        expect(mockInstantiate).toHaveBeenCalledTimes(1);
+        expect(mockRemovePrefabInfoFromNode).toHaveBeenCalledWith(canvas);
+        expect(parent.addChild).toHaveBeenCalledWith(canvas);
+    });
+
+    it('adds UITransform to the prefab root when the host selects that prefab branch', async () => {
+        mockGetCurrentEditorType.mockReturnValue('prefab');
+        const scene = new MockNode('Scene');
+        const root = new MockNode('PrefabRoot');
+        const parent = new MockNode('ChildParent');
+        const previewCanvas = new MockNode('PreviewCanvas');
+        root.parent = scene;
+        mockGetRootNode.mockReturnValue(root);
+        mockCreateShouldHideInHierarchyCanvasNode.mockResolvedValue(previewCanvas);
+        const { NodeService } = require('../../scene-process/service/node');
+        const service = new NodeService();
+
+        await expect(service.checkCanvasRequired('2d', true, parent, undefined, 'add-root-ui-transform')).resolves.toBe(parent);
+
+        expect(root.addComponent).toHaveBeenCalledWith('cc.UITransform');
+        expect(mockCreateShouldHideInHierarchyCanvasNode).toHaveBeenCalledWith(mockScene, '2d');
+        expect(root.parent).toBe(previewCanvas);
+        expect(mockLoadAny).not.toHaveBeenCalled();
+    });
+
+    it('reuses an existing UITransform parent in prefab mode before using host handling', async () => {
+        mockGetCurrentEditorType.mockReturnValue('prefab');
+        const parent = new MockNode('ChildParent');
+        const uiParent = new MockNode('UIParent');
+        mockGetUITransformParentNode.mockReturnValue(uiParent);
+        const { NodeService } = require('../../scene-process/service/node');
+        const service = new NodeService();
+
+        await expect(service.checkCanvasRequired('2d', true, parent, undefined, 'create-canvas')).resolves.toBe(parent);
+
+        expect(mockLoadAny).not.toHaveBeenCalled();
+        expect(mockInstantiate).not.toHaveBeenCalled();
+    });
+});

--- a/src/core/scene/test/service-core/prefab-preview-canvas-command.test.ts
+++ b/src/core/scene/test/service-core/prefab-preview-canvas-command.test.ts
@@ -1,0 +1,186 @@
+const mockCreateShouldHideInHierarchyCanvasNode = jest.fn();
+const mockBaseRemoveNode = jest.fn();
+
+class MockNode {
+    uuid: string;
+    name: string;
+    parent: MockNode | null = null;
+    children: MockNode[] = [];
+    components: any[] = [];
+    private _valid = true;
+
+    constructor(name = 'Node') {
+        this.name = name;
+        this.uuid = `${name}-${Math.random().toString(16).slice(2)}`;
+    }
+
+    get isValid() {
+        return this._valid;
+    }
+
+    addChild(node: MockNode) {
+        if (node.parent) {
+            node.parent.children = node.parent.children.filter(child => child !== node);
+        }
+        this.children.push(node);
+        node.parent = this;
+    }
+
+    setSiblingIndex(index: number) {
+        if (!this.parent) {
+            return;
+        }
+        this.parent.children = this.parent.children.filter(child => child !== this);
+        this.parent.children.splice(index, 0, this);
+    }
+
+    isChildOf(parent: MockNode) {
+        let current = this.parent;
+        while (current) {
+            if (current === parent) {
+                return true;
+            }
+            current = current.parent;
+        }
+        return false;
+    }
+
+    destroyForTest() {
+        this._valid = false;
+        if (this.parent) {
+            this.parent.children = this.parent.children.filter(child => child !== this);
+            this.parent = null;
+        }
+    }
+}
+
+const mockScene = new MockNode('Scene');
+const nodeByUuid = new Map<string, MockNode>();
+const nodeByPath = new Map<string, MockNode>();
+const removedUuids: string[] = [];
+
+function registerNode(node: MockNode, path: string) {
+    nodeByUuid.set(node.uuid, node);
+    nodeByPath.set(path, node);
+}
+
+jest.mock('cc', () => ({
+    director: { getScene: jest.fn(() => mockScene) },
+    Node: MockNode,
+    Scene: MockNode,
+}));
+
+(global as any).cc = require('cc');
+(global as any).EditorExtends = {
+    Node: {
+        getNode: jest.fn((uuid: string) => nodeByUuid.get(uuid) ?? null),
+        getNodeByPath: jest.fn((path: string) => nodeByPath.get(path) ?? null),
+        getNodePath: jest.fn((node: MockNode) => {
+            for (const [path, current] of nodeByPath.entries()) {
+                if (current === node) {
+                    return path;
+                }
+            }
+            return '';
+        }),
+        remove: jest.fn((uuid: string) => {
+            removedUuids.push(uuid);
+            nodeByUuid.delete(uuid);
+        }),
+    },
+    Component: {
+        remove: jest.fn(),
+    },
+};
+
+jest.mock('../../scene-process/service/node/index', () => ({
+    __esModule: true,
+    default: {
+        baseRemoveNode: mockBaseRemoveNode,
+    },
+}));
+
+jest.mock('../../scene-process/service/node/node-create', () => ({
+    createShouldHideInHierarchyCanvasNode: mockCreateShouldHideInHierarchyCanvasNode,
+}));
+
+import { PrefabPreviewCanvasCommand } from '../../scene-process/service/undo/commands/prefab-preview-canvas-command';
+
+describe('PrefabPreviewCanvasCommand', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        nodeByUuid.clear();
+        nodeByPath.clear();
+        removedUuids.length = 0;
+        mockScene.children = [];
+        mockScene.parent = null;
+        registerNode(mockScene, '/');
+        mockBaseRemoveNode.mockImplementation((node: MockNode) => node.destroyForTest());
+        mockCreateShouldHideInHierarchyCanvasNode.mockImplementation(async (scene: MockNode) => {
+            const preview = new MockNode('should_hide_in_hierarchy');
+            scene.addChild(preview);
+            registerNode(preview, '/should_hide_in_hierarchy');
+            return preview;
+        });
+    });
+
+    it('moves the prefab root back on undo and recreates the preview Canvas on redo', async () => {
+        const root = new MockNode('PrefabRoot');
+        const preview = new MockNode('should_hide_in_hierarchy');
+        const camera = new MockNode('Camera');
+        mockScene.addChild(preview);
+        preview.addChild(camera);
+        preview.addChild(root);
+        registerNode(root, '/PrefabRoot');
+        registerNode(preview, '/should_hide_in_hierarchy');
+        registerNode(camera, '/should_hide_in_hierarchy/Camera');
+
+        const command = new PrefabPreviewCanvasCommand({
+            rootUuid: root.uuid,
+            rootPath: '/PrefabRoot',
+            rootParentUuid: mockScene.uuid,
+            rootParentPath: '/',
+            rootSiblingIndex: 0,
+            previewCanvasUuid: preview.uuid,
+            previewCanvasPath: '/should_hide_in_hierarchy',
+            removePreviewCanvasOnUndo: true,
+            workMode: '2d',
+        });
+
+        await expect(command.undo()).resolves.toMatchObject({ success: true });
+        expect(root.parent).toBe(mockScene);
+        expect(preview.isValid).toBe(false);
+        expect(removedUuids).toContain(preview.uuid);
+
+        await expect(command.redo()).resolves.toMatchObject({ success: true });
+        expect(root.parent?.name).toBe('should_hide_in_hierarchy');
+        expect(root.parent).not.toBe(preview);
+        expect(mockCreateShouldHideInHierarchyCanvasNode).toHaveBeenCalledWith(mockScene, '2d');
+    });
+
+    it('keeps a pre-existing preview Canvas when undoing the root reparent', async () => {
+        const root = new MockNode('PrefabRoot');
+        const preview = new MockNode('should_hide_in_hierarchy');
+        mockScene.addChild(preview);
+        preview.addChild(root);
+        registerNode(root, '/PrefabRoot');
+        registerNode(preview, '/should_hide_in_hierarchy');
+
+        const command = new PrefabPreviewCanvasCommand({
+            rootUuid: root.uuid,
+            rootPath: '/PrefabRoot',
+            rootParentUuid: mockScene.uuid,
+            rootParentPath: '/',
+            rootSiblingIndex: 0,
+            previewCanvasUuid: preview.uuid,
+            previewCanvasPath: '/should_hide_in_hierarchy',
+            removePreviewCanvasOnUndo: false,
+            workMode: '2d',
+        });
+
+        await expect(command.undo()).resolves.toMatchObject({ success: true });
+        expect(root.parent).toBe(mockScene);
+        expect(preview.isValid).toBe(true);
+        expect(mockBaseRemoveNode).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Summary:
- Preserve Canvas requirement checks for scene-mode 2D UI node creation, including empty 2D UI nodes.
- Add prefabCanvasHandling so the host IDE can map the Creator prompt choices to the same creation branches: add UITransform to the prefab root, create a Canvas parent, or cancel Canvas adaptation.
- Apply the same externally selected prefab UI handling to component creation.
- Cover NodeService and ComponentService with runtime tests instead of source-text assertions.

Testing:
- npx tsc -p tsconfig.json --noEmit
- npm run test -- src/core/scene/test/service-core/node-create-canvas-required.test.ts src/core/scene/test/service-core/component-prefab-ui-handling.test.ts --runInBand
- npm run test -- --runInBand (fails locally because node_modules/gl/build/Release/webgl.node was built for NODE_MODULE_VERSION 140 while the current Node.js runtime requires 127; this prevents asset-db startup and cascades into scene RPC tests)