### PR TITLE
fix(scene): restore prefab asset reference after undo of delete

### DIFF
--- a/src/core/scene/scene-process/service/prefab/node.ts
+++ b/src/core/scene/scene-process/service/prefab/node.ts
@@ -615,7 +615,7 @@ class NodeOperation {
         }
     }
 
-    private checkToAddPrefabAssetMap(node: Node) {
+    public checkToAddPrefabAssetMap(node: Node) {
         // @ts-ignore
         const prefabInfo = node['_prefab'];
         const prefabInstance = prefabInfo?.instance;
@@ -1521,6 +1521,12 @@ class NodeOperation {
         // 这里为了 Undo 能正常工作，不使用 softReload 的方式，需要注意处理好数据的一致性
         this.syncPrefabInfo(assetRootNode, node, node);
 
+        // syncPrefabInfo may overwrite prefabInfo.asset with a null/uninitialized
+        // value from the asset root node's _prefab.asset. Re-ensure the correct
+        // reference on the root and propagate to children that syncPrefabInfo may
+        // have skipped (e.g. when mounted children cause a structure mismatch).
+        this.ensurePrefabAssetOnTree(node, asset);
+
         this.checkToAddPrefabAssetMap(node);
 
         return true;
@@ -1656,6 +1662,26 @@ class NodeOperation {
             const srcChildNode = assetNode.children[i];
             const dstChildNode = dstChildren[i];
             this.syncPrefabInfo(srcChildNode, dstChildNode, rootNode);
+        }
+    }
+
+    private ensurePrefabAssetOnTree(node: Node, asset: any): void {
+        // @ts-ignore member access
+        const prefabInfo = node['_prefab'];
+        if (prefabInfo && !prefabInfo.asset) {
+            prefabInfo.asset = asset;
+        }
+
+        for (const child of node.children ?? []) {
+            // @ts-ignore member access
+            const childPrefab = child['_prefab'];
+            if (!childPrefab) {
+                continue;
+            }
+            if (childPrefab.instance) {
+                continue;
+            }
+            this.ensurePrefabAssetOnTree(child, asset);
         }
     }
 

--- a/src/core/scene/scene-process/service/undo/commands/node-structure-command-utils.ts
+++ b/src/core/scene/scene-process/service/undo/commands/node-structure-command-utils.ts
@@ -1,8 +1,9 @@
 import { Node } from 'cc';
 import { NodeEventType, type IUndoCommandMeta, type IUndoRedoResult } from '../../../../common';
-import { Service } from '../../core';
 import nodeMgr from '../../node/index';
 import { editorPrefabUtils } from '../../prefab/prefab-editor-utils';
+import { nodeOperation } from '../../prefab/node';
+import { sceneUtils } from '../../scene/utils';
 import {
     createUndoId,
     success,
@@ -87,28 +88,10 @@ export function captureNodeStructureSnapshot(
 }
 
 function serializeNodeStructure(node: Node, serialization: NodeStructureSerialization): string {
-    const serialized = shouldSerializeAsPrefab(node, serialization)
+    const serialized = serialization === 'prefab'
         ? editorPrefabUtils.serialize(node)
-        : EditorExtends.serialize(node);
+        : EditorExtends.serialize(node, { reserveContentsForSyncablePrefab: true });
     return typeof serialized === 'string' ? serialized : JSON.stringify(serialized);
-}
-
-function shouldSerializeAsPrefab(node: Node, serialization: NodeStructureSerialization): boolean {
-    if (serialization === 'prefab') {
-        return true;
-    }
-    if (serialization === 'node') {
-        return false;
-    }
-    return hasPrefabData(node);
-}
-
-function hasPrefabData(node: Node): boolean {
-    if (node['_prefab']) {
-        return true;
-    }
-
-    return (node.children ?? []).some(child => hasPrefabData(child));
 }
 
 function captureUuidTree(node: Node): INodeUuidSnapshot {
@@ -135,7 +118,6 @@ export async function restoreNodeStructureSnapshot(snapshot: INodeStructureSnaps
     }
 
     try {
-        await relinkPrefabAsset(restoredNode, snapshot);
         nodeMgr.emit('node:before-add', restoredNode);
         nodeMgr.emit('node:before-change', parent);
 
@@ -144,6 +126,10 @@ export async function restoreNodeStructureSnapshot(snapshot: INodeStructureSnaps
             restoredNode.setSiblingIndex(snapshot.siblingIndex);
         }
         restoreSubtreeUuids(restoredNode, snapshot.uuidTree);
+
+        // Relink after addChild — setParent triggers engine-side prefab
+        // processing that can clear _prefab.asset set before the add.
+        await relinkPrefabAsset(restoredNode, snapshot);
 
         nodeMgr.emit('node:add', restoredNode);
         nodeMgr.emit('node:change', parent, { source: 'undo', type: NodeEventType.CHILD_CHANGED });
@@ -168,10 +154,37 @@ async function relinkPrefabAsset(node: Node, snapshot: INodeStructureSnapshot): 
         return;
     }
 
-    const prefabService = Service.Prefab as unknown as {
-        linkNodeWithPrefabAsset: (node: Node, assetUuid: string) => Promise<void>;
-    };
-    await prefabService.linkNodeWithPrefabAsset(node, snapshot.prefabAssetUuid);
+    try {
+        const asset = await sceneUtils.loadAny(snapshot.prefabAssetUuid);
+        setPrefabAssetOnTree(node, asset);
+        nodeOperation.checkToAddPrefabAssetMap(node);
+    } catch (_error) {
+        // best-effort: asset may have been removed from the project
+    }
+}
+
+function setPrefabAssetOnTree(node: Node, asset: any): void {
+    const prefabInfo = (node as any)['_prefab'];
+    if (prefabInfo) {
+        prefabInfo.asset = asset;
+    }
+    for (const child of node.children ?? []) {
+        setPrefabAssetOnChildren(child, asset);
+    }
+}
+
+function setPrefabAssetOnChildren(node: Node, asset: any): void {
+    const prefabInfo = (node as any)['_prefab'];
+    if (!prefabInfo) {
+        return;
+    }
+    if (prefabInfo.instance) {
+        return;
+    }
+    prefabInfo.asset = asset;
+    for (const child of node.children ?? []) {
+        setPrefabAssetOnChildren(child, asset);
+    }
 }
 
 export function removeNodeStructureSnapshot(

--- a/src/core/scene/test/undo-node-structure-serialization.test.ts
+++ b/src/core/scene/test/undo-node-structure-serialization.test.ts
@@ -1,5 +1,8 @@
 const mockPrefabSerialize = jest.fn();
 const mockGetNodePath = jest.fn((node: MockNode) => node.path);
+const mockAssetToNodesMap = new Map<string, any[]>();
+const mockCcRuntime: Record<string, any> = {};
+const mockSceneUtilsLoadAny = jest.fn();
 
 class MockNode {
     isValid = true;
@@ -13,12 +16,14 @@ class MockNode {
     getSiblingIndex(): number {
         return this.parent ? this.parent.children.indexOf(this) : 0;
     }
+
+    setSiblingIndex(_index: number): void { }
 }
 
-jest.mock('cc', () => ({
-    editorExtrasTag: Symbol('editorExtrasTag'),
-    Node: MockNode,
-}));
+jest.mock('cc', () => new Proxy(
+    { editorExtrasTag: Symbol('editorExtrasTag'), Node: MockNode },
+    { get: (t, p) => (p in t ? (t as any)[p] : mockCcRuntime[p as string]) },
+));
 
 jest.mock('../scene-process/service/node/index', () => ({
     __esModule: true,
@@ -28,6 +33,26 @@ jest.mock('../scene-process/service/node/index', () => ({
 jest.mock('../scene-process/service/prefab/prefab-editor-utils', () => ({
     editorPrefabUtils: {
         serialize: mockPrefabSerialize,
+    },
+}));
+
+jest.mock('../scene-process/service/prefab/node', () => ({
+    nodeOperation: {
+        assetToNodesMap: mockAssetToNodesMap,
+        checkToAddPrefabAssetMap: jest.fn((node: any) => {
+            const prefabInfo = node._prefab;
+            if (!prefabInfo?.instance || !prefabInfo.asset?._uuid) return;
+            const uuid = prefabInfo.asset._uuid;
+            let nodes = mockAssetToNodesMap.get(uuid);
+            if (!nodes) { nodes = []; mockAssetToNodesMap.set(uuid, nodes); }
+            if (!nodes.includes(node)) nodes.push(node);
+        }),
+    },
+}));
+
+jest.mock('../scene-process/service/scene/utils', () => ({
+    sceneUtils: {
+        loadAny: mockSceneUtilsLoadAny,
     },
 }));
 
@@ -45,27 +70,31 @@ import { editorExtrasTag } from 'cc';
 import { captureNodeStructureSnapshot } from '../scene-process/service/undo/commands/node-structure-command-utils';
 
 describe('captureNodeStructureSnapshot serialization', () => {
+    let mockEditorSerialize: jest.Mock;
+
     beforeEach(() => {
         mockPrefabSerialize.mockReset();
         mockPrefabSerialize.mockReturnValue(JSON.stringify({ __type__: 'cc.Prefab' }));
         mockGetNodePath.mockClear();
+        mockAssetToNodesMap.clear();
+        mockEditorSerialize = jest.fn((node: MockNode) => JSON.stringify({
+            __type__: 'cc.Node',
+            uuid: node.uuid,
+            name: node.name,
+        }));
         (global as any).EditorExtends = {
-            serialize: jest.fn((node: MockNode) => JSON.stringify({
-                __type__: 'cc.Node',
-                uuid: node.uuid,
-                name: node.name,
-            })),
+            serialize: mockEditorSerialize,
         };
     });
 
-    it('serializes a plain node as node JSON instead of prefab JSON', () => {
+    it('serializes a plain node with reserveContentsForSyncablePrefab', () => {
         const node = new MockNode('plain-node', 'PlainNode');
         node.path = '/PlainNode';
 
         const snapshot = captureNodeStructureSnapshot(node as any);
 
         expect(snapshot).not.toBeNull();
-        expect((global as any).EditorExtends.serialize).toHaveBeenCalledWith(node);
+        expect(mockEditorSerialize).toHaveBeenCalledWith(node, { reserveContentsForSyncablePrefab: true });
         expect(mockPrefabSerialize).not.toHaveBeenCalled();
         expect(JSON.parse(snapshot!.serializedJson)).toMatchObject({
             __type__: 'cc.Node',
@@ -73,7 +102,7 @@ describe('captureNodeStructureSnapshot serialization', () => {
         });
     });
 
-    it('keeps prefab serialization for prefab-related nodes', () => {
+    it('uses node serialization with reserveContentsForSyncablePrefab for prefab-related nodes in auto mode', () => {
         const node = new MockNode('prefab-node', 'PrefabNode') as MockNode & { _prefab?: unknown };
         node.path = '/PrefabNode';
         node._prefab = { instance: {} };
@@ -81,14 +110,15 @@ describe('captureNodeStructureSnapshot serialization', () => {
         const snapshot = captureNodeStructureSnapshot(node as any);
 
         expect(snapshot).not.toBeNull();
-        expect(mockPrefabSerialize).toHaveBeenCalledWith(node);
-        expect((global as any).EditorExtends.serialize).not.toHaveBeenCalled();
+        expect(mockEditorSerialize).toHaveBeenCalledWith(node, { reserveContentsForSyncablePrefab: true });
+        expect(mockPrefabSerialize).not.toHaveBeenCalled();
         expect(JSON.parse(snapshot!.serializedJson)).toMatchObject({
-            __type__: 'cc.Prefab',
+            __type__: 'cc.Node',
+            uuid: 'prefab-node',
         });
     });
 
-    it('serializes mounted plain nodes as node JSON instead of prefab JSON', () => {
+    it('serializes mounted plain nodes with reserveContentsForSyncablePrefab', () => {
         const prefabRoot = new MockNode('prefab-root', 'PrefabRoot');
         const node = new MockNode('mounted-button', 'Button') as MockNode & {
             [editorExtrasTag]?: { mountedRoot?: MockNode };
@@ -100,7 +130,7 @@ describe('captureNodeStructureSnapshot serialization', () => {
         const snapshot = captureNodeStructureSnapshot(node as any);
 
         expect(snapshot).not.toBeNull();
-        expect((global as any).EditorExtends.serialize).toHaveBeenCalledWith(node);
+        expect(mockEditorSerialize).toHaveBeenCalledWith(node, { reserveContentsForSyncablePrefab: true });
         expect(mockPrefabSerialize).not.toHaveBeenCalled();
         expect(JSON.parse(snapshot!.serializedJson)).toMatchObject({
             __type__: 'cc.Node',
@@ -108,7 +138,7 @@ describe('captureNodeStructureSnapshot serialization', () => {
         });
     });
 
-    it('can force prefab serialization for prefab undo snapshots', () => {
+    it('uses prefab serialization only when explicitly requested', () => {
         const node = new MockNode('plain-prefab-editor-root', 'PlainPrefabRoot');
         node.path = '/PlainPrefabRoot';
 
@@ -116,6 +146,219 @@ describe('captureNodeStructureSnapshot serialization', () => {
 
         expect(snapshot).not.toBeNull();
         expect(mockPrefabSerialize).toHaveBeenCalledWith(node);
-        expect((global as any).EditorExtends.serialize).not.toHaveBeenCalled();
+        expect(mockEditorSerialize).not.toHaveBeenCalled();
+    });
+
+    it('captures prefabAssetUuid only for nodes with _prefab.instance', () => {
+        const childNode = new MockNode('child', 'Child') as MockNode & { _prefab?: unknown };
+        childNode.path = '/Child';
+        childNode._prefab = { root: {}, asset: { _uuid: 'some-uuid' } };
+
+        const snapshot = captureNodeStructureSnapshot(childNode as any);
+
+        expect(snapshot!.prefabAssetUuid).toBeUndefined();
+    });
+
+    it('returns null for invalid nodes', () => {
+        const node = new MockNode('invalid');
+        node.isValid = false;
+
+        expect(captureNodeStructureSnapshot(node as any)).toBeNull();
+    });
+
+    it('returns null when serialization produces empty output', () => {
+        const node = new MockNode('empty', 'Empty');
+        node.path = '/Empty';
+        mockEditorSerialize.mockReturnValue('');
+
+        expect(captureNodeStructureSnapshot(node as any)).toBeNull();
+    });
+
+    it('captures uuid tree for subtree restoration', () => {
+        const parent = new MockNode('parent', 'Parent');
+        parent.path = '/Parent';
+        const child = new MockNode('child', 'Child');
+        child.components = [{ uuid: 'comp-1' }];
+        parent.children = [child];
+        child.parent = parent;
+
+        const snapshot = captureNodeStructureSnapshot(parent as any);
+
+        expect(snapshot!.uuidTree).toEqual({
+            uuid: 'parent',
+            componentUuids: [],
+            children: [{
+                uuid: 'child',
+                componentUuids: ['comp-1'],
+                children: [],
+            }],
+        });
+    });
+});
+
+describe('restoreNodeStructureSnapshot asset map registration', () => {
+    let mockLoadWithJson: jest.Mock;
+
+    beforeEach(() => {
+        mockAssetToNodesMap.clear();
+
+        mockSceneUtilsLoadAny.mockReset();
+        mockSceneUtilsLoadAny.mockResolvedValue({ _uuid: 'prefab-asset-uuid' });
+
+        mockLoadWithJson = jest.fn((_json: any, _opts: any, cb: (err: Error | null, asset: any) => void) => {
+            const node = new MockNode('restored-node', 'Restored') as MockNode & { _prefab?: any };
+            node._prefab = { instance: {}, root: node, asset: null };
+            cb(null, node);
+        });
+
+        mockCcRuntime.assetManager = {
+            loadWithJson: mockLoadWithJson,
+        };
+        mockCcRuntime.director = { getScene: () => null };
+
+        (global as any).cc = mockCcRuntime;
+
+        (global as any).EditorExtends = {
+            serialize: jest.fn(() => '{}'),
+        };
+
+        const shared = require('../scene-process/service/undo/commands/command-utils-shared');
+        shared.getEditorNodeManager.mockReturnValue({
+            getNode: jest.fn(() => null),
+            getNodeByPath: jest.fn(() => null),
+        });
+        shared.isNodeInCurrentScene.mockReturnValue(false);
+    });
+
+    afterEach(() => {
+        delete mockCcRuntime.assetManager;
+        delete mockCcRuntime.director;
+        delete (global as any).cc;
+    });
+
+    it('registers prefab instance root in assetToNodesMap after relinkPrefabAsset', async () => {
+        const parentNode = new MockNode('parent', 'Parent') as any;
+        parentNode.addChild = jest.fn((child: any) => {
+            child.parent = parentNode;
+            parentNode.children.push(child);
+        });
+        parentNode.isValid = true;
+
+        const shared = require('../scene-process/service/undo/commands/command-utils-shared');
+        shared.getEditorNodeManager.mockReturnValue({
+            getNode: jest.fn((uuid: string) => uuid === 'parent' ? parentNode : null),
+            getNodeByPath: jest.fn(() => null),
+            changeNodeUUID: jest.fn(),
+        });
+        shared.isNodeInCurrentScene.mockImplementation((node: any) => node === parentNode);
+
+        const nodeMgrMod = require('../scene-process/service/node/index');
+        nodeMgrMod.default.emit = jest.fn();
+
+        const { restoreNodeStructureSnapshot } = require('../scene-process/service/undo/commands/node-structure-command-utils');
+
+        const snapshot = {
+            uuid: 'restored-node',
+            path: '/Parent/Restored',
+            parentUuid: 'parent',
+            parentPath: '/Parent',
+            siblingIndex: 0,
+            serializedJson: JSON.stringify({ __type__: 'cc.Node' }),
+            prefabAssetUuid: 'prefab-asset-uuid',
+            uuidTree: { uuid: 'restored-node', componentUuids: [], children: [] },
+        };
+        const meta = { id: 'test:id', label: 'test', type: 'test', scope: {}, timestamp: 1 };
+
+        await restoreNodeStructureSnapshot(snapshot, meta);
+
+        expect(mockAssetToNodesMap.has('prefab-asset-uuid')).toBe(true);
+        const registered = mockAssetToNodesMap.get('prefab-asset-uuid')!;
+        expect(registered).toHaveLength(1);
+        expect(registered[0]._prefab.asset._uuid).toBe('prefab-asset-uuid');
+    });
+
+    it('does not register in assetToNodesMap when prefabAssetUuid is absent', async () => {
+        const parentNode = new MockNode('parent', 'Parent') as any;
+        parentNode.addChild = jest.fn((child: any) => {
+            child.parent = parentNode;
+            parentNode.children.push(child);
+        });
+        parentNode.isValid = true;
+
+        mockLoadWithJson.mockImplementation((_json: any, _opts: any, cb: any) => {
+            const node = new MockNode('child-node', 'Child') as MockNode & { _prefab?: any };
+            node._prefab = { root: {}, asset: null };
+            cb(null, node);
+        });
+
+        const shared = require('../scene-process/service/undo/commands/command-utils-shared');
+        shared.getEditorNodeManager.mockReturnValue({
+            getNode: jest.fn((uuid: string) => uuid === 'parent' ? parentNode : null),
+            getNodeByPath: jest.fn(() => null),
+            changeNodeUUID: jest.fn(),
+        });
+        shared.isNodeInCurrentScene.mockImplementation((node: any) => node === parentNode);
+
+        const nodeMgrMod = require('../scene-process/service/node/index');
+        nodeMgrMod.default.emit = jest.fn();
+
+        const { restoreNodeStructureSnapshot } = require('../scene-process/service/undo/commands/node-structure-command-utils');
+
+        const snapshot = {
+            uuid: 'child-node',
+            path: '/Parent/Child',
+            parentUuid: 'parent',
+            parentPath: '/Parent',
+            siblingIndex: 0,
+            serializedJson: JSON.stringify({ __type__: 'cc.Node' }),
+            uuidTree: { uuid: 'child-node', componentUuids: [], children: [] },
+        };
+        const meta = { id: 'test:id', label: 'test', type: 'test', scope: {}, timestamp: 1 };
+
+        await restoreNodeStructureSnapshot(snapshot, meta);
+
+        expect(mockAssetToNodesMap.size).toBe(0);
+    });
+
+    it('still restores node successfully when prefab asset loading fails', async () => {
+        mockSceneUtilsLoadAny.mockRejectedValue(new Error('加载资源超时: prefab-asset-uuid'));
+
+        const parentNode = new MockNode('parent', 'Parent') as any;
+        parentNode.addChild = jest.fn((child: any) => {
+            child.parent = parentNode;
+            parentNode.children.push(child);
+        });
+        parentNode.isValid = true;
+
+        const shared = require('../scene-process/service/undo/commands/command-utils-shared');
+        shared.getEditorNodeManager.mockReturnValue({
+            getNode: jest.fn((uuid: string) => uuid === 'parent' ? parentNode : null),
+            getNodeByPath: jest.fn(() => null),
+            changeNodeUUID: jest.fn(),
+        });
+        shared.isNodeInCurrentScene.mockImplementation((node: any) => node === parentNode);
+
+        const nodeMgrMod = require('../scene-process/service/node/index');
+        nodeMgrMod.default.emit = jest.fn();
+
+        const { restoreNodeStructureSnapshot } = require('../scene-process/service/undo/commands/node-structure-command-utils');
+
+        const snapshot = {
+            uuid: 'restored-node',
+            path: '/Parent/Restored',
+            parentUuid: 'parent',
+            parentPath: '/Parent',
+            siblingIndex: 0,
+            serializedJson: JSON.stringify({ __type__: 'cc.Node' }),
+            prefabAssetUuid: 'prefab-asset-uuid',
+            uuidTree: { uuid: 'restored-node', componentUuids: [], children: [] },
+        };
+        const meta = { id: 'test:id', label: 'test', type: 'test', scope: {}, timestamp: 1 };
+
+        const result = await restoreNodeStructureSnapshot(snapshot, meta);
+
+        expect(result.success).toBe(true);
+        expect(parentNode.children).toHaveLength(1);
+        expect(mockAssetToNodesMap.size).toBe(0);
     });
 });


### PR DESCRIPTION
## Changes

- **Serialization**: Scene-level undo (`auto` mode) now uses `EditorExtends.serialize(node, { reserveContentsForSyncablePrefab: true })` instead of routing through `editorPrefabUtils.serialize` for nodes with `_prefab` data. Only explicit `serialization: 'prefab'` (prefab editor undo) goes through the full Prefab serialization path with mounted data validation, external reference stripping, and nested instance root cleanup.
- **Asset restoration**: Replace the two-step `Service.Prefab.linkNodeWithPrefabAsset` + fallback approach with a direct `sceneUtils.loadAny` (60s timeout, cache-busting) + `setPrefabAssetOnTree` + `nodeOperation.checkToAddPrefabAssetMap`. This avoids the silent failure path where `linkNodeWithPrefabAsset` returns undefined and the fallback's conditional assignment (`!prefabInfo.asset`) fails to overwrite an engine-cleared reference.
- **`setPrefabAssetOnTree`**: Unconditionally assigns asset on the root node (handles post-`addChild` engine clearing), and stops recursion at nested prefab instance boundaries via `setPrefabAssetOnChildren`.
- **`ensurePrefabAssetOnTree` (node.ts)**: Remove incorrect asset backfill for nested prefab instances — they reference their own prefab asset, not the parent's.
- **`checkToAddPrefabAssetMap`**: Changed from `private` to `public` so it can be called from the undo restore path.

## Tests

1. Prefab editor: delete a normal child node, undo, verify the node's color and Prefab status are unchanged.
2. Delete a Prefab instance root node, undo, verify that Apply, Revert, Unlink, and Unpack operations are still available.
3. Delete a node containing nested Prefab instances, undo, verify the inner and outer Prefab assets are each correctly restored.
4. Delete an instance with propertyOverrides, undo, verify the overrides are preserved and not cleaned up.
5. Delete an instance with mountedChildren or mountedComponents, undo, verify the mounted data remains intact.
6. Delete a node, then remove the corresponding Prefab asset from the project, undo, verify the node restores in Lost Asset state (red) and the operation does not hang.
