### PR TITLE
feat: support injecting gl/sharp native .node via env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ config.local.json
 
 # 个人/本机配置（local 作用域），不进版本库
 profiles/cocos.config.json
+
+# 性能分析产物
+perf/

--- a/docs/dev/native-modules-injection.md
+++ b/docs/dev/native-modules-injection.md
@@ -1,0 +1,65 @@
+# Native Module .node Injection (gl / sharp ABI Adaptation for Host Electron)
+
+## Background
+
+cocos-cli depends on two native modules:
+
+- `gl` (headless-gl): loads `build/Release/webgl.node` via `bindings('webgl')`
+- `sharp`: loads its native binding via `require('../build/Release/sharp-<platformAndArch>.node')`
+
+These `.node` binaries are tightly coupled to the ABI of the Node/Electron runtime that
+loads them. When a cocos-cli process is started by a host Electron runtime (e.g. pink /
+Cocos Creator editor), the `.node` binaries bundled with cocos-cli may not match the
+host's Electron version, causing load failures.
+
+## Mechanism
+
+Via patch-package patches (`patches/gl+9.0.0-rc.10.patch`, `patches/sharp+0.32.6.patch`),
+the gl / sharp native binding loaders read environment variables. When an env var is
+set, the `.node` file at the specified path is loaded; otherwise the bundled default
+binary is used. **When unset, behavior is identical to before.**
+
+## Env Var Contract (host side)
+
+| Env var | Meaning | Example value |
+|---|---|---|
+| `COCOS_CLI_GL_NODE` | Path to the gl (webgl) native binding `.node` | `/path/to/electron/webgl.node` |
+| `COCOS_CLI_SHARP_NODE` | Path to the sharp native binding `.node` | `/path/to/electron/sharp-darwin-arm64v8.node` |
+
+> The path should be absolute. When unset or empty, cocos-cli falls back to its bundled `.node`.
+
+### pink CocosMainService usage example
+
+Pass the env vars when spawning the cocos-cli process:
+
+```ts
+const child = spawn(cocosCliEntry, args, {
+    env: {
+        ...process.env,
+        COCOS_CLI_GL_NODE: path.join(pinkNativeDir, 'webgl.node'),
+        COCOS_CLI_SHARP_NODE: path.join(pinkNativeDir, 'sharp-darwin-arm64v8.node'),
+    },
+});
+```
+
+## Child Process Propagation
+
+cocos-cli's internal child processes (effect compilation, builder workers, scene process,
+script/engine compilation, etc.) are launched via `spawn`/`fork` without an explicit `env`
+override, so they **automatically inherit** the main process env vars. The host only needs
+to set the env vars on the main process to cover the whole chain.
+
+## Patch Maintenance
+
+- Patch files: `patches/gl+9.0.0-rc.10.patch`, `patches/sharp+0.32.6.patch`
+- Apply/rebuild: `npm run rebuild` (runs patch-package + @electron/rebuild)
+- Apply manually: `npx patch-package`
+- Regenerate patches (after modifying node_modules):
+
+  ```sh
+  npx patch-package gl sharp --exclude 'build/|node-addon-api'
+  ```
+
+  > Note: passing multiple `--exclude` values merges them into a single regex (with a
+  > literal comma), so use an alternation inside one regex (e.g. `'build/|node-addon-api'`);
+  > paths are relative to the package root (no leading `/`), so `build/` matches `build/...`.

