### PR TITLE
fix(scene): provide Editor project path in scene process

### DIFF
--- a/src/core/base/editor-shim.ts
+++ b/src/core/base/editor-shim.ts
@@ -1,0 +1,14 @@
+export function ensureEditorProjectPath(projectPath: string): any {
+    const globalObject = globalThis as any;
+
+    if (!globalObject.Editor || typeof globalObject.Editor !== 'object') {
+        globalObject.Editor = {};
+    }
+
+    globalObject.Editor.Project = {
+        ...(globalObject.Editor.Project ?? {}),
+        path: projectPath,
+    };
+
+    return globalObject.Editor;
+}

--- a/src/core/preview/extension-host/editor-shim.ts
+++ b/src/core/preview/extension-host/editor-shim.ts
@@ -1,4 +1,5 @@
 import { compressUUID, decompressUUID } from '../../base/utils/uuid';
+import { ensureEditorProjectPath } from '../../base/editor-shim';
 import { MessageBus } from './message-bus';
 import { ProfileStore } from './profile-store';
 
@@ -18,12 +19,12 @@ export interface EditorShimContext {
 export function installEditorShim(ctx: EditorShimContext): void {
     const g = globalThis as any;
     if (g.Editor && g.Editor.__cliExtensionHost) {
-        g.Editor.Project.path = ctx.projectPath;
+        ensureEditorProjectPath(ctx.projectPath);
         return;
     }
     g.Editor = {
         __cliExtensionHost: true,
-        Project: { path: ctx.projectPath },
+        Project: {},
         Message: {
             request: (domain: string, message: string, ...args: any[]) => ctx.bus.dispatch(domain, message, ...args),
             send: (domain: string, message: string, ...args: any[]) => { void ctx.bus.dispatch(domain, message, ...args); },
@@ -47,4 +48,5 @@ export function installEditorShim(ctx: EditorShimContext): void {
         Metrics: { trackEvent: () => { /* no-op */ } },
         Panel: { open: () => { /* no-op */ }, close: () => { /* no-op */ } },
     };
+    ensureEditorProjectPath(ctx.projectPath);
 }

--- a/src/core/scene/scene-process/editor-shim.test.ts
+++ b/src/core/scene/scene-process/editor-shim.test.ts
@@ -1,0 +1,40 @@
+import { installSceneEditorShim } from './editor-shim';
+
+describe('scene-process editor shim', () => {
+    let previousEditor: any;
+
+    beforeEach(() => {
+        previousEditor = (globalThis as any).Editor;
+        delete (globalThis as any).Editor;
+    });
+
+    afterEach(() => {
+        if (previousEditor === undefined) {
+            delete (globalThis as any).Editor;
+        } else {
+            (globalThis as any).Editor = previousEditor;
+        }
+    });
+
+    it('installs the project path used by userland macro modules', () => {
+        installSceneEditorShim('D:/project');
+
+        expect((globalThis as any).Editor.Project.path).toBe('D:/project');
+    });
+
+    it('preserves an existing Editor object while refreshing Project.path', () => {
+        const request = jest.fn();
+        (globalThis as any).Editor = {
+            Message: { request },
+            Project: { path: 'D:/old-project', name: 'old-project' },
+        };
+
+        installSceneEditorShim('D:/new-project');
+
+        expect((globalThis as any).Editor.Message.request).toBe(request);
+        expect((globalThis as any).Editor.Project).toEqual({
+            path: 'D:/new-project',
+            name: 'old-project',
+        });
+    });
+});

--- a/src/core/scene/scene-process/editor-shim.ts
+++ b/src/core/scene/scene-process/editor-shim.ts
@@ -1,0 +1,13 @@
+import { ensureEditorProjectPath } from '../../base/editor-shim';
+
+export function installSceneEditorShim(projectPath: string): void {
+    const editor = ensureEditorProjectPath(projectPath);
+
+    if (!editor.__cliExtensionHost) {
+        editor.__cliSceneProcess = true;
+    }
+
+    editor.I18n ??= {
+        t: (key: string) => key,
+    };
+}

--- a/src/core/scene/scene-process/main.ts
+++ b/src/core/scene/scene-process/main.ts
@@ -4,6 +4,7 @@ import { parseCommandLineArgs, resolveSceneAssetBase } from './utils';
 import { Engine } from '../../engine';
 import { join } from 'path';
 import { serviceManager } from './service/service-manager';
+import { installSceneEditorShim } from './editor-shim';
 
 async function startup() {
     // 监听进程退出事件
@@ -30,6 +31,7 @@ async function startup() {
     }
 
     // 初始化 service-manager
+    installSceneEditorShim(projectPath);
     serviceManager.initialize(serverURL ?? '');
 
     await Engine.init(enginePath);


### PR DESCRIPTION
## Summary
- Add a shared helper for keeping `Editor.Project.path` available in Node-side editor shims.
- Install a minimal scene-process `Editor` shim before scene services initialize.
- Reuse the shared project-path helper from the preview extension-host shim.

## Problem
Project scripts that import userland macros, for example:

```ts
import { env_dev } from 'cc/userland/macro';
```

are resolved by `@cocos/lib-programming` through `Editor.Project.path` so it can load `temp/programming/custom-macro.js`. In the IDE scene process, `Editor` was not defined, which caused startup to fail with `ReferenceError: Editor is not defined`.

## Validation
- `npx jest src/core/scene/scene-process/editor-shim.test.ts --runInBand`
- `npx tsc -b`