### PR TITLE
fix(scene): preserve editor camera world transform

### DIFF
--- a/src/core/scene/scene-process/service/camera/modes/wander-mode.ts
+++ b/src/core/scene/scene-process/service/camera/modes/wander-mode.ts
@@ -240,8 +240,8 @@ class WanderMode extends ModeBase3D {
         Vec3.add(eye, eye, v3d);
         Vec3.lerp(this._curPos, this._curPos, eye, this._damping);
 
-        this._cameraCtrl.node.setPosition(this._curPos);
-        this._cameraCtrl.node.setRotation(this._curRot);
+        this._cameraCtrl.node.setWorldPosition(this._curPos);
+        this._cameraCtrl.node.setWorldRotation(this._curRot);
         this._curMouseDX = 0;
         this._curMouseDY = 0;
         this._cameraCtrl.updateGrid();


### PR DESCRIPTION
## Summary
- update wander camera writes to preserve world-space position and rotation
- prevent parent scene transforms from being applied again during right-click camera movement

## Root cause
Wander mode reads the editor camera transform in world space, then wrote the same values back through local-space APIs. This only appears when the camera has a transformed parent. In the scene editor, the editor camera is under the persistent Editor Scene Background node, which is attached to the active scene. If the scene root has a non-zero transform, each wander update applies that parent transform again.

## Reproduction
1. Create or open a 3D scene whose Scene root has a non-zero position, rotation, or scale.
2. Select a node and focus the scene view.
3. Right-click in the scene view without moving the mouse, then release the button.
4. Repeat the click. The camera view moves farther from the scene on each interaction.

## Validation
- npx tsc -p tsconfig.json --noEmit --pretty false
- npm run build:static-web