### PR TITLE
fix(scene): disable 3D physics in editor mode

### DIFF
--- a/src/core/scene/scene-process/engine-bootstrap.test.ts
+++ b/src/core/scene/scene-process/engine-bootstrap.test.ts
@@ -120,6 +120,11 @@ describe('scene-process engine bootstrap', () => {
                     runInEditor: false,
                     switchTo: jest.fn(),
                 },
+                PhysicsSystem: {
+                    instance: {
+                        enable: true,
+                    },
+                },
             },
             ResolutionPolicy: {
                 SHOW_ALL: 'show-all',
@@ -188,6 +193,13 @@ describe('scene-process engine bootstrap', () => {
                 }),
             }),
         }));
+    });
+
+    it('disables physics simulation for the scene editor process', async () => {
+        await startup({ serverURL: 'http://localhost:7456' });
+
+        expect((globalThis as any).cc.physics.selector.switchTo).toHaveBeenCalledWith('builtin');
+        expect((globalThis as any).cc.physics.PhysicsSystem.instance.enable).toBe(false);
     });
 
     it('loads scene editor bundles through the original asset manager', async () => {

--- a/src/core/scene/scene-process/engine-bootstrap.ts
+++ b/src/core/scene/scene-process/engine-bootstrap.ts
@@ -128,6 +128,9 @@ export async function startup(options: {
 
     // 切换物理引擎
     cc.physics.selector.switchTo(backend);
+    if (cc.physics.PhysicsSystem?.instance) {
+        cc.physics.PhysicsSystem.instance.enable = false;
+    }
     const dr = config?.overrideSettings?.screen?.designResolution;
     const drWidth = dr?.width ?? 1280;
     const drHeight = dr?.height ?? 720;


### PR DESCRIPTION
Disables 3D physics simulation in the scene editor process to prevent rigid bodies from updating node transforms during editor ticks.

Tests:
        - npx jest src/core/scene/scene-process/engine-bootstrap.test.ts --runInBand