### PR TITLE
fix(scene): report missing prefab UUID on open

### DIFF
--- a/src/api/base/schema-base.ts
+++ b/src/api/base/schema-base.ts
@@ -78,7 +78,12 @@ export function getCommonErrorStatus(error: unknown): CommonStatus {
         return COMMON_STATUS.BAD_REQUEST;
     }
 
-    if (code === 'ENOENT' || /ENOENT|no such file or directory|not found|not exist|cannot find|can not find|can not be found|无法找到资源/i.test(message)) {
+    if (
+        code === 'ENOENT'
+        || code === String(HTTP_STATUS.NOT_FOUND)
+        || /ENOENT|no such file or directory|not found|not exist|cannot find|can not find|can not be found|dependent asset is missing|无法找到资源/i.test(message)
+        || /(?:asset fetch failed\s*\(|status(?: code)?[: ]+|HTTP\s*)404\b/i.test(message)
+    ) {
         return COMMON_STATUS.NOT_FOUND;
     }
 

--- a/src/core/scene/scene-process/service/error-utils.ts
+++ b/src/core/scene/scene-process/service/error-utils.ts
@@ -1,4 +1,11 @@
-const DOWNLOAD_FAILED_RE = /^download failed: .*\/([\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}(?:@[^.]+)?)\.json/i;
+const UUID_PATTERN = '[\\da-f]{8}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{12}';
+const DOWNLOAD_FAILED_RE = new RegExp(`download failed: .*\\/(${UUID_PATTERN}(?:@[^.?\\s/]+)?)\\.(?:json|bin)`, 'i');
+const ASSET_FETCH_FAILED_RE = new RegExp(`asset fetch failed\\s*\\(\\s*404\\s*\\)\\s*:\\s*(${UUID_PATTERN}(?:@[^\\s]+)?)`, 'i');
+
+function extractMissingUuid(errInfo: string): string | null {
+    const knownFormat = DOWNLOAD_FAILED_RE.exec(errInfo) || ASSET_FETCH_FAILED_RE.exec(errInfo);
+    return knownFormat?.[1] ?? null;
+}
 
 export async function enrichMissingDependencyError(
     errInfo: string,
@@ -6,11 +13,10 @@ export async function enrichMissingDependencyError(
     queryAssetInfo?: (uuid: string) => Promise<{ url?: string } | null>,
     querySubAssetName?: (mainUuid: string, subId: string) => Promise<string | null>,
 ): Promise<string> {
-    const result = DOWNLOAD_FAILED_RE.exec(errInfo);
-    if (!result) {
+    const missingUuid = extractMissingUuid(errInfo);
+    if (!missingUuid) {
         return `The asset ${ownerAsset} cannot be loaded. Detail: ${errInfo}`;
     }
-    const missingUuid = result[1];
     let assetDesc = missingUuid;
 
     if (queryAssetInfo) {

--- a/src/core/scene/test/enrich-missing-dependency-error.test.ts
+++ b/src/core/scene/test/enrich-missing-dependency-error.test.ts
@@ -19,6 +19,14 @@ describe('enrichMissingDependencyError', () => {
         expect(msg).toContain(SUB_UUID);
     });
 
+    it('extracts uuid from the browser asset-fetch 404 message', async () => {
+        const errInfo = `Asset fetch failed (404): ${UUID}`;
+        const msg = await enrichMissingDependencyError(errInfo, OWNER);
+        expect(msg).toContain(OWNER);
+        expect(msg).toContain(UUID);
+        expect(msg).toContain('dependent asset is missing');
+    });
+
     it('includes asset url when queryAssetInfo resolves for full uuid', async () => {
         const errInfo = `download failed: http://localhost:1234/${SUB_UUID}.json`;
         const query = jest.fn().mockResolvedValue({ url: 'db://assets/SK_Foo.fbx@b47c0' });

--- a/tests/scene-open-error-status.test.ts
+++ b/tests/scene-open-error-status.test.ts
@@ -56,4 +56,20 @@ describe('scene-open error status', () => {
         expect(result.code).toBe(COMMON_STATUS.FAIL);
         expect(result.reason).toContain('Cannot read properties');
     });
+
+    it('returns 404 with the missing prefab uuid', async () => {
+        const missingUuid = '12345678-abcd-1234-abcd-1234567890ab';
+        mockSceneOpen.mockRejectedValue(new Error(
+            `The asset db://assets/scene-with-deleted-prefab.scene cannot be loaded because a dependent asset is missing: ${missingUuid}`
+        ));
+
+        const result = await new SceneApi().open({
+            dbURLOrUUID: 'db://assets/scene-with-deleted-prefab.scene',
+            includeChildren: true,
+            includeComponents: false,
+        });
+
+        expect(result.code).toBe(COMMON_STATUS.NOT_FOUND);
+        expect(result.reason).toContain(missingUuid);
+    });
 });


### PR DESCRIPTION
Related issue:  https://zentao.sud.center/index.php?m=bug&f=view&bugID=833


## Summary

- Include the missing Prefab UUID when opening a scene that references a deleted asset.
- Recognize browser `Asset fetch failed (404)` errors and existing `.json` or `.bin` download failures.
- Return the common `404 Not Found` status for missing scene dependencies.

## Reproduction

1. Add a Prefab to a scene and save the scene.
2. Delete the Prefab asset.
3. Open the scene through the scene API.

The response now identifies the missing asset UUID instead of returning a 404 without actionable details.

## Testing

- Added coverage for UUID extraction from browser asset-fetch errors.
- Added coverage for the scene-open 404 response and missing UUID.
- Verified 3 test suites with 43 passing tests.