### PR TITLE
[break] fix(scene): persist gizmo display config per-field to prevent default…

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -6125,7 +6125,7 @@ export declare interface ICameraService {
     zoomReset(): void;
     alignNodeToSceneView(nodes: string[]): void;
     alignSceneViewToNode(nodes: string[]): void;
-    setGridColor(color: number[]): void;
+    setGridColor(color: number[], persist?: boolean): void;
     setOriginAxes2D(config: IOriginAxesConfig): void;
     setOriginAxes3D(config: IOriginAxesConfig): void;
     onUpdate(deltaTime: number): void;

--- a/src/core/preview/preview-settings.ts
+++ b/src/core/preview/preview-settings.ts
@@ -76,6 +76,13 @@ async function generatePreviewSettings(startScene: string, sceneEditor: boolean)
         const { fillIncludeModulesFromProjectConfig } = await import('../builder/share/common-options-validator');
         const tmp = await queryDefaultBuildConfigByPlatform('web-desktop');
         const options = JSON.parse(JSON.stringify(tmp));
+        // 预览必须 debug=true，否则内置 bundle 加载即崩（Cannot read properties of undefined (reading 'cc.EffectAsset')）。
+        // 原因：预览的 getPreviewSettings 只跑 data/setting task，不跑 bundle 构建，bundle 配置永远不经过
+        // bundle.compress()——config.paths 里类型保留为字符串（'cc.EffectAsset' 等），config.types 数组也从未生成。
+        // 而引擎 asset-manager/config.ts processOptions 仅在 config.debug === false 时才把 entry[1] 当索引去
+        // types[entry[1]] 解压；此时 config.types 为 undefined，就会 undefined['cc.EffectAsset'] 抛错。
+        // config.debug 直接取自 options.debug，故这里必须置 true，让引擎按未压缩格式读取，跳过解压分支。
+        options.debug = true;
         // 与正式构建（builder createBuildTask）保持一致：从 cocos.config.json 补全 includeModules。
         // 预览路径原本不补全，options.includeModules 为空/默认时，内置资源包会漏掉当前模块（尤其是所选
         // 物理后端 physics-cannon/ammo/physx/builtin）的 dependentAssets，比如内置物理材质

--- a/src/core/scene/common/camera.ts
+++ b/src/core/scene/common/camera.ts
@@ -23,7 +23,7 @@ export interface ICameraService {
     zoomReset(): void;
     alignNodeToSceneView(nodes: string[]): void;
     alignSceneViewToNode(nodes: string[]): void;
-    setGridColor(color: number[]): void;
+    setGridColor(color: number[], persist?: boolean): void;
     setOriginAxes2D(config: IOriginAxesConfig): void;
     setOriginAxes3D(config: IOriginAxesConfig): void;
     onUpdate(deltaTime: number): void;

--- a/src/core/scene/scene-process/service/camera.ts
+++ b/src/core/scene/scene-process/service/camera.ts
@@ -1,6 +1,6 @@
 import { Camera, Canvas, Color, Layers, Vec3, gfx } from 'cc';
 import { BaseService } from './core';
-import { register, Service } from './core/decorator';
+import { register, Service, queryRegisteredService } from './core/decorator';
 import { CameraController2D } from './camera/camera-controller-2d';
 import { CameraController3D } from './camera/camera-controller-3d';
 import CameraControllerBase from './camera/camera-controller-base';
@@ -8,7 +8,7 @@ import { CameraMoveMode, CameraUtils } from './camera/utils';
 import EditorCameraComponent from './camera/editor-camera-component';
 import { OperationPriority } from './operation/types';
 import { Rpc } from '../rpc';
-import type { ICameraConfig, ICameraEvents, ICameraService, IOriginAxesConfig } from '../../common';
+import type { ICameraConfig, ICameraEvents, ICameraService, IGizmoService, IOriginAxesConfig } from '../../common';
 import type { IGizmoConfig } from '../../scene-configs';
 
 /**
@@ -193,7 +193,7 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
 
     private _applyGizmoDisplay(config: Partial<IGizmoConfig>): void {
         if (config.gridVisible !== undefined) this.setGridVisible(config.gridVisible, false);
-        if (config.gridColor !== undefined) this.setGridColor(config.gridColor);
+        if (config.gridColor !== undefined) this.setGridColor(config.gridColor, false);
         this._syncControllerGridVisibility();
         Service.Engine.repaintInEditMode();
     }
@@ -204,8 +204,18 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
         }
     }
 
-    setGridColor(color: number[]): void {
+    setGridColor(color: number[], persist = true): void {
         if (!color || color.length < 3) return;
+        // gridColor 的配置归 Gizmo 的 GizmoConfig 所有并由其统一持久化（与 cocos-editor GizmoManager 一致）。
+        // 面板经由本方法改色时转交 Gizmo：更新运行时配置并定向落盘（gizmo.gridColor），避免只改渲染而不落盘（重开丢失）。
+        // Gizmo.setGridColor 内部会回调本方法（persist=false）完成 2D/3D 控制器渲染。
+        if (persist) {
+            const gizmo = queryRegisteredService<IGizmoService>('Gizmo');
+            if (gizmo) {
+                gizmo.setGridColor(color); // 其内部会回调 setGridColor(color, false) 完成渲染
+                return;
+            }
+        }
         const [r = 166, g = 166, b = 166, a = 255] = color;
         this._controller3D.lineColor = new Color(r, g, b, a);
         this._controller3D.updateGrid();

--- a/src/core/scene/scene-process/service/gizmo.ts
+++ b/src/core/scene/scene-process/service/gizmo.ts
@@ -433,23 +433,34 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
         try {
             const rpc = Rpc.getInstance();
             const current = await rpc.request('sceneConfigInstance', 'get', ['gizmo', 'local']) as Record<string, any> ?? {};
+            // 注意：GizmoConfig 拥有的字段（gridColor、is3DIcon、iconSize、toolsVisibility3d、
+            // originAxis2D、originAxis3D）不在此写入，改由各自 setter 定向落盘（见 _saveGizmoConfigField），
+            // 避免打开场景切回 position 触发的 saveConfig 用尚未载入的默认值覆盖已保存的配置。
+            // 这里用 ...current 保留磁盘上已有的这些字段，只写会随场景/操作实时变化的字段。
             const gizmoConfig = {
                 ...current,
                 is2D: this.is2D,
-                is3DIcon: this.isIconGizmo3D(),
-                iconSize: this.queryIconGizmoSize(),
                 transformToolName: this.transformToolName,
                 viewMode: this.viewMode,
                 pivot: this.pivot,
                 coordinate: this.coordinate,
-                toolsVisibility3d: this.queryToolsVisibility3d(),
                 snapConfigs: this.transformToolData.snapConfigs.getPureDataObject(),
                 rectSnapConfig: rectTransformSnapping.getPureDataObject(),
-                gridColor: this.queryGridColor(),
-                originAxis2D: this.queryOriginAxes2D(),
-                originAxis3D: this.queryOriginAxes3D(),
             };
             await rpc.request('sceneConfigInstance', 'set', ['gizmo', gizmoConfig, 'local']);
+        } catch {
+            // Config persistence not available
+        }
+    }
+
+    // GizmoConfig 拥有的字段单独定向落盘，与 _saveSnapConfig 一致，不经过整块 saveConfig。
+    // 原因：saveConfig 会用 GizmoConfig 静态量重新快照所有字段，若某字段尚未从磁盘载入（仍是默认值），
+    // 由其它改动触发的 saveConfig 会把它写回默认值，覆盖上次保存的个性化配置。改为逐字段定向落盘后，
+    // 每次只写发生变化的那个字段，其余字段由 saveConfig 的 ...current 从磁盘原样保留。
+    private async _saveGizmoConfigField(subKey: string, value: unknown): Promise<void> {
+        try {
+            const rpc = Rpc.getInstance();
+            await rpc.request('sceneConfigInstance', 'set', [`gizmo.${subKey}`, value, 'local']);
         } catch {
             // Config persistence not available
         }
@@ -504,7 +515,7 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
             }
         }
         Service.Engine?.repaintInEditMode?.();
-        void this.saveConfig();
+        void this._saveGizmoConfigField('toolsVisibility3d', GizmoConfig.toolsVisibility3d);
     }
 
     isIconGizmo3D(): boolean {
@@ -521,7 +532,7 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
             }
         });
         Service.Engine?.repaintInEditMode?.();
-        void this.saveConfig();
+        void this._saveGizmoConfigField('is3DIcon', GizmoConfig.isIconGizmo3D);
     }
 
     queryIconGizmoSize(): number {
@@ -538,7 +549,7 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
             }
         });
         Service.Engine?.repaintInEditMode?.();
-        void this.saveConfig();
+        void this._saveGizmoConfigField('iconSize', GizmoConfig.iconGizmoSize);
     }
 
     queryGridColor(): number[] {
@@ -548,8 +559,8 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
     setGridColor(color: number[]): void {
         if (!color) return;
         GizmoConfig.gridColor = [...color];
-        Service.Camera?.setGridColor?.(color);
-        void this.saveConfig();
+        Service.Camera?.setGridColor?.(color, false);
+        void this._saveGizmoConfigField('gridColor', [...color]);
     }
 
     queryOriginAxes2D(): IOriginAxesConfig {
@@ -560,7 +571,7 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
         if (!config) return;
         GizmoConfig.originAxis2D = { ...config };
         Service.Camera?.setOriginAxes2D?.(config);
-        void this.saveConfig();
+        void this._saveGizmoConfigField('originAxis2D', { ...GizmoConfig.originAxis2D });
     }
 
     queryOriginAxes3D(): IOriginAxesConfig {
@@ -571,7 +582,7 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
         if (!config) return;
         GizmoConfig.originAxis3D = { ...config };
         Service.Camera?.setOriginAxes3D?.(config);
-        void this.saveConfig();
+        void this._saveGizmoConfigField('originAxis3D', { ...GizmoConfig.originAxis3D });
     }
 
     setIconVisible(visible: boolean): void {

--- a/src/core/scene/test/camera-view-mode-config.test.ts
+++ b/src/core/scene/test/camera-view-mode-config.test.ts
@@ -10,6 +10,7 @@ const mockService: any = {
     Gizmo: {
         backgroundNode: { name: 'background' },
         transformToolData: { is2D: false },
+        setGridColor: jest.fn(),
     },
     Operation: {
         addListener: jest.fn(),
@@ -62,6 +63,7 @@ jest.mock('cc', () => ({
 jest.mock('../scene-process/service/core/decorator', () => ({
     register: () => () => undefined,
     Service: mockService,
+    queryRegisteredService: (name: string) => mockService[name] ?? null,
 }));
 
 jest.mock('../scene-process/rpc', () => ({
@@ -212,6 +214,35 @@ describe('CameraService view mode config', () => {
         expect(camera.controller3D.updateOriginAxisByConfig).toHaveBeenCalledWith(originAxis3D);
         expect(camera.controller2D.showGrid).toHaveBeenLastCalledWith(false);
         expect(camera.controller3D.showGrid).toHaveBeenLastCalledWith(true);
+    });
+
+    it('delegates grid color changes to the Gizmo config owner so they persist', () => {
+        const { CameraService } = require('../scene-process/service/camera');
+        const camera = new CameraService();
+        camera.init();
+        (mockService.Gizmo.setGridColor as jest.Mock).mockClear();
+
+        camera.setGridColor([12, 34, 56, 78]);
+
+        // 归属 Gizmo：由 Gizmo.setGridColor 更新 GizmoConfig 并整块落盘，避免只改渲染而不持久化
+        expect(mockService.Gizmo.setGridColor).toHaveBeenCalledWith([12, 34, 56, 78]);
+    });
+
+    it('only applies grid color to controllers without delegating when persist is false', () => {
+        const { CameraService } = require('../scene-process/service/camera');
+        const camera = new CameraService();
+        camera.init();
+        (mockService.Gizmo.setGridColor as jest.Mock).mockClear();
+
+        camera.setGridColor([12, 34, 56, 78], false);
+
+        expect(mockService.Gizmo.setGridColor).not.toHaveBeenCalled();
+        expect(camera.controller3D.lineColor).toEqual(
+            expect.objectContaining({ r: 12, g: 34, b: 56, a: 78 }),
+        );
+        expect(camera.controller2D.lineColor).toEqual(
+            expect.objectContaining({ r: 12, g: 34, b: 56, a: 78 }),
+        );
     });
 });
 

--- a/src/core/scene/test/gizmo-reload-events.test.ts
+++ b/src/core/scene/test/gizmo-reload-events.test.ts
@@ -71,7 +71,10 @@ jest.mock('../scene-process/service/gizmo/transform-tool', () => ({
     TransformToolData: class TransformToolData extends EventEmitter {
         toolName = 'position';
         is2D = true;
-        snapConfigs = {};
+        snapConfigs = {
+            getPureDataObject: () => ({}),
+            initFromData: () => undefined,
+        };
     },
 }));
 
@@ -344,5 +347,114 @@ describe('Gizmo editor lifecycle', () => {
         expect(secondGizmo).not.toBe(firstGizmo);
         expect(secondGizmo.destroyed).toBe(false);
         expect(secondGizmo.target).toBe(secondComponent);
+    });
+
+    it('persists grid color with a targeted write, independent of the whole-object save', async () => {
+        const stored: Record<string, any> = { gridColor: [11, 22, 33, 44] };
+        const request = jest.fn((_svc: string, method: string, args: any[]) => {
+            const [key] = args;
+            if (method === 'get') {
+                if (key === 'gizmo') return Promise.resolve(stored);
+                if (key === 'gizmo.gridColor') return Promise.resolve(stored.gridColor);
+                return Promise.resolve(undefined);
+            }
+            if (method === 'set') {
+                if (key === 'gizmo.gridColor') stored.gridColor = args[1];
+                else if (key === 'gizmo') Object.assign(stored, args[1]);
+                return Promise.resolve(true);
+            }
+            return Promise.resolve(undefined);
+        });
+        const { Rpc } = require('../scene-process/rpc');
+        Rpc.getInstance.mockReturnValue({ request });
+
+        const { GizmoService } = require('../scene-process/service/gizmo');
+        const gizmo = new GizmoService();
+
+        // 面板改色：定向写入 gizmo.gridColor（local），不依赖初始加载/整块 saveConfig
+        gizmo.setGridColor([200, 100, 50, 255]);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const gridSet = request.mock.calls.find(
+            (c: any[]) => c[1] === 'set' && c[2][0] === 'gizmo.gridColor',
+        );
+        expect(gridSet).toBeDefined();
+        expect(gridSet![2][1]).toEqual([200, 100, 50, 255]);
+        expect(gridSet![2][2]).toBe('local');
+        expect(stored.gridColor).toEqual([200, 100, 50, 255]);
+    });
+
+    it('does not let the whole-object saveConfig clobber previously saved GizmoConfig fields with defaults', async () => {
+        // 磁盘上已保存的、非默认的 GizmoConfig 字段
+        const stored: Record<string, any> = {
+            gridColor: [11, 22, 33, 44],
+            is3DIcon: true,
+            iconSize: 5,
+            toolsVisibility3d: false,
+            originAxis2D: { x: false, y: false, z: true },
+            originAxis3D: { x: false, y: true, z: false },
+        };
+        const request = jest.fn((_svc: string, method: string, args: any[]) => {
+            if (method === 'get') return Promise.resolve(stored);
+            if (method === 'set') {
+                Object.assign(stored, args[1]);
+                return Promise.resolve(true);
+            }
+            return Promise.resolve(undefined);
+        });
+        const { Rpc } = require('../scene-process/rpc');
+        Rpc.getInstance.mockReturnValue({ request });
+
+        const { GizmoService } = require('../scene-process/service/gizmo');
+        const gizmo = new GizmoService();
+
+        // 模拟切工具/切视图触发的 saveConfig：此时 GizmoConfig 各静态量仍是默认值，
+        // saveConfig 不应写入这些字段，应保留磁盘上已保存的值。
+        await gizmo.saveConfig();
+
+        const setCall = request.mock.calls.find((c: any[]) => c[1] === 'set');
+        expect(setCall).toBeDefined();
+        const written = setCall![2][1];
+        // ...current 保留了已保存的字段，而非被默认值覆盖
+        expect(written.gridColor).toEqual([11, 22, 33, 44]);
+        expect(written.is3DIcon).toBe(true);
+        expect(written.iconSize).toBe(5);
+        expect(written.toolsVisibility3d).toBe(false);
+        expect(written.originAxis2D).toEqual({ x: false, y: false, z: true });
+        expect(written.originAxis3D).toEqual({ x: false, y: true, z: false });
+    });
+
+    it('persists other GizmoConfig fields with their own targeted writes', async () => {
+        const stored: Record<string, any> = {};
+        const request = jest.fn((_svc: string, method: string, args: any[]) => {
+            const [key] = args;
+            if (method === 'get') {
+                if (key === 'gizmo') return Promise.resolve(stored);
+                return Promise.resolve(stored[String(key).replace('gizmo.', '')]);
+            }
+            if (method === 'set') {
+                if (String(key).startsWith('gizmo.')) stored[String(key).replace('gizmo.', '')] = args[1];
+                else if (key === 'gizmo') Object.assign(stored, args[1]);
+                return Promise.resolve(true);
+            }
+            return Promise.resolve(undefined);
+        });
+        const { Rpc } = require('../scene-process/rpc');
+        Rpc.getInstance.mockReturnValue({ request });
+
+        const { GizmoService } = require('../scene-process/service/gizmo');
+        const gizmo = new GizmoService();
+
+        gizmo.setOriginAxes2D({ x: false, y: true, z: false });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const axisSet = request.mock.calls.find(
+            (c: any[]) => c[1] === 'set' && c[2][0] === 'gizmo.originAxis2D',
+        );
+        expect(axisSet).toBeDefined();
+        expect(axisSet![2][1]).toEqual({ x: false, y: true, z: false });
+        expect(axisSet![2][2]).toBe('local');
     });
 });


### PR DESCRIPTION
Summary                                                                                                                                                         
                                                                                                                                                                  
  - fix(preview): force debug=true in preview settings. Preview never runs bundle.compress(), so bundle configs stay uncompressed (type strings, no types array). 
  The engine only decodes correctly when config.debug !== false, so an unset flag crashed internal-bundle load. config.debug follows options.debug, so we force it
  to true.                                                                                                                                                        
  - fix(scene): persist gizmo display config per-field. Grid/axes settings now persist field-by-field; setGridColor gained an optional persist flag so the        
  render-only path doesn't clobber saved config. (Signature change → needs [break] in PR title.)                                                                  
                                                                                                                                                                  
  Reproduction                                                                                                                                                    
                                                                                                                                                                  
  - Preview: launch browser preview → boot crashes with Cannot read properties of undefined (reading 'cc.EffectAsset') at config.ts:165.                          
  - Gizmo: change grid color/axes, reload scene → saved values reset to defaults.                                                                                 
                                                                                                                                                                  
  Testing                                                                                                                                                         
                                                                                                                                                                  
  - npx tsc -b clean.                                                                                                                                             
  - camera-view-mode-config.test.ts / gizmo-reload-events.test.ts cover per-field persistence and setGridColor routing.                                           
  - Manual: preview reloads without the cc.EffectAsset error. 