### PR TITLE
Align wander startup state with Creator

### DIFF
--- a/src/core/scene/scene-process/service/camera/modes/engine-state.ts
+++ b/src/core/scene/scene-process/service/camera/modes/engine-state.ts
@@ -1,0 +1,20 @@
+import { Service } from '../../core/decorator';
+import { NeedAnimState } from '../../engine';
+
+export function enterCameraState(state: NeedAnimState) {
+    try {
+        (Service.Engine as any)?.enterState?.(state);
+    } catch (e) {
+        // Engine may not be ready
+    }
+}
+
+export function exitCameraState(state: NeedAnimState) {
+    try {
+        (Service.Engine as any)?.exitState?.(state);
+    } catch (e) {
+        // Engine may not be ready
+    }
+}
+
+export { NeedAnimState };

--- a/src/core/scene/scene-process/service/camera/modes/orbit-mode.ts
+++ b/src/core/scene/scene-process/service/camera/modes/orbit-mode.ts
@@ -3,6 +3,7 @@ import ModeBase3D from './mode-base-3d';
 import { CameraMoveMode } from '../utils';
 import type { ISceneMouseEvent } from '../../operation/types';
 import type { CameraController3D } from '../camera-controller-3d';
+import { enterCameraState, exitCameraState, NeedAnimState } from './engine-state';
 
 class OrbitMode extends ModeBase3D {
     private _rotateSpeed = 0.006;
@@ -17,21 +18,11 @@ class OrbitMode extends ModeBase3D {
         node.getWorldRotation(this._curRot);
         this._cameraCtrl.viewDist = Vec3.distance(this._curPos, this._cameraCtrl.sceneViewCenter);
         this._cameraCtrl.emit('camera-move-mode', CameraMoveMode.ORBIT);
-        try {
-            const { Service } = require('../../core/decorator');
-            Service.Engine?.repaintInEditMode?.();
-        } catch (e) {
-            // Engine may not be ready
-        }
+        enterCameraState(NeedAnimState.CAMERA_ORBIT);
     }
 
     public async exit() {
-        try {
-            const { Service } = require('../../core/decorator');
-            Service.Engine?.repaintInEditMode?.();
-        } catch (e) {
-            // Engine may not be ready
-        }
+        exitCameraState(NeedAnimState.CAMERA_ORBIT);
     }
 
     onMouseDown(event: ISceneMouseEvent): boolean {

--- a/src/core/scene/scene-process/service/camera/modes/pan-mode.ts
+++ b/src/core/scene/scene-process/service/camera/modes/pan-mode.ts
@@ -3,6 +3,7 @@ import ModeBase3D from './mode-base-3d';
 import { CameraMoveMode } from '../utils';
 import type { ISceneMouseEvent } from '../../operation/types';
 import type { CameraController3D } from '../camera-controller-3d';
+import { enterCameraState, exitCameraState, NeedAnimState } from './engine-state';
 
 const v3a = new Vec3();
 const v3b = new Vec3();
@@ -26,22 +27,12 @@ class PanMode extends ModeBase3D {
         Vec3.normalize(this._up, this._up);
 
         this._cameraCtrl.emit('camera-move-mode', CameraMoveMode.PAN);
-        try {
-            const { Service } = require('../../core/decorator');
-            Service.Engine?.repaintInEditMode?.();
-        } catch (e) {
-            // Engine may not be ready
-        }
+        enterCameraState(NeedAnimState.CAMERA_PAN);
     }
 
     public async exit() {
         this._cameraCtrl.updateViewCenterByDist(-this._cameraCtrl.viewDist);
-        try {
-            const { Service } = require('../../core/decorator');
-            Service.Engine?.repaintInEditMode?.();
-        } catch (e) {
-            // Engine may not be ready
-        }
+        exitCameraState(NeedAnimState.CAMERA_PAN);
     }
 
     onMouseMove(event: ISceneMouseEvent): boolean {

--- a/src/core/scene/scene-process/service/camera/modes/wander-mode.ts
+++ b/src/core/scene/scene-process/service/camera/modes/wander-mode.ts
@@ -4,6 +4,7 @@ import { CameraMoveMode, CameraUtils } from '../utils';
 import { AnimVec3 } from '../animate-value';
 import type { ISceneMouseEvent, ISceneKeyboardEvent } from '../../operation/types';
 import type { CameraController3D } from '../camera-controller-3d';
+import { enterCameraState, exitCameraState, NeedAnimState } from './engine-state';
 
 const v3b = new Vec3();
 const v3c = new Vec3();
@@ -94,13 +95,7 @@ class WanderMode extends ModeBase3D {
 
         this._cameraCtrl.emit('camera-move-mode', CameraMoveMode.WANDER);
         CameraUtils.showWanderTip();
-
-        try {
-            const { Service } = require('../../core/decorator');
-            Service.Engine?.repaintInEditMode?.();
-        } catch (e) {
-            // Engine may not be ready
-        }
+        enterCameraState(NeedAnimState.CAMERA_WANDER);
     }
 
     public async exit() {
@@ -113,14 +108,8 @@ class WanderMode extends ModeBase3D {
         }
 
         this._cameraCtrl.updateViewCenterByDist(-this._cameraCtrl.viewDist);
+        exitCameraState(NeedAnimState.CAMERA_WANDER);
         this._velocity.set(0, 0, 0);
-
-        try {
-            const { Service } = require('../../core/decorator');
-            Service.Engine?.repaintInEditMode?.();
-        } catch (e) {
-            // Engine may not be ready
-        }
     }
 
     onMouseMove(event: ISceneMouseEvent): boolean {
@@ -254,16 +243,6 @@ class WanderMode extends ModeBase3D {
         Vec3.transformQuat(v3d, v3d, this._curRot);
         Vec3.add(eye, eye, v3d);
         Vec3.lerp(this._curPos, this._curPos, eye, this._damping);
-
-        // CLI-specific: request repaint since we don't have enterState/exitState
-        if (this._wanderKeyDown || this._curMouseDX !== 0 || this._curMouseDY !== 0) {
-            try {
-                const { Service } = require('../../core/decorator');
-                Service.Engine?.repaintInEditMode?.();
-            } catch (e) {
-                // Engine may not be ready
-            }
-        }
 
         this._cameraCtrl.node.setPosition(this._curPos);
         this._cameraCtrl.node.setRotation(this._curRot);

--- a/src/core/scene/scene-process/service/camera/modes/wander-mode.ts
+++ b/src/core/scene/scene-process/service/camera/modes/wander-mode.ts
@@ -81,10 +81,6 @@ class WanderMode extends ModeBase3D {
 
         this._curMouseDX = 0;
         this._curMouseDY = 0;
-        this._wanderKeyDown = false;
-        this._shiftKey = false;
-        this._wanderSpeedTarget = 0;
-        this._wanderAnim.value = new Vec3();
 
         try {
             const { Service } = require('../../core/decorator');


### PR DESCRIPTION
Related issue:
https://zentao.sud.center/index.php?m=bug&f=view&bugID=858

## Summary
- keep the existing wander easing state when entering wander mode
- align right-button WASD startup behavior with Creator

## Validation
- npx tsc --noEmit --pretty false