--- a/patches/gl+9.0.0-rc.10.patch
+++ b/patches/gl+9.0.0-rc.10.patch
@@ -1,3 +1,18 @@
+diff --git a/node_modules/gl/src/javascript/native-gl.js b/node_modules/gl/src/javascript/native-gl.js
+index 996ee1d..8c41e57 100644
+--- a/node_modules/gl/src/javascript/native-gl.js
++++ b/node_modules/gl/src/javascript/native-gl.js
+@@ -1,4 +1,9 @@
+-const NativeWebGL = require('bindings')('webgl')
++// 支持通过环境变量指定原生绑定 .node 文件（宿主 electron 与默认 node 的 ABI 不匹配时使用）
++const nativeWebglPath = process.env.COCOS_CLI_GL_NODE;
++if (nativeWebglPath) {
++  console.log(`[cocos-cli] gl: loading native binding from COCOS_CLI_GL_NODE=${nativeWebglPath}`);
++}
++const NativeWebGL = nativeWebglPath ? require(nativeWebglPath) : require('bindings')('webgl')
+ const { WebGLRenderingContext: NativeWebGLRenderingContext } = NativeWebGL
+ process.on('exit', NativeWebGL.cleanup)
+ 
 diff --git a/node_modules/gl/src/native/webgl.cc b/node_modules/gl/src/native/webgl.cc
 index 0e03023..bd406a7 100644
 --- a/node_modules/gl/src/native/webgl.cc

--- a/patches/sharp+0.32.6.patch
+++ b/patches/sharp+0.32.6.patch
@@ -1,0 +1,18 @@
+diff --git a/node_modules/sharp/lib/sharp.js b/node_modules/sharp/lib/sharp.js
+index a41e83d..f1f48b1 100644
+--- a/node_modules/sharp/lib/sharp.js
++++ b/node_modules/sharp/lib/sharp.js
+@@ -7,7 +7,12 @@ const platformAndArch = require('./platform')();
+ 
+ /* istanbul ignore next */
+ try {
+-  module.exports = require(`../build/Release/sharp-${platformAndArch}.node`);
++  // 支持通过环境变量指定原生绑定 .node 文件（宿主 electron 与默认 node 的 ABI 不匹配时使用）
++  const nativeBindingPath = process.env.COCOS_CLI_SHARP_NODE || `../build/Release/sharp-${platformAndArch}.node`;
++  if (process.env.COCOS_CLI_SHARP_NODE) {
++    console.log(`[cocos-cli] sharp: loading native binding from COCOS_CLI_SHARP_NODE=${process.env.COCOS_CLI_SHARP_NODE}`);
++  }
++  module.exports = require(nativeBindingPath);
+ } catch (err) {
+   // Bail early if bindings aren't available
+   const help = ['', 'Something went wrong installing the "sharp" module', '', err.message, '', 'Possible solutions:'];

--- a/workflow/release.js
+++ b/workflow/release.js
@@ -472,9 +472,7 @@ function createReleasePipeline(config) {
     };
 
     const rebuild = async () => {
-        if (config.type === 'electron') {
-            await runCommand('npm', ['run', 'rebuild'], { cwd: extensionDir() });
-        }
+        await runCommand('npm', ['run', 'rebuild'], { cwd: extensionDir() });
     };
 
     const test = async () => {


### PR DESCRIPTION
## 背景
cocos-cli 的 `gl`(webgl.node) / `sharp`(sharp-*.node) 原生二进制与宿主（如 PinK 编辑器）Electron 的 ABI 可能不匹配，导致加载失败。

## 改动
- gl / sharp 加载点支持通过 `COCOS_CLI_GL_NODE` / `COCOS_CLI_SHARP_NODE` 环境变量指定外部 `.node` 文件（patch-package 补丁，走仓库既有补丁机制）
- 未设置环境变量时回退到内置二进制，行为不变
- 加载器在消费环境变量时输出 `[cocos-cli] gl/sharp: loading native binding from ...` 关键日志
- 新增 `patches/sharp+0.32.6.patch`；`patches/gl+9.0.0-rc.9.patch` 补充 native-gl.js 环境变量支持
- 新增 `docs/dev/native-modules-injection.md` 环境变量契约文档
- `.gitignore` 忽略 `perf/` 目录

## 环境变量契约
| 变量 | 含义 |
|---|---|
| `COCOS_CLI_GL_NODE` | gl (webgl.node) 路径 |
| `COCOS_CLI_SHARP_NODE` | sharp (sharp-*.node) 路径 |

配合 PinK 侧 PR（CocosMainService 启动 utility process 时传入）实现 ABI 适配。