### PR TITLE
Fix scene asset preview loading

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -1536,6 +1536,7 @@ export declare class BundleManager extends BuildTaskBase implements IBundleManag
     private initInternalBundleConfigs;
     private patchProjectBundleConfig;
     private initBundleRootAssets;
+    private addSceneEditorAssets;
     private initBundleShareAssets;
     bundleDataTask(): Promise<void>;
     private compressImage;

--- a/src/core/builder/worker/builder/asset-handler/bundle/index.ts
+++ b/src/core/builder/worker/builder/asset-handler/bundle/index.ts
@@ -542,6 +542,10 @@ export class BundleManager extends BuildTaskBase implements IBundleManager {
         }
 
         if (launchBundle) {
+            if (this.options.preview && (this.options as any).sceneEditor) {
+                this.addSceneEditorAssets(launchBundle);
+            }
+
             // 加入项目设置中的 renderPipeline 资源
             if (this.options.renderPipeline) {
                 launchBundle.addRootAsset(buildAssetLibrary.getAsset(this.options.renderPipeline));
@@ -557,6 +561,15 @@ export class BundleManager extends BuildTaskBase implements IBundleManager {
         console.debug(`  Number of all scripts: ${this.cache.scriptUuids.length}`);
         console.debug(`  Number of other assets: ${this.cache.assetUuids.length}`);
         this.updateProcess('Init bundle root assets success...');
+    }
+
+    private addSceneEditorAssets(bundle: IBundle) {
+        for (const uuid of this.cache.assetUuids) {
+            const asset = buildAssetLibrary.getAsset(uuid);
+            if (asset) {
+                bundle.addRootAsset(asset);
+            }
+        }
     }
 
     /**

--- a/src/core/preview/preview-settings.ts
+++ b/src/core/preview/preview-settings.ts
@@ -9,6 +9,10 @@ import type { IPreviewSettingsResult } from '../builder/@types/private';
  */
 const cache = new Map<string, IPreviewSettingsResult>();
 
+function makeCacheKey(startScene: string, sceneEditor: boolean): string {
+    return JSON.stringify({ startScene, sceneEditor });
+}
+
 /**
  * 预览尚未就绪时抛出。路由据此返回可重试的 503，而不是生成缺 builtinAssets 的坏 settings 或裸 500。
  *
@@ -37,7 +41,16 @@ export class PreviewNotReadyError extends Error {
  * @param startScene 启动场景的 uuid 或 db:// url，留空表示使用项目默认启动场景
  */
 export async function getCachedPreviewSettings(startScene = ''): Promise<IPreviewSettingsResult> {
-    const cached = cache.get(startScene);
+    return await getCachedSettings(startScene, false);
+}
+
+export async function getCachedSceneEditorSettings(): Promise<IPreviewSettingsResult> {
+    return await getCachedSettings('', true);
+}
+
+async function getCachedSettings(startScene: string, sceneEditor: boolean): Promise<IPreviewSettingsResult> {
+    const cacheKey = makeCacheKey(startScene, sceneEditor);
+    const cached = cache.get(cacheKey);
     if (cached) {
         return cached;
     }
@@ -46,8 +59,8 @@ export async function getCachedPreviewSettings(startScene = ''): Promise<IPrevie
     if (!assetDBManager.ready) {
         throw new PreviewNotReadyError();
     }
-    const result = await generatePreviewSettings(startScene);
-    cache.set(startScene, result);
+    const result = await generatePreviewSettings(startScene, sceneEditor);
+    cache.set(cacheKey, result);
     return result;
 }
 
@@ -55,7 +68,7 @@ export async function getCachedPreviewSettings(startScene = ''): Promise<IPrevie
  * 生成并**校验**预览 settings。未就绪（生成抛错或 builtinAssets 为空）时抛 PreviewNotReadyError。
  * 抽出为独立函数，供 getCachedPreviewSettings 与 live-reload 的就绪探测复用；不写缓存。
  */
-async function generatePreviewSettings(startScene: string): Promise<IPreviewSettingsResult> {
+async function generatePreviewSettings(startScene: string, sceneEditor: boolean): Promise<IPreviewSettingsResult> {
     const { assetManager } = await import('../assets');
     let result: IPreviewSettingsResult;
     try {
@@ -90,6 +103,7 @@ async function generatePreviewSettings(startScene: string): Promise<IPreviewSett
             effectiveScene = await resolveDefaultStartScene();
         }
         (options as any).startScene = effectiveScene;
+        (options as any).sceneEditor = sceneEditor;
         // 预览模式下注册项目中的全部场景，使运行时 cc.director.loadScene(name)/(uuid) 可加载任意场景，
         // 对齐编辑器预览行为。构建配置里的 scenes 默认只含构建时勾选的子集，会导致脚本里按名
         // loadScene 其它场景时报 "not in the build settings before playing"。

--- a/src/core/scene/scene-process/engine-bootstrap.test.ts
+++ b/src/core/scene/scene-process/engine-bootstrap.test.ts
@@ -74,6 +74,20 @@ describe('scene-process engine bootstrap', () => {
             })
             .mockResolvedValueOnce({
                 json: async () => ['base', 'custom-pipeline'],
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    settings: {
+                        assets: {
+                            preloadBundles: [{ bundle: 'main' }],
+                        },
+                        engine: {
+                            builtinAssets: ['builtin-material'],
+                        },
+                    },
+                    bundleConfigs: [],
+                }),
             });
         (globalThis as any).document = {
             getElementById: jest.fn(() => null),
@@ -109,6 +123,11 @@ describe('scene-process engine bootstrap', () => {
             },
             assetManager: {
                 loadAny: jest.fn(),
+                loadBundle: jest.fn((_url: string, callback: Function) => callback(null, {})),
+                getBundle: jest.fn(() => null),
+                downloader: {
+                    appendTimeStamp: true,
+                },
                 bundles: {
                     forEach: jest.fn(),
                 },
@@ -139,41 +158,66 @@ describe('scene-process engine bootstrap', () => {
         }));
     });
 
-    it('reloads project assets without using the browser cache', async () => {
-        const oldAsset = { _uuid: 'asset-uuid', old: true };
-        const newAsset = { _uuid: '', old: false };
-        const cache = new Map<string, any>([['asset-uuid', oldAsset]]);
-        const assets = {
-            get: jest.fn((uuid: string) => cache.get(uuid)),
-            add: jest.fn((uuid: string, asset: any) => cache.set(uuid, asset)),
-            remove: jest.fn((uuid: string) => cache.delete(uuid)),
-        };
-        (globalThis as any).cc.assetManager.assets = assets;
-        (globalThis as any).cc.deserialize = jest.fn(() => newAsset);
-        (global.fetch as jest.Mock)
+    it('applies scene editor asset settings to cc.game.init', async () => {
+        await startup({ serverURL: 'http://localhost:7456' });
+
+        expect(global.fetch).toHaveBeenCalledWith(
+            'http://localhost:7456/scene-editor/settings.json',
+            { cache: 'no-store' },
+        );
+        expect((globalThis as any).cc.game.init).toHaveBeenCalledWith(expect.objectContaining({
+            overrideSettings: expect.objectContaining({
+                assets: expect.objectContaining({
+                    server: 'http://localhost:7456',
+                    importBase: 'assets/general/import',
+                    nativeBase: 'assets/general/native',
+                    remoteBundles: [],
+                    subpackages: [],
+                    preloadBundles: [{ bundle: 'main' }],
+                }),
+                engine: expect.objectContaining({
+                    builtinAssets: ['builtin-material'],
+                }),
+            }),
+        }));
+    });
+
+    it('loads scene editor bundles through the original asset manager', async () => {
+        (global.fetch as jest.Mock).mockReset()
             .mockResolvedValueOnce({
-                text: async () => '.json',
+                json: async () => ({
+                    overrideSettings: {
+                        rendering: {},
+                    },
+                }),
+            })
+            .mockResolvedValueOnce({
+                json: async () => ['base'],
             })
             .mockResolvedValueOnce({
                 ok: true,
-                json: async () => ({}),
+                json: async () => ({
+                    settings: { assets: {} },
+                    bundleConfigs: [
+                        { name: 'main', deps: ['internal'] },
+                        { name: 'internal', deps: [] },
+                    ],
+                }),
             });
 
         await startup({ serverURL: 'http://localhost:7456' });
 
-        const loaded = await new Promise<any>((resolve, reject) => {
-            (globalThis as any).cc.assetManager.loadAny(
-                'asset-uuid',
-                { reloadAsset: true },
-                (err: Error | null, asset: any) => err ? reject(err) : resolve(asset),
-            );
-        });
-
-        expect(loaded).toBe(newAsset);
-        expect(assets.remove).toHaveBeenCalledWith('asset-uuid');
-        expect(global.fetch).toHaveBeenCalledWith(
-            expect.stringMatching(/^http:\/\/localhost:7456\/import\/asset-uuid\.json\?isBrowser=true&_t=/),
-            { cache: 'no-store' },
+        expect((globalThis as any).cc.assetManager.loadBundle).toHaveBeenNthCalledWith(
+            1,
+            'http://localhost:7456/scene-editor/assets/internal',
+            expect.any(Function),
         );
+        expect((globalThis as any).cc.assetManager.loadBundle).toHaveBeenNthCalledWith(
+            2,
+            'http://localhost:7456/scene-editor/assets/main',
+            expect.any(Function),
+        );
+        expect((globalThis as any).cc.assetManager.downloader.appendTimeStamp).toBe(true);
+        expect((globalThis as any).cc.assetManager.loadAny).not.toHaveBeenCalled();
     });
 });

--- a/src/core/scene/scene-process/engine-bootstrap.test.ts
+++ b/src/core/scene/scene-process/engine-bootstrap.test.ts
@@ -68,7 +68,16 @@ describe('scene-process engine bootstrap', () => {
             .mockResolvedValueOnce({
                 json: async () => ({
                     overrideSettings: {
+                        engine: {
+                            builtinAssets: ['engine-builtin'],
+                        },
                         rendering: {},
+                        assets: {
+                            server: 'http://localhost:7456',
+                            importBase: 'scripting/asset-library',
+                            nativeBase: 'scripting/asset-library',
+                            remoteBundles: ['internal', 'main'],
+                        },
                     },
                 }),
             })
@@ -125,6 +134,7 @@ describe('scene-process engine bootstrap', () => {
                 loadAny: jest.fn(),
                 loadBundle: jest.fn((_url: string, callback: Function) => callback(null, {})),
                 getBundle: jest.fn(() => null),
+                removeBundle: jest.fn(),
                 downloader: {
                     appendTimeStamp: true,
                 },
@@ -158,7 +168,7 @@ describe('scene-process engine bootstrap', () => {
         }));
     });
 
-    it('applies scene editor asset settings to cc.game.init', async () => {
+    it('keeps engine asset settings when querying scene editor settings', async () => {
         await startup({ serverURL: 'http://localhost:7456' });
 
         expect(global.fetch).toHaveBeenCalledWith(
@@ -169,14 +179,12 @@ describe('scene-process engine bootstrap', () => {
             overrideSettings: expect.objectContaining({
                 assets: expect.objectContaining({
                     server: 'http://localhost:7456',
-                    importBase: 'assets/general/import',
-                    nativeBase: 'assets/general/native',
-                    remoteBundles: [],
-                    subpackages: [],
-                    preloadBundles: [{ bundle: 'main' }],
+                    importBase: 'scripting/asset-library',
+                    nativeBase: 'scripting/asset-library',
+                    remoteBundles: ['internal', 'main'],
                 }),
                 engine: expect.objectContaining({
-                    builtinAssets: ['builtin-material'],
+                    builtinAssets: ['engine-builtin'],
                 }),
             }),
         }));
@@ -219,5 +227,42 @@ describe('scene-process engine bootstrap', () => {
         );
         expect((globalThis as any).cc.assetManager.downloader.appendTimeStamp).toBe(true);
         expect((globalThis as any).cc.assetManager.loadAny).not.toHaveBeenCalled();
+    });
+
+    it('keeps the existing internal bundle while loading scene editor bundles', async () => {
+        const internalBundle = { name: 'internal' };
+        (globalThis as any).cc.assetManager.getBundle = jest.fn((name: string) => {
+            return name === 'internal' ? internalBundle : null;
+        });
+        (global.fetch as jest.Mock).mockReset()
+            .mockResolvedValueOnce({
+                json: async () => ({
+                    overrideSettings: {
+                        rendering: {},
+                    },
+                }),
+            })
+            .mockResolvedValueOnce({
+                json: async () => ['base'],
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    settings: { assets: {} },
+                    bundleConfigs: [
+                        { name: 'resources', deps: ['internal'] },
+                        { name: 'internal', deps: [] },
+                    ],
+                }),
+            });
+
+        await startup({ serverURL: 'http://localhost:7456' });
+
+        expect((globalThis as any).cc.assetManager.removeBundle).not.toHaveBeenCalledWith(internalBundle);
+        expect((globalThis as any).cc.assetManager.loadBundle).toHaveBeenCalledTimes(1);
+        expect((globalThis as any).cc.assetManager.loadBundle).toHaveBeenCalledWith(
+            'http://localhost:7456/scene-editor/assets/resources',
+            expect.any(Function),
+        );
     });
 });

--- a/src/core/scene/scene-process/engine-bootstrap.ts
+++ b/src/core/scene/scene-process/engine-bootstrap.ts
@@ -5,7 +5,7 @@ import { Service as DecoratorService } from './service/core/decorator';
 import { messageManager } from './service/message';
 import { initLocalI18n } from './i18n';
 import { CUSTOM_PIPELINE_MODULE } from '../../engine/graphics-config';
-import { applySceneEditorAssetSettings, fetchSceneEditorSettings, syncSceneEditorBundles } from './scene-editor-assets';
+import { fetchSceneEditorSettings, syncSceneEditorBundles } from './scene-editor-assets';
 
 import './service';
 
@@ -39,7 +39,6 @@ export async function startup(options: {
         config.overrideSettings.rendering.effectSettingsPath = `${serverURL}/scripting/engine/effect-settings`;
     }
     const sceneEditorSettings = await fetchSceneEditorSettings(serverURL);
-    applySceneEditorAssetSettings(config, serverURL, sceneEditorSettings?.settings);
 
     serviceManager.initialize(serverURL);
 

--- a/src/core/scene/scene-process/engine-bootstrap.ts
+++ b/src/core/scene/scene-process/engine-bootstrap.ts
@@ -5,6 +5,7 @@ import { Service as DecoratorService } from './service/core/decorator';
 import { messageManager } from './service/message';
 import { initLocalI18n } from './i18n';
 import { CUSTOM_PIPELINE_MODULE } from '../../engine/graphics-config';
+import { applySceneEditorAssetSettings, fetchSceneEditorSettings, syncSceneEditorBundles } from './scene-editor-assets';
 
 import './service';
 
@@ -37,6 +38,8 @@ export async function startup(options: {
     if (customPipeline && !config.overrideSettings.rendering.effectSettingsPath) {
         config.overrideSettings.rendering.effectSettingsPath = `${serverURL}/scripting/engine/effect-settings`;
     }
+    const sceneEditorSettings = await fetchSceneEditorSettings(serverURL);
+    applySceneEditorAssetSettings(config, serverURL, sceneEditorSettings?.settings);
 
     serviceManager.initialize(serverURL);
 
@@ -67,18 +70,6 @@ export async function startup(options: {
         } catch (e) {
             console.error('Failed to load engine module:', mod, 'e:', e);
         }
-    }
-
-    let _decodeCCONBinaryCached = false;
-    let _decodeCCONBinary: ((bytes: Uint8Array) => any) | null = null;
-    async function getDecodeCCONBinary(): Promise<((bytes: Uint8Array) => any) | null> {
-        if (_decodeCCONBinaryCached) return _decodeCCONBinary;
-        try {
-            const m: any = await System.import('cc/editor/serialization');
-            _decodeCCONBinary = m?.decodeCCONBinary ?? null;
-        } catch { _decodeCCONBinary = null; }
-        _decodeCCONBinaryCached = true;
-        return _decodeCCONBinary;
     }
 
     // ---- hack creator 使用的一些 engine 参数
@@ -121,6 +112,7 @@ export async function startup(options: {
     cc.physics.selector.runInEditor = true;
 
     await cc.game.init(config);
+    await syncSceneEditorBundles(serverURL, sceneEditorSettings?.bundleConfigs);
 
     let backend = 'builtin';
     const Backends: Record<string, string> = {
@@ -179,309 +171,6 @@ export async function startup(options: {
     // services create cameras that would otherwise render on mainWindow
     // before any scene is loaded, causing FRAMEBUFFER_INCOMPLETE errors.
     DecoratorService.Engine.pause();
-
-    // Override assetManager.loadAny to fetch project assets from the server
-    // when they aren't found in any loaded bundle (e.g., main bundle not loaded).
-    const am = cc.assetManager;
-    const origLoadAny = am.loadAny.bind(am);
-
-    // Tracks per-uuid native (image/buffer) loading. An asset is added to the
-    // asset cache before its native data is attached (so circular references can
-    // resolve), which means a concurrent cache hit could otherwise return a
-    // texture/image whose width/height are still 0. Cache hits await this to get
-    // fully-loaded dimensions; see loadFromServer / loadAny below.
-    const nativeReady = new Map<string, Promise<void>>();
-
-    // Dedups concurrent loads of the same uuid during the fetch/deserialize
-    // window (before the asset is registered in the cache). Without this, two
-    // sprite frames sharing a texture can each start a separate load, producing
-    // duplicate half-initialized instances and racing the nativeReady bookkeeping
-    // (one loader deleting the other's readiness promise), which leaves a
-    // width-0 texture reachable via a cache hit.
-    const inFlight = new Map<string, Promise<{ err: any; asset: any }>>();
-
-    function tryDecompress(uuid: string): string {
-        if (uuid.includes('-')) return uuid;
-        try {
-            return (EditorExtends.UuidUtils as any)?.decompressUuid?.(uuid) ?? uuid;
-        } catch { return uuid; }
-    }
-
-    function isUuidInBundles(uuid: string): boolean {
-        const variants = [uuid, uuid.split('@')[0]];
-        const dec = tryDecompress(uuid);
-        if (dec !== uuid) variants.push(dec, dec.split('@')[0]);
-
-        let found = false;
-        am.bundles.forEach((bundle: any) => {
-            if (found) return;
-            for (const v of variants) {
-                if (bundle.getAssetInfo(v)) { found = true; return; }
-            }
-        });
-        return found;
-    }
-
-    const silentClassFinder = (id: string) => cc.js?.getClassById?.(id) ?? cc._MissingScript ?? null;
-
-    interface IServerLoadOptions {
-        reloadAsset?: boolean;
-    }
-
-    function addCacheBust(url: string): string {
-        const separator = url.includes('?') ? '&' : '?';
-        return `${url}${separator}_t=${Date.now()}`;
-    }
-
-    function fetchAsset(url: string, options?: IServerLoadOptions): Promise<Response> {
-        if (options?.reloadAsset) {
-            return fetch(addCacheBust(url), { cache: 'no-store' });
-        }
-        return fetch(url);
-    }
-
-    function removeAssetCache(uuid: string): void {
-        const dec = tryDecompress(uuid);
-        const variants = new Set([uuid, dec]);
-        for (const id of variants) {
-            try {
-                if (am.assets.get(id)) {
-                    am.assets.remove?.(id);
-                }
-            } catch {
-                // Asset cache implementations differ between engine builds.
-            }
-            nativeReady.delete(id);
-        }
-    }
-
-    async function queryNativeExt(uuid: string, options?: IServerLoadOptions): Promise<string> {
-        // The imported asset JSON (e.g. cc.ImageAsset, serialized as
-        // { fmt, w:0, h:0 }) does not embed the native extension — it lives in
-        // the asset's library file map. Recover it so assets whose real data
-        // (and, for images, their width/height) come from the native file can
-        // be loaded. Without this, an ImageAsset stays 0x0, its Texture2D
-        // reports width 0, and every SpriteFrame on it fails checkRect and gets
-        // its rect reset (e.g. sprite frames from a plist atlas in a prefab).
-        try {
-            const res = await fetchAsset(`${serverURL}/query-asset-info/${encodeURIComponent(uuid)}`, options);
-            if (!res.ok) return '';
-            const info: any = await res.json();
-            const lib = info?.library;
-            if (!lib) return '';
-            // The native entry is the library file that is not the serialized
-            // asset itself (.json / .cconb).
-            const key = Object.keys(lib).find((k) => k !== '.json' && k !== '.cconb');
-            return key ?? '';
-        } catch {
-            return '';
-        }
-    }
-
-    async function loadNativeAsset(asset: any, uuid: string, options?: IServerLoadOptions): Promise<void> {
-        let nativeExt: string | undefined = asset._native;
-        // Only ImageAsset needs the native-extension recovery: its serialized
-        // JSON is { fmt, w:0, h:0 } and the real dimensions come from the native
-        // image. Restricting the extra /query-asset-info lookup to images avoids
-        // issuing a blocking request for every other asset in the graph
-        // (prefabs, components, materials, ...), which would otherwise stall a
-        // large scene/prefab load.
-        if (!nativeExt && cc.ImageAsset && asset instanceof cc.ImageAsset) {
-            nativeExt = await queryNativeExt(uuid, options);
-            if (nativeExt) asset._native = nativeExt;
-        }
-        if (!nativeExt) return;
-
-        const encodedUuid = encodeURIComponent(uuid);
-        const isSubAsset = nativeExt.length > 0 && nativeExt[0] !== '.';
-        const nativeUrl = isSubAsset
-            ? `${serverURL}/native/${encodedUuid}/${nativeExt}?isBrowser=true`
-            : `${serverURL}/native/${encodedUuid}${nativeExt}?isBrowser=true`;
-
-        try {
-            const res = await fetchAsset(nativeUrl, options);
-            if (!res.ok) return;
-
-            const ext = nativeExt.split('.').pop()?.toLowerCase() ?? '';
-            const imageExts = ['png', 'jpg', 'jpeg', 'bmp', 'webp', 'gif'];
-
-            if (imageExts.includes(ext)) {
-                const blob = await res.blob();
-                const img = new Image();
-                img.crossOrigin = 'anonymous';
-                await new Promise<void>((resolve, reject) => {
-                    img.onload = () => resolve();
-                    img.onerror = reject;
-                    img.src = URL.createObjectURL(blob);
-                });
-                asset._nativeAsset = img;
-            } else {
-                asset._nativeAsset = await res.arrayBuffer();
-            }
-        } catch { /* native data unavailable */ }
-    }
-
-    async function loadFromServer(uuid: string, onComplete: any, options?: IServerLoadOptions) {
-        try {
-            const encodedUuid = encodeURIComponent(uuid);
-
-            // Query the correct file extension — assets may be stored as
-            // binary (.bin/cconb) instead of .json.
-            let ext = 'json';
-            try {
-                const extRes = await fetchAsset(`${serverURL}/query-extname/${encodedUuid}`, options);
-                const queryExt = (await extRes.text()).trim();
-                if (queryExt === '.cconb') ext = 'bin';
-            } catch { /* default to json */ }
-
-            const res = await fetchAsset(`${serverURL}/import/${encodedUuid}.${ext}?isBrowser=true`, options);
-            if (!res.ok) throw new Error(`Asset fetch failed (${res.status}): ${uuid}`);
-
-            const isBinary = ext === 'bin';
-            let deserializeInput: any;
-            if (isBinary) {
-                const rawBytes = new Uint8Array(await res.arrayBuffer());
-                const decode = await getDecodeCCONBinary();
-                if (decode) {
-                    deserializeInput = decode(rawBytes);
-                } else {
-                    console.warn(`[loadFromServer] decodeCCONBinary not available, cannot decode CCONB for ${uuid}`);
-                    onComplete?.(new Error('decodeCCONBinary not available'), null);
-                    return;
-                }
-            } else {
-                deserializeInput = await res.json();
-            }
-
-            const Details = cc.deserialize?.Details;
-            let asset;
-            let details: any;
-            const deserializeOpts = { classFinder: silentClassFinder };
-
-            if (Details) {
-                details = Details.pool?.get?.() ?? new Details();
-                if (details.reset) details.reset();
-                asset = cc.deserialize(deserializeInput, details, deserializeOpts);
-            } else {
-                asset = cc.deserialize(deserializeInput, undefined, deserializeOpts);
-            }
-
-            // Register in the cache BEFORE resolving dependencies. Circular
-            // references (e.g. a SpriteAtlas lists its SpriteFrames while each
-            // SpriteFrame references its atlas back) would otherwise re-enter
-            // loadFromServer for an asset already being loaded and recurse
-            // forever. With the (partial) instance already cached, the circular
-            // loadAny below resolves to it and the cycle is broken.
-            asset._uuid = uuid;
-            am.assets.add(uuid, asset);
-
-            // For width/data-sensitive leaf assets (textures/images), publish a
-            // readiness promise now — synchronously with the cache add — so a
-            // concurrent cache hit waits for the fully-loaded asset instead of
-            // reading a still-zero-sized one. These types never take part in a
-            // dependency cycle, so awaiting them cannot deadlock. Other
-            // (potentially cyclic) types are intentionally left without a promise
-            // so their cache hits return the partial instance immediately, which
-            // is what breaks the cycle above.
-            let resolveReady: (() => void) | undefined;
-            const needsReady = (cc.TextureBase && asset instanceof cc.TextureBase)
-                || (cc.ImageAsset && asset instanceof cc.ImageAsset);
-            if (needsReady) {
-                nativeReady.set(uuid, new Promise<void>((r) => { resolveReady = r; }));
-            }
-
-            try {
-                if (details) {
-                    const uuidList = details.uuidList;
-                    if (uuidList && uuidList.length > 0) {
-                        const depMap: Record<string, any> = {};
-                        await Promise.all(
-                            uuidList
-                                .filter((id: any) => typeof id === 'string')
-                                .map((depUuid: string) => new Promise<void>((resolve) => {
-                                    am.loadAny(depUuid, options?.reloadAsset ? { reloadAsset: true } : undefined, (err: any, depAsset: any) => {
-                                        if (!err && depAsset) depMap[depUuid] = depAsset;
-                                        resolve();
-                                    });
-                                })),
-                        );
-                        if (details.assignAssetsBy) {
-                            details.assignAssetsBy((depUuid: string) => depMap[depUuid] ?? null);
-                        }
-                    }
-                    Details.pool?.put?.(details);
-                }
-
-                stripNullComponents(asset);
-                if (asset.data) stripNullComponents(asset.data);
-                await loadNativeAsset(asset, uuid, options);
-                try { if (asset.onLoaded) asset.onLoaded(); } catch { /* some assets need specific native data */ }
-            } finally {
-                if (resolveReady) {
-                    nativeReady.delete(uuid);
-                    resolveReady();
-                }
-            }
-            onComplete?.(null, asset);
-        } catch (e: any) {
-            console.warn(`[AssetFallback] load failed for ${uuid}:`, e);
-            onComplete?.(e, null);
-        }
-    }
-
-    am.loadAny = function (requests: any, options: any, onComplete: any) {
-        if (typeof options === 'function') {
-            onComplete = options;
-            options = null;
-        }
-        const uuid = typeof requests === 'string' ? requests
-            : Array.isArray(requests) ? requests[0]
-            : requests?.uuid || requests;
-
-        if (typeof uuid === 'string' && !isUuidInBundles(uuid)) {
-            const dec = tryDecompress(uuid);
-            const reloadAsset = options?.reloadAsset === true;
-            if (reloadAsset) {
-                removeAssetCache(uuid);
-                removeAssetCache(dec);
-            }
-            const cached = am.assets.get(uuid) ?? am.assets.get(dec);
-            if (cached && !reloadAsset) {
-                // The asset may be cached but still loading its native data
-                // (added to the cache early to break circular refs). Wait for it
-                // so shared textures/images report their real width/height.
-                const nr = nativeReady.get(uuid) ?? nativeReady.get(dec);
-                if (nr) {
-                    nr.then(() => onComplete?.(null, cached), () => onComplete?.(null, cached));
-                } else {
-                    onComplete?.(null, cached);
-                }
-                return;
-            }
-            // Dedup concurrent loads of the same uuid that arrive before it is
-            // registered in the cache, so only one loadFromServer runs per asset.
-            // (Circular back-references hit the cache above — the asset is cached
-            // before its dependencies are resolved — so they never reach here,
-            // meaning this await can never target an ancestor and cannot deadlock.)
-            const inf = !reloadAsset ? (inFlight.get(uuid) ?? inFlight.get(dec)) : null;
-            if (inf) {
-                inf.then(({ err, asset }) => onComplete?.(err, asset));
-                return;
-            }
-            let settle!: (r: { err: any; asset: any }) => void;
-            const p = new Promise<{ err: any; asset: any }>((resolve) => { settle = resolve; });
-            if (!reloadAsset) {
-                inFlight.set(uuid, p);
-            }
-            loadFromServer(uuid, (err: any, asset: any) => {
-                inFlight.delete(uuid);
-                onComplete?.(err, asset);
-                settle({ err, asset });
-            }, { reloadAsset });
-            return;
-        }
-        origLoadAny(requests, options, onComplete);
-    };
 
     await serviceManager.initAllServices();
 

--- a/src/core/scene/scene-process/scene-editor-assets.ts
+++ b/src/core/scene/scene-process/scene-editor-assets.ts
@@ -1,0 +1,135 @@
+declare const cc: any;
+
+export interface ISceneEditorSettings {
+    settings?: Record<string, any>;
+    bundleConfigs?: Array<{ name: string; deps?: string[] }>;
+}
+
+let bundleConfigSignature = '';
+
+export async function fetchSceneEditorSettings(serverURL: string): Promise<ISceneEditorSettings | null> {
+    try {
+        const url = new URL(`${serverURL}/scene-editor/settings.json`);
+        const res = await fetch(url.toString(), { cache: 'no-store' });
+        if (!res.ok) {
+            console.warn(`[scene-editor-assets] Failed to query settings: ${res.status}`);
+            return null;
+        }
+        return await res.json();
+    } catch (err) {
+        console.warn('[scene-editor-assets] Failed to query settings:', err);
+        return null;
+    }
+}
+
+export function applySceneEditorAssetSettings(config: Record<string, any>, serverURL: string, sceneSettings?: Record<string, any>): void {
+    const assets = sceneSettings?.assets;
+    if (assets) {
+        config.overrideSettings.assets = {
+            ...assets,
+            server: serverURL,
+            importBase: 'assets/general/import',
+            nativeBase: 'assets/general/native',
+            remoteBundles: [],
+            subpackages: [],
+        };
+    }
+
+    const builtinAssets = sceneSettings?.engine?.builtinAssets;
+    if (Array.isArray(builtinAssets)) {
+        config.overrideSettings.engine = {
+            ...config.overrideSettings.engine,
+            builtinAssets,
+        };
+    }
+}
+
+export async function syncSceneEditorBundles(
+    serverURL?: string,
+    bundleConfigs?: Array<{ name: string; deps?: string[] }>,
+): Promise<ISceneEditorSettings | null> {
+    const resolvedServerURL = serverURL || (globalThis as any).WebEnv?.serverURL;
+    if (!resolvedServerURL) {
+        return null;
+    }
+
+    let configs = bundleConfigs;
+    let settings: ISceneEditorSettings | null = null;
+    if (!configs) {
+        settings = await fetchSceneEditorSettings(resolvedServerURL);
+        configs = settings?.bundleConfigs;
+    }
+    if (!configs?.length) {
+        return settings;
+    }
+
+    const signature = JSON.stringify(configs);
+    if (signature === bundleConfigSignature) {
+        return settings;
+    }
+
+    const configMap = new Map<string, { name: string; deps?: string[] }>();
+    for (const config of configs) {
+        if (config?.name) {
+            configMap.set(config.name, config);
+        }
+    }
+
+    for (const name of configMap.keys()) {
+        const bundle = cc.assetManager.getBundle?.(name);
+        if (bundle && cc.assetManager.removeBundle) {
+            cc.assetManager.removeBundle(bundle);
+        }
+    }
+
+    const loaded = new Set<string>();
+    const loading = new Set<string>();
+
+    async function loadByName(name: string): Promise<void> {
+        if (!name || loaded.has(name) || loading.has(name)) {
+            return;
+        }
+        loading.add(name);
+        const config = configMap.get(name);
+        for (const dep of config?.deps ?? []) {
+            if (configMap.has(dep)) {
+                await loadByName(dep);
+            }
+        }
+
+        await new Promise<void>((resolve) => {
+            const downloader = cc.assetManager.downloader;
+            const previousAppendTimeStamp = downloader?.appendTimeStamp;
+            if (downloader && typeof previousAppendTimeStamp === 'boolean') {
+                downloader.appendTimeStamp = false;
+            }
+
+            try {
+                cc.assetManager.loadBundle(`${resolvedServerURL}/scene-editor/assets/${name}`, (err: Error | null) => {
+                    if (downloader && typeof previousAppendTimeStamp === 'boolean') {
+                        downloader.appendTimeStamp = previousAppendTimeStamp;
+                    }
+                    if (err) {
+                        console.warn(`[scene-editor-assets] Failed to load bundle ${name}:`, err);
+                    }
+                    resolve();
+                });
+            } catch (err) {
+                if (downloader && typeof previousAppendTimeStamp === 'boolean') {
+                    downloader.appendTimeStamp = previousAppendTimeStamp;
+                }
+                console.warn(`[scene-editor-assets] Failed to load bundle ${name}:`, err);
+                resolve();
+            }
+        });
+
+        loaded.add(name);
+        loading.delete(name);
+    }
+
+    for (const name of configMap.keys()) {
+        await loadByName(name);
+    }
+    bundleConfigSignature = signature;
+    return settings;
+}

--- a/src/core/scene/scene-process/scene-editor-assets.ts
+++ b/src/core/scene/scene-process/scene-editor-assets.ts
@@ -6,6 +6,7 @@ export interface ISceneEditorSettings {
 }
 
 let bundleConfigSignature = '';
+const INTERNAL_BUNDLE_NAME = 'internal';
 
 export async function fetchSceneEditorSettings(serverURL: string): Promise<ISceneEditorSettings | null> {
     try {
@@ -19,28 +20,6 @@ export async function fetchSceneEditorSettings(serverURL: string): Promise<IScen
     } catch (err) {
         console.warn('[scene-editor-assets] Failed to query settings:', err);
         return null;
-    }
-}
-
-export function applySceneEditorAssetSettings(config: Record<string, any>, serverURL: string, sceneSettings?: Record<string, any>): void {
-    const assets = sceneSettings?.assets;
-    if (assets) {
-        config.overrideSettings.assets = {
-            ...assets,
-            server: serverURL,
-            importBase: 'assets/general/import',
-            nativeBase: 'assets/general/native',
-            remoteBundles: [],
-            subpackages: [],
-        };
-    }
-
-    const builtinAssets = sceneSettings?.engine?.builtinAssets;
-    if (Array.isArray(builtinAssets)) {
-        config.overrideSettings.engine = {
-            ...config.overrideSettings.engine,
-            builtinAssets,
-        };
     }
 }
 
@@ -76,6 +55,9 @@ export async function syncSceneEditorBundles(
     }
 
     for (const name of configMap.keys()) {
+        if (name === INTERNAL_BUNDLE_NAME) {
+            continue;
+        }
         const bundle = cc.assetManager.getBundle?.(name);
         if (bundle && cc.assetManager.removeBundle) {
             cc.assetManager.removeBundle(bundle);
@@ -87,6 +69,10 @@ export async function syncSceneEditorBundles(
 
     async function loadByName(name: string): Promise<void> {
         if (!name || loaded.has(name) || loading.has(name)) {
+            return;
+        }
+        if (name === INTERNAL_BUNDLE_NAME && cc.assetManager.getBundle?.(INTERNAL_BUNDLE_NAME)) {
+            loaded.add(name);
             return;
         }
         loading.add(name);

--- a/src/core/scene/scene-process/service/engine.ts
+++ b/src/core/scene/scene-process/service/engine.ts
@@ -91,6 +91,18 @@ export class EngineService extends BaseService<IEngineEvents> implements IEngine
         }
     }
 
+    public forceRepaintInEditMode() {
+        this._shouldRepaintInEM = true;
+        if (this._paused) {
+            this._shouldRepaintInEM = false;
+            this.tickInEditMode(0);
+            this.broadcast('engine:update');
+            try { Service.Camera?.onUpdate?.(0); } catch { /* not registered yet */ }
+            try { Service.Gizmo?.onUpdate?.(0); } catch { /* not registered yet */ }
+            this.broadcast('engine:ticked');
+        }
+    }
+
     /**
      * 渲染调试视图（DebugView）：单一通道调试 / 组合光照项开关 / 纯光照带固有色 / 级联阴影染色。
      * 与 cocos-editor scene-facade-manager.changeDebugOption 对齐。

--- a/src/core/scene/scene-process/service/preview/asset-reload.ts
+++ b/src/core/scene/scene-process/service/preview/asset-reload.ts
@@ -20,14 +20,31 @@ export function removePreviewAssetCache(uuid: string): void {
     }
 }
 
-export async function loadPreviewAsset<T>(uuid: string, label: string, timeoutMs = 10000): Promise<T> {
-    removePreviewAssetCache(uuid);
+interface LoadPreviewAssetOptions {
+    reloadAsset?: boolean;
+    timeoutMs?: number;
+}
+
+export async function loadPreviewAsset<T>(
+    uuid: string,
+    label: string,
+    options: LoadPreviewAssetOptions = {},
+): Promise<T> {
+    const timeoutMs = options.timeoutMs ?? 10000;
+    if (options.reloadAsset) {
+        removePreviewAssetCache(uuid);
+    }
     return await new Promise<T>((resolve, reject) => {
         const timeout = setTimeout(() => reject(new Error(`Load ${label} timeout: ${uuid}`)), timeoutMs);
-        assetManager.loadAny(uuid, { reloadAsset: true }, (err: any, asset: T) => {
+        const done = (err: any, asset: T) => {
             clearTimeout(timeout);
             if (err) reject(err);
             else resolve(asset);
-        });
+        };
+        if (options.reloadAsset) {
+            assetManager.loadAny(uuid, { reloadAsset: true }, done);
+        } else {
+            assetManager.loadAny(uuid, done);
+        }
     });
 }

--- a/src/core/scene/scene-process/service/preview/index.ts
+++ b/src/core/scene/scene-process/service/preview/index.ts
@@ -128,8 +128,13 @@ export class PreviewService extends BaseService<IPreviewEvents> implements IPrev
         // 清理上一个预览的相机
         if (this._activePreview) {
             const prev = this._activePreview as any;
-            if (prev.cameraComp) {
+            if (typeof prev.hide === 'function') {
+                prev.hide();
+            } else if (prev.cameraComp) {
                 prev.cameraComp.enabled = false;
+                if (prev.camera) {
+                    prev.camera.enabled = false;
+                }
             }
         }
 
@@ -140,7 +145,7 @@ export class PreviewService extends BaseService<IPreviewEvents> implements IPrev
 
         // 将相机挂到 mainWindow 上屏渲染
         this.attachToMainWindow(entry.instance as InteractivePreview);
-        Service.Engine.repaintInEditMode();
+        await this.refreshPreviewCameraView(entry.instance as InteractivePreview);
 
         return this._activePreview;
     }
@@ -198,6 +203,7 @@ export class PreviewService extends BaseService<IPreviewEvents> implements IPrev
 
         if (inst.worldAxis) {
             inst.worldAxis._sceneGizmoCamera.camera.changeTargetWindow(mainWindow);
+            inst.worldAxis._sceneGizmoCamera.camera.enabled = true;
             if (inst.enableAxis) {
                 inst.worldAxis.show();
             }
@@ -205,6 +211,45 @@ export class PreviewService extends BaseService<IPreviewEvents> implements IPrev
     }
 
     // --- 缩略图生成 ---
+
+    private async refreshPreviewCameraView(previewInstance: InteractivePreview) {
+        const preview = previewInstance as any;
+        if (typeof preview.resetCameraView !== 'function') {
+            Service.Engine.repaintInEditMode();
+            return;
+        }
+
+        preview.resetCameraView();
+        Service.Engine.repaintInEditMode();
+
+        await new Promise<void>((resolve) => {
+            let resolved = false;
+            const finish = () => {
+                if (resolved) return;
+                resolved = true;
+                resolve();
+            };
+            const timer = setTimeout(finish, 100);
+            cc.director.once(cc.Director.EVENT_AFTER_DRAW, () => {
+                clearTimeout(timer);
+                finish();
+            });
+        });
+
+        if (this._activePreview !== previewInstance) return;
+        this.attachToMainWindow(previewInstance);
+        preview.resetCameraView();
+        this.forcePreviewRepaint();
+    }
+
+    private forcePreviewRepaint() {
+        const engine = Service.Engine as any;
+        if (typeof engine.forceRepaintInEditMode === 'function') {
+            engine.forceRepaintInEditMode();
+        } else {
+            Service.Engine.repaintInEditMode();
+        }
+    }
 
     public async generateThumbnail(uuid: string, assetType: string, width = 128, height = 128) {
         const entry = this.resolvePreview(assetType);

--- a/src/core/scene/scene-process/service/preview/interactive-preview.ts
+++ b/src/core/scene/scene-process/service/preview/interactive-preview.ts
@@ -515,6 +515,13 @@ class InteractivePreview extends PreviewBase implements IPreviewInstance {
 
     public hide() {
         this.cameraComp.enabled = false;
+        if (this.camera) {
+            this.camera.enabled = false;
+        }
+        if (this.worldAxis) {
+            this.worldAxis.hide();
+            this.worldAxis._sceneGizmoCamera.camera.enabled = false;
+        }
     }
 
     public resetCameraView() {

--- a/src/core/scene/scene-process/service/preview/material-preview.ts
+++ b/src/core/scene/scene-process/service/preview/material-preview.ts
@@ -13,6 +13,7 @@ import {
     Node,
     renderer,
     director,
+    assetManager,
 } from 'cc';
 
 const regions = [new gfx.BufferTextureCopy()];
@@ -79,9 +80,163 @@ function getPrimitiveData(): Record<string, IPrimitiveInfo> {
 
 const tempVec3A = new Vec3();
 const tempVec3B = new Vec3();
+const transientMaterialOverridePatchKey = Symbol.for('cocos.cli.materialPreview.transientMaterialOverrides');
 
 import type { IMaterialPreviewInstance } from '../../../common/preview';
 import { loadPreviewAsset } from './asset-reload';
+
+function collectTextureProperties(value: any, out: any[]) {
+    if (!value) return;
+    if (Array.isArray(value)) {
+        value.forEach((item) => collectTextureProperties(item, out));
+        return;
+    }
+    if (typeof value.getGFXTexture === 'function') {
+        out.push(value);
+    }
+}
+
+function getMaterialTextureProperties(material: Material): any[] {
+    const textures: any[] = [];
+    const propsArray = (material as any)._props;
+    if (!Array.isArray(propsArray)) {
+        return textures;
+    }
+    for (const props of propsArray) {
+        if (!props) continue;
+        for (const key of Object.keys(props)) {
+            collectTextureProperties(props[key], textures);
+        }
+    }
+    return textures;
+}
+
+function getMaterialTextureEntries(material: Material): Array<{ passIndex: number; name: string; value: any }> {
+    const entries: Array<{ passIndex: number; name: string; value: any }> = [];
+    const propsArray = (material as any)._props;
+    if (!Array.isArray(propsArray)) {
+        return entries;
+    }
+    propsArray.forEach((props, passIndex) => {
+        if (!props) return;
+        for (const name of Object.keys(props)) {
+            const value = props[name];
+            const textures: any[] = [];
+            collectTextureProperties(value, textures);
+            if (textures.length) {
+                entries.push({ passIndex, name, value });
+            }
+        }
+    });
+    return entries;
+}
+
+function areTexturesReady(textures: any[]): boolean {
+    return textures.every((texture) => {
+        const gfxTexture = texture.getGFXTexture?.();
+        return !!gfxTexture && !!gfxTexture.width && !!gfxTexture.height;
+    });
+}
+
+async function waitForMaterialTextures(material: Material, timeoutMs = 1000): Promise<void> {
+    const textures = getMaterialTextureProperties(material);
+    if (!textures.length || areTexturesReady(textures)) {
+        return;
+    }
+
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 16));
+        if (areTexturesReady(textures)) {
+            return;
+        }
+    }
+}
+
+function refreshMaterialTextureBindings(material: Material) {
+    for (const { passIndex, name, value } of getMaterialTextureEntries(material)) {
+        material.setProperty(name, value, passIndex);
+    }
+}
+
+function getActivePreviewService(): any {
+    return (globalThis as any).cli?.Scene?.Preview;
+}
+
+function isMaterialPreviewActive(): boolean {
+    const previewService = getActivePreviewService();
+    return !!previewService && previewService.activePreview === previewService.materialPreview;
+}
+
+function isTransientPreviewMaterial(material: any): boolean {
+    return isMaterialPreviewActive()
+        && material
+        && material.constructor === Material
+        && !material._uuid;
+}
+
+function getPassCount(material: any): number {
+    const effectAsset = material._effectAsset;
+    const techIdx = material._techIdx || 0;
+    const technique = effectAsset?.techniques?.[techIdx];
+    return technique?.passes?.length || material._passes?.length || 1;
+}
+
+function applyMaterialRecord(material: any, key: '_defines' | '_states', overrides: Record<string, any>, passIdx?: number) {
+    if (!overrides || typeof overrides !== 'object') {
+        return;
+    }
+
+    const records = Array.isArray(material[key]) ? material[key] : (material[key] = []);
+    const applyAt = (index: number) => {
+        records[index] = {
+            ...(records[index] || {}),
+            ...overrides,
+        };
+    };
+
+    if (passIdx === undefined) {
+        for (let i = 0; i < getPassCount(material); i++) {
+            applyAt(i);
+        }
+    } else {
+        applyAt(passIdx);
+    }
+
+    material._update?.(true);
+}
+
+function installTransientMaterialOverridePatch() {
+    const proto = Material.prototype as any;
+    if (proto[transientMaterialOverridePatchKey]) {
+        return;
+    }
+
+    const recompileShaders = proto.recompileShaders;
+    const overridePipelineStates = proto.overridePipelineStates;
+
+    Object.defineProperty(proto, transientMaterialOverridePatchKey, {
+        configurable: false,
+        enumerable: false,
+        value: true,
+    });
+
+    proto.recompileShaders = function patchedRecompileShaders(overrides: Record<string, any>, passIdx?: number) {
+        if (isTransientPreviewMaterial(this)) {
+            applyMaterialRecord(this, '_defines', overrides, passIdx);
+            return;
+        }
+        return recompileShaders.call(this, overrides, passIdx);
+    };
+
+    proto.overridePipelineStates = function patchedOverridePipelineStates(overrides: Record<string, any>, passIdx?: number) {
+        if (isTransientPreviewMaterial(this)) {
+            applyMaterialRecord(this, '_states', overrides, passIdx);
+            return;
+        }
+        return overridePipelineStates.call(this, overrides, passIdx);
+    };
+}
 
 export class MaterialPreview extends InteractivePreview implements IMaterialPreviewInstance {
     private lightComp!: DirectionalLight;
@@ -103,7 +258,9 @@ export class MaterialPreview extends InteractivePreview implements IMaterialPrev
 
     public init(registerName: string, queryName: string) {
         super.init(registerName, queryName);
+        installTransientMaterialOverridePatch();
         const device = director.root!.device;
+        const isSceneNative = !!(globalThis as any).isSceneNative;
 
         this.uniformBuffer = device.createBuffer(new gfx.BufferInfo(
             gfx.BufferUsageBit.UNIFORM,
@@ -112,12 +269,13 @@ export class MaterialPreview extends InteractivePreview implements IMaterialPrev
         ));
         this.dummyUniformBuffer = device.createBuffer(new gfx.BufferViewInfo(this.uniformBuffer, 0, this.uniformBuffer.size));
 
-        this.storageBuffer = device.createBuffer(new gfx.BufferInfo(
-            gfx.BufferUsageBit.UNIFORM,
+        this.storageBuffer = !isSceneNative ? this.uniformBuffer : device.createBuffer(new gfx.BufferInfo(
+            gfx.BufferUsageBit.STORAGE,
             gfx.MemoryUsageBit.HOST | gfx.MemoryUsageBit.DEVICE,
             16,
         ));
-        this.dummyStorageBuffer = device.createBuffer(new gfx.BufferViewInfo(this.storageBuffer, 0, this.storageBuffer.size));
+        this.dummyStorageBuffer = !isSceneNative ? this.dummyUniformBuffer :
+            device.createBuffer(new gfx.BufferViewInfo(this.storageBuffer, 0, this.storageBuffer.size));
 
         this.dummySampleTexture = device.createTexture(new gfx.TextureInfo(
             gfx.TextureType.TEX2D,
@@ -125,9 +283,9 @@ export class MaterialPreview extends InteractivePreview implements IMaterialPrev
             gfx.Format.RGBA8,
             4, 4,
         ));
-        this.dummyStorageTexture = device.createTexture(new gfx.TextureInfo(
+        this.dummyStorageTexture = !isSceneNative ? this.dummySampleTexture : device.createTexture(new gfx.TextureInfo(
             gfx.TextureType.TEX2D,
-            gfx.TextureUsageBit.SAMPLED,
+            gfx.TextureUsageBit.STORAGE,
             gfx.Format.RGBA8,
             4, 4,
         ));
@@ -150,8 +308,8 @@ export class MaterialPreview extends InteractivePreview implements IMaterialPrev
         this._modelNode = this.modelComp.node;
     }
 
-    public setMaterial(material: Material | null) {
-        if (material && material !== this.material) {
+    public setMaterial(material: Material | null, force = false) {
+        if (material && (force || material !== this.material)) {
             const comp = this.modelComp;
             const _matInsInfo = {
                 parent: material,
@@ -210,7 +368,10 @@ export class MaterialPreview extends InteractivePreview implements IMaterialPrev
         }
         try {
             const material = await loadPreviewAsset<Material>(uuid, 'material');
-            this.setMaterial(material);
+            await waitForMaterialTextures(material);
+            refreshMaterialTextureBindings(material);
+            this.setMaterial(material, true);
+            assetManager.assetListener?.emit(uuid, material);
             this.resetCameraView();
         } catch (e) {
             console.warn(`[MaterialPreview] setMaterial failed:`, e);
@@ -221,12 +382,12 @@ export class MaterialPreview extends InteractivePreview implements IMaterialPrev
     public switchPrimitive(type: string) {
         const data = getPrimitiveData();
         if (!data[type]) return;
+        if (type === this.currentPrimitive) return;
         this.currentPrimitive = type;
         this.modelComp.mesh = data[type].mesh;
         this.updateDs();
         this.modelComp.node.setScale(data[type].scale);
         this.cameraComp.enabled = true;
-        this.resetCameraView();
     }
 
     public setLightEnable(enable: boolean) {

--- a/src/core/scene/scene-process/service/preview/model-preview.ts
+++ b/src/core/scene/scene-process/service/preview/model-preview.ts
@@ -41,7 +41,7 @@ export class ModelPreview extends InteractivePreview {
         const prefabUuid = await this.resolvePrefabUuid(uuid);
 
         removePreviewAssetCache(uuid);
-        const prefabAsset = await loadPreviewAsset<Prefab>(prefabUuid, 'model');
+        const prefabAsset = await loadPreviewAsset<Prefab>(prefabUuid, 'model', { reloadAsset: true });
 
         this.cameraComp.enabled = true;
 
@@ -57,12 +57,21 @@ export class ModelPreview extends InteractivePreview {
 
         this.resetCamera(this._modelNode);
 
-        Service.Engine.repaintInEditMode();
         return await new Promise((resolve) => {
             cc.director.once(cc.Director.EVENT_AFTER_DRAW, () => {
                 this.perfectCameraView(getBoundaryOfMeshNodes([this._modelNode!]));
+                const engine = Service.Engine as any;
+                if (typeof engine.forceRepaintInEditMode === 'function') {
+                    engine.forceRepaintInEditMode();
+                }
                 resolve(null);
             });
+            const engine = Service.Engine as any;
+            if (typeof engine.forceRepaintInEditMode === 'function') {
+                engine.forceRepaintInEditMode();
+            } else {
+                Service.Engine.repaintInEditMode();
+            }
         });
     }
 

--- a/src/core/scene/scene.scripting.middleware.ts
+++ b/src/core/scene/scene.scripting.middleware.ts
@@ -1,6 +1,7 @@
 import type { IMiddlewareContribution } from '../../server/interfaces';
 import { Request, Response, NextFunction } from 'express';
-import { basename, join } from 'path';
+import { basename, isAbsolute, join, relative } from 'path';
+import { existsSync } from 'fs';
 import ejs from 'ejs';
 import { GlobalPaths } from '../../global';
 import { scriptingRoutes } from '../preview/scripting-routes';
@@ -26,6 +27,87 @@ export default {
                     const templatePath = join(GlobalPaths.workspace, 'static', 'web', 'scene-editor.ejs');
                     const html = await ejs.renderFile(templatePath, renderData);
                     res.status(200).send(html);
+                } catch (err) {
+                    next(err);
+                }
+            },
+        },
+        {
+            url: '/scene-editor/settings.json',
+            async handler(req: Request, res: Response, next: NextFunction) {
+                try {
+                    const { getCachedSceneEditorSettings } = await import('../preview/preview-settings');
+                    const result = await getCachedSceneEditorSettings();
+                    res.set('Cache-Control', 'no-store');
+                    res.status(200).json({
+                        settings: result.settings,
+                        bundleConfigs: result.bundleConfigs,
+                    });
+                } catch (err) {
+                    const { PreviewNotReadyError } = await import('../preview/preview-settings');
+                    if (err instanceof PreviewNotReadyError) {
+                        res.set('Retry-After', '1');
+                        return res.status(503).json({ error: 'Preview settings are not ready.' });
+                    }
+                    next(err);
+                }
+            },
+        },
+        {
+            url: /^\/scene-editor\/assets\/([^/]+)\/(?:config|cc\.config)\.json$/,
+            async handler(req: Request, res: Response, next: NextFunction) {
+                try {
+                    const match = req.path.match(/^\/scene-editor\/assets\/([^/]+)\/(?:config|cc\.config)\.json$/);
+                    if (!match) {
+                        return next();
+                    }
+                    const { getCachedSceneEditorSettings } = await import('../preview/preview-settings');
+                    const settings = await getCachedSceneEditorSettings();
+                    const config = settings.bundleConfigs.find((item: any) => item.name === match[1]);
+                    if (!config) {
+                        return next();
+                    }
+                    res.set('Cache-Control', 'no-store');
+                    res.status(200).json(config);
+                } catch (err) {
+                    next(err);
+                }
+            },
+        },
+        {
+            url: /^\/scene-editor\/assets\/([^/]+)\/index\.js$/,
+            async handler(req: Request, res: Response, next: NextFunction) {
+                try {
+                    const match = req.path.match(/^\/scene-editor\/assets\/([^/]+)\/index\.js$/);
+                    if (!match) {
+                        return next();
+                    }
+                    const { getCachedSceneEditorSettings } = await import('../preview/preview-settings');
+                    const settings = await getCachedSceneEditorSettings();
+                    if (!settings.bundleConfigs.find((item: any) => item.name === match[1])) {
+                        return next();
+                    }
+                    res.type('application/javascript').send(
+                        `System.register("virtual:///prerequisite-imports/${match[1]}", [], function () {` +
+                        ` "use strict"; return { setters: [], execute: function () {} }; });`);
+                } catch (err) {
+                    next(err);
+                }
+            },
+        },
+        {
+            url: /^\/scene-editor\/assets\/[^/]+\/(?:import|native)\/(.*)/,
+            async handler(req: Request, res: Response, next: NextFunction) {
+                try {
+                    const match = req.path.match(/^\/scene-editor\/assets\/[^/]+\/(?:import|native)\/(.*)/);
+                    if (!match) {
+                        return next();
+                    }
+                    const filePath = await resolveSceneEditorLibraryFile(match[1]);
+                    if (!filePath) {
+                        return next();
+                    }
+                    res.sendFile(filePath, { dotfiles: 'allow' });
                 } catch (err) {
                     next(err);
                 }
@@ -76,3 +158,33 @@ export default {
         disconnect: (_socket: any) => { }
     },
 } as IMiddlewareContribution;
+
+let sceneEditorLibraryDirsCache: string[] | null = null;
+
+async function getSceneEditorLibraryDirs(): Promise<string[]> {
+    if (sceneEditorLibraryDirsCache) {
+        return sceneEditorLibraryDirsCache;
+    }
+    const { assetDBManager } = await import('../assets');
+    const dirs = Object.values(assetDBManager.assetDBInfo)
+        .map((info: any) => info.library)
+        .filter((item): item is string => !!item);
+    sceneEditorLibraryDirsCache = Array.from(new Set(dirs));
+    return sceneEditorLibraryDirsCache;
+}
+
+async function resolveSceneEditorLibraryFile(tail: string): Promise<string | undefined> {
+    const encodedTail = tail.replace(/[^\\/@]+/g, encodeURIComponent);
+    const dirs = await getSceneEditorLibraryDirs();
+    for (const dir of dirs) {
+        const full = join(dir, encodedTail);
+        const rel = relative(dir, full);
+        if (rel.startsWith('..') || isAbsolute(rel)) {
+            continue;
+        }
+        if (existsSync(full)) {
+            return full;
+        }
+    }
+    return undefined;
+}

--- a/src/core/scene/test/preview-asset-reload.test.ts
+++ b/src/core/scene/test/preview-asset-reload.test.ts
@@ -1,0 +1,45 @@
+const assetManager = {
+    assets: {
+        has: jest.fn(() => true),
+        remove: jest.fn(),
+    },
+    loadAny: jest.fn((uuid: string, optionsOrCallback: any, callback?: Function) => {
+        const done = typeof optionsOrCallback === 'function' ? optionsOrCallback : callback;
+        done(null, { uuid, loaded: true });
+    }),
+};
+
+jest.mock('cc', () => ({
+    assetManager,
+}), { virtual: true });
+
+import { loadPreviewAsset } from '../scene-process/service/preview/asset-reload';
+
+describe('preview asset reload', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (globalThis as any).cc = { assetManager };
+        (globalThis as any).WebEnv = { serverURL: 'http://localhost:7456' };
+    });
+
+    it('loads the requested preview asset through the engine asset manager', async () => {
+        await expect(loadPreviewAsset('material-uuid', 'material')).resolves.toEqual({ uuid: 'material-uuid', loaded: true });
+
+        expect(assetManager.assets.remove).not.toHaveBeenCalled();
+        expect(assetManager.loadAny).toHaveBeenCalledWith(
+            'material-uuid',
+            expect.any(Function),
+        );
+    });
+
+    it('reloads the requested preview asset when required', async () => {
+        await expect(loadPreviewAsset('model-prefab-uuid', 'model', { reloadAsset: true })).resolves.toEqual({ uuid: 'model-prefab-uuid', loaded: true });
+
+        expect(assetManager.assets.remove).toHaveBeenCalledWith('model-prefab-uuid');
+        expect(assetManager.loadAny).toHaveBeenCalledWith(
+            'model-prefab-uuid',
+            { reloadAsset: true },
+            expect.any(Function),
+        );
+    });
+});

--- a/src/core/scene/test/scene-editor-settings-route.test.ts
+++ b/src/core/scene/test/scene-editor-settings-route.test.ts
@@ -1,0 +1,86 @@
+const mockGetCachedSceneEditorSettings = jest.fn();
+
+jest.mock('../../preview/preview-settings', () => ({
+    getCachedSceneEditorSettings: (...args: any[]) => mockGetCachedSceneEditorSettings(...args),
+    PreviewNotReadyError: class PreviewNotReadyError extends Error {},
+}));
+
+import SceneScriptingMiddleware from '../scene.scripting.middleware';
+
+function findSettingsHandler() {
+    const route = (SceneScriptingMiddleware.get || []).find((item: any) => item.url === '/scene-editor/settings.json');
+    if (!route) {
+        throw new Error('Missing scene editor settings route');
+    }
+    return route.handler as (req: any, res: any, next: any) => Promise<void>;
+}
+
+function findRouteHandler(pattern: RegExp) {
+    const route = (SceneScriptingMiddleware.get || []).find((item: any) => String(item.url) === String(pattern));
+    if (!route) {
+        throw new Error(`Missing route: ${pattern}`);
+    }
+    return route.handler as (req: any, res: any, next: any) => Promise<void>;
+}
+
+describe('scene editor settings route', () => {
+    beforeEach(() => {
+        mockGetCachedSceneEditorSettings.mockReset().mockResolvedValue({
+            settings: { assets: {} },
+            bundleConfigs: [{ name: 'main', deps: [], paths: { 'fbx-uuid@material': ['flower/material', 'cc.Material', 1] } }],
+        });
+    });
+
+    it('serves scene editor settings from the scene editor asset environment', async () => {
+        const handler = findSettingsHandler();
+        const res = {
+            set: jest.fn(),
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn(),
+        };
+        const next = jest.fn();
+
+        await handler({ query: {} }, res, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(mockGetCachedSceneEditorSettings).toHaveBeenCalledWith();
+        expect(res.set).toHaveBeenCalledWith('Cache-Control', 'no-store');
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith({
+            settings: { assets: {} },
+            bundleConfigs: [{ name: 'main', deps: [], paths: { 'fbx-uuid@material': ['flower/material', 'cc.Material', 1] } }],
+        });
+    });
+
+    it('serves scene editor bundle config from the latest scene editor settings', async () => {
+        const settingsHandler = findSettingsHandler();
+        const configHandler = findRouteHandler(/^\/scene-editor\/assets\/([^/]+)\/(?:config|cc\.config)\.json$/);
+        const settingsRes = {
+            set: jest.fn(),
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn(),
+        };
+        const configRes = {
+            set: jest.fn(),
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn(),
+        };
+        const next = jest.fn();
+
+        await settingsHandler({ query: {} }, settingsRes, next);
+        await configHandler(
+            { path: '/scene-editor/assets/main/config.json' },
+            configRes,
+            next,
+        );
+
+        expect(next).not.toHaveBeenCalled();
+        expect(configRes.set).toHaveBeenCalledWith('Cache-Control', 'no-store');
+        expect(configRes.status).toHaveBeenCalledWith(200);
+        expect(configRes.json).toHaveBeenCalledWith({
+            name: 'main',
+            deps: [],
+            paths: { 'fbx-uuid@material': ['flower/material', 'cc.Material', 1] },
+        });
+    });
+});


### PR DESCRIPTION
Related issue: 
https://zentao.sud.center/index.php?m=bug&f=view&bugID=857

## Summary
- load scene-editor asset settings and bundles through the normal asset manager flow
- add scene-editor routes for bundle config and library resources
- keep material preview shader and pipeline overrides on transient preview materials so texture defines stay active
- refresh preview cameras after model and material asset changes

## Verification
- npm run test -- --runTestsByPath src/core/scene/scene-process/engine-bootstrap.test.ts src/core/scene/test/preview-asset-reload.test.ts src/core/scene/test/scene-editor-settings-route.test.ts --runInBand
- npx tsc -b --pretty false