### PR TITLE
fix(google-play): refine build options and gradle cache handling

### DIFF
--- a/src/core/builder/platforms/android/package.json
+++ b/src/core/builder/platforms/android/package.json
@@ -19,6 +19,7 @@
             "customFields": [
                 "isSoFileCompressed",
                 "androidInstant",
+                "appABIs",
                 "apiLevel",
                 "keystorePath",
                 "useDebugKeystore",

--- a/src/core/builder/platforms/android/src/config.ts
+++ b/src/core/builder/platforms/android/src/config.ts
@@ -77,35 +77,10 @@ const config: IPlatformBuildPluginConfig = {
         },
         appABIs: {
             label: 'i18n:android.options.appABIs',
-            type: 'object',
-            properties: {
-                'arm64-v8a': {
-                    label: 'arm64-v8a',
-                    type: 'boolean',
-                    default: true,
-                },
-                'arm-v7a': {
-                    label: 'arm-v7a',
-                    type: 'boolean',
-                    default: false,
-                },
-                x86: {
-                    label: 'x86',
-                    type: 'boolean',
-                    default: false,
-                },
-                x86_64: {
-                    label: 'x86_64',
-                    type: 'boolean',
-                    default: false,
-                },
-            },
-            default: {
-                'arm64-v8a': true,
-                'arm-v7a': false,
-                x86: false,
-                x86_64: false,
-            },
+            type: 'array',
+            items: { type: 'string' },
+            default: ['arm64-v8a'],
+            hidden: true,
         },
         resizeableActivity: {
             label: 'i18n:android.options.resizeable_activity',

--- a/src/core/builder/platforms/android/src/view/build-config.tsx
+++ b/src/core/builder/platforms/android/src/view/build-config.tsx
@@ -17,6 +17,10 @@ interface NativeEngineInfo {
     path?: string;
 }
 
+type AppABI = 'armeabi-v7a' | 'arm64-v8a' | 'x86' | 'x86_64';
+
+const APP_ABIS: AppABI[] = ['armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'];
+
 const MAX_ASPECT_RATIO_OPTIONS = [
     { label: '2.4 (12:5)', value: '2.4' },
     { label: '1.77 (16:9)', value: '16:9' },
@@ -42,6 +46,7 @@ const DEFAULTS: Record<string, unknown> = {
     xxteaKey: createEncryptionKey(),
     compressZip: false,
     JobSystem: 'none',
+    appABIs: ['arm64-v8a'],
 };
 
 const ROW: CSSProperties = { padding: '2px 16px 6px 0px' };
@@ -121,6 +126,13 @@ function boolValue(value: unknown, fallback = false): boolean {
 function numberValue(value: unknown, fallback: number): number {
     const parsed = typeof value === 'number' ? value : Number.parseInt(String(value ?? ''), 10);
     return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function appABIsValue(value: unknown): AppABI[] {
+    if (!Array.isArray(value)) {
+        return ['arm64-v8a'];
+    }
+    return value.filter((item): item is AppABI => APP_ABIS.includes(item as AppABI));
 }
 
 function parseAspectRatio(value: string): number {
@@ -224,6 +236,28 @@ function TextField({
     );
 }
 
+function CheckboxLine({
+    checked,
+    disabled,
+    label,
+    tooltip,
+    onChange,
+}: {
+    key?: unknown;
+    checked: boolean;
+    disabled?: boolean;
+    label?: string;
+    tooltip?: string;
+    onChange: (value: boolean) => void;
+}) {
+    return (
+        <label style={{ ...INLINE, minHeight: 22 }} title={tooltip}>
+            <Checkbox checked={checked} disabled={disabled} onCheckedChange={(next: boolean) => onChange(!!next)} />
+            {label && <span>{label}</span>}
+        </label>
+    );
+}
+
 export default function AndroidBuildView({ value, onChange, bridge, commonValue }: PlatformBuildViewProps) {
     const [bundle, setBundle] = useState<Record<string, unknown>>({});
     const [apiLevels, setApiLevels] = useState<number[]>([]);
@@ -240,6 +274,7 @@ export default function AndroidBuildView({ value, onChange, bridge, commonValue 
     const isDebugMode = boolValue(commonValue?.debug);
     const maxAspectRatio = stringValue(current.maxAspectRatio);
     const jobSystem = stringValue(current.JobSystem) || 'none';
+    const appABIs = appABIsValue(current.appABIs);
     const inferredMaxAspectRatioMode = maxAspectRatioSelection(maxAspectRatio);
     const selectedMaxAspectRatioMode = maxAspectRatioMode || inferredMaxAspectRatioMode;
 
@@ -314,6 +349,9 @@ export default function AndroidBuildView({ value, onChange, bridge, commonValue 
         } else if (apiLevel < 19) {
             next.apiLevel = t('tips.apilevel_limit', { version: '19' });
         }
+        if (!appABIs.length) {
+            next.appABIs = t('tips.at_least_one');
+        }
 
         const normalized = normalizeAspectRatio(maxAspectRatio);
         const ratio = parseAspectRatio(normalized);
@@ -339,8 +377,12 @@ export default function AndroidBuildView({ value, onChange, bridge, commonValue 
             next.xxteaKey = t('tips.not_empty');
         }
         return next;
-    }, [apiLevels.length, androidInstant, bundle, current, encrypted, jobSystem, maxAspectRatio, t, useDebugKeystore]);
+    }, [apiLevels.length, androidInstant, appABIs, bundle, current, encrypted, jobSystem, maxAspectRatio, t, useDebugKeystore]);
 
+    const toggleAbi = (abi: AppABI, checked: boolean) => {
+        const next = checked ? [...appABIs, abi] : appABIs.filter((item) => item !== abi);
+        set('appABIs', Array.from(new Set(next)));
+    };
     const setUseDebugKeystore = (checked: boolean) => {
         set('useDebugKeystore', checked);
         if (checked) {
@@ -446,6 +488,17 @@ export default function AndroidBuildView({ value, onChange, bridge, commonValue 
                     </div>
                 </TypedField>
                 {errors.apiLevel && <div style={ERROR}>{errors.apiLevel}</div>}
+            </div>
+
+            <div style={ROW}>
+                <TypedField label="APP ABI" tooltip={t('tips.appABIs')}>
+                    <div style={STACK}>
+                        {APP_ABIS.map((abi) => (
+                            <CheckboxLine key={abi} checked={appABIs.includes(abi)} label={abi} onChange={(checked) => toggleAbi(abi, checked)} />
+                        ))}
+                    </div>
+                </TypedField>
+                {errors.appABIs && <div style={ERROR}>{errors.appABIs}</div>}
             </div>
 
             <div style={ROW}>

--- a/src/core/builder/platforms/google-play/i18n/en.js
+++ b/src/core/builder/platforms/google-play/i18n/en.js
@@ -31,6 +31,7 @@ module.exports = {
         upsideDown: 'Upside Down',
         app_bundle: 'App Bundle',
         google_play_instant: 'Google Play Instant',
+        google_play_billing: 'Google Play Billing',
         input_sdk: 'Input SDK',
         remoteUrl: 'Remote URL',
     },

--- a/src/core/builder/platforms/google-play/src/config.ts
+++ b/src/core/builder/platforms/google-play/src/config.ts
@@ -67,6 +67,7 @@ const config: IPlatformBuildPluginConfig = {
                 gles3: true,
                 gles2: true,
             },
+            hidden: true,
         },
         packageName: {
             label: 'i18n:google-play.options.package_name',
@@ -94,8 +95,8 @@ const config: IPlatformBuildPluginConfig = {
                     type: 'boolean',
                     default: true,
                 },
-                'arm-v7a': {
-                    label: 'arm-v7a',
+                'armeabi-v7a': {
+                    label: 'armeabi-v7a',
                     type: 'boolean',
                     default: false,
                 },
@@ -116,6 +117,7 @@ const config: IPlatformBuildPluginConfig = {
                 x86: false,
                 x86_64: false,
             },
+            hidden: true,
         },
         useDebugKeystore: {
             label: 'i18n:google-play.KEYSTORE.use_debug_keystore',
@@ -184,6 +186,7 @@ const config: IPlatformBuildPluginConfig = {
                 landscapeRight: true,
                 landscapeLeft: true,
             },
+            hidden: true,
         },
         appBundle: {
             label: 'i18n:google-play.options.app_bundle',
@@ -197,14 +200,16 @@ const config: IPlatformBuildPluginConfig = {
             default: false,
         },
         googleBilling: {
-            label: 'i18n:google-play.tips.google_play_billing',
+            label: 'i18n:google-play.options.google_play_billing',
             type: 'boolean',
             default: true,
+            hidden: true,
         },
         inputSDK: {
             label: 'i18n:google-play.options.input_sdk',
             type: 'boolean',
             default: false,
+            hidden: true,
         },
         remoteUrl: {
             label: 'i18n:google-play.options.remoteUrl',

--- a/src/core/builder/platforms/google-play/src/config.ts
+++ b/src/core/builder/platforms/google-play/src/config.ts
@@ -88,35 +88,9 @@ const config: IPlatformBuildPluginConfig = {
         },
         appABIs: {
             label: 'i18n:google-play.options.appABIs',
-            type: 'object',
-            properties: {
-                'arm64-v8a': {
-                    label: 'arm64-v8a',
-                    type: 'boolean',
-                    default: true,
-                },
-                'armeabi-v7a': {
-                    label: 'armeabi-v7a',
-                    type: 'boolean',
-                    default: false,
-                },
-                x86: {
-                    label: 'x86',
-                    type: 'boolean',
-                    default: false,
-                },
-                x86_64: {
-                    label: 'x86_64',
-                    type: 'boolean',
-                    default: false,
-                },
-            },
-            default: {
-                'arm64-v8a': true,
-                'arm-v7a': false,
-                x86: false,
-                x86_64: false,
-            },
+            type: 'array',
+            items: { type: 'string' },
+            default: ['arm64-v8a'],
             hidden: true,
         },
         useDebugKeystore: {

--- a/src/core/builder/platforms/google-play/src/custom-icon.ts
+++ b/src/core/builder/platforms/google-play/src/custom-icon.ts
@@ -23,7 +23,21 @@ export interface ICustomIconInfo {
 }
 
 function defaultIconRoot(): string {
-    return join(__dirname, '../static/icons');
+    const sourceRoot = join(__dirname, '../static/icons');
+    if (hasDefaultIcon(sourceRoot)) {
+        return sourceRoot;
+    }
+
+    const distViewRoot = join(__dirname, '../../static/icons');
+    if (hasDefaultIcon(distViewRoot)) {
+        return distViewRoot;
+    }
+
+    return sourceRoot;
+}
+
+function hasDefaultIcon(base: string): boolean {
+    return existsSync(join(base, 'mipmap-mdpi', 'ic_launcher.png'));
 }
 
 function getCustomIconRoot(projectRoot: string, outputName: string): string {

--- a/src/core/builder/platforms/native-common/pack-tool/platforms/google-play.ts
+++ b/src/core/builder/platforms/native-common/pack-tool/platforms/google-play.ts
@@ -6,6 +6,7 @@ import { spawn, spawnSync } from 'child_process';
 import { platform } from 'os';
 import * as xml2js from 'xml2js';
 import NativePackTool, { CocosParams } from '../base/default';
+import { cleanBrokenGradleWrapperCache } from './gradle-utils';
 
 export interface IOrientation {
     landscapeLeft: boolean;
@@ -140,6 +141,7 @@ export default class GooglePlayPackTool extends NativePackTool {
         if (!fs.existsSync(projDir)) {
             throw new Error(`dir ${projDir} not exits`);
         }
+        cleanBrokenGradleWrapperCache(projDir, 'GooglePlay');
         let gradle = 'gradlew';
         if (process.platform === 'win32') {
             gradle += '.bat';

--- a/src/core/builder/platforms/native-common/pack-tool/platforms/gradle-utils.ts
+++ b/src/core/builder/platforms/native-common/pack-tool/platforms/gradle-utils.ts
@@ -1,0 +1,76 @@
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as ps from 'path';
+
+const GradleLockStaleMs = 2 * 60 * 1000;
+
+function getGradleUserHome(): string {
+    return process.env.GRADLE_USER_HOME || ps.join(os.homedir(), '.gradle');
+}
+
+function parseDistributionFileName(wrapperProperties: string): string | null {
+    const content = fs.readFileSync(wrapperProperties, 'utf8');
+    const match = content.match(/^distributionUrl\s*=\s*(.+)$/m);
+    if (!match) {
+        return null;
+    }
+    const distributionUrl = match[1].trim().replace(/\\:/g, ':').replace(/\\/g, '');
+    const fileName = ps.basename(decodeURIComponent(distributionUrl));
+    return fileName.endsWith('.zip') ? fileName : null;
+}
+
+function isStaleLock(file: string): boolean {
+    try {
+        const stat = fs.statSync(file);
+        return Date.now() - stat.mtimeMs > GradleLockStaleMs;
+    } catch {
+        return false;
+    }
+}
+
+function shouldCleanDistributionDir(dir: string, distributionFileName: string): boolean {
+    const files = fs.readdirSync(dir);
+    const hasDistributionZip = files.includes(distributionFileName);
+    const hasTempDownload = files.some((file) => file.endsWith('.part') || file.endsWith('.tmp'));
+    const hasStaleLock = files
+        .filter((file) => file.endsWith('.lck') || file.endsWith('.lock'))
+        .some((file) => isStaleLock(ps.join(dir, file)));
+    return !hasDistributionZip || hasTempDownload || hasStaleLock;
+}
+
+export function cleanBrokenGradleWrapperCache(projectDir: string, tag = 'Gradle') {
+    const wrapperProperties = ps.join(projectDir, 'gradle', 'wrapper', 'gradle-wrapper.properties');
+    if (!fs.existsSync(wrapperProperties)) {
+        return;
+    }
+
+    const distributionFileName = parseDistributionFileName(wrapperProperties);
+    if (!distributionFileName) {
+        return;
+    }
+
+    const distributionName = distributionFileName.replace(/\.zip$/, '');
+    const distsDir = ps.join(getGradleUserHome(), 'wrapper', 'dists');
+    const distributionRoot = ps.join(distsDir, distributionName);
+    if (!fs.existsSync(distributionRoot)) {
+        return;
+    }
+
+    for (const hashName of fs.readdirSync(distributionRoot)) {
+        const cacheDir = ps.join(distributionRoot, hashName);
+        if (!fs.statSync(cacheDir).isDirectory()) {
+            continue;
+        }
+
+        if (!shouldCleanDistributionDir(cacheDir, distributionFileName)) {
+            continue;
+        }
+
+        try {
+            fs.removeSync(cacheDir);
+            console.warn(`[${tag}] Removed broken Gradle wrapper cache: ${cacheDir}`);
+        } catch (error) {
+            console.warn(`[${tag}] Failed to remove broken Gradle wrapper cache: ${cacheDir}`, error);
+        }
+    }
+}


### PR DESCRIPTION
Hide Google Play options that should not be exposed in the build UI, add the missing billing label, and align the armeabi-v7a key.

Resolve default icon roots from both source and built layouts, and clean broken Gradle wrapper distribution caches before running the Google Play make step.