### PR TITLE
fix(google-play): update min SDK version and unify build log filenames

### DIFF
--- a/src/core/builder/index.ts
+++ b/src/core/builder/index.ts
@@ -34,8 +34,15 @@ function getBuilderLogRoot() {
     return basename(projectTempDir) === 'builder' ? projectTempDir : join(projectTempDir, 'builder');
 }
 
-function normalizeBuildLogDest(logDest: string | undefined, taskName: string) {
-    const fallback = join(getBuilderLogRoot(), 'log', `${taskName.replace(/[\\/:*?"<>|]/g, '_')}-${Date.now()}.log`);
+// Log filename: {platform}-{action}-{timestamp}.log
+// e.g. google-play-build-1234567890.log, google-play-make-1234567890.log, google-play-bundle-build-1234567890.log
+function normalizeBuildLogDest(logDest: string | undefined, taskName: string, platform?: string) {
+    const sanitize = (s: string) => s.replace(/[\\/:*?"<>|]/g, '_');
+    const sanitizedTask = sanitize(taskName);
+    const sanitizedPlatform = platform ? sanitize(platform) : undefined;
+    const label = platform === taskName ? 'build' : sanitizedTask;
+    const parts = sanitizedPlatform ? [sanitizedPlatform, label, `${Date.now()}`] : [sanitizedTask, `${Date.now()}`];
+    const fallback = join(getBuilderLogRoot(), 'log', `${parts.join('-')}.log`);
     let resolvedLogDest = logDest ? utils.Path.resolveToRaw(logDest) : fallback;
     if (!isAbsolute(resolvedLogDest)) {
         resolvedLogDest = join(builderConfig.projectRoot, resolvedLogDest);
@@ -46,7 +53,7 @@ function normalizeBuildLogDest(logDest: string | undefined, taskName: string) {
 function ensureBuildLogSink(options: { logDest?: string; taskName?: string; platform?: string }, fallbackTaskName: string, logDest?: string) {
     const taskName = options.taskName || fallbackTaskName;
     options.taskName = taskName;
-    options.logDest = normalizeBuildLogDest(logDest || options.logDest, taskName);
+    options.logDest = normalizeBuildLogDest(logDest || options.logDest, taskName, options.platform);
     newConsole.record(options.logDest);
     return options.logDest;
 }
@@ -129,12 +136,12 @@ export async function createBundleBuildTask(bundleOptions: IBundleBuildOptions) 
 export async function buildBundleOnly(bundleOptions: IBundleBuildOptions): Promise<IBuildResultData> {
     const startTime = Date.now();
     const options = bundleOptions.buildTaskOptions;
-    const tasksLabel = bundleOptions.taskName || 'bundle Build';
+    const tasksLabel = bundleOptions.taskName || 'bundle-build';
     const taskStartTime = Date.now();
     const restoreLogSink = newConsole.createLogSinkRestorer();
 
     try {
-        bundleOptions.logDest = ensureBuildLogSink(options, tasksLabel, bundleOptions.logDest);
+        bundleOptions.logDest = ensureBuildLogSink({ platform: options.platform }, tasksLabel, bundleOptions.logDest);
         newConsole.stage('BUNDLE', `${tasksLabel} (${options.platform}) starting...`);
         console.debug('Start build task, options:', options);
         newConsole.trackMemoryStart(`builder:build-bundle-total`);
@@ -222,7 +229,7 @@ function mergeBuildStageRuntimeOptions(buildOptions: IBuildTaskOption<any>, opti
 
 export async function executeBuildStageTask(taskId: string, stageName: string, options: IBuildStageOptions, onProgress?: BuildStageProgressCallback): Promise<IBuildResultData> {
     if (!options.taskName) {
-        options.taskName = stageName + ' build';
+        options.taskName = stageName;
     }
     const restoreLogSink = newConsole.createLogSinkRestorer();
     ensureBuildLogSink(options, options.taskName, options.logDest);

--- a/src/core/builder/platforms/native-common/pack-tool/platforms/google-play.ts
+++ b/src/core/builder/platforms/native-common/pack-tool/platforms/google-play.ts
@@ -55,7 +55,7 @@ export interface IGooglePlayParams {
     isSoFileCompressed: boolean;
 }
 
-const DefaultAPILevel = 27;
+const DefaultAPILevel = 36;
 
 
 export default class GooglePlayPackTool extends NativePackTool {
@@ -371,11 +371,7 @@ export default class GooglePlayPackTool extends NativePackTool {
             if (process.platform === 'win32') {
                 keystorePath = cchelper.fixPath(keystorePath);
             }
-            let apiLevel = options.apiLevel;
-            if (!apiLevel) {
-                apiLevel = DefaultAPILevel;
-            }
-            console.log(`AndroidAPI level ${apiLevel}`);
+
             let content = fs.readFileSync(gradlePropertyPath, 'utf-8');
             if (keystorePath) {
                 content = content.replace(/.*RELEASE_STORE_FILE=.*/, `RELEASE_STORE_FILE=${keystorePath}`);
@@ -389,8 +385,18 @@ export default class GooglePlayPackTool extends NativePackTool {
                 content = content.replace(/.*RELEASE_KEY_PASSWORD=.*/, `# RELEASE_KEY_PASSWORD=${options.keystoreAliasPassword}`);
             }
 
-            const compileSDKVersion = this.parseVersion(content, 'PROP_COMPILE_SDK_VERSION', 27);
-            const minimalSDKVersion = this.parseVersion(content, 'PROP_MIN_SDK_VERSION', 21);
+            // compileSdkVersion: 27 -> 36, avoid android-36 (Preview) resource linking errors
+            // https://developer.android.com/google/play/requirements/target-sdk
+            let apiLevel = options.apiLevel || DefaultAPILevel;
+            console.log(`Android API level ${apiLevel}`);
+            const compileSdkVersion = Math.max(apiLevel, 36);
+            const compileSDKVersion = this.parseVersion(content, 'PROP_COMPILE_SDK_VERSION', compileSdkVersion);
+
+            // play-services-oss-licenses, introduced on Feb 2, 2026, requires minSdkVersion 24.
+            // https://developers.google.com/android/guides/releases
+            // Previously, Google Play Games Services for C++ required minSdkVersion 19:
+            // https://developer.android.com/games/pgs/cpp/cpp-setup
+            const minimalSDKVersion = this.parseVersion(content, 'PROP_MIN_SDK_VERSION', 24);
 
             content = content.replace(/PROP_TARGET_SDK_VERSION=.*/, `PROP_TARGET_SDK_VERSION=${apiLevel}`);
             content = content.replace(/PROP_COMPILE_SDK_VERSION=.*/, `PROP_COMPILE_SDK_VERSION=${Math.max(apiLevel, compileSDKVersion, 27)}`);

--- a/src/core/builder/test/build-bundle-only.spec.ts
+++ b/src/core/builder/test/build-bundle-only.spec.ts
@@ -1,0 +1,121 @@
+import { join } from 'path';
+import EventEmitter from 'events';
+
+const mockRestoreLogSink = jest.fn();
+
+jest.mock('fs-extra', () => ({}));
+
+jest.mock('../manager/plugin', () => ({
+    pluginManager: {},
+}));
+
+jest.mock('../share/builder-config', () => ({
+    __esModule: true,
+    default: {
+        projectRoot: 'project-root',
+        projectTempDir: 'project-root/temp',
+    },
+}));
+
+jest.mock('../share/common-options-validator', () => ({
+    fillIncludeModulesFromProjectConfig: jest.fn(),
+}));
+
+jest.mock('../../base/console', () => ({
+    newConsole: {
+        createLogSinkRestorer: jest.fn(() => mockRestoreLogSink),
+        record: jest.fn(),
+        stage: jest.fn(),
+        trackMemoryStart: jest.fn(),
+        trackMemoryEnd: jest.fn(),
+        taskComplete: jest.fn(),
+        success: jest.fn(),
+        error: jest.fn(),
+        progress: jest.fn(),
+    },
+}));
+
+jest.mock('../../base/utils', () => ({
+    __esModule: true,
+    default: {
+        Path: {
+            resolveToRaw: jest.fn((path: string) => path),
+            resolveToUrl: jest.fn((path: string) => `project://${path}`),
+        },
+    },
+}));
+
+jest.mock('../../assets/manager/asset', () => ({
+    __esModule: true,
+    default: { queryAsset: jest.fn() },
+}));
+
+function createMockBuilder(error?: any) {
+    const emitter = new EventEmitter();
+    return Object.assign(emitter, {
+        run: jest.fn(async () => !error),
+        error,
+        buildExitRes: { code: 0, dest: 'build/out', custom: {} },
+    });
+}
+
+jest.mock('../worker/builder/asset-handler/bundle', () => ({
+    BundleManager: {
+        create: jest.fn(async () => createMockBuilder()),
+    },
+}));
+
+describe('buildBundleOnly', () => {
+    let consoleDebug: jest.SpyInstance;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        consoleDebug = jest.spyOn(console, 'debug').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        consoleDebug.mockRestore();
+    });
+
+    it('uses bundleOptions.taskName for log filename instead of buildTaskOptions.taskName', async () => {
+        const { buildBundleOnly } = await import('../index');
+        const { newConsole } = await import('../../base/console');
+
+        const buildTaskOptions = {
+            platform: 'google-play',
+            taskName: 'google-play',
+        } as any;
+
+        await buildBundleOnly({
+            taskName: 'my-bundle',
+            dest: 'build/google-play',
+            buildTaskOptions,
+        });
+
+        const logDest = (newConsole.record as jest.Mock).mock.calls[0][0];
+        expect(logDest).toMatch(/temp[\\/]builder[\\/]log[\\/]google-play-my-bundle-/);
+        expect(logDest).toMatch(/\.log$/);
+        expect(buildTaskOptions.taskName).toBe('google-play');
+    });
+
+    it('falls back to bundle-build when bundleOptions.taskName is empty', async () => {
+        const { buildBundleOnly } = await import('../index');
+        const { newConsole } = await import('../../base/console');
+
+        const buildTaskOptions = {
+            platform: 'google-play',
+            taskName: 'google-play',
+        } as any;
+
+        await buildBundleOnly({
+            taskName: '',
+            dest: 'build/google-play',
+            buildTaskOptions,
+        });
+
+        const logDest = (newConsole.record as jest.Mock).mock.calls[0][0];
+        expect(logDest).toMatch(/temp[\\/]builder[\\/]log[\\/]google-play-bundle-build-/);
+        expect(logDest).toMatch(/\.log$/);
+        expect(buildTaskOptions.taskName).toBe('google-play');
+    });
+});

--- a/src/core/builder/test/execute-build-stage-task.spec.ts
+++ b/src/core/builder/test/execute-build-stage-task.spec.ts
@@ -339,7 +339,7 @@ describe('executeBuildStageTask', () => {
 
         expect(newConsole.record).toHaveBeenCalledTimes(1);
         const logDest = (newConsole.record as jest.Mock).mock.calls[0][0];
-        expect(logDest).toMatch(/temp[\\/]builder[\\/]log[\\/]upload build-/);
+        expect(logDest).toMatch(/temp[\\/]builder[\\/]log[\\/]openpaas-upload-/);
         expect(logDest).toMatch(/\.log$/);
         expect(receivedOptions.logDest).toBe(logDest);
     });
@@ -355,7 +355,7 @@ describe('executeBuildStageTask', () => {
 
         expect(newConsole.record).toHaveBeenCalledTimes(1);
         const logDest = (newConsole.record as jest.Mock).mock.calls[0][0];
-        expect(logDest).toMatch(/temp[\\/]builder[\\/]log[\\/]run build-/);
+        expect(logDest).toMatch(/temp[\\/]builder[\\/]log[\\/]web-desktop-run-/);
         expect(logDest).toMatch(/\.log$/);
         expect(hookModule.run).toHaveBeenCalledWith('build/web-desktop', undefined);
     });
@@ -413,11 +413,44 @@ describe('executeBuildStageTask', () => {
         });
 
         const firstLogDest = (newConsole.record as jest.Mock).mock.calls[0][0];
-        expect(firstLogDest).toContain('upload build-');
+        expect(firstLogDest).toContain('openpaas-upload-');
         expect(firstLogDest).toMatch(/\.log$/);
         expect(result).toEqual({
             code: 34,
             reason: 'missing build options',
         });
+    });
+
+    it('uses build as action label when taskName equals platform', async () => {
+        const { executeBuildStageTask } = await import('../index');
+        const { newConsole } = await import('../../base/console');
+
+        await executeBuildStageTask('task-id', 'run', {
+            dest: 'build/web-desktop',
+            platform: 'web-desktop',
+            taskName: 'web-desktop',
+        });
+
+        const logDest = (newConsole.record as jest.Mock).mock.calls[0][0];
+        expect(logDest).toMatch(/temp[\\/]builder[\\/]log[\\/]web-desktop-build-/);
+        expect(logDest).toMatch(/\.log$/);
+    });
+
+    it('includes platform prefix in log filename for mini-game platforms', async () => {
+        const { executeBuildStageTask } = await import('../index');
+        const { newConsole } = await import('../../base/console');
+        mockGetHooksInfo.mockReturnValue({
+            pkgNameOrder: ['wechatgame'],
+            infos: { wechatgame: { path: 'wechatgame/hooks', internal: true } },
+        });
+
+        await executeBuildStageTask('task-id', 'run', {
+            dest: 'build/wechatgame',
+            platform: 'wechatgame',
+        });
+
+        const logDest = (newConsole.record as jest.Mock).mock.calls[0][0];
+        expect(logDest).toMatch(/temp[\\/]builder[\\/]log[\\/]wechatgame-run-/);
+        expect(logDest).toMatch(/\.log$/);
     });
 });


### PR DESCRIPTION
## Changes
- Raise google-play `DefaultAPILevel` from 27 to 36, update `compileSdkVersion` and `minSdkVersion` defaults to meet latest Google Play requirements
- Unify build log filename format to `{platform}-{action}-{timestamp}.log` (e.g. `google-play-build-xxx.log`, `google-play-make-xxx.log`)
- Sanitize both platform and taskName in log filenames to prevent illegal paths on Windows
- Ensure `buildBundleOnly` uses `bundleOptions.taskName` for log naming instead of falling through to `buildTaskOptions.taskName`
- Update and add tests for the new log naming convention

## Test plan
- [x] Build google-play platform, compile successfully