### PR TITLE
fix(asset-db): handle Windows paths case-insensitively

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -103,6 +103,10 @@ jobs:
         id: unit-tests
         run: npm run test:quiet
 
+      - name: Run AssetDB package tests
+        if: runner.os == 'Windows'
+        run: npm run test:asset-db
+
       - name: Run E2E tests
         id: e2e-tests
         uses: ./.github/actions/run-e2e-tests

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -15,22 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.filter.outputs.should_run }}
-      asset_db_changed: ${{ steps.filter.outputs.asset_db_changed }}
     steps:
-      # issue_comment 事件没有 base_ref，统一从 PR 信息中获取准确的基准提交。
-      - name: Get PR base commit
-        id: pr
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pullNumber = context.payload.pull_request?.number ?? context.issue.number;
-            const { data: pull } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pullNumber,
-            });
-            core.setOutput('base_sha', pull.base.sha);
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -41,31 +26,14 @@ jobs:
         id: filter
         shell: bash
         run: |
-          BASE_SHA="${{ steps.pr.outputs.base_sha }}"
-          git fetch --no-tags origin "$BASE_SHA"
-          CHANGED_FILES=$(git diff --name-only "$BASE_SHA"...HEAD)
-
-          # 仅 AssetDB 源码、测试及构建配置变更时运行独立测试，README 等文档变更不触发。
-          ASSET_DB_CHANGED=false
-          while IFS= read -r file; do
-            case "$file" in
-              packages/asset-db/source/*|\
-              packages/asset-db/test/*|\
-              packages/asset-db/scripts/*|\
-              packages/asset-db/package.json|\
-              packages/asset-db/tsconfig.json)
-                ASSET_DB_CHANGED=true
-                break
-                ;;
-            esac
-          done <<< "$CHANGED_FILES"
-          echo "asset_db_changed=$ASSET_DB_CHANGED" >> "$GITHUB_OUTPUT"
-
           # 评论触发时始终运行
           if [ "${{ github.event_name }}" = "issue_comment" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          BASE_REF="origin/${{ github.base_ref }}"
+          CHANGED_FILES=$(git diff --name-only "$BASE_REF"...HEAD)
 
           # 仅 dts/snapshot 相关文件变更时跳过 pr-test
           DTS_ONLY=true
@@ -135,9 +103,9 @@ jobs:
         id: unit-tests
         run: npm run test:quiet
 
-      # Windows 上覆盖大小写不敏感路径行为；无关改动由 check-changes 跳过。
+      # pull_request 与 issue_comment 的 PR 标题字段不同，取当前事件中存在的标题进行检测。
       - name: Run AssetDB package tests
-        if: runner.os == 'Windows' && needs.check-changes.outputs.asset_db_changed == 'true'
+        if: runner.os == 'Windows' && contains(github.event.pull_request.title || github.event.issue.title, 'asset-db')
         run: npm run test:asset-db
 
       - name: Run E2E tests

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -17,6 +17,7 @@ jobs:
       should_run: ${{ steps.filter.outputs.should_run }}
       asset_db_changed: ${{ steps.filter.outputs.asset_db_changed }}
     steps:
+      # issue_comment 事件没有 base_ref，统一从 PR 信息中获取准确的基准提交。
       - name: Get PR base commit
         id: pr
         uses: actions/github-script@v7
@@ -44,6 +45,7 @@ jobs:
           git fetch --no-tags origin "$BASE_SHA"
           CHANGED_FILES=$(git diff --name-only "$BASE_SHA"...HEAD)
 
+          # 仅 AssetDB 源码、测试及构建配置变更时运行独立测试，README 等文档变更不触发。
           ASSET_DB_CHANGED=false
           while IFS= read -r file; do
             case "$file" in
@@ -133,6 +135,7 @@ jobs:
         id: unit-tests
         run: npm run test:quiet
 
+      # Windows 上覆盖大小写不敏感路径行为；无关改动由 check-changes 跳过。
       - name: Run AssetDB package tests
         if: runner.os == 'Windows' && needs.check-changes.outputs.asset_db_changed == 'true'
         run: npm run test:asset-db

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -15,7 +15,21 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.filter.outputs.should_run }}
+      asset_db_changed: ${{ steps.filter.outputs.asset_db_changed }}
     steps:
+      - name: Get PR base commit
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pullNumber = context.payload.pull_request?.number ?? context.issue.number;
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullNumber,
+            });
+            core.setOutput('base_sha', pull.base.sha);
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -26,14 +40,30 @@ jobs:
         id: filter
         shell: bash
         run: |
+          BASE_SHA="${{ steps.pr.outputs.base_sha }}"
+          git fetch --no-tags origin "$BASE_SHA"
+          CHANGED_FILES=$(git diff --name-only "$BASE_SHA"...HEAD)
+
+          ASSET_DB_CHANGED=false
+          while IFS= read -r file; do
+            case "$file" in
+              packages/asset-db/source/*|\
+              packages/asset-db/test/*|\
+              packages/asset-db/scripts/*|\
+              packages/asset-db/package.json|\
+              packages/asset-db/tsconfig.json)
+                ASSET_DB_CHANGED=true
+                break
+                ;;
+            esac
+          done <<< "$CHANGED_FILES"
+          echo "asset_db_changed=$ASSET_DB_CHANGED" >> "$GITHUB_OUTPUT"
+
           # 评论触发时始终运行
           if [ "${{ github.event_name }}" = "issue_comment" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-
-          BASE_REF="origin/${{ github.base_ref }}"
-          CHANGED_FILES=$(git diff --name-only "$BASE_REF"...HEAD)
 
           # 仅 dts/snapshot 相关文件变更时跳过 pr-test
           DTS_ONLY=true
@@ -104,7 +134,7 @@ jobs:
         run: npm run test:quiet
 
       - name: Run AssetDB package tests
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && needs.check-changes.outputs.asset_db_changed == 'true'
         run: npm run test:asset-db
 
       - name: Run E2E tests

--- a/packages/asset-db/source/libs/asset-db.ts
+++ b/packages/asset-db/source/libs/asset-db.ts
@@ -20,6 +20,15 @@ import { ParallelQueue } from 'workflow-extra';
 import fg from 'fast-glob';
 import { CustomConsole, LogLevel } from './console';
 import { Migrate, Migrator } from './migrator';
+import {
+    assertNoPathIdentityConflicts,
+    getMapStoredPathKey,
+    isSamePath,
+    PathCaseConflictError,
+    PathMap,
+    PathSet,
+    resolveRealPathCase,
+} from './path-identity';
 
 export { map } from './manager';
 
@@ -153,7 +162,7 @@ export class AssetDB extends EventEmitter {
     };
 
     // path 对应 asset 的 map
-    path2asset: Map<string, Asset> = new Map;
+    path2asset: Map<string, Asset> = new PathMap;
 
     // uuid 对应 asset 的 map
     uuid2asset: Map<string, Asset> = new Map;
@@ -401,7 +410,28 @@ export class AssetDB extends EventEmitter {
      */
     async startWithCache() {
         await this.prepareStart();
-        await this.restoreFromCache();
+        try {
+            const managerCacheConflict = this.infoManager.cacheConflict || this.dependencyManager.cacheConflict;
+            if (managerCacheConflict) {
+                throw managerCacheConflict;
+            }
+            await this.restoreFromCache();
+        } catch (error) {
+            if (!(error instanceof PathCaseConflictError)) {
+                throw error;
+            }
+            this.console.warn(error.message);
+            this.console.warn(`Discard invalid cache for asset-db(${this.options.name}) and rebuild it from disk.`);
+            this.uuid2asset.clear();
+            this.path2asset.clear();
+            // Dependency records can only be reconstructed by running importers.
+            // Invalidating mtime information prevents the normal startup fast path
+            // from treating every asset as unchanged.
+            if (this.dependencyManager.cacheConflict) {
+                this.infoManager.destroy();
+            }
+            await this.refresh(this.options.target, { ignoreSelf: true });
+        }
     }
 
     async updateInfoManager() {
@@ -466,8 +496,10 @@ export class AssetDB extends EventEmitter {
         });
         const recordInfo = await migrator.run(cacheJSON, version, [this]);
 
