### PR TITLE
fix(google-play): ensure gradlew has execute permission on macOS/Linux

### DIFF
--- a/src/core/builder/platforms/native-common/pack-tool/platforms/google-play.ts
+++ b/src/core/builder/platforms/native-common/pack-tool/platforms/google-play.ts
@@ -144,6 +144,7 @@ export default class GooglePlayPackTool extends NativePackTool {
         if (process.platform === 'win32') {
             gradle += '.bat';
         } else {
+            await fs.chmod(ps.join(projDir, 'gradlew'), '755');
             gradle = './' + gradle;
         }
 


### PR DESCRIPTION
## Changes
- Add `fs.chmod(gradlew, '755')` before invoking gradlew on non-Windows platforms to ensure execute permission is set

## Test plan
- [x] Build google-play platform on macOS, make stage completes without permission denied error
- [ ] https://zentao.sud.center/index.php?m=bug&f=view&bugID=860