### PR TITLE
feat(engine): populate module config cache from render-config

### DIFF
--- a/src/core/engine/index.ts
+++ b/src/core/engine/index.ts
@@ -2,7 +2,7 @@ import fse from 'fs-extra';
 import { existsSync, readdirSync, statSync } from 'fs';
 import { EngineInfo } from './@types/public';
 import type { IEngineConfig, IEngineProjectConfig, IInitEngineInfo, IJointTextureLayoutPreviewResult } from './@types/config';
-import { IModuleConfig, ModuleRenderConfig } from './@types/modules';
+import type { CategoryDetail, IFeatureItem, IModuleConfig, IModuleItem, ModuleRenderConfig } from './@types/modules';
 import { join } from 'path';
 import { cloneDeep, merge } from 'lodash';
 import { configurationRegistry, IBaseConfiguration } from '../configuration';
@@ -65,6 +65,11 @@ const Backends2D = {
 // 所以界面上的 勾选动作 和 状态判断 都要忽略这个列表的数据，从 3.8.6 开始我将这个 ignoreKeys 改成 ignoreModules 从 视图层移到主进程
 // 直接在数据源上过滤掉，减少 视图层的判断
 const ignoreModules = ['custom-pipeline-post-process'];
+
+function extractMacros(expression: string): string[] {
+    // envCondition uses a small "$MACRO || $MACRO" grammar shared with the engine compiler.
+    return expression.split('||').map(match => match.trim().substring(1));
+}
 
 class EngineManager implements IEngine {
     private _init: boolean = false;
@@ -267,24 +272,96 @@ class EngineManager implements IEngine {
         const globalConfigKey = projectConfig.globalConfigKey || Object.keys(projectConfig.configs)[0];
         return projectConfig.configs[globalConfigKey];
     }
+    private createModuleConfigCache(): IModuleConfig {
+        return {
+            moduleDependMap: {},
+            moduleDependedMap: {},
+            nativeCodeModules: [],
+            moduleCmakeConfig: {},
+            features: {},
+            moduleTreeDump: {
+                default: {},
+                categories: {},
+            },
+            ignoreModules,
+            envLimitModule: {},
+        };
+    }
 
-    /**
-     * TODO init data in register project modules
-     */
-    private moduleConfigCache: IModuleConfig = {
-        moduleDependMap: {}, // 依赖关系
-        moduleDependedMap: {}, // 被依赖的关系
-        nativeCodeModules: [], // 原生模块(构建功能需要用到)
-        moduleCmakeConfig: {}, // 模块的 cmake 配置 3.8.6 从 moduleConfig 挪到这边
-        features: {}, // 引擎提供的所有选项(包括选项的 options)
-        // 用于界面渲染的数据
-        moduleTreeDump: {
-            default: {},
-            categories: {},
-        },
-        ignoreModules: ignoreModules,
-        envLimitModule: {}, // 记录有环境限制的模块数据
-    };
+    private initModuleConfigCache(engineRoot: string) {
+        try {
+            this.initRenderConfig2ModuleConfigCache(getEngineRenderConfig(engineRoot));
+        } catch (error) {
+            // A missing or malformed custom-engine config must not leave a partially derived cache behind.
+            this.moduleConfigCache = this.createModuleConfigCache();
+            console.warn('[Engine] Failed to initialize engine module configuration from engine source.', error);
+        }
+    }
+
+    private initRenderConfig2ModuleConfigCache(modulesInfo: ModuleRenderConfig) {
+        // Build into a fresh object and publish it only when complete, avoiding stale or partial engine data.
+        const moduleConfigCache = this.createModuleConfigCache();
+        const moduleTreeDumpCategories: Record<string, CategoryDetail> = {};
+        Object.entries(modulesInfo.categories).forEach(([key, category]) => {
+            // render-config categories contain metadata only; `modules` belongs to the derived display tree.
+            moduleTreeDumpCategories[key] = {
+                ...cloneDeep(category),
+                modules: {},
+            };
+        });
+
+        const addModule = (key: string, moduleItem: IFeatureItem) => {
+            moduleConfigCache.features[key] = moduleItem;
+
+            if (moduleItem.cmakeConfig) {
+                moduleConfigCache.moduleCmakeConfig[key] = {
+                    native: moduleItem.cmakeConfig,
+                };
+            }
+            if (moduleItem.isNativeModule) {
+                moduleConfigCache.nativeCodeModules.push(key);
+            }
+            if (moduleItem.envCondition) {
+                moduleConfigCache.envLimitModule[key] = {
+                    envList: extractMacros(moduleItem.envCondition),
+                    fallback: moduleItem.fallback,
+                };
+            }
+            if (moduleItem.dependencies) {
+                moduleConfigCache.moduleDependMap[key] = moduleItem.dependencies;
+                moduleItem.dependencies.forEach((module) => {
+                    moduleConfigCache.moduleDependedMap[module] = moduleConfigCache.moduleDependedMap[module] || [];
+                    moduleConfigCache.moduleDependedMap[module].push(key);
+                });
+            }
+        };
+        const addModuleOrGroup = (key: string, moduleItem: IModuleItem) => {
+            // Keep groups for the settings UI, while flattening their options for build-time lookups.
+            moduleConfigCache.features[key] = moduleItem;
+            if ('options' in moduleItem) {
+                Object.entries(moduleItem.options).forEach(([moduleId, module]) => {
+                    addModule(moduleId, module);
+                });
+            } else {
+                addModule(key, moduleItem);
+            }
+        };
+
+        Object.entries(modulesInfo.features).forEach(([key, moduleItem]) => {
+            addModuleOrGroup(key, moduleItem);
+            if (!ignoreModules.includes(key)) {
+                if (moduleItem.category && moduleTreeDumpCategories[moduleItem.category]) {
+                    moduleTreeDumpCategories[moduleItem.category].modules[key] = moduleItem;
+                } else {
+                    moduleConfigCache.moduleTreeDump.default[key] = moduleItem;
+                }
+            }
+        });
+        moduleConfigCache.moduleTreeDump.categories = moduleTreeDumpCategories;
+        this.moduleConfigCache = moduleConfigCache;
+    }
+
+    private moduleConfigCache: IModuleConfig = this.createModuleConfigCache();
 
     get type() {
         return this._config.includeModules.includes('3d') ? '3d' : '2d';
@@ -321,6 +398,7 @@ class EngineManager implements IEngine {
         this._info.version = await import(join(enginePath, 'package.json')).then((pkg) => pkg.version);
         this._info.tmpDir = join(enginePath, '.temp');
         this._loadEngineI18n(enginePath);
+        this.initModuleConfigCache(this._info.typescript.path);
         this._defaultConfig = this.resolveDefaultConfig(this._info.typescript.path);
         const configInstance = await configurationRegistry.register('engine', {
             defaults: this.defaultConfig,

--- a/tests/engine-module-config.test.ts
+++ b/tests/engine-module-config.test.ts
@@ -1,0 +1,266 @@
+import { resolve } from 'path';
+import type { IFeatureGroup, ModuleRenderConfig } from '../src/core/engine/@types/modules';
+
+// Engine's asset APIs are unrelated to module-cache derivation and pull in a separately built workspace package.
+jest.mock('../src/core/assets', () => ({
+    assetManager: {},
+}));
+
+function createRenderConfig(): ModuleRenderConfig {
+    return {
+        version: 'test',
+        categories: {
+            gameplay: {
+                label: 'Gameplay',
+            },
+            empty: {
+                label: 'Empty category',
+            },
+        },
+        features: {
+            spine: {
+                default: true,
+                label: 'Spine',
+                category: 'gameplay',
+                options: {
+                    'spine-3.8': {
+                        default: true,
+                        label: 'Spine 3.8',
+                        flags: {},
+                        cmakeConfig: 'USE_SPINE_3_8',
+                        isNativeModule: true,
+                        dependencies: ['2d'],
+                    },
+                    'spine-4.2': {
+                        default: false,
+                        label: 'Spine 4.2',
+                        flags: {},
+                        cmakeConfig: 'USE_SPINE_4_2',
+                        isNativeModule: true,
+                        envCondition: '$NATIVE',
+                        fallback: 'spine-3.8',
+                    },
+                },
+            },
+            'physics-2d-box2d': {
+                default: true,
+                label: 'Box2D',
+                category: 'physics',
+                flags: {},
+                isNativeModule: true,
+                envCondition: '$NATIVE || $HTML5',
+                fallback: 'physics-2d-box2d-wasm',
+            },
+            audio: {
+                default: true,
+                label: 'Audio',
+                category: 'gameplay',
+                flags: {},
+                dependencies: ['2d'],
+            },
+            base: {
+                default: true,
+                label: 'Base',
+                flags: {},
+                dependencies: [],
+            },
+            'custom-pipeline-post-process': {
+                default: false,
+                label: 'Post Process',
+                category: 'gameplay',
+                flags: {},
+            },
+        },
+    };
+}
+
+describe('engine module config cache', () => {
+    beforeEach(() => {
+        jest.resetModules();
+    });
+
+    it('should build module config cache from grouped and plain render config entries', () => {
+        const renderConfig = createRenderConfig();
+        const { Engine } = require('../src/core/engine') as typeof import('../src/core/engine');
+
+        (Engine as any).initRenderConfig2ModuleConfigCache(renderConfig);
+        const moduleConfig = Engine.queryModuleConfig();
+        const spineGroup = renderConfig.features.spine as IFeatureGroup;
+
+        expect(moduleConfig.moduleCmakeConfig['spine-3.8']).toEqual({ native: 'USE_SPINE_3_8' });
+        expect(moduleConfig.moduleCmakeConfig['spine-4.2']).toEqual({ native: 'USE_SPINE_4_2' });
+        expect(moduleConfig.nativeCodeModules).toEqual(expect.arrayContaining([
+            'spine-3.8',
+            'spine-4.2',
+            'physics-2d-box2d',
+        ]));
+        expect(moduleConfig.features.spine).toBe(spineGroup);
+        expect(moduleConfig.features['spine-4.2']).toBe(spineGroup.options['spine-4.2']);
+        expect(moduleConfig.features.audio).toBe(renderConfig.features.audio);
+    });
+
+    it('should record env limits for plain modules and grouped options', () => {
+        const renderConfig = createRenderConfig();
+        const { Engine } = require('../src/core/engine') as typeof import('../src/core/engine');
+
+        (Engine as any).initRenderConfig2ModuleConfigCache(renderConfig);
+        const moduleConfig = Engine.queryModuleConfig();
+
+        expect(moduleConfig.envLimitModule['physics-2d-box2d']).toEqual({
+            envList: ['NATIVE', 'HTML5'],
+            fallback: 'physics-2d-box2d-wasm',
+        });
+        expect(moduleConfig.envLimitModule['spine-4.2']).toEqual({
+            envList: ['NATIVE'],
+            fallback: 'spine-3.8',
+        });
+    });
+
+    it('should accumulate reverse dependencies and preserve explicitly empty dependencies', () => {
+        const renderConfig = createRenderConfig();
+        const { Engine } = require('../src/core/engine') as typeof import('../src/core/engine');
+
+        (Engine as any).initRenderConfig2ModuleConfigCache(renderConfig);
+        const moduleConfig = Engine.queryModuleConfig();
+
+        expect(moduleConfig.moduleDependMap['spine-3.8']).toEqual(['2d']);
+        expect(moduleConfig.moduleDependMap.audio).toEqual(['2d']);
+        expect(moduleConfig.moduleDependMap.base).toEqual([]);
+        expect(moduleConfig.moduleDependMap['custom-pipeline-post-process']).toBeUndefined();
+        expect(moduleConfig.moduleDependedMap['2d']).toEqual(['spine-3.8', 'audio']);
+    });
+
+    it('should build display tree data without mutating render config categories', () => {
+        const renderConfig = createRenderConfig();
+        const { Engine } = require('../src/core/engine') as typeof import('../src/core/engine');
+
+        (Engine as any).initRenderConfig2ModuleConfigCache(renderConfig);
+        const moduleConfig = Engine.queryModuleConfig();
+
+        expect(moduleConfig.moduleTreeDump.categories.gameplay.modules.spine).toBe(renderConfig.features.spine);
+        expect(moduleConfig.moduleTreeDump.categories.gameplay.modules.audio).toBe(renderConfig.features.audio);
+        expect(moduleConfig.moduleTreeDump.categories.empty).toEqual({
+            label: 'Empty category',
+            modules: {},
+        });
+        expect(moduleConfig.moduleTreeDump.default.base).toBe(renderConfig.features.base);
+        expect(moduleConfig.moduleTreeDump.default['physics-2d-box2d']).toBe(renderConfig.features['physics-2d-box2d']);
+        expect(renderConfig.categories).toEqual({
+            gameplay: { label: 'Gameplay' },
+            empty: { label: 'Empty category' },
+        });
+    });
+
+    it('should replace the previous cache when render config is initialized again', () => {
+        const { Engine } = require('../src/core/engine') as typeof import('../src/core/engine');
+        const nextRenderConfig: ModuleRenderConfig = {
+            version: 'next',
+            categories: {},
+            features: {
+                next: {
+                    default: true,
+                    label: 'Next',
+                    flags: {},
+                },
+            },
+        };
+
+        (Engine as any).initRenderConfig2ModuleConfigCache(createRenderConfig());
+        (Engine as any).initRenderConfig2ModuleConfigCache(nextRenderConfig);
+
+        expect(Engine.queryModuleConfig().features).toEqual({ next: nextRenderConfig.features.next });
+        expect(Engine.queryModuleConfig().nativeCodeModules).toEqual([]);
+        expect(Engine.queryModuleConfig().moduleTreeDump).toEqual({
+            default: { next: nextRenderConfig.features.next },
+            categories: {},
+        });
+    });
+
+    it('should keep ignored modules in feature metadata but hide them from display tree', () => {
+        const renderConfig = createRenderConfig();
+        const { Engine } = require('../src/core/engine') as typeof import('../src/core/engine');
+
+        (Engine as any).initRenderConfig2ModuleConfigCache(renderConfig);
+        const moduleConfig = Engine.queryModuleConfig();
+
+        expect(moduleConfig.ignoreModules).toContain('custom-pipeline-post-process');
+        expect(moduleConfig.features['custom-pipeline-post-process']).toBe(renderConfig.features['custom-pipeline-post-process']);
+        expect(moduleConfig.moduleTreeDump.categories.gameplay.modules['custom-pipeline-post-process']).toBeUndefined();
+        expect(moduleConfig.moduleTreeDump.default['custom-pipeline-post-process']).toBeUndefined();
+    });
+
+    it('should reset to an empty cache when render config loading fails', () => {
+        const { Engine } = require('../src/core/engine') as typeof import('../src/core/engine');
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        (Engine as any).initRenderConfig2ModuleConfigCache(createRenderConfig());
+        expect(Engine.queryModuleConfig().moduleCmakeConfig['spine-4.2']).toEqual({ native: 'USE_SPINE_4_2' });
+
+        (Engine as any).initModuleConfigCache('__missing_engine_root__');
+
+        expect(Engine.queryModuleConfig()).toMatchObject({
+            moduleDependMap: {},
+            moduleDependedMap: {},
+            nativeCodeModules: [],
+            moduleCmakeConfig: {},
+            features: {},
+            moduleTreeDump: {
+                default: {},
+                categories: {},
+            },
+            ignoreModules: ['custom-pipeline-post-process'],
+            envLimitModule: {},
+        });
+        expect(warnSpy).toHaveBeenCalledWith(
+            '[Engine] Failed to initialize engine module configuration from engine source.',
+            expect.objectContaining({ code: 'ENOENT' })
+        );
+        warnSpy.mockRestore();
+    });
+
+    it('should initialize module config cache through Engine.init', async () => {
+        const renderConfig = createRenderConfig();
+        const getEngineRenderConfig = jest.fn(() => renderConfig);
+        const register = jest.fn(async (_namespace: string, options: { defaults: unknown }) => ({
+            getAll: () => ({}),
+            getDefaultConfig: () => options.defaults,
+            on: jest.fn(),
+        }));
+
+        jest.doMock('../src/core/configuration', () => ({
+            configurationRegistry: { register },
+        }));
+        jest.doMock('../src/core/engine/dynamic-metadata', () => ({
+            getEngineRenderConfig,
+            getLocalizedEngineRenderConfig: jest.fn(),
+            getEngineDynamicConfigContribution: jest.fn(() => ({
+                defaults: {
+                    includeModules: [],
+                    flags: {},
+                    macroConfig: {},
+                },
+                metadata: {},
+            })),
+        }));
+
+        try {
+            const { Engine } = require('../src/core/engine') as typeof import('../src/core/engine');
+            const engineRoot = resolve(__dirname, '..');
+
+            await Engine.init(engineRoot);
+
+            expect(getEngineRenderConfig).toHaveBeenCalledTimes(1);
+            expect(getEngineRenderConfig).toHaveBeenCalledWith(engineRoot);
+            expect(register).toHaveBeenCalledWith('engine', expect.objectContaining({
+                defaults: expect.any(Object),
+                nodes: expect.any(Function),
+            }));
+            expect(Engine.queryModuleConfig().moduleCmakeConfig['spine-4.2']).toEqual({
+                native: 'USE_SPINE_4_2',
+            });
+        } finally {
+            jest.dontMock('../src/core/configuration');
+            jest.dontMock('../src/core/engine/dynamic-metadata');
+        }
+    });
+});


### PR DESCRIPTION
## Changes
- Initialize `moduleConfigCache` during `Engine.init()` by deriving dependency maps, cmake config, native modules, env limits and display tree from the engine's `render-config.json`
- Replace the previous static empty cache (which had a TODO) with actual data, so `queryModuleConfig()` returns populated results
- Native build hooks (`native-common/hooks.ts`) now correctly inject cmake `ON/OFF` flags based on project module selection

## Test plan
- [ ] Project settings: select Spine 4.2 (deselect Spine 3.8), build for native platform, verify the app runs without crash
- [ ] Inspect the generated `cfg.cmake` for correct flags:
  ```
  set(USE_SPINE_3_8 OFF)
  set(USE_SPINE_4_2 ON)
  ```
- [ ] Unit test: `npx jest tests/engine-module-config.test.ts`