-        await Promise.all(recordInfo.data.paths.map(async (relativePath) => {
-            const path = join(this.options.target, relativePath);
+        const cachedPaths = recordInfo.data.paths.map((relativePath) => join(this.options.target, relativePath));
+        assertNoPathIdentityConflicts(cachedPaths);
+
+        await Promise.all(cachedPaths.map(async (path) => {
             try {
                 const metaFile = join(path + '.meta');
                 const metaInfo = await this.metaManager.get(metaFile);
@@ -618,9 +650,12 @@ export class AssetDB extends EventEmitter {
         path = normalize(path);
 
         // 如果是数据库文件夹，默认就忽略自己
-        if (path === this.options.target) {
+        if (isSamePath(path, this.options.target)) {
             options.ignoreSelf = true;
+            path = this.options.target;
         }
+
+        path = resolveRealPathCase(path, this.options.target);
 
         // 向上递归查询，查询自己的父级文件夹是否存在
         // 如果父文件夹不在 db 里，则自动加入
@@ -631,7 +666,7 @@ export class AssetDB extends EventEmitter {
         }
 
         // 检查是不是配置的 root 路径的子目录，如果不是子路径，则返回刷新 0 个资源
-        if (!isSubPath(path, this.options.target) && path !== this.options.target) {
+        if (!isSubPath(path, this.options.target) && !isSamePath(path, this.options.target)) {
             throw new Error(`asset(${path}) is not in asset-db(${this.options.name})`);
         }
         let files: string[] = [];
@@ -643,6 +678,7 @@ export class AssetDB extends EventEmitter {
                     files = [path];
                 } else {
                     const globPath = process.platform === 'win32' ? path.replace(/\\/g, '/') : path;
+                    const scanBasePath = path;
                     // ! 要写绝对路径，否则可能在某些 win 机器上无法忽略文件
                     const search = options.globList || [
                         `**/*`,
@@ -659,12 +695,12 @@ export class AssetDB extends EventEmitter {
                     });
 
                     files.forEach((file, index) => {
-                        files[index] = join(globPath, file);
+                        files[index] = join(scanBasePath, file);
                     });
 
                     // 当扫描的路径不是根目录的时候，把被扫描的路径也检查一次
-                    if (path !== this.options.target) {
-                        files.splice(0, 0, path);
+                    if (!isSamePath(path, this.options.target)) {
+                        files.splice(0, 0, scanBasePath);
                     }
                 }
             } catch (error) {
@@ -672,6 +708,7 @@ export class AssetDB extends EventEmitter {
                 files = [];
             }
         }
+        assertNoPathIdentityConflicts(files);
         // 文件分组，如果有多个组，会在上一个组导入完成后，才开始下一个组的导入流程
         if (options.hooks && options.hooks.afterScan) {
             try {
@@ -682,9 +719,11 @@ export class AssetDB extends EventEmitter {
         }
 
         // 扫描文件到的文件记录
-        const fileSet: Set<string> = new Set();
-        const deleteSet: Set<string> = new Set();
-        const addSet: Set<string> = new Set();
+        const fileSet: Set<string> = new PathSet();
+        const deleteSet: Set<string> = new PathSet();
+        const addSet: Set<string> = new PathSet();
+        const caseChangedSet: Set<string> = new PathSet();
+        const caseChangedAssets: Asset[] = [];
         const afterError = (error: unknown) => {
             this.taskManager.clear();
             this.unlock();
@@ -696,6 +735,15 @@ export class AssetDB extends EventEmitter {
             const deleteFiles: string[] = [];
             if (this.preImporterHandler) {
                 for (let file of files) {
+                    const storedPath = getMapStoredPathKey(this.path2asset, file);
+                    if (storedPath !== undefined && storedPath !== file && normalize(storedPath) !== normalize(file)) {
+                        const asset = this.path2asset.get(storedPath);
+                        if (asset) {
+                            this._updateAssetPathCase(asset, file);
+                            caseChangedAssets.push(asset);
+                            caseChangedSet.add(file);
+                        }
+                    }
                     if (!this.path2asset.has(file)) {
                         if (this.preImporterHandler(file)) {
                             preAddFiles.push(file);
@@ -708,6 +756,15 @@ export class AssetDB extends EventEmitter {
                 }
             } else {
                 for (let file of files) {
+                    const storedPath = getMapStoredPathKey(this.path2asset, file);
+                    if (storedPath !== undefined && storedPath !== file && normalize(storedPath) !== normalize(file)) {
+                        const asset = this.path2asset.get(storedPath);
+                        if (asset) {
+                            this._updateAssetPathCase(asset, file);
+                            caseChangedAssets.push(asset);
+                            caseChangedSet.add(file);
+                        }
+                    }
                     if (!this.path2asset.has(file)) {
                         addFiles.push(file);
                         addSet.add(file);
@@ -718,7 +775,7 @@ export class AssetDB extends EventEmitter {
 
             this.path2asset.forEach((asset, file) => {
                 if (files.length === 0 || !fileSet.has(file)) {
-                    if (file === path || isSubPath(file, path)) {
+                    if (isSamePath(file, path) || isSubPath(file, path)) {
                         deleteFiles.push(file);
                         deleteSet.add(file);
                     }
@@ -726,6 +783,11 @@ export class AssetDB extends EventEmitter {
             });
 
             this.taskManager.stop();
+
+            for (const asset of caseChangedAssets) {
+                asset.action = AssetActionEnum.change;
+                asset.task = this.taskManager.addTask(asset);
+            }
 
             // 判断添加的资源和移动、删除的资源
             await this._checkAssetsStatSync(preAddFiles, deleteFiles, deleteSet);
@@ -746,7 +808,7 @@ export class AssetDB extends EventEmitter {
             // 没有改动的数据
             const tasks: Promise<any>[] = [];
             for (let file of files) {
-                if (!addSet.has(file) && !deleteSet.has(file)) {
+                if (!addSet.has(file) && !deleteSet.has(file) && !caseChangedSet.has(file)) {
                     const asset = this.path2asset.get(file);
                     if (asset) {
                         tasks.push(this._checkAssetStat(asset));
@@ -802,7 +864,7 @@ export class AssetDB extends EventEmitter {
 
     private _replaceUUID(asset: Asset, oAsset: Asset) {
         if (oAsset !== asset) {
-            if (asset.source === oAsset.source) {
+            if (isSamePath(asset.source, oAsset.source)) {
                 console.trace(`_replaceUUID invalid in asset ${asset.source}`);
                 return;
             }
@@ -817,6 +879,27 @@ export class AssetDB extends EventEmitter {
             }
             asset.meta.uuid = newUUID;
         }
+    }
+
+    private _updateAssetPathCase(asset: Asset, source: string) {
+        const previousSource = asset.source;
+        const previousUrl = asset.url;
+        if (previousSource === source) {
+            return;
+        }
+
+        this.path2asset.set(source, asset);
+        asset._source = source;
+        const sourceExtname = extname(source);
+        asset.extname = sourceExtname.toLowerCase();
+        asset.basename = basename(source, sourceExtname);
+        asset.updateUrl();
+
+        this.infoManager.updatePathCase(previousSource, source);
+        this.infoManager.updatePathCase(previousSource + '.meta', source + '.meta');
+        this.metaManager.updatePathCase(previousSource + '.meta', source + '.meta');
+        this.dependencyManager.updatePathCase(previousSource, source);
+        this.dependencyManager.updatePathCase(previousUrl, asset.url);
     }
 
     /**
@@ -851,7 +934,7 @@ export class AssetDB extends EventEmitter {
                 if (
                     deleteSet.has(uuidCacheAsset.source) ||
                     (
-                        uuidCacheAsset.source !== file &&
+                        !isSamePath(uuidCacheAsset.source, file) &&
                         !existsSync(uuidCacheAsset.source)
                     )
                 ) {

--- a/packages/asset-db/source/libs/dependency.ts
+++ b/packages/asset-db/source/libs/dependency.ts
@@ -4,10 +4,19 @@ import { existsSync, readJSONSync, outputJSONSync } from 'fs-extra';
 import { join, relative } from 'path';
 import { CustomConsole } from './console';
 import { Migrate, Migrator } from './migrator';
+import {
+    assertNoPathIdentityConflicts,
+    createPathRecord,
+    findPathAwareIndex,
+    isSamePath,
+    PathCaseConflictError,
+    replacePathRecordKey,
+} from './path-identity';
 
 interface DependMap {
     path: { [path: string]: string[] };
     uuid: { [uuid: string]: string[] };
+    [type: string]: { [path: string]: string[] };
 }
 interface RecordInfoMap {
     data: DependMap
@@ -36,8 +45,8 @@ const migrations: Migrate<any>[] = [{
 function getDefaultRecordInfo(): RecordInfoMap {
     return {
         data: {
-            path: {},
-            uuid: {},
+            path: createPathRecord<string[]>(),
+            uuid: createPathRecord<string[]>(),
         },
         version: DependencyManager.version,
     };
@@ -45,7 +54,7 @@ function getDefaultRecordInfo(): RecordInfoMap {
 
 // 关联性 map，一个资源更改后需要通知依赖这个资源的其他资源
 // 这里记录的就是依赖某个资源的其他资源列表
-const associatedMap: { [index: string]: string[] } = {};
+const associatedMap: { [index: string]: string[] } = createPathRecord<string[]>();
 
 /**
  * 资源关联以及依赖关系列表，主要影响导入队列以及是否需要重新导入
@@ -66,6 +75,7 @@ export class DependencyManager {
     // 保存使用的 timer
     _saveTimer: any = null;
     private console: CustomConsole;
+    cacheConflict: PathCaseConflictError | null = null;
     constructor(customConsole: CustomConsole, pathRoot: string) {
         this.console = customConsole || console;
         this.pathRoot = pathRoot;
@@ -76,9 +86,15 @@ export class DependencyManager {
      */
     async setRecordJSON(path: string) {
         this.file = path;
+        this.cacheConflict = null;
         try {
             await this._restoreCache(path);
         } catch (error) {
+            if (error instanceof PathCaseConflictError) {
+                this.destroy();
+                this.dependMap = getDefaultRecordInfo().data;
+                this.cacheConflict = error;
+            }
             this.console.warn(error);
         }
     }
@@ -89,13 +105,27 @@ export class DependencyManager {
             return;
         }
         // 处理缓存数据
-        const { path: pathRecord, uuid: uuidRecord } = this.dependMap;
+        const restoredSourcePaths = [
+            ...Object.keys(cacheInfo.data.path),
+            ...Object.keys(cacheInfo.data.uuid),
+        ].map((relativePath) => join(this.pathRoot, relativePath));
+        assertNoPathIdentityConflicts(restoredSourcePaths);
+        const restoredDependMap = getDefaultRecordInfo().data;
+        const { path: pathRecord, uuid: uuidRecord } = restoredDependMap;
         Object.keys(cacheInfo.data.path).forEach((relativePath) => {
-            pathRecord[join(this.pathRoot, relativePath)] = cacheInfo.data.path[relativePath].map((subPath => join(this.pathRoot, subPath)));
+            const restoredDependencies: string[] = [];
+            cacheInfo.data.path[relativePath].forEach((subPath) => {
+                const dependencyPath = join(this.pathRoot, subPath);
+                if (findPathAwareIndex(restoredDependencies, dependencyPath) === -1) {
+                    restoredDependencies.push(dependencyPath);
+                }
+            });
+            pathRecord[join(this.pathRoot, relativePath)] = restoredDependencies;
         })
         Object.keys(cacheInfo.data.uuid).forEach((relativePath) => {
             uuidRecord[join(this.pathRoot, relativePath)] = cacheInfo.data.uuid[relativePath];
         })
+        this.dependMap = restoredDependMap;
         // 补全关联列表
         for (let type in this.dependMap) {
             const typeMap = this.dependMap[type];
@@ -103,7 +133,7 @@ export class DependencyManager {
                 const array = typeMap[path];
                 array.forEach((urlOrPathOrUUID) => {
                     associatedMap[urlOrPathOrUUID] = associatedMap[urlOrPathOrUUID] || [];
-                    if (associatedMap[urlOrPathOrUUID].indexOf(path) !== -1) {
+                    if (findPathAwareIndex(associatedMap[urlOrPathOrUUID], path) !== -1) {
                         return;
                     }
                     associatedMap[urlOrPathOrUUID].push(path);
@@ -168,7 +198,7 @@ export class DependencyManager {
      * @param dependNames
      */
     add(type: string, key: string, depends: string | string[]) {
-        const typeMap = this.dependMap[type] = this.dependMap[type] || {};
+        const typeMap = this.dependMap[type] = this.dependMap[type] || createPathRecord<string[]>();
 
         const array = typeMap[key] = typeMap[key] || [];
 
@@ -176,7 +206,7 @@ export class DependencyManager {
             depends = [depends];
         }
         depends.forEach((depend) => {
-            if (depend && array.indexOf(depend) !== -1) {
+            if (depend && findPathAwareIndex(array, depend) !== -1) {
                 return;
             }
 
@@ -185,7 +215,7 @@ export class DependencyManager {
 
             // 记录到关联列表
             const associated = associatedMap[depend] = associatedMap[depend] || [];
-            if (associated.indexOf(key) === -1) {
+            if (findPathAwareIndex(associated, key) === -1) {
                 associated.push(key);
             }
         });
@@ -204,7 +234,10 @@ export class DependencyManager {
         // 删除依赖列表
         this.dependMap[type][key].forEach((str) => {
             const array = associatedMap[str];
-            const index = array.indexOf(key);
+            if (!array) {
+                return;
+            }
+            const index = findPathAwareIndex(array, key);
             if (index !== -1) {
                 array.splice(index, 1);
             }
@@ -214,6 +247,30 @@ export class DependencyManager {
         });
 
         delete this.dependMap[type][key];
+        this.save();
+    }
+
+    updatePathCase(previousPath: string, nextPath: string) {
+        for (const type in this.dependMap) {
+            const typeMap = this.dependMap[type];
+            replacePathRecordKey(typeMap, previousPath, nextPath);
+            Object.keys(typeMap).forEach((key) => {
+                typeMap[key].forEach((value, index) => {
+                    if (isSamePath(value, previousPath)) {
+                        typeMap[key][index] = nextPath;
+                    }
+                });
+            });
+        }
+
+        replacePathRecordKey(associatedMap, previousPath, nextPath);
+        Object.keys(associatedMap).forEach((key) => {
+            associatedMap[key].forEach((value, index) => {
+                if (isSamePath(value, previousPath)) {
+                    associatedMap[key][index] = nextPath;
+                }
+            });
+        });
         this.save();
     }
 
@@ -233,7 +290,7 @@ export class DependencyManager {
                     if (!associatedMap[str]) {
                         return;
                     }
-                    const index = associatedMap[str].indexOf(key);
+                    const index = findPathAwareIndex(associatedMap[str], key);
                     if (index !== -1) {
                         associatedMap[str].splice(index, 1);
                     }

--- a/packages/asset-db/source/libs/info.ts
+++ b/packages/asset-db/source/libs/info.ts
@@ -4,6 +4,13 @@ import { existsSync, readJSONSync, outputJSONSync, remove, removeSync } from 'fs
 import { CustomConsole } from './console';
 import { join, relative } from 'path';
 import { Migrate, Migrator } from './migrator';
+import {
+    assertNoPathIdentityConflicts,
+    createPathRecord,
+    isSamePath,
+    PathCaseConflictError,
+    replacePathRecordKey,
+} from './path-identity';
 
 export interface SimpleInfo {
     time: number;
@@ -73,7 +80,7 @@ const migrations: Migrate<any>[] = [{
 function getDefaultRecordInfo(): RecordInfoMap {
     return {
         version: InfoManager.version,
-        map: {},
+        map: createPathRecord<SimpleInfo>(),
         missing: {},
     };
 }
@@ -90,6 +97,7 @@ export class InfoManager {
     pathRoot: string;
     private recordInfo: RecordInfoMap;
     private console: CustomConsole;
+    cacheConflict: PathCaseConflictError | null = null;
     constructor(customConsole: CustomConsole, pathRoot: string) {
         this.console = customConsole || console;
         this.pathRoot = pathRoot;
@@ -105,9 +113,14 @@ export class InfoManager {
      */
     async setRecordJSON(path: string) {
         this.file = path;
+        this.cacheConflict = null;
         try {
             await this._restoreCache(path);
         } catch (error) {
+            if (error instanceof PathCaseConflictError) {
+                this.recordInfo = getDefaultRecordInfo();
+                this.cacheConflict = error;
+            }
             this.console.warn(error);
         }
     }
@@ -118,8 +131,10 @@ export class InfoManager {
         if (!storeRecordInfo) {
             return;
         }
-        Object.keys(storeRecordInfo.map).forEach((path) => {
-            recordInfo.map[join(this.pathRoot, path)] = storeRecordInfo.map[path];
+        const restoredPaths = Object.keys(storeRecordInfo.map).map((path) => join(this.pathRoot, path));
+        assertNoPathIdentityConflicts(restoredPaths);
+        Object.keys(storeRecordInfo.map).forEach((path, index) => {
+            recordInfo.map[restoredPaths[index]] = storeRecordInfo.map[path];
         })
         // missing 数据只记录绝对路径
         recordInfo.missing = storeRecordInfo.missing;
@@ -260,6 +275,20 @@ export class InfoManager {
      */
     getMissingInfo(uuid: string) {
         return this.recordInfo.missing[uuid] || null;
+    }
+
+    updatePathCase(previousPath: string, nextPath: string) {
+        let changed = replacePathRecordKey(this.recordInfo.map, previousPath, nextPath);
+        Object.keys(this.recordInfo.missing).forEach((uuid) => {
+            const info = this.recordInfo.missing[uuid];
+            if (isSamePath(info.path, previousPath) && info.path !== nextPath) {
+                info.path = nextPath;
+                changed = true;
+            }
+        });
+        if (changed) {
+            this.save();
+        }
     }
 
     /**

--- a/packages/asset-db/source/libs/manager.ts
+++ b/packages/asset-db/source/libs/manager.ts
@@ -3,7 +3,7 @@
 import type { AssetDB } from './asset-db';
 import type { Asset, VirtualAsset } from './asset';
 
-import { isSubPath } from './utils';
+import { isSamePath, isSubPath } from './utils';
 import { getAssociatedFiles } from './dependency';
 import { isAbsolute, relative, join } from 'path';
 import { parse } from 'url';
@@ -107,6 +107,20 @@ export function queryUrl(uuid_path: string): string {
         for (let name in map) {
             const db = map[name];
             if (isSubPath(uuid_path, db.options.target)) {
+                const searcher = uuid_path.split('@');
+                let asset: Asset | VirtualAsset | undefined = db.path2asset.get(searcher[0]);
+                while (!asset && searcher.length > 1) {
+                    searcher[0] += '@' + searcher[1];
+                    searcher.splice(1, 1);
+                    asset = db.path2asset.get(searcher[0]);
+                }
+                if (asset) {
+                    let url = asset.url;
+                    for (let index = 1; index < searcher.length; index++) {
+                        url += `@${searcher[index]}`;
+                    }
+                    return url;
+                }
                 let pathname = relative(db.options.target, uuid_path);
                 pathname = pathname.replace(/\\/g, '/');
                 return `db://${name}/${pathname}`;
@@ -284,7 +298,7 @@ export async function refresh(uuid_url_path: string) {
     if (isAbsolute(uuid_url_path)) {
         for (let name in map) {
             const db = map[name];
-            if (db.options.target === uuid_url_path || isSubPath(uuid_url_path, db.options.target)) {
+            if (isSamePath(db.options.target, uuid_url_path) || isSubPath(uuid_url_path, db.options.target)) {
                 return await db.refresh(uuid_url_path);
             }
         }

--- a/packages/asset-db/source/libs/meta.ts
+++ b/packages/asset-db/source/libs/meta.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync } from 'fs-extra';
 import { v1, v4 } from 'node-uuid';
 import { CustomConsole } from './console';
 import { fsDelete, fsExists, fsWriteFile, IAssetDeleteOptions, IAssetWriteFileOptions } from './filesystem';
+import { createPathRecord, isSamePath, replacePathRecordKey } from './path-identity';
 
 // Meta json 文件的格式
 export interface Meta {
@@ -142,7 +143,7 @@ export function completionMeta(meta: any): Meta {
 export class MetaManager {
 
     // 资源与 meta 的映射列表
-    path2meta: { [index: string]: MetaInfo } = {};
+    path2meta: { [index: string]: MetaInfo } = createPathRecord<MetaInfo>();
     private console: CustomConsole;
     constructor(customConsole: CustomConsole) {
         this.console = customConsole || console;
@@ -153,7 +154,7 @@ export class MetaManager {
      * @param manager
      */
     destroy() {
-        this.path2meta = {};
+        this.path2meta = createPathRecord<MetaInfo>();
     }
 
     /**
@@ -292,6 +293,10 @@ export class MetaManager {
     }
 
     move(pathA: string, pathB: string) {
+        if (isSamePath(pathA, pathB)) {
+            replacePathRecordKey(this.path2meta, pathA, pathB);
+            return;
+        }
         if (this.path2meta[pathB]) {
             const json = this.path2meta[pathB].json;
             this.path2meta[pathB].json = this.path2meta[pathA].json;
@@ -300,5 +305,9 @@ export class MetaManager {
             this.path2meta[pathB] = this.path2meta[pathA];
         }
         delete this.path2meta[pathA];
+    }
+
+    updatePathCase(previousPath: string, nextPath: string) {
+        replacePathRecordKey(this.path2meta, previousPath, nextPath);
     }
 }

--- a/packages/asset-db/source/libs/path-identity.ts
+++ b/packages/asset-db/source/libs/path-identity.ts
@@ -1,0 +1,332 @@
+'use strict';
+
+import { readdirSync } from 'fs';
+import { isAbsolute, join, normalize, parse, relative, sep } from 'path';
+
+const fileNameLowerCaseRegExp = /[^\u0130\u0131\u00DFa-z0-9\\/:\-_\. ]+/g;
+const pathRecordIndexes = new WeakMap<object, Map<string, string>>();
+
+function toLowerCase(value: string): string {
+    return value.toLowerCase();
+}
+
+function toWindowsPathSegmentKey(value: string): string {
+    return value.replace(fileNameLowerCaseRegExp, toLowerCase);
+}
+
+function normalizeAbsolutePath(value: string): string {
+    let normalized = normalize(value);
+    const root = parse(normalized).root;
+    while (normalized.length > root.length && normalized.endsWith(sep)) {
+        normalized = normalized.slice(0, -1);
+    }
+    return normalized;
+}
+
+/**
+ * Generate a stable identity key for an absolute filesystem path.
+ * Non-path values such as UUIDs and db:// URLs are returned unchanged.
+ */
+export function toPathKey(value: string): string {
+    if (!isAbsolute(value)) {
+        return value;
+    }
+
+    const normalized = normalizeAbsolutePath(value);
+    if (process.platform !== 'win32') {
+        return normalized;
+    }
+
+    // Keep the same Unicode exceptions used by Creator/TypeScript filename keys.
+    return toWindowsPathSegmentKey(normalized);
+}
+
+/**
+ * Resolve the casing currently stored on disk for a path inside a known root.
+ * The configured root casing is preserved because Windows drive letters do not
+ * have a filesystem-provided canonical representation.
+ */
+export function resolveRealPathCase(value: string, root: string): string {
+    const normalized = normalizeAbsolutePath(value);
+    const normalizedRoot = normalizeAbsolutePath(root);
+    if (
+        process.platform !== 'win32' ||
+        !isAbsolute(normalized) ||
+        !isAbsolute(normalizedRoot)
+    ) {
+        return normalized;
+    }
+
+    if (toPathKey(normalized) === toPathKey(normalizedRoot)) {
+        return normalizedRoot;
+    }
+
+    const relativePath = relative(normalizedRoot, normalized);
+    if (!relativePath || relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+        return normalized;
+    }
+
+    const segments = relativePath.split(sep).filter(Boolean);
+    let resolved = normalizedRoot;
+    for (let index = 0; index < segments.length; index++) {
+        let entries: string[];
+        try {
+            entries = readdirSync(resolved);
+        } catch {
+            return join(resolved, ...segments.slice(index));
+        }
+
+        const segmentKey = toWindowsPathSegmentKey(segments[index]);
+        const matches = entries.filter((entry) => toWindowsPathSegmentKey(entry) === segmentKey);
+        if (matches.length > 1) {
+            throw new PathCaseConflictError(
+                join(resolved, matches[0]),
+                join(resolved, matches[1]),
+            );
+        }
+        if (matches.length === 0) {
+            return join(resolved, ...segments.slice(index));
+        }
+        resolved = join(resolved, matches[0]);
+    }
+    return resolved;
+}
+
+export function isSamePath(left: string, right: string): boolean {
+    if (!isAbsolute(left) || !isAbsolute(right)) {
+        return left === right;
+    }
+    return toPathKey(left) === toPathKey(right);
+}
+
+export function isSubPath(candidate: string, root: string): boolean {
+    if (!isAbsolute(candidate) || !isAbsolute(root)) {
+        return false;
+    }
+
+    const candidateKey = toPathKey(candidate);
+    const rootKey = toPathKey(root);
+    if (candidateKey === rootKey) {
+        return false;
+    }
+
+    const rootWithSeparator = rootKey.endsWith(sep) ? rootKey : rootKey + sep;
+    return candidateKey.startsWith(rootWithSeparator);
+}
+
+export class PathCaseConflictError extends Error {
+    readonly code = 'ASSET_DB_PATH_CASE_CONFLICT';
+    readonly paths: readonly [string, string];
+
+    constructor(existingPath: string, incomingPath: string) {
+        super(
+            `Windows path case conflict: "${existingPath}" and "${incomingPath}" ` +
+            'resolve to the same case-insensitive identity. AssetDB cannot index both paths.'
+        );
+        this.name = 'PathCaseConflictError';
+        this.paths = [existingPath, incomingPath];
+    }
+}
+
+export class PathMap<Value> extends Map<string, Value> {
+    private readonly keyIndex = new Map<string, string>();
+
+    constructor(entries?: readonly (readonly [string, Value])[] | null) {
+        super();
+        if (entries) {
+            entries.forEach(([key, value]) => this.set(key, value));
+        }
+    }
+
+    getStoredKey(key: string): string | undefined {
+        return this.keyIndex.get(toPathKey(key));
+    }
+
+    override has(key: string): boolean {
+        return this.keyIndex.has(toPathKey(key));
+    }
+
+    override get(key: string): Value | undefined {
+        const storedKey = this.getStoredKey(key);
+        return storedKey === undefined ? undefined : super.get(storedKey);
+    }
+
+    override set(key: string, value: Value): this {
+        const identityKey = toPathKey(key);
+        const storedKey = this.keyIndex.get(identityKey);
+        if (storedKey !== undefined && storedKey !== key) {
+            super.delete(storedKey);
+        }
+        this.keyIndex.set(identityKey, key);
+        super.set(key, value);
+        return this;
+    }
+
+    override delete(key: string): boolean {
+        const identityKey = toPathKey(key);
+        const storedKey = this.keyIndex.get(identityKey);
+        if (storedKey === undefined) {
+            return false;
+        }
+        this.keyIndex.delete(identityKey);
+        return super.delete(storedKey);
+    }
+
+    override clear(): void {
+        this.keyIndex.clear();
+        super.clear();
+    }
+}
+
+export class PathSet extends Set<string> {
+    private readonly valueIndex = new Map<string, string>();
+
+    constructor(values?: readonly string[] | null) {
+        super();
+        values?.forEach((value) => this.add(value));
+    }
+
+    getStoredValue(value: string): string | undefined {
+        return this.valueIndex.get(toPathKey(value));
+    }
+
+    override has(value: string): boolean {
+        return this.valueIndex.has(toPathKey(value));
+    }
+
+    override add(value: string): this {
+        const identityKey = toPathKey(value);
+        const storedValue = this.valueIndex.get(identityKey);
+        if (storedValue !== undefined && storedValue !== value) {
+            super.delete(storedValue);
+        }
+        this.valueIndex.set(identityKey, value);
+        super.add(value);
+        return this;
+    }
+
+    override delete(value: string): boolean {
+        const identityKey = toPathKey(value);
+        const storedValue = this.valueIndex.get(identityKey);
+        if (storedValue === undefined) {
+            return false;
+        }
+        this.valueIndex.delete(identityKey);
+        return super.delete(storedValue);
+    }
+
+    override clear(): void {
+        this.valueIndex.clear();
+        super.clear();
+    }
+}
+
+export type PathRecord<Value> = { [path: string]: Value };
+
+/**
+ * Create an object-compatible path dictionary. Bracket access and Object.keys()
+ * remain available while absolute Windows path lookups become case-insensitive.
+ */
+export function createPathRecord<Value>(): PathRecord<Value> {
+    const target: PathRecord<Value> = {};
+    const keyIndex = new Map<string, string>();
+
+    const proxy = new Proxy(target, {
+        get(current, property) {
+            if (typeof property !== 'string') {
+                return Reflect.get(current, property);
+            }
+            const storedKey = keyIndex.get(toPathKey(property));
+            return Reflect.get(current, storedKey === undefined ? property : storedKey);
+        },
+        set(current, property, value) {
+            if (typeof property !== 'string') {
+                return Reflect.set(current, property, value);
+            }
+            const identityKey = toPathKey(property);
+            const storedKey = keyIndex.get(identityKey);
+            if (storedKey !== undefined && storedKey !== property) {
+                Reflect.deleteProperty(current, storedKey);
+            }
+            keyIndex.set(identityKey, property);
+            return Reflect.set(current, property, value);
+        },
+        deleteProperty(current, property) {
+            if (typeof property !== 'string') {
+                return Reflect.deleteProperty(current, property);
+            }
+            const identityKey = toPathKey(property);
+            const storedKey = keyIndex.get(identityKey);
+            if (storedKey === undefined) {
+                return true;
+            }
+            keyIndex.delete(identityKey);
+            return Reflect.deleteProperty(current, storedKey);
+        },
+        has(current, property) {
+            if (typeof property !== 'string') {
+                return Reflect.has(current, property);
+            }
+            const storedKey = keyIndex.get(toPathKey(property));
+            return storedKey === undefined ? Reflect.has(current, property) : true;
+        },
+        getOwnPropertyDescriptor(current, property) {
+            if (typeof property !== 'string') {
+                return Reflect.getOwnPropertyDescriptor(current, property);
+            }
+            const storedKey = keyIndex.get(toPathKey(property));
+            return Reflect.getOwnPropertyDescriptor(current, storedKey === undefined ? property : storedKey);
+        },
+    });
+
+    pathRecordIndexes.set(proxy, keyIndex);
+    return proxy;
+}
+
+export function getPathRecordStoredKey<Value>(record: PathRecord<Value>, key: string): string | undefined {
+    const index = pathRecordIndexes.get(record);
+    if (index) {
+        return index.get(toPathKey(key));
+    }
+    return Object.prototype.hasOwnProperty.call(record, key) ? key : undefined;
+}
+
+export function replacePathRecordKey<Value>(record: PathRecord<Value>, oldKey: string, newKey: string): boolean {
+    const storedKey = getPathRecordStoredKey(record, oldKey);
+    if (storedKey === undefined) {
+        return false;
+    }
+    const value = record[storedKey];
+    if (storedKey !== newKey) {
+        delete record[storedKey];
+    }
+    record[newKey] = value;
+    return true;
+}
+
+export function getMapStoredPathKey<Value>(map: Map<string, Value>, key: string): string | undefined {
+    return map instanceof PathMap ? map.getStoredKey(key) : (map.has(key) ? key : undefined);
+}
+
+export function getSetStoredPathValue(set: Set<string>, value: string): string | undefined {
+    return set instanceof PathSet ? set.getStoredValue(value) : (set.has(value) ? value : undefined);
+}
+
+export function findPathAwareIndex(values: readonly string[], value: string): number {
+    return values.findIndex((candidate) => isSamePath(candidate, value));
+}
+
+export function assertNoPathIdentityConflicts(paths: readonly string[]): void {
+    if (process.platform !== 'win32') {
+        return;
+    }
+
+    const seen = new PathMap<true>();
+    for (const path of paths) {
+        const storedPath = seen.getStoredKey(path);
+        if (storedPath !== undefined && storedPath !== path && normalize(storedPath) !== normalize(path)) {
+            throw new PathCaseConflictError(storedPath, path);
+        }
+        seen.set(path, true);
+    }
+}

--- a/packages/asset-db/source/libs/utils.ts
+++ b/packages/asset-db/source/libs/utils.ts
@@ -75,9 +75,3 @@ export function nameToId(name: string, extend?: number) {
     }
     return id;
 }
-
-/**
- * 判断 path 是否是 root 内的文件夹
- * @param path
- * @param root
- */

--- a/packages/asset-db/source/libs/utils.ts
+++ b/packages/asset-db/source/libs/utils.ts
@@ -1,8 +1,11 @@
 'use strict';
 
 import { readdir, stat, existsSync, Stats, statSync, readdirSync } from 'fs-extra';
-import { isAbsolute, resolve, normalize, join, relative, sep } from 'path';
+import { isAbsolute, resolve, normalize, join, relative } from 'path';
 import { createHash } from 'crypto';
+import { isSubPath } from './path-identity';
+
+export { isSamePath, isSubPath, toPathKey } from './path-identity';
 
 /**
  * 将一个 path 转成绝对地址
@@ -78,17 +81,3 @@ export function nameToId(name: string, extend?: number) {
  * @param path
  * @param root
  */
-export function isSubPath(path: string, root: string) {
-    // path = normalize(path);
-    // root = normalize(root);
-
-    if (path === root) {
-        return false;
-    }
-
-    if (path.startsWith(root + sep)) {
-        return true;
-    }
-
-    return false;
-}

--- a/packages/asset-db/test/1.basic.spec.js
+++ b/packages/asset-db/test/1.basic.spec.js
@@ -7,6 +7,14 @@ const fse = require('fs-extra');
 const path = require('path');
 
 const utils = require('../dist/libs/utils');
+const {
+    assertNoPathIdentityConflicts,
+    createPathRecord,
+    PathMap,
+    PathSet,
+    resolveRealPathCase,
+    toPathKey,
+} = require('../dist/libs/path-identity');
 
 describe('工具函数', () => {
 
@@ -58,6 +66,115 @@ describe('工具函数', () => {
             utils.isSubPath('/Users2/name', '/Users/name').should.to.equal(false);
             utils.isSubPath('/Users/name', '/Users/name2').should.to.equal(false);
             utils.isSubPath('/Users/name2', '/Users/name').should.to.equal(false);
+        }
+    });
+
+    it('Windows 磁盘路径使用大小写不敏感的 identity key', function() {
+        const original = path.join(process.cwd(), 'CaseFolder', 'Asset.TEST');
+        const variant = original.toLowerCase();
+
+        if (process.platform === 'win32') {
+            toPathKey(original).should.equal(toPathKey(variant));
+            toPathKey(original.replace(/\\/g, '/')).should.equal(toPathKey(variant));
+            utils.isSamePath(original, variant).should.equal(true);
+            utils.isSubPath(path.join(variant, 'Child'), original).should.equal(true);
+            toPathKey('\\\\Server\\Share\\CaseFolder\\Asset.TEST')
+                .should.equal(toPathKey('\\\\server\\share\\casefolder\\asset.test'));
+            toPathKey('\\\\?\\C:\\CaseFolder\\Asset.TEST')
+                .should.equal(toPathKey('\\\\?\\c:\\casefolder\\asset.test'));
+        } else {
+            toPathKey(original).should.not.equal(toPathKey(variant));
+            utils.isSamePath(original, variant).should.equal(false);
+        }
+
+        toPathKey('db://assets/CaseFolder/Asset.TEST').should.equal('db://assets/CaseFolder/Asset.TEST');
+        toPathKey('550E8400-E29B-41D4-A716-446655440000').should.equal('550E8400-E29B-41D4-A716-446655440000');
+    });
+
+    it('PathMap 与 PathSet 保留原始 key 并按平台比较路径', function() {
+        const original = path.join(process.cwd(), 'CaseFolder', 'Asset.TEST');
+        const variant = original.toLowerCase();
+        const map = new PathMap([[original, 1]]);
+        const set = new PathSet([original]);
+
+        if (process.platform === 'win32') {
+            map.get(variant).should.equal(1);
+            set.has(variant).should.equal(true);
+            map.set(variant, 2);
+            set.add(variant);
+            map.size.should.equal(1);
+            set.size.should.equal(1);
+            Array.from(map.keys()).should.deep.equal([variant]);
+            Array.from(set.values()).should.deep.equal([variant]);
+            Array.from(map.values()).should.deep.equal([2]);
+            Array.from(map.entries()).should.deep.equal([[variant, 2]]);
+            Array.from(map).should.deep.equal([[variant, 2]]);
+            let forEachEntry;
+            map.forEach((value, key, owner) => {
+                forEachEntry = [key, value, owner === map];
+            });
+            forEachEntry.should.deep.equal([variant, 2, true]);
+            map.delete(original).should.equal(true);
+            set.delete(original).should.equal(true);
+            map.size.should.equal(0);
+            set.size.should.equal(0);
+            map.set(original, 3).clear();
+            set.add(original).clear();
+            map.size.should.equal(0);
+            set.size.should.equal(0);
+        } else {
+            map.has(variant).should.equal(false);
+            set.has(variant).should.equal(false);
+        }
+    });
+
+    it('PathRecord 保持对象访问兼容并支持 Windows 大小写变体', function() {
+        const original = path.join(process.cwd(), 'CaseFolder', 'Asset.TEST.meta');
+        const variant = original.toLowerCase();
+        const record = createPathRecord();
+        record[original] = { value: 1 };
+
+        if (process.platform === 'win32') {
+            record[variant].value.should.equal(1);
+            (variant in record).should.equal(true);
+            record[variant] = { value: 2 };
+            Object.keys(record).should.deep.equal([variant]);
+            JSON.parse(JSON.stringify(record))[variant].value.should.equal(2);
+            delete record[original];
+            Object.keys(record).should.deep.equal([]);
+        } else {
+            (record[variant] === undefined).should.equal(true);
+        }
+    });
+
+    it('Windows 同 identity 的不同扫描路径会明确报错', function() {
+        if (process.platform !== 'win32') {
+            return;
+        }
+        const original = path.join(process.cwd(), 'CaseFolder', 'Asset.TEST');
+        const variant = path.join(process.cwd(), 'casefolder', 'asset.test');
+        (() => assertNoPathIdentityConflicts([original, variant])).should.throw(/Windows path case conflict/);
+    });
+
+    it('Windows 增量路径解析会检测大小写敏感目录中的真实冲突', function() {
+        if (process.platform !== 'win32') {
+            return;
+        }
+
+        const root = path.join(process.cwd(), 'case-sensitive-root');
+        const originalReaddirSync = fs.readdirSync;
+        fs.readdirSync = (directory) => {
+            if (utils.isSamePath(directory, root)) {
+                return ['A.test', 'a.test'];
+            }
+            return originalReaddirSync(directory);
+        };
+
+        try {
+            (() => resolveRealPathCase(path.join(root, 'a.test'), root))
+                .should.throw(/Windows path case conflict/);
+        } finally {
+            fs.readdirSync = originalReaddirSync;
         }
     });
 

--- a/packages/asset-db/test/18.path-case.spec.js
+++ b/packages/asset-db/test/18.path-case.spec.js
@@ -1,0 +1,347 @@
+'use strict';
+
+const { expect } = require('chai');
+const path = require('path');
+const fse = require('fs-extra');
+const { v4 } = require('node-uuid');
+
+const {
+    create,
+    queryAsset,
+    queryUUID,
+    queryUrl,
+    refresh,
+    reimport,
+} = require('../dist');
+const { getAssociatedFiles } = require('../dist/libs/dependency');
+const { Importer } = require('../dist/libs/importer');
+const { completionMeta } = require('../dist/libs/meta');
+
+const describeWindows = process.platform === 'win32' ? describe : describe.skip;
+let importerDependency = '';
+let cacheImporterDependency = '';
+
+function toggleAsciiCase(value) {
+    return value.replace(/[a-z]/gi, (character) => (
+        character === character.toLowerCase() ? character.toUpperCase() : character.toLowerCase()
+    ));
+}
+
+class TestImporter extends Importer {
+    get name() {
+        return 'test';
+    }
+
+    async import(asset) {
+        if (importerDependency) {
+            asset.depend(importerDependency);
+        }
+    }
+}
+
+class NoopImporter extends Importer {
+    get name() {
+        return 'test';
+    }
+
+    async import() {
+        // No generated files are required for cache tests.
+    }
+}
+
+class DependencyCacheImporter extends Importer {
+    get name() {
+        return 'test';
+    }
+
+    async import(asset) {
+        if (cacheImporterDependency && asset.basename === 'Source') {
+            asset.depend(cacheImporterDependency);
+        }
+    }
+}
+
+describeWindows('AssetDB Windows path identity', () => {
+    const PATHS = {
+        ROOT: path.join(__dirname, 'path-case'),
+        TARGET: path.join(__dirname, 'path-case', 'AssetsRoot'),
+        LIBRARY: path.join(__dirname, 'path-case', 'Library'),
+        TEMP: path.join(__dirname, 'path-case', 'Temp'),
+        FILE: path.join(__dirname, 'path-case', 'AssetsRoot', 'CaseDir', 'CaseAsset.TEST'),
+        DEPENDENCY: path.join(__dirname, 'path-case', 'AssetsRoot', 'Shared', 'Dependency.test'),
+        UUID: v4(),
+    };
+
+    let database;
+
+    before(async () => {
+        importerDependency = PATHS.DEPENDENCY;
+        fse.ensureDirSync(PATHS.LIBRARY);
+        fse.outputJSONSync(PATHS.FILE, { value: 1 }, { spaces: 2 });
+        fse.outputJSONSync(PATHS.FILE + '.meta', completionMeta({ uuid: PATHS.UUID }), { spaces: 2 });
+        database = create({
+            name: 'path-case',
+            target: PATHS.TARGET,
+            library: PATHS.LIBRARY,
+            temp: PATHS.TEMP,
+            level: 0,
+        });
+        database.importerManager.add(TestImporter, ['.test']);
+        await database.start();
+    });
+
+    after(async () => {
+        await database.stop();
+        await new Promise((resolve) => setTimeout(resolve, 600));
+        fse.removeSync(PATHS.ROOT);
+        importerDependency = '';
+    });
+
+    it('matches casing variants across query, UUID, URL, reimport, refresh, info, meta, and dependency APIs', async () => {
+        const variant = toggleAsciiCase(PATHS.FILE);
+        const dependencyVariant = toggleAsciiCase(PATHS.DEPENDENCY);
+        const asset = queryAsset(variant);
+
+        expect(asset).to.not.equal(null);
+        expect(asset.uuid).to.equal(PATHS.UUID);
+        expect(asset.source).to.equal(PATHS.FILE);
+        expect(queryUUID(variant)).to.equal(PATHS.UUID);
+        expect(database.pathToUuid(variant)).to.equal(PATHS.UUID);
+        expect(queryUrl(variant)).to.equal('db://path-case/CaseDir/CaseAsset.TEST');
+
+        const reimported = await reimport(variant);
+        expect(reimported.uuid).to.equal(PATHS.UUID);
+        expect(await refresh(variant)).to.be.a('number');
+        expect(queryAsset(variant).source).to.equal(PATHS.FILE);
+
+        expect(database.infoManager.get(variant)).to.not.equal(null);
+        expect(database.metaManager.path2meta[toggleAsciiCase(PATHS.FILE + '.meta')]).to.not.equal(undefined);
+
+        asset.depend(dependencyVariant);
+        expect(getAssociatedFiles(dependencyVariant)).to.deep.equal([PATHS.FILE]);
+    });
+
+    it('preserves UUID while adopting real casing after a case-only rename', async () => {
+        const previousPath = PATHS.FILE;
+        const nextPath = path.join(path.dirname(previousPath), 'CASEASSET.test');
+        const temporaryPath = path.join(path.dirname(previousPath), 'asset-case-rename.tmp');
+        const previousSize = database.path2asset.size;
+        const previousAsset = database.getAsset(PATHS.UUID);
+        const previousUrl = previousAsset.url;
+        const urlDependent = database.path2asset.get(path.dirname(previousPath));
+        urlDependent.depend(previousUrl);
+
+        fse.moveSync(previousPath, temporaryPath);
+        fse.moveSync(temporaryPath, nextPath);
+        fse.moveSync(previousPath + '.meta', temporaryPath + '.meta');
+        fse.moveSync(temporaryPath + '.meta', nextPath + '.meta');
+
+        await database.refresh(nextPath);
+
+        const asset = database.getAsset(PATHS.UUID);
+        expect(asset.source).to.equal(nextPath);
+        expect(asset.url).to.equal('db://path-case/CaseDir/CASEASSET.test');
+        expect(asset.basename).to.equal('CASEASSET');
+        expect(asset.extname).to.equal('.test');
+        expect(database.path2asset.size).to.equal(previousSize);
+        expect(Array.from(database.path2asset.keys())).to.include(nextPath);
+        expect(queryAsset(previousPath).uuid).to.equal(PATHS.UUID);
+        expect(queryUrl(previousPath)).to.equal(asset.url);
+
+        const infoPaths = [];
+        await database.infoManager.forEach((file) => infoPaths.push(file));
+        expect(infoPaths).to.include(nextPath);
+        expect(infoPaths).to.include(nextPath + '.meta');
+        expect(Object.keys(database.metaManager.path2meta)).to.include(nextPath + '.meta');
+        expect(getAssociatedFiles(toggleAsciiCase(PATHS.DEPENDENCY))).to.deep.equal([nextPath]);
+        expect(getAssociatedFiles(asset.url)).to.include(urlDependent.source);
+        expect(getAssociatedFiles(previousUrl)).to.deep.equal([]);
+    });
+
+    it('adopts real descendant casing when a renamed directory is refreshed directly', async () => {
+        const asset = database.getAsset(PATHS.UUID);
+        const previousDirectory = path.dirname(asset.source);
+        const nextDirectory = path.join(path.dirname(previousDirectory), 'CASEDIR');
+        const temporaryDirectory = path.join(path.dirname(previousDirectory), 'directory-case-rename.tmp');
+        const previousMeta = previousDirectory + '.meta';
+        const nextMeta = nextDirectory + '.meta';
+        const temporaryMeta = temporaryDirectory + '.meta';
+
+        fse.moveSync(previousDirectory, temporaryDirectory);
+        fse.moveSync(temporaryDirectory, nextDirectory);
+        if (fse.existsSync(previousMeta)) {
+            fse.moveSync(previousMeta, temporaryMeta);
+            fse.moveSync(temporaryMeta, nextMeta);
+        }
+
+        await database.refresh(nextDirectory);
+
+        expect(asset.source).to.equal(path.join(nextDirectory, 'CASEASSET.test'));
+        expect(asset.url).to.equal('db://path-case/CASEDIR/CASEASSET.test');
+        expect(queryAsset(toggleAsciiCase(asset.source)).uuid).to.equal(PATHS.UUID);
+    });
+
+    it('rejects conflicting paths returned by a directory scan', async () => {
+        const fastGlob = require('fast-glob');
+        const originalSync = fastGlob.sync;
+        const root = path.join(__dirname, 'path-case-scan-conflict');
+        const target = path.join(root, 'target');
+        const conflictDatabase = create({
+            name: 'path-case-scan-conflict',
+            target,
+            library: path.join(root, 'library'),
+            temp: path.join(root, 'temp'),
+            level: 0,
+        });
+        fse.ensureDirSync(target);
+
+        let error;
+        try {
+            fastGlob.sync = () => ['A.test', 'a.test'];
+            await conflictDatabase.start();
+        } catch (caught) {
+            error = caught;
+        } finally {
+            fastGlob.sync = originalSync;
+            await conflictDatabase.stop();
+            fse.removeSync(root);
+        }
+
+        expect(error).to.be.an('error');
+        expect(error.code).to.equal('ASSET_DB_PATH_CASE_CONFLICT');
+        expect(error.paths.map((item) => path.basename(item))).to.deep.equal(['A.test', 'a.test']);
+    });
+
+    it('discards a conflicting core cache and rebuilds it from disk', async () => {
+        const root = path.join(__dirname, 'path-case-cache-conflict');
+        const target = path.join(root, 'Target');
+        const library = path.join(root, 'Library');
+        const temp = path.join(root, 'Temp');
+        const file = path.join(target, 'CacheDir', 'CacheAsset.test');
+        const uuid = v4();
+        const options = {
+            name: 'path-case-cache-conflict',
+            target,
+            library,
+            temp,
+            level: 0,
+        };
+
+        fse.outputJSONSync(file, { value: 1 }, { spaces: 2 });
+        fse.outputJSONSync(file + '.meta', completionMeta({ uuid }), { spaces: 2 });
+        fse.ensureDirSync(library);
+
+        const initialDatabase = create(options);
+        initialDatabase.importerManager.add(NoopImporter, ['.test']);
+        await initialDatabase.start();
+        await initialDatabase.stop();
+
+        const cachePath = path.join(library, `.${options.name}`);
+        const cache = fse.readJSONSync(cachePath);
+        cache.data.paths.push(toggleAsciiCase(cache.data.paths[0]));
+        fse.outputJSONSync(cachePath, cache, { spaces: 2 });
+
+        const restoredDatabase = create(options);
+        restoredDatabase.importerManager.add(NoopImporter, ['.test']);
+        await restoredDatabase.startWithCache();
+
+        expect(restoredDatabase.path2asset.get(toggleAsciiCase(file)).uuid).to.equal(uuid);
+        const rebuiltCache = fse.readJSONSync(cachePath);
+        expect(rebuiltCache.data.paths.length).to.equal(new Set(rebuiltCache.data.paths.map((item) => item.toLowerCase())).size);
+
+        await restoredDatabase.stop();
+        await new Promise((resolve) => setTimeout(resolve, 600));
+        fse.removeSync(root);
+    });
+
+    it('reimports assets to rebuild dependencies after a dependency cache conflict', async () => {
+        const root = path.join(__dirname, 'path-case-dependency-cache-conflict');
+        const target = path.join(root, 'Target');
+        const library = path.join(root, 'Library');
+        const source = path.join(target, 'Source.test');
+        const dependency = path.join(target, 'Dependency.test');
+        const options = {
+            name: 'path-case-dependency-cache-conflict',
+            target,
+            library,
+            temp: path.join(root, 'Temp'),
+            level: 0,
+        };
+
+        fse.outputJSONSync(source, { value: 1 }, { spaces: 2 });
+        fse.outputJSONSync(dependency, { value: 2 }, { spaces: 2 });
+        fse.ensureDirSync(library);
+
+        cacheImporterDependency = dependency;
+        try {
+            const initialDatabase = create(options);
+            initialDatabase.importerManager.add(DependencyCacheImporter, ['.test']);
+            await initialDatabase.start();
+            await initialDatabase.stop();
+
+            const dependencyCachePath = path.join(library, `.${options.name}-dependency.json`);
+            const dependencyCache = fse.readJSONSync(dependencyCachePath);
+            const storedPath = Object.keys(dependencyCache.data.path)
+                .find((item) => /Source\.test$/i.test(item));
+            dependencyCache.data.path[toggleAsciiCase(storedPath)] = dependencyCache.data.path[storedPath];
+            fse.outputJSONSync(dependencyCachePath, dependencyCache, { spaces: 2 });
+
+            const restoredDatabase = create(options);
+            restoredDatabase.importerManager.add(DependencyCacheImporter, ['.test']);
+            await restoredDatabase.startWithCache();
+
+            expect(restoredDatabase.dependencyManager.cacheConflict).to.be.an('error');
+            expect(getAssociatedFiles(toggleAsciiCase(dependency))).to.include(source);
+
+            await restoredDatabase.stop();
+        } finally {
+            cacheImporterDependency = '';
+            fse.removeSync(root);
+        }
+    });
+
+    it('discards a conflicting info cache instead of silently restoring it', async () => {
+        const root = path.join(__dirname, 'path-case-info-cache-conflict');
+        const target = path.join(root, 'Target');
+        const library = path.join(root, 'Library');
+        const file = path.join(target, 'InfoDir', 'InfoAsset.test');
+        const uuid = v4();
+        const options = {
+            name: 'path-case-info-cache-conflict',
+            target,
+            library,
+            temp: path.join(root, 'Temp'),
+            level: 0,
+        };
+
+        fse.ensureDirSync(library);
+        fse.outputJSONSync(file, { value: 1 }, { spaces: 2 });
+        fse.outputJSONSync(file + '.meta', completionMeta({ uuid }), { spaces: 2 });
+
+        const initialDatabase = create(options);
+        initialDatabase.importerManager.add(NoopImporter, ['.test']);
+        await initialDatabase.start();
+        await initialDatabase.stop();
+
+        const infoCachePath = path.join(library, `.${options.name}-info.json`);
+        const infoCache = fse.readJSONSync(infoCachePath);
+        const storedPath = Object.keys(infoCache.map).find((item) => /InfoAsset\.test$/i.test(item));
+        infoCache.map[toggleAsciiCase(storedPath)] = infoCache.map[storedPath];
+        fse.outputJSONSync(infoCachePath, infoCache, { spaces: 2 });
+
+        const restoredDatabase = create(options);
+        restoredDatabase.importerManager.add(NoopImporter, ['.test']);
+        await restoredDatabase.startWithCache();
+
+        expect(restoredDatabase.infoManager.cacheConflict).to.be.an('error');
+        expect(restoredDatabase.path2asset.get(toggleAsciiCase(file)).uuid).to.equal(uuid);
+        expect(restoredDatabase.infoManager.get(toggleAsciiCase(file))).to.not.equal(null);
+
+        await restoredDatabase.stop();
+        const rebuiltInfoCache = fse.readJSONSync(infoCachePath);
+        const identityKeys = Object.keys(rebuiltInfoCache.map).map((item) => item.toLowerCase());
+        expect(identityKeys.length).to.equal(new Set(identityKeys).size);
+
+        fse.removeSync(root);
+    });
+});

--- a/packages/asset-db/test/4.dependency.spec.js
+++ b/packages/asset-db/test/4.dependency.spec.js
@@ -80,6 +80,34 @@ describe('Dependency 管理器', () => {
         expect(getAssociatedFiles('e2')).to.deep.equal(['e']);
     });
 
+    it('Windows 缓存中的大小写重复路径依赖会安全去重', async () => {
+        if (process.platform !== 'win32') {
+            return;
+        }
+
+        const cacheRoot = path.join(PATH.ROOT, 'case-cache');
+        const cacheFile = path.join(cacheRoot, 'dependency.json');
+        const source = path.join(cacheRoot, 'Source.test');
+        const dependency = path.join(cacheRoot, 'Dependency.test');
+        fse.outputJSONSync(cacheFile, {
+            version: DependencyManager.version,
+            data: {
+                path: {
+                    'Source.test': ['Dependency.test', 'dEPENDENCY.TEST'],
+                },
+                uuid: {},
+            },
+        }, { spaces: 2 });
+
+        const manager = new DependencyManager(console, cacheRoot);
+        await manager.setRecordJSON(cacheFile);
+
+        expect(getAssociatedFiles(dependency.toLowerCase())).to.deep.equal([source]);
+        expect(() => manager.remove('path', source.toLowerCase())).to.not.throw();
+        expect(getAssociatedFiles(dependency)).to.deep.equal([]);
+        manager.destroy();
+    });
+
     it('销毁管理器', async () => {
         DEPEND1.destroy();
         expect(getAssociatedFiles('d1')).to.deep.equal([]);

--- a/packages/asset-db/test/9.import.spec.js
+++ b/packages/asset-db/test/9.import.spec.js
@@ -192,7 +192,9 @@ describe('资源导入以及刷新等', () => {
 
     it('UUID 冲突的情况下，分配新的 id', async () => {
         record.length = 0;
-        const file = path.join(__dirname, './operation/target', '2.test');
+        // 2.TEST already exists above and is the same Windows filesystem path as 2.test.
+        const file = path.join(__dirname, './operation/target', '4.test');
+        fse.copyFileSync(PATH.FILE, file);
         fse.copyFileSync(PATH.FILE + '.meta', file + '.meta');
         await DB.refresh(file);
         expect(record.length).to.deep.equals(1);

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -1106,6 +1106,7 @@ export declare class AssetDB extends EventEmitter {
     reimport(fileOrUUID: string): Promise<VirtualAsset | null>;
     refresh(path: string, options?: AssetDBRefreshOptions): Promise<number>;
     private _replaceUUID;
+    private _updateAssetPathCase;
     private _checkAssetsStatSync;
     private _checkAssetStat;
 }
@@ -1733,6 +1734,7 @@ export declare class DependencyManager {
     dependMap: DependMap;
     _saveTimer: any;
     private console;
+    cacheConflict: PathCaseConflictError | null;
     constructor(customConsole: CustomConsole, pathRoot: string);
     setRecordJSON(path: string): Promise<void>;
     private _restoreCache;
@@ -1741,6 +1743,7 @@ export declare class DependencyManager {
     saveImmediate(): void;
     add(type: string, key: string, depends: string | string[]): void;
     remove(type: string, key: string): void;
+    updatePathCase(previousPath: string, nextPath: string): void;
     destroy(): void;
 }
 export declare interface DependMap {
@@ -1749,6 +1752,9 @@ export declare interface DependMap {
     };
     uuid: {
         [uuid: string]: string[];
+    };
+    [type: string]: {
+        [path: string]: string[];
     };
 }
 export declare interface DirectoryAssetUserData {
@@ -3148,6 +3154,7 @@ export declare class InfoManager {
     pathRoot: string;
     private recordInfo;
     private console;
+    cacheConflict: PathCaseConflictError | null;
     constructor(customConsole: CustomConsole, pathRoot: string);
     _saveTimer: null | NodeJS.Timeout;
     setRecordJSON(path: string): Promise<void>;
@@ -3161,6 +3168,7 @@ export declare class InfoManager {
     get(path: string): SimpleInfo;
     private addMissing;
     getMissingInfo(uuid: string): MissingAssetInfo;
+    updatePathCase(previousPath: string, nextPath: string): void;
     compare(path: string, mtimeMs: number): boolean;
     forEach(handler: Function): Promise<void>;
 }
@@ -3828,6 +3836,7 @@ export declare class MetaManager {
     remove(path: string, options?: IAssetDeleteOptions): Promise<void>;
     get(path: string): Promise<MetaInfo>;
     move(pathA: string, pathB: string): void;
+    updatePathCase(previousPath: string, nextPath: string): void;
 }
 export declare enum MinigamePlatform {
     WECHAT = 0,
@@ -4211,6 +4220,11 @@ export declare interface ParticleAssetUserData {
     rotatePerS: number;
     rotatePerSVar: number;
     spriteFrameUuid: string;
+}
+export declare class PathCaseConflictError extends Error {
+    readonly code = "ASSET_DB_PATH_CASE_CONFLICT";
+    readonly paths: readonly [string, string];
+    constructor(existingPath: string, incomingPath: string);
 }
 export declare type Physics = 'cannon' | 'ammo' | 'builtin';
 export declare type Platform = InternalPlatform | string;

--- a/src/core/assets/test/operation-filesystem-bridge.test.ts
+++ b/src/core/assets/test/operation-filesystem-bridge.test.ts
@@ -243,6 +243,25 @@ describe('asset operation filesystem bridge', () => {
         expect(result).toEqual({ source: asset.source });
     });
 
+    it('reimportAsset accepts a Windows absolute path with different casing without retrying', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const requestPath = 'g:\\Project\\Assets\\Game.ts';
+        const asset = {
+            init: true,
+            imported: true,
+            invalid: false,
+            source: 'G:\\Project\\Assets\\Game.ts',
+        };
+        mockReimport.mockResolvedValue(asset);
+
+        const result = await assetOperation.reimportAsset(requestPath);
+
+        expect(mockReimport).toHaveBeenCalledTimes(1);
+        expect(mockReimport).toHaveBeenCalledWith(requestPath);
+        expect(mockQueryAsset).not.toHaveBeenCalled();
+        expect(result).toEqual({ source: asset.source });
+    });
+
     it('reimportAsset still reports a genuinely missing asset', async () => {
         const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
         mockReimport.mockResolvedValue(null);


### PR DESCRIPTION
## 修复说明

修复 Windows 下 AssetDB 因路径大小写差异导致的查询、刷新及重导入失败。

### 主要改动

- 为绝对磁盘路径提供统一的大小写不敏感 identity。
- 保留磁盘真实 casing，不强制修改公开的 source 和 URL。
- 支持文件及目录 case-only rename。
- 检测 case-sensitive 目录中的同名冲突并明确报错。
- 修复 info、meta、dependency 及缓存恢复路径。
- dependency 缓存冲突时强制重建依赖。
- 同步迁移 case-only rename 前后的 URL 依赖。

### 测试方法
对于大小写混合的目录和文件名

在 PinK 中完成：
查询、打开、保存资源
Refresh
Reimport
Save As
创建、复制、移动、删除资源

确认没有：
Asset not found
查询或重导入超时
重复资源
UUID 意外变化