### PR TITLE
Fix(assets): enhance asset reimport metadata, fix lodash import issue

### DIFF
--- a/src/core/assets/manager/asset.ts
+++ b/src/core/assets/manager/asset.ts
@@ -4,7 +4,7 @@ import { url2path, url2uuid } from '../utils';
 import EventEmitter from 'events';
 import { AssetManagerEvents, IAsset, IAssetInfo, IAssetDBInfo } from '../@types/private';
 import type { ThumbnailInfo, ThumbnailSize } from '../@types/protected/asset-handler';
-import assetQuery from './query';
+import assetQuery, { ASSET_TREE_INFO_DATA_KEYS } from './query';
 import assetOperation from './operation';
 import assetHandlerManager from './asset-handler';
 import animationGraphVariant from '../animation-graph-variant';
@@ -151,7 +151,7 @@ class AssetManager extends EventEmitter {
         if (!asset || !asset.uuid) {
             return null;
         }
-        return assetManager.queryAssetInfo(asset.uuid, ['subAssets', 'displayName', 'extends']);
+        return assetManager.queryAssetInfo(asset.uuid, ASSET_TREE_INFO_DATA_KEYS);
     }
 
     private _snapshotAssetChangeInfo(asset: IAsset): IAssetInfo | null {

--- a/src/core/assets/manager/operation.ts
+++ b/src/core/assets/manager/operation.ts
@@ -15,7 +15,7 @@ import assetHandlerManager from './asset-handler';
 import { copyAssetSource } from './asset-copy';
 import { copyPath, moveAssetSource, removeAssetSource, renamePath } from './filesystem';
 import i18n from '../../base/i18n';
-import assetQuery from './query';
+import assetQuery, { ASSET_TREE_INFO_DATA_KEYS } from './query';
 import utils from '../../base/utils';
 import EventEmitter from 'events';
 import { mergeMeta } from '../asset-handler/utils';
@@ -705,7 +705,7 @@ class AssetOperation extends EventEmitter {
         if (!asset.imported || asset.invalid) {
             throw asset.importError || new Error(`Reimport asset ${asset.source} failed`);
         }
-        return assetQuery.encodeAsset(asset);
+        return assetQuery.encodeAsset(asset, ASSET_TREE_INFO_DATA_KEYS);
     }
 
     /**

--- a/src/core/assets/manager/query.ts
+++ b/src/core/assets/manager/query.ts
@@ -14,6 +14,16 @@ import utils from '../../base/utils';
 import { existsSync, readJSONSync, readdirSync } from 'fs-extra';
 import * as path from 'path';
 
+export const DEFAULT_ASSET_INFO_DATA_KEYS = [
+    'subAssets',
+    'displayName',
+] as const satisfies readonly (keyof IAssetInfo)[];
+
+export const ASSET_TREE_INFO_DATA_KEYS = [
+    ...DEFAULT_ASSET_INFO_DATA_KEYS,
+    'extends',
+] as const satisfies readonly (keyof IAssetInfo)[];
+
 declare global {
     var assetQuery: AssetQueryManager;
 }
@@ -137,7 +147,7 @@ class AssetQueryManager {
         return null;
     }
 
-    queryAssetInfo(urlOrUUIDOrPath: string, dataKeys?: (keyof IAssetInfo)[]): IAssetInfo | null {
+    queryAssetInfo(urlOrUUIDOrPath: string, dataKeys?: readonly (keyof IAssetInfo)[]): IAssetInfo | null {
         if (!urlOrUUIDOrPath || typeof urlOrUUIDOrPath !== 'string') {
             throw new Error('parameter error');
         }
@@ -177,7 +187,7 @@ class AssetQueryManager {
      * @param uuid 资源的唯一标识符
      * @param dataKeys 资源输出可选项
      */
-    queryAssetInfoByUUID(uuid: string, dataKeys?: (keyof IAssetInfo)[]): IAssetInfo | null {
+    queryAssetInfoByUUID(uuid: string, dataKeys?: readonly (keyof IAssetInfo)[]): IAssetInfo | null {
         if (!uuid) {
             return null;
         }
@@ -195,7 +205,7 @@ class AssetQueryManager {
      * @param options 搜索配置
      * @param dataKeys 指定需要的资源信息字段
      */
-    queryAssetInfos(options?: QueryAssetsOption, dataKeys?: (keyof IAssetInfo)[]): IAssetInfo[] {
+    queryAssetInfos(options?: QueryAssetsOption, dataKeys?: readonly (keyof IAssetInfo)[]): IAssetInfo[] {
         let allAssets: IAsset[] = [];
         const dbInfos: IAssetInfo[] = [];
         // 循环每一个已经启动的 database
@@ -323,7 +333,7 @@ class AssetQueryManager {
      * @param asset
      * @param invalid 是否是无效的资源，例如已被删除的资源
      */
-    encodeAsset(asset: IAsset, dataKeys: (keyof IAssetInfo)[] = ['subAssets', 'displayName'], invalid = false) {
+    encodeAsset(asset: IAsset, dataKeys: readonly (keyof IAssetInfo)[] = DEFAULT_ASSET_INFO_DATA_KEYS, invalid = false) {
         let name = '';
         let source = '';
         let file = '';

--- a/src/core/assets/test/operation-filesystem-bridge.test.ts
+++ b/src/core/assets/test/operation-filesystem-bridge.test.ts
@@ -23,6 +23,7 @@ const mockAddTask = jest.fn(async (func: Function, args: any[]) => await func(..
 const mockGetCreateMenuByName = jest.fn();
 const mockCreateAssetByHandler = jest.fn();
 const mockSaveAssetByHandler = jest.fn();
+const mockAssetTreeInfoDataKeys = ['subAssets', 'displayName', 'extends'] as const;
 const { dirname, join } = require('path') as typeof import('path');
 
 jest.mock('fs-extra', () => ({
@@ -120,6 +121,7 @@ jest.mock('../asset-config', () => ({
 
 jest.mock('../manager/query', () => ({
     __esModule: true,
+    ASSET_TREE_INFO_DATA_KEYS: mockAssetTreeInfoDataKeys,
     default: {
         queryAsset: (...args: any[]) => mockQueryAsset(...args),
         encodeAsset: jest.fn((asset) => ({ source: asset.source })),
@@ -260,6 +262,21 @@ describe('asset operation filesystem bridge', () => {
         expect(mockReimport).toHaveBeenCalledWith(requestPath);
         expect(mockQueryAsset).not.toHaveBeenCalled();
         expect(result).toEqual({ source: asset.source });
+    });
+
+    it('reimportAsset serializes the asset tree metadata contract', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const assetQuery = require('../manager/query').default as typeof import('../manager/query').default;
+        const asset = {
+            imported: true,
+            invalid: false,
+            source: 'D:/project/assets/Texture.png',
+        };
+        mockReimport.mockResolvedValue(asset);
+
+        await assetOperation.reimportAsset('texture-uuid');
+
+        expect(assetQuery.encodeAsset).toHaveBeenCalledWith(asset, ['subAssets', 'displayName', 'extends']);
     });
 
     it('reimportAsset still reports a genuinely missing asset', async () => {

--- a/src/core/engine/editor-extends/manager/node.ts
+++ b/src/core/engine/editor-extends/manager/node.ts
@@ -2,13 +2,13 @@
 
 import type { Node } from 'cc';
 import { EventEmitter } from 'events';
+import findLast from 'lodash/findLast';
 
 import * as ObjectWalker from '../missing-reporter/object-walker';
 import utils from '../../../base/utils';
 import pathManager from './node-path-manager';
 import { validateNodeName } from './path-utils';
 
-const lodash = require('lodash');
 
 export default class NodeManager extends EventEmitter {
     // 当前在场景树中的节点集合,包括在层级管理器中隐藏的
@@ -252,7 +252,7 @@ export default class NodeManager extends EventEmitter {
                 }
 
                 if (isAsset || isScript) {
-                    const node = lodash.findLast(parsedObjects, (item: any) => item instanceof cc.Node);
+                    const node = findLast(parsedObjects, (item: any) => item instanceof cc.Node);
 
                     if (node && !nodesUuid.includes(node.uuid)) {
                         nodesUuid.push(node.uuid);


### PR DESCRIPTION
This pull request makes several improvements to the asset management system by standardizing the way asset metadata fields are selected and serialized, ensuring consistency across the codebase. It introduces constants for commonly used sets of asset info keys, updates method signatures to use these constants, and adds a test to verify correct serialization during asset reimport. Additionally, it refactors a utility import in the node manager for clarity.

**Asset metadata key management:**

* Introduced `DEFAULT_ASSET_INFO_DATA_KEYS` and `ASSET_TREE_INFO_DATA_KEYS` constants in `query.ts` to standardize which metadata fields are included when querying or serializing asset information. These are now used throughout the asset management code.
* Updated method signatures in `AssetQueryManager` (`queryAssetInfo`, `queryAssetInfoByUUID`, `queryAssetInfos`, `encodeAsset`) to accept `readonly` arrays of keys, defaulting to the new constants for consistency and type safety. [[1]](diffhunk://#diff-c27bbb8edfe5b656e7375f119cab4d4a225890e2ce5ca86d0593cfa5f7eac49fL140-R150) [[2]](diffhunk://#diff-c27bbb8edfe5b656e7375f119cab4d4a225890e2ce5ca86d0593cfa5f7eac49fL180-R190) [[3]](diffhunk://#diff-c27bbb8edfe5b656e7375f119cab4d4a225890e2ce5ca86d0593cfa5f7eac49fL198-R208) [[4]](diffhunk://#diff-c27bbb8edfe5b656e7375f119cab4d4a225890e2ce5ca86d0593cfa5f7eac49fL326-R336)

**Usage of standardized asset info keys:**

* Updated calls to `queryAssetInfo` and `encodeAsset` in `asset.ts` and `operation.ts` to use `ASSET_TREE_INFO_DATA_KEYS` instead of hardcoding key arrays, ensuring all relevant metadata is included for asset tree operations. [[1]](diffhunk://#diff-589f82b570605301e5e56250bdee437b1126118f8cd441831e8f9afad3d4be02L7-R7) [[2]](diffhunk://#diff-589f82b570605301e5e56250bdee437b1126118f8cd441831e8f9afad3d4be02L154-R154) [[3]](diffhunk://#diff-72879da1810b741920025102c01ac75ca2fd80973baf3724b840ec608e006960L18-R18) [[4]](diffhunk://#diff-72879da1810b741920025102c01ac75ca2fd80973baf3724b840ec608e006960L708-R708)

**Testing improvements:**

* Added a unit test in `operation-filesystem-bridge.test.ts` to verify that `reimportAsset` serializes asset metadata using the correct contract (`ASSET_TREE_INFO_DATA_KEYS`). [[1]](diffhunk://#diff-91964a840927d98129d2616940af4b721c787b48a7083375b74e8a2c7ceafcd8R26) [[2]](diffhunk://#diff-91964a840927d98129d2616940af4b721c787b48a7083375b74e8a2c7ceafcd8R124) [[3]](diffhunk://#diff-91964a840927d98129d2616940af4b721c787b48a7083375b74e8a2c7ceafcd8R248-R262)

**Codebase cleanup:**

* Replaced a dynamic `lodash` import with a direct import of `findLast` from `lodash` in `node.ts` for improved clarity and tree-shaking. [[1]](diffhunk://#diff-678cd1c8008e34f915d3698747ec1fd576e05b54d7c2c034554e9e495da42628R5-L10) [[2]](diffhunk://#diff-678cd1c8008e34f915d3698747ec1fd576e05b54d7c2c034554e9e495da42628L249-R249)