### PR TITLE
Fix component gizmo change notifications

### DIFF
--- a/src/core/scene/scene-process/service/gizmo/base/gizmo-base.ts
+++ b/src/core/scene/scene-process/service/gizmo/base/gizmo-base.ts
@@ -1,5 +1,5 @@
 import { Node, Component } from 'cc';
-import type { IUndoScope } from '../../../../common';
+import { NodeEventType, type IUndoScope } from '../../../../common';
 import {
     broadcastAnimationPropertyCommitted,
     normalizeAnimationPropertyCommitPath,
@@ -257,8 +257,13 @@ class GizmoBase<T extends Component = Component> {
         }
     }
 
-    protected onComponentChanged(_node: Node) {
-        // broadcast node change（CLI 中暂不实现）
+    protected onComponentChanged(node: Node) {
+        try {
+            const svcEvents = getServiceEvents();
+            svcEvents?.emit?.('node:change', node, { type: NodeEventType.COMPONENT_CHANGED });
+        } catch (e) {
+            console.warn('[Gizmo] Failed to emit component change event:', e);
+        }
     }
 
     public onEditorCameraMoved() {}

--- a/src/core/scene/test/gizmo-base-animation-commit.test.ts
+++ b/src/core/scene/test/gizmo-base-animation-commit.test.ts
@@ -37,6 +37,7 @@ describe('GizmoBase animation property commit event', () => {
         const { globalEventEmitter } = require('../scene-process/service/core/global-events');
         globalEventEmitter.removeAllListeners('gizmo:control-end');
         globalEventEmitter.removeAllListeners('animation:property-committed');
+        globalEventEmitter.removeAllListeners('node:change');
         globalEventEmitter.on('gizmo:control-end', (payload: unknown) => {
             broadcasts.push(['gizmo:control-end', payload]);
         });
@@ -55,6 +56,7 @@ describe('GizmoBase animation property commit event', () => {
         const { globalEventEmitter } = require('../scene-process/service/core/global-events');
         globalEventEmitter.removeAllListeners('gizmo:control-end');
         globalEventEmitter.removeAllListeners('animation:property-committed');
+        globalEventEmitter.removeAllListeners('node:change');
     });
 
     it('broadcasts normalized committed property payload on control end', async () => {
@@ -146,5 +148,27 @@ describe('GizmoBase animation property commit event', () => {
             propPath: 'position',
             source: 'engine',
         }]);
+    });
+
+    it('emits a component-changed node event when a component gizmo updates data', () => {
+        const { globalEventEmitter } = require('../scene-process/service/core/global-events');
+        const { NodeEventType } = require('../common');
+        const changes: unknown[][] = [];
+        globalEventEmitter.on('node:change', (...args: unknown[]) => {
+            changes.push(args);
+        });
+        const GizmoBase = require('../scene-process/service/gizmo/base/gizmo-base').default;
+        class TestGizmo extends GizmoBase {
+            emitComponentChanged(node: any) {
+                this.onComponentChanged(node);
+            }
+        }
+        const node = { uuid: 'Light' };
+
+        new (TestGizmo as any)(null).emitComponentChanged(node);
+
+        expect(changes).toEqual([
+            [node, { type: NodeEventType.COMPONENT_CHANGED }],
+        ]);
     });
 });


### PR DESCRIPTION
Related issue:  https://zentao.sud.center/index.php?m=bug&f=view&bugID=861

## Summary
- Emit component-changed node events when component gizmos update component data
- Restore the notification path used by light/probe gizmo handles so scene services, inspectors, and redraw logic observe the change
- Add coverage for the GizmoBase component change notification path

## Verification
- npm run test -- src/core/scene/test/gizmo-base-animation-commit.test.ts