### PR TITLE
fix: stabilize imported asset previews and glTF validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14285,9 +14285,9 @@
             }
         },
         "node_modules/gltf-validator": {
-            "version": "2.0.0-dev.3.10",
-            "resolved": "https://registry.npmmirror.com/gltf-validator/-/gltf-validator-2.0.0-dev.3.10.tgz",
-            "integrity": "sha512-odJ4k0tRkGXiDGn78yDBg+fBbAIvBnXxh3RwAta0emSxGtyagFE8B4xELB1oYe3S5RD8Ci3uZAsZaascH2LAEQ==",
+            "version": "2.0.0-dev.2.7",
+            "resolved": "https://registry.npmmirror.com/gltf-validator/-/gltf-validator-2.0.0-dev.2.7.tgz",
+            "integrity": "sha512-OmI/inmNEL9uDTxj6KNF+/oZ7df2okhi1HKMV7cjakzo2k/MFKpa95R4dMG6WQx1KaiZAG7hvdpSxvjtkTyb2A==",
             "license": "Apache-2.0"
         },
         "node_modules/gltfpack": {

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -1255,6 +1255,7 @@ export declare class BuilderAssetCache implements BuilderCache {
     init(): Promise<void>;
     hasAsset(uuid: string): Promise<boolean>;
     addAsset(asset: IAsset, type?: string): void;
+    private addSingleAsset;
     removeAsset(uuid: string, type?: string): void;
     getAssetInfo(uuid: string): IAssetInfo;
     addInstance(instance: any): void;

--- a/src/core/assets/asset-handler/assets/gltf/validation-worker.ts
+++ b/src/core/assets/asset-handler/assets/gltf/validation-worker.ts
@@ -1,0 +1,42 @@
+import fs from 'fs';
+import { Severity, validateBytes, validateString, type ValidationOptions } from 'gltf-validator';
+
+interface ValidationWorkerRequest {
+    gltfFilePath: string;
+}
+
+function send(message: unknown) {
+    if (typeof process.send === 'function') {
+        process.send(message, () => process.disconnect());
+    }
+}
+
+process.once('message', async (message: ValidationWorkerRequest) => {
+    try {
+        const { gltfFilePath } = message;
+        const validationOptions: ValidationOptions = {
+            uri: gltfFilePath,
+            ignoredIssues: [],
+            severityOverrides: {
+                NON_RELATIVE_URI: Severity.Information,
+                UNDECLARED_EXTENSION: Severity.Warning,
+                ACCESSOR_TOTAL_OFFSET_ALIGNMENT: Severity.Information,
+            },
+        };
+        const isGlb = gltfFilePath.endsWith('.glb');
+        // For some glTF files exported by fbx2glTF, the validator can report
+        // invalid JSON when it is given bytes. Read textual glTF as a string.
+        const report = await (isGlb
+            ? validateBytes(Uint8Array.from(fs.readFileSync(gltfFilePath)), validationOptions)
+            : validateString(fs.readFileSync(gltfFilePath).toString(), validationOptions));
+        send({ report });
+    } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        send({
+            error: {
+                message: err.message,
+                stack: err.stack,
+            },
+        });
+    }
+});

--- a/src/core/assets/asset-handler/assets/gltf/validation.ts
+++ b/src/core/assets/asset-handler/assets/gltf/validation.ts
@@ -1,22 +1,65 @@
-import fs from 'fs';
-import { Severity, validateBytes, validateString, ValidationOptions } from 'gltf-validator';
+import { fork } from 'child_process';
+import path from 'path';
+import type { Report } from 'gltf-validator';
+
+const enum ValidationSeverity {
+    Error = 0,
+    Warning = 1,
+    Information = 3,
+}
+
+interface ValidationWorkerResponse {
+    report?: Report;
+    error?: {
+        message: string;
+        stack?: string;
+    };
+}
+
+function runValidatorInNodeProcess(gltfFilePath: string): Promise<Report> {
+    return new Promise((resolve, reject) => {
+        const worker = fork(path.join(__dirname, 'validation-worker.js'), [], {
+            stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
+        });
+        let settled = false;
+        const finish = (callback: () => void) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            callback();
+        };
+        const timeout = setTimeout(() => {
+            finish(() => {
+                worker.kill();
+                reject(new Error(`glTF validation timed out: ${gltfFilePath}`));
+            });
+        }, 30_000);
+
+        worker.once('error', (error) => finish(() => reject(error)));
+        worker.once('exit', (code, signal) => {
+            if (!settled) {
+                finish(() => reject(new Error(`glTF validation worker exited before replying (code=${code}, signal=${signal})`)));
+            }
+        });
+        worker.once('message', (message: ValidationWorkerResponse) => {
+            if (message?.error) {
+                const error = new Error(message.error.message);
+                error.stack = message.error.stack ?? error.stack;
+                finish(() => reject(error));
+                return;
+            }
+            if (!message?.report) {
+                finish(() => reject(new Error('glTF validation worker returned an invalid response.')));
+                return;
+            }
+            finish(() => resolve(message.report!));
+        });
+        worker.send({ gltfFilePath });
+    });
+}
 
 export async function validateGlTf(gltfFilePath: string, assetPath: string) {
-    const validationOptions: ValidationOptions = {
-        uri: gltfFilePath,
-        ignoredIssues: [],
-        severityOverrides: {
-            NON_RELATIVE_URI: Severity.Information,
-            UNDECLARED_EXTENSION: Severity.Warning,
-            ACCESSOR_TOTAL_OFFSET_ALIGNMENT: Severity.Information,
-        },
-    };
-    const isGlb = gltfFilePath.endsWith('.glb');
-    // For some gltf(fbx2glTf exported), the gltf-validator may emit `invalid JSON` error.
-    // We should read the string by self.
-    const report = await (isGlb
-        ? validateBytes(Uint8Array.from(fs.readFileSync(gltfFilePath)), validationOptions)
-        : validateString(fs.readFileSync(gltfFilePath).toString()));
+    const report = await runValidatorInNodeProcess(gltfFilePath);
 
     // Remove specified errors.
     const ignoredMessages = report.issues.messages.filter((message) => {
@@ -36,10 +79,10 @@ export async function validateGlTf(gltfFilePath: string, assetPath: string) {
     });
     for (const message of ignoredMessages) {
         switch (message.severity) {
-            case Severity.Error:
+            case ValidationSeverity.Error:
                 --report.issues.numErrors;
                 break;
-            case Severity.Warning:
+            case ValidationSeverity.Warning:
                 --report.issues.numInfos;
                 break;
         }
@@ -60,7 +103,7 @@ export async function validateGlTf(gltfFilePath: string, assetPath: string) {
                 'this may cause problem unexpectly, ' +
                 'please fix them: ' +
                 '\n' +
-                `${strintfyMessages(Severity.Error)}\n`,
+                `${strintfyMessages(ValidationSeverity.Error)}\n`,
         );
         // throw new Error(`Bad glTf format ${assetPath}.`);
     } else if (report.issues.numWarnings !== 0) {
@@ -69,9 +112,9 @@ export async function validateGlTf(gltfFilePath: string, assetPath: string) {
                 'the result may be not what you want, ' +
                 'please fix them if possible: ' +
                 '\n' +
-                `${strintfyMessages(Severity.Warning)}\n`,
+                `${strintfyMessages(ValidationSeverity.Warning)}\n`,
         );
     } else if (report.issues.numHints !== 0 || report.issues.numInfos !== 0) {
-        console.debug(`Logs from ${assetPath}:` + '\n' + `${strintfyMessages(Severity.Information)}\n`);
+        console.debug(`Logs from ${assetPath}:` + '\n' + `${strintfyMessages(ValidationSeverity.Information)}\n`);
     }
 }

--- a/src/core/assets/test/lib-assets-rpc-serialization.test.ts
+++ b/src/core/assets/test/lib-assets-rpc-serialization.test.ts
@@ -1,0 +1,31 @@
+const queryAssetInfo = jest.fn();
+
+jest.mock('../index', () => ({
+    assetDBManager: {},
+    assetManager: {
+        queryAssetInfo: (...args: any[]) => queryAssetInfo(...args),
+    },
+}));
+
+import { queryAssetInfo as queryTransportAssetInfo } from '../../../lib/assets/assets';
+
+describe('asset RPC serialization', () => {
+    beforeEach(() => {
+        queryAssetInfo.mockReset();
+    });
+
+    it('strips non-cloneable helper functions from queryAssetInfo results', async () => {
+        queryAssetInfo.mockReturnValue({
+            uuid: 'asset-uuid',
+            importer: 'fbx',
+            helper() {},
+            nested: { callback() {} },
+        });
+
+        await expect(queryTransportAssetInfo('asset-uuid')).resolves.toEqual({
+            uuid: 'asset-uuid',
+            importer: 'fbx',
+            nested: {},
+        });
+    });
+});

--- a/src/core/builder/test/builder-asset-cache.spec.ts
+++ b/src/core/builder/test/builder-asset-cache.spec.ts
@@ -1,0 +1,70 @@
+const queryAssetProperty = jest.fn();
+
+jest.mock('../../assets/manager/asset', () => ({
+    __esModule: true,
+    default: {
+        queryAssetProperty: (...args: any[]) => queryAssetProperty(...args),
+    },
+}));
+
+jest.mock('../worker/builder/manager/asset-library', () => ({
+    __esModule: true,
+    buildAssetLibrary: {
+        init: jest.fn(),
+        getAsset: jest.fn(),
+    },
+}));
+
+jest.mock('../share/builder-config', () => ({
+    __esModule: true,
+    default: {},
+}));
+
+import { BuilderAssetCache } from '../worker/builder/manager/asset';
+
+function asset(uuid: string, files: string[], subAssets: Record<string, any> = {}) {
+    return {
+        uuid,
+        url: `db://assets/${uuid}`,
+        invalid: false,
+        _assetDB: {},
+        meta: { files },
+        subAssets,
+    };
+}
+
+describe('BuilderAssetCache', () => {
+    beforeEach(() => {
+        queryAssetProperty.mockReset();
+        queryAssetProperty.mockImplementation((value: { uuid: string }) => {
+            if (value.uuid.endsWith('@prefab')) return 'cc.Prefab';
+            if (value.uuid.endsWith('@material')) return 'cc.Material';
+            return 'cc.FBX';
+        });
+    });
+
+    it('includes imported FBX child assets required by scene-editor previews', () => {
+        const fbx = asset('flower', [], {
+            prefab: asset('flower@prefab', ['.json']),
+            material: asset('flower@material', ['.json']),
+        });
+        const cache = new BuilderAssetCache();
+
+        cache.addAsset(fbx as any);
+
+        // The FBX root has no .json, while Creator previews its cc.Prefab child.
+        expect(cache.assetUuids).toEqual(['flower@prefab', 'flower@material']);
+    });
+
+    it('does not add duplicates when an asset tree is visited more than once', () => {
+        const fbx = asset('flower', [], {
+            prefab: asset('flower@prefab', ['.json']),
+        });
+        const cache = new BuilderAssetCache();
+
+        cache.addAsset(fbx as any);
+        cache.addAsset(fbx as any);
+
+        expect(cache.assetUuids).toEqual(['flower@prefab']);
+    });
+});

--- a/src/core/builder/worker/builder/asset-handler/bundle/index.ts
+++ b/src/core/builder/worker/builder/asset-handler/bundle/index.ts
@@ -566,7 +566,10 @@ export class BundleManager extends BuildTaskBase implements IBundleManager {
     private addSceneEditorAssets(bundle: IBundle) {
         for (const uuid of this.cache.assetUuids) {
             const asset = buildAssetLibrary.getAsset(uuid);
-            if (asset) {
+            // 引擎内置资源已经由 internal bundle 统一收集。Scene Editor 预览若再把它们
+            // 加入启动 bundle，会让同一资源进入两个 bundle；例如 default_skybox 的 HDR
+            // 与 PNG 会在主 bundle 中得到相同的动态加载 URL。
+            if (asset && !asset.url.startsWith('db://internal/')) {
                 bundle.addRootAsset(asset);
             }
         }

--- a/src/core/builder/worker/builder/manager/asset.ts
+++ b/src/core/builder/worker/builder/manager/asset.ts
@@ -65,24 +65,42 @@ export class BuilderAssetCache implements IBuilderCache {
             console.warn('The addAsset method no longer supports the AssetInfo type, so please pass parameters that conform to the IAsset interface definition.');
             asset = buildAssetLibrary.getAsset(asset.uuid);
         }
+
+        // FBX/GLTF 的根资源本身没有 library .json；可预览的 Prefab、Material、Mesh
+        // 都是其 VirtualAsset 子资源。Creator 的资源检查器会直接传这些子资源 UUID 给
+        // scene preview，所以预览构建也必须把整棵资源树加入 cache。此前仅缓存根节点，
+        // 导致 scene-editor bundle 漏掉这些子资源，最终预览请求到不存在的根 UUID .json。
+        const visit = (current: IAsset, currentType?: string) => {
+            this.addSingleAsset(current, currentType);
+            for (const subAsset of Object.values(current.subAssets || {})) {
+                visit(subAsset);
+            }
+        };
+        visit(asset, type);
+    }
+
+    private addSingleAsset(asset: IAsset, type?: string) {
         const ccType = type || assetManager.queryAssetProperty(asset, 'type');
-        // 分类到指定的位置
         switch (ccType) {
             case 'cc.SceneAsset':
-                this.scenes.push({
-                    uuid: asset.uuid,
-                    url: asset.url,
-                });
+                if (!this.scenes.some((scene) => scene.uuid === asset.uuid)) {
+                    this.scenes.push({
+                        uuid: asset.uuid,
+                        url: asset.url,
+                    });
+                }
                 break;
             case 'cc.Script':
                 // hack 过滤特殊的声明文件，过滤资源模板内的脚本
-                if (asset.url.toLowerCase().endsWith('.d.ts')) {
-                    break;
+                if (!asset.url.toLowerCase().endsWith('.d.ts') && !this.scriptUuids.includes(asset.uuid)) {
+                    this.scriptUuids.push(asset.uuid);
                 }
-                this.scriptUuids.push(asset.uuid);
                 break;
             default:
-                if (asset.meta.files.includes('.json') || hasCCONFormatAssetInLibrary(asset)) {
+                if (
+                    (asset.meta.files.includes('.json') || hasCCONFormatAssetInLibrary(asset))
+                    && !this.assetUuids.includes(asset.uuid)
+                ) {
                     this.assetUuids.push(asset.uuid);
                 }
         }

--- a/src/core/preview/preview-settings.ts
+++ b/src/core/preview/preview-settings.ts
@@ -8,6 +8,12 @@ import type { IPreviewSettingsResult } from '../builder/@types/private';
  * live-reload 调 `invalidatePreviewSettings()` 清空缓存，下次请求重新生成。
  */
 const cache = new Map<string, IPreviewSettingsResult>();
+// Builder 以及 buildAssetLibrary 使用了进程级共享状态，不能并发生成预览 settings。
+// 同一个 HTTP 请求的 settings/ bundleConfigs 路由也会同时访问这里：先合并同 key
+// 的请求，再把不同 key 的生成串行化，避免多个 Builder 相互覆盖进度和临时状态。
+const pending = new Map<string, { version: number; promise: Promise<IPreviewSettingsResult>; }>();
+let cacheVersion = 0;
+let generationTail: Promise<void> = Promise.resolve();
 
 function makeCacheKey(startScene: string, sceneEditor: boolean): string {
     return JSON.stringify({ startScene, sceneEditor });
@@ -59,9 +65,44 @@ async function getCachedSettings(startScene: string, sceneEditor: boolean): Prom
     if (!assetDBManager.ready) {
         throw new PreviewNotReadyError();
     }
-    const result = await generatePreviewSettings(startScene, sceneEditor);
-    cache.set(cacheKey, result);
-    return result;
+
+    const pendingEntry = pending.get(cacheKey);
+    if (pendingEntry && pendingEntry.version === cacheVersion) {
+        return await pendingEntry.promise;
+    }
+
+    const version = cacheVersion;
+    const promise = runSettingsGeneration(async () => {
+        const result = await generatePreviewSettings(startScene, sceneEditor);
+        // 资源变化后不能让已经过期的异步生成重新写入缓存。
+        if (version === cacheVersion) {
+            cache.set(cacheKey, result);
+        }
+        return result;
+    });
+    pending.set(cacheKey, { version, promise });
+    try {
+        return await promise;
+    } finally {
+        const current = pending.get(cacheKey);
+        if (current?.promise === promise) {
+            pending.delete(cacheKey);
+        }
+    }
+}
+
+async function runSettingsGeneration<T>(task: () => Promise<T>): Promise<T> {
+    const previous = generationTail;
+    let release!: () => void;
+    generationTail = new Promise<void>((resolve) => {
+        release = resolve;
+    });
+    await previous;
+    try {
+        return await task();
+    } finally {
+        release();
+    }
 }
 
 /**
@@ -177,5 +218,7 @@ async function resolveDefaultStartScene(): Promise<string> {
  * 清空预览 settings 缓存。脚本重编译或资源变化后调用。
  */
 export function invalidatePreviewSettings(): void {
+    cacheVersion++;
     cache.clear();
+    pending.clear();
 }

--- a/src/core/preview/test/preview-settings-concurrency.test.ts
+++ b/src/core/preview/test/preview-settings-concurrency.test.ts
@@ -1,0 +1,87 @@
+const mockAssetDBManager = { ready: true };
+const mockAssetManager = {
+    queryAssetInfo: jest.fn(() => undefined),
+    queryAssetInfos: jest.fn(() => [{ uuid: 'scene-uuid' }]),
+};
+const mockGetPreviewSettings = jest.fn();
+
+jest.mock('../../assets', () => ({
+    assetDBManager: mockAssetDBManager,
+    assetManager: mockAssetManager,
+}));
+
+jest.mock('../../builder', () => ({
+    getPreviewSettings: mockGetPreviewSettings,
+    queryDefaultBuildConfigByPlatform: jest.fn(async () => ({ includeModules: [] })),
+}));
+
+jest.mock('../../builder/share/common-options-validator', () => ({
+    fillIncludeModulesFromProjectConfig: jest.fn(async () => undefined),
+}));
+
+import {
+    getCachedPreviewSettings,
+    getCachedSceneEditorSettings,
+    invalidatePreviewSettings,
+} from '../preview-settings';
+
+const result = { settings: { engine: { builtinAssets: ['builtin'] }, rendering: {} } } as any;
+
+function nextTurn(): Promise<void> {
+    return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('preview settings generation concurrency', () => {
+    beforeEach(() => {
+        mockAssetDBManager.ready = true;
+        mockAssetManager.queryAssetInfo.mockClear();
+        mockAssetManager.queryAssetInfos.mockClear();
+        mockGetPreviewSettings.mockReset();
+        invalidatePreviewSettings();
+    });
+
+    it('coalesces requests for the same settings key', async () => {
+        let resolveGeneration!: () => void;
+        mockGetPreviewSettings.mockImplementation(async () => {
+            await new Promise<void>((resolve) => {
+                resolveGeneration = resolve;
+            });
+            return result;
+        });
+
+        const first = getCachedPreviewSettings();
+        const second = getCachedPreviewSettings();
+        await nextTurn();
+
+        expect(mockGetPreviewSettings).toHaveBeenCalledTimes(1);
+        resolveGeneration();
+        await expect(Promise.all([first, second])).resolves.toEqual([result, result]);
+    });
+
+    it('serializes different preview settings keys', async () => {
+        const resolvers: Array<() => void> = [];
+        let active = 0;
+        let maxActive = 0;
+        mockGetPreviewSettings.mockImplementation(async () => {
+            active++;
+            maxActive = Math.max(maxActive, active);
+            await new Promise<void>((resolve) => {
+                resolvers.push(resolve);
+            });
+            active--;
+            return result;
+        });
+
+        const game = getCachedPreviewSettings();
+        const sceneEditor = getCachedSceneEditorSettings();
+        await nextTurn();
+        expect(resolvers).toHaveLength(1);
+        resolvers.shift()!();
+        await nextTurn();
+        expect(resolvers).toHaveLength(1);
+        resolvers.shift()!();
+
+        await expect(Promise.all([game, sceneEditor])).resolves.toEqual([result, result]);
+        expect(maxActive).toBe(1);
+    });
+});

--- a/src/core/scene/scene-process/service/preview/model-preview.ts
+++ b/src/core/scene/scene-process/service/preview/model-preview.ts
@@ -15,21 +15,20 @@ export class ModelPreview extends InteractivePreview {
 
     // For gltf/fbx root assets, resolve to the Prefab sub-asset UUID
     // (the root asset has no .json library file — only sub-assets do)
-    private async resolvePrefabUuid(uuid: string): Promise<string> {
-        try {
-            const assetInfo = await Rpc.getInstance().request('assetManager', 'queryAssetInfo', [uuid, ['subAssets']]);
-            if (assetInfo?.subAssets) {
-                for (const name of Object.keys(assetInfo.subAssets)) {
-                    const sub = assetInfo.subAssets[name];
-                    if (sub.importer === 'gltf-scene' || sub.type === 'cc.Prefab') {
-                        return sub.uuid;
-                    }
-                }
-            }
-        } catch (e) {
-            console.warn('[ModelPreview] Failed to resolve prefab sub-asset:', e);
+    private async resolvePrefabUuid(uuid: string): Promise<string | null> {
+        // Creator's FBX inspector explicitly passes the generated cc.Prefab
+        // child to ModelPreview. A source FBX/GLTF root has no library .json,
+        // therefore it must never be used as a fallback load target.
+        const assetInfo = await Rpc.getInstance().request('assetManager', 'queryAssetInfo', [uuid, ['subAssets']]);
+        if (assetInfo?.type === 'cc.Prefab') {
+            return assetInfo.uuid || uuid;
         }
-        return uuid;
+        for (const sub of Object.values(assetInfo?.subAssets || {}) as any[]) {
+            if (sub?.type === 'cc.Prefab' || sub?.importer === 'gltf-scene') {
+                return sub.uuid;
+            }
+        }
+        return null;
     }
 
     public async setModel(uuid: string) {
@@ -39,6 +38,9 @@ export class ModelPreview extends InteractivePreview {
         }
 
         const prefabUuid = await this.resolvePrefabUuid(uuid);
+        if (!prefabUuid) {
+            throw new Error(`Unable to preview model ${uuid}: the imported cc.Prefab sub-asset is unavailable.`);
+        }
 
         removePreviewAssetCache(uuid);
         const prefabAsset = await loadPreviewAsset<Prefab>(prefabUuid, 'model', { reloadAsset: true });

--- a/src/core/scene/test/model-preview-resolution.test.ts
+++ b/src/core/scene/test/model-preview-resolution.test.ts
@@ -1,0 +1,60 @@
+const request = jest.fn();
+
+jest.mock('../scene-process/service/preview/interactive-preview', () => ({
+    InteractivePreview: class {},
+    getBoundaryOfMeshNodes: jest.fn(),
+}));
+
+jest.mock('cc', () => ({
+    DirectionalLight: class {},
+    Scene: class {},
+    Node: class {},
+    Prefab: class {},
+    instantiate: jest.fn(),
+}), { virtual: true });
+
+jest.mock('../scene-process/service/core/decorator', () => ({
+    Service: {},
+}));
+
+jest.mock('../scene-process/rpc', () => ({
+    Rpc: {
+        getInstance: jest.fn(() => ({ request })),
+    },
+}));
+
+jest.mock('../scene-process/service/preview/asset-reload', () => ({
+    loadPreviewAsset: jest.fn(),
+    removePreviewAssetCache: jest.fn(),
+}));
+
+import { ModelPreview } from '../scene-process/service/preview/model-preview';
+
+describe('ModelPreview FBX resolution', () => {
+    const resolvePrefabUuid = (uuid: string) =>
+        (ModelPreview.prototype as any).resolvePrefabUuid.call({}, uuid);
+
+    beforeEach(() => {
+        request.mockReset();
+    });
+
+    it('uses the generated Prefab child UUID, matching Creator FBX preview routing', async () => {
+        request.mockResolvedValue({
+            uuid: 'fbx-root',
+            type: 'cc.Asset',
+            subAssets: {
+                mesh: { uuid: 'fbx-root@mesh', type: 'cc.Mesh' },
+                prefab: { uuid: 'fbx-root@prefab', type: 'cc.Prefab', importer: 'gltf-scene' },
+            },
+        });
+
+        await expect(resolvePrefabUuid('fbx-root')).resolves.toBe('fbx-root@prefab');
+        expect(request).toHaveBeenCalledWith('assetManager', 'queryAssetInfo', ['fbx-root', ['subAssets']]);
+    });
+
+    it('does not fall back to the FBX root UUID when its Prefab child is unavailable', async () => {
+        request.mockResolvedValue({ uuid: 'fbx-root', type: 'cc.Asset', subAssets: {} });
+
+        await expect(resolvePrefabUuid('fbx-root')).resolves.toBeNull();
+    });
+});

--- a/src/lib/assets/assets.ts
+++ b/src/lib/assets/assets.ts
@@ -100,7 +100,12 @@ export async function queryAssetInfo(
     urlOrUUIDOrPath: string,
     dataKeys?: string[] | undefined
 ): Promise<IAssetInfo | null> {
-    return await assetManager.queryAssetInfo(urlOrUUIDOrPath, dataKeys as (keyof IAssetInfo)[] | undefined);
+    const info = await assetManager.queryAssetInfo(urlOrUUIDOrPath, dataKeys as (keyof IAssetInfo)[] | undefined);
+    // This module is exposed through the Electron MessagePort RPC bridge. Some
+    // asset-db implementations attach helper functions to otherwise plain asset
+    // data; those functions cannot be structured-cloned and made Asset Preview's
+    // queryAssetInfo() fail before it can resolve FBX Prefab sub-assets.
+    return info ? JSON.parse(JSON.stringify(info)) as IAssetInfo : null;
 }
 
 /**


### PR DESCRIPTION
Related issue:  https://zentao.sud.center/index.php?m=bug&f=view&bugID=905

## Summary
- include imported FBX and glTF sub-assets in scene editor preview bundles
- load generated Prefab sub-assets for model preview instead of source FBX/GLTF UUIDs
- run glTF validation in a regular Node child process when importing from Cocos Host

## Cause
FBX and glTF source assets do not own a loadable library JSON record. Their generated Prefab, Material, Mesh, and Texture sub-assets do. Preview bundle metadata previously omitted those sub-assets, which could make the preview service request the source UUID and receive a 404. In addition, Cocos Host does not provide the CommonJS runtime expected by gltf-validator.

## Verification
- npx tsc -b
- npx jest src/core/builder/test/builder-asset-cache.spec.ts src/core/scene/test/model-preview-resolution.test.ts src/core/scene/test/preview-asset-reload.test.ts --runInBand