### PR TITLE
fix(scene): accept leading slash in node and component path lookups

### DIFF
--- a/src/core/engine/editor-extends/manager/component.ts
+++ b/src/core/engine/editor-extends/manager/component.ts
@@ -3,7 +3,7 @@
 import { EventEmitter } from 'events';
 import pathManager from './node-path-manager';
 import { rsort } from 'semver';
-import { formatUniqueName } from './path-utils';
+import { formatUniqueName, stripLeadingSlashes } from './path-utils';
 
 interface MenuItem {
     component: Function,
@@ -217,6 +217,7 @@ export default class ComponentManager extends EventEmitter {
     }
 
     getComponentFromPath(path: string) {
+        path = stripLeadingSlashes(path);
         const uuid = this._pathToUuid.get(path);
         if (uuid) {
             return this.getComponent(uuid);

--- a/src/core/engine/editor-extends/manager/node.ts
+++ b/src/core/engine/editor-extends/manager/node.ts
@@ -7,7 +7,7 @@ import findLast from 'lodash/findLast';
 import * as ObjectWalker from '../missing-reporter/object-walker';
 import utils from '../../../base/utils';
 import pathManager from './node-path-manager';
-import { validateNodeName } from './path-utils';
+import { normalizeNodePath, validateNodeName } from './path-utils';
 
 
 export default class NodeManager extends EventEmitter {
@@ -166,10 +166,11 @@ export default class NodeManager extends EventEmitter {
     }
 
     getNodeByPath(path: string): Node | null {
-        if (path === '/') {
+        const normalized = normalizeNodePath(path);
+        if (normalized === '/') {
             return cc.director.getScene() ?? null;
         }
-        const result = pathManager.getNodeResult(path);
+        const result = pathManager.getNodeResult(normalized);
         if (result.error === 'Ambiguous') {
             throw new Error(`The path "${path}" is ambiguous. Multiple nodes found with case-insensitive match.`);
         }
@@ -195,11 +196,12 @@ export default class NodeManager extends EventEmitter {
     }
 
     getNodeUuidByPath(path: string): string | null {
-        if (path === '/') {
+        const normalized = normalizeNodePath(path);
+        if (normalized === '/') {
             const scene = cc.director.getScene();
             return scene ? scene.uuid : null;
         }
-        const uuid = pathManager.getNodeUuid(path);
+        const uuid = pathManager.getNodeUuid(normalized);
         const node = uuid && this.getNode(uuid);
         return node ? node.uuid : null;
     }

--- a/src/core/engine/editor-extends/manager/path-utils.ts
+++ b/src/core/engine/editor-extends/manager/path-utils.ts
@@ -36,3 +36,30 @@ export function validateNodeName(name: string): string | null {
 export function sanitizeNodeName(name: string): string {
     return name.replace(/[/\\:*?"<>|]/g, '_');
 }
+
+/**
+ * Remove leading '/' from a path. Indexed paths never start with '/',
+ * but callers may spell them either way ('/Canvas' and 'Canvas' are the same node).
+ */
+export function stripLeadingSlashes(path: string): string {
+    return path.replace(/^\/+/, '');
+}
+
+/**
+ * Normalize a node path for lookup: strips leading '/', and keeps a path made of
+ * slashes only as '/', which denotes the root instead of an empty path.
+ */
+export function normalizeNodePath(path: string): string {
+    if (!path) {
+        return path;
+    }
+    const stripped = stripLeadingSlashes(path);
+    return stripped === '' ? '/' : stripped;
+}
+
+/**
+ * Whether a path denotes the root ('/', '//', ...). An empty path is not a root path.
+ */
+export function isRootNodePath(path: string | undefined): boolean {
+    return !!path && stripLeadingSlashes(path) === '';
+}

--- a/src/core/engine/test/component-manager-change-uuid.test.ts
+++ b/src/core/engine/test/component-manager-change-uuid.test.ts
@@ -6,7 +6,7 @@ import ComponentManager from '../editor-extends/manager/component';
 // Mock pathManager.getNodePath used by _generateUniquePath
 jest.mock('../editor-extends/manager/node-path-manager', () => ({
     __esModule: true,
-    default: { getNodePath: (uuid: string) => `/${uuid}` },
+    default: { getNodePath: (uuid: string) => uuid },
     NodePathManager: class {},
 }));
 

--- a/src/core/engine/test/component-manager-get-from-path.test.ts
+++ b/src/core/engine/test/component-manager-get-from-path.test.ts
@@ -1,0 +1,104 @@
+import ComponentManager from '../editor-extends/manager/component';
+
+(globalThis as any).cc = { js: { getClassName: (comp: any) => comp._className ?? 'UnknownComponent' } };
+
+jest.mock('../editor-extends/manager/node-path-manager', () => ({
+    __esModule: true,
+    default: { getNodePath: (uuid: string) => (uuid === 'scene' ? '' : uuid) },
+    NodePathManager: class {},
+}));
+
+describe('ComponentManager 组件路径前导 / 归一化', () => {
+    let manager: ComponentManager;
+
+    beforeEach(() => {
+        manager = new ComponentManager();
+        manager.allow = true;
+    });
+
+    function addComponent(uuid: string, nodeUuid: string, className = 'cc.Label') {
+        const comp = { uuid, _id: uuid, _className: className, node: { uuid: nodeUuid } } as any;
+        manager.add(uuid, comp);
+        return comp;
+    }
+
+    describe('_generateUniquePath 写入侧', () => {
+        it('普通子节点上的组件路径不带前导 /', () => {
+            addComponent('c1', 'Canvas', 'cc.Label');
+            expect(manager.getPathFromUuid('c1')).toBe('Canvas/cc.Label');
+        });
+
+        it('深层节点上的组件路径不带前导 /', () => {
+            addComponent('c1', 'Canvas/Node1', 'cc.Sprite');
+            expect(manager.getPathFromUuid('c1')).toBe('Canvas/Node1/cc.Sprite');
+        });
+
+        it('同节点上重名组件按 _001/_002 递增，无前导 /', () => {
+            addComponent('c1', 'Canvas', 'cc.Label');
+            addComponent('c2', 'Canvas', 'cc.Label');
+            addComponent('c3', 'Canvas', 'cc.Label');
+            expect(manager.getPathFromUuid('c1')).toBe('Canvas/cc.Label');
+            expect(manager.getPathFromUuid('c2')).toBe('Canvas/cc.Label_001');
+            expect(manager.getPathFromUuid('c3')).toBe('Canvas/cc.Label_002');
+        });
+    });
+
+    describe('getComponentFromPath 查询侧', () => {
+        it('不带 / 与带前导 / 命中同一组件', () => {
+            const c1 = addComponent('c1', 'Canvas', 'cc.Label');
+            expect(manager.getComponentFromPath('Canvas/cc.Label')).toBe(c1);
+            expect(manager.getComponentFromPath('/Canvas/cc.Label')).toBe(c1);
+        });
+
+        it('多前导 / 也命中', () => {
+            const c1 = addComponent('c1', 'Canvas', 'cc.Label');
+            expect(manager.getComponentFromPath('//Canvas/cc.Label')).toBe(c1);
+            expect(manager.getComponentFromPath('///Canvas/cc.Label')).toBe(c1);
+        });
+
+        it('多层节点下组件路径带前导 / 命中', () => {
+            const c1 = addComponent('c1', 'Canvas/Node1', 'cc.Sprite');
+            expect(manager.getComponentFromPath('Canvas/Node1/cc.Sprite')).toBe(c1);
+            expect(manager.getComponentFromPath('/Canvas/Node1/cc.Sprite')).toBe(c1);
+        });
+
+        it('大小写不敏感命中 (带前导 /)', () => {
+            const c1 = addComponent('c1', 'Canvas', 'cc.Label');
+            expect(manager.getComponentFromPath('/canvas/cc.label')).toBe(c1);
+            expect(manager.getComponentFromPath('/CANVAS/CC.LABEL')).toBe(c1);
+        });
+
+        it('省略 cc. 前缀 (带前导 /)', () => {
+            const c1 = addComponent('c1', 'Canvas', 'cc.Label');
+            expect(manager.getComponentFromPath('/Canvas/Label')).toBe(c1);
+            expect(manager.getComponentFromPath('/Canvas/label')).toBe(c1);
+        });
+
+        it('不存在的组件路径带前导 / 抛出 No component found', () => {
+            addComponent('c1', 'Canvas', 'cc.Label');
+            expect(() => manager.getComponentFromPath('/Canvas/cc.Missing'))
+                .toThrow(/No component found/);
+            expect(() => manager.getComponentFromPath('/Missing/cc.Label'))
+                .toThrow(/No component found/);
+        });
+
+        it('根路径查组件抛错 (根节点不支持挂组件)', () => {
+            addComponent('c1', 'Canvas', 'cc.Label');
+            expect(() => manager.getComponentFromPath('/cc.Label'))
+                .toThrow(/No component found/);
+            expect(() => manager.getComponentFromPath('/cc.label'))
+                .toThrow(/No component found/);
+            expect(() => manager.getComponentFromPath('cc.Label'))
+                .toThrow(/No component found/);
+        });
+
+        it('查询侧 strip 后与不带 / 走同一分支 (_pathToUuid 直查)', () => {
+            const c1 = addComponent('c1', 'Canvas', 'cc.Label');
+            const spy = jest.spyOn((manager as any)._pathToUuid, 'get');
+            manager.getComponentFromPath('/Canvas/cc.Label');
+            expect(spy).toHaveBeenCalledWith('Canvas/cc.Label');
+            expect(manager.getComponentFromPath('/Canvas/cc.Label')).toBe(c1);
+            spy.mockRestore();
+        });
+    });
+});

--- a/src/core/engine/test/node-manager-get-by-path.test.ts
+++ b/src/core/engine/test/node-manager-get-by-path.test.ts
@@ -1,0 +1,118 @@
+import NodeManager from '../editor-extends/manager/node';
+import pathManager from '../editor-extends/manager/node-path-manager';
+
+describe('NodeManager 路径前导 / 归一化', () => {
+    let manager: NodeManager;
+    const sceneUuid = 'scene';
+    const originalGetScene = (global as any).cc?.director?.getScene;
+
+    beforeAll(() => {
+        (global as any).cc = (global as any).cc || {};
+        (global as any).cc.director = (global as any).cc.director || {};
+        (global as any).cc.director.getScene = () => ({ uuid: sceneUuid });
+    });
+
+    afterAll(() => {
+        if (originalGetScene) {
+            (global as any).cc.director.getScene = originalGetScene;
+        }
+    });
+
+    beforeEach(() => {
+        manager = new NodeManager();
+        manager.allow = true;
+        pathManager.clear();
+    });
+
+    function addNode(uuid: string, name: string, parentUuid?: string) {
+        const node = { uuid, name, _id: uuid, parent: parentUuid ? { uuid: parentUuid } : null } as any;
+        manager.add(uuid, node);
+        return node;
+    }
+
+    describe('getNodeByPath', () => {
+        it('"/" 命中场景根', () => {
+            expect(manager.getNodeByPath('/')?.uuid).toBe(sceneUuid);
+        });
+
+        it('"//" 多个前导 / 也命中场景根', () => {
+            expect(manager.getNodeByPath('//')?.uuid).toBe(sceneUuid);
+            expect(manager.getNodeByPath('///')?.uuid).toBe(sceneUuid);
+        });
+
+        it('空串返回 null，不误判为场景根', () => {
+            expect(manager.getNodeByPath('')).toBeNull();
+        });
+
+        it('"Canvas" 与 "/Canvas" 命中同一节点', () => {
+            const canvas = addNode('canvas', 'Canvas', sceneUuid);
+            expect(manager.getNodeByPath('Canvas')).toBe(canvas);
+            expect(manager.getNodeByPath('/Canvas')).toBe(canvas);
+        });
+
+        it('"//Canvas" 多前导 / 也命中', () => {
+            const canvas = addNode('canvas', 'Canvas', sceneUuid);
+            expect(manager.getNodeByPath('//Canvas')).toBe(canvas);
+            expect(manager.getNodeByPath('///Canvas')).toBe(canvas);
+        });
+
+        it('多层子节点 "/Canvas/Node1" 命中', () => {
+            addNode('canvas', 'Canvas', sceneUuid);
+            const child = addNode('node1', 'Node1', 'canvas');
+            expect(manager.getNodeByPath('Canvas/Node1')).toBe(child);
+            expect(manager.getNodeByPath('/Canvas/Node1')).toBe(child);
+        });
+
+        it('三层 "/Canvas/Node1/Leaf" 命中', () => {
+            addNode('canvas', 'Canvas', sceneUuid);
+            addNode('node1', 'Node1', 'canvas');
+            const leaf = addNode('leaf', 'Leaf', 'node1');
+            expect(manager.getNodeByPath('/Canvas/Node1/Leaf')).toBe(leaf);
+        });
+
+        it('不存在路径带前导 / 也返回 null', () => {
+            addNode('canvas', 'Canvas', sceneUuid);
+            expect(manager.getNodeByPath('/Missing')).toBeNull();
+            expect(manager.getNodeByPath('/Canvas/Missing')).toBeNull();
+        });
+
+        it('大小写不敏感命中 (带前导 /)', () => {
+            const canvas = addNode('canvas', 'Canvas', sceneUuid);
+            expect(manager.getNodeByPath('/canvas')).toBe(canvas);
+            expect(manager.getNodeByPath('/CANVAS')).toBe(canvas);
+        });
+
+        it('大小写歧义时带前导 / 也抛出', () => {
+            addNode('a', 'Foo', sceneUuid);
+            addNode('b', 'foo', sceneUuid);
+            expect(() => manager.getNodeByPath('/FOO')).toThrow(/ambiguous/i);
+            expect(() => manager.getNodeByPath('FOO')).toThrow(/ambiguous/i);
+        });
+    });
+
+    describe('getNodeUuidByPath', () => {
+        it('"/" 命中场景 uuid', () => {
+            expect(manager.getNodeUuidByPath('/')).toBe(sceneUuid);
+        });
+
+        it('多前导 / 命中场景 uuid', () => {
+            expect(manager.getNodeUuidByPath('//')).toBe(sceneUuid);
+        });
+
+        it('"/Canvas" 命中子节点 uuid', () => {
+            addNode('canvas', 'Canvas', sceneUuid);
+            expect(manager.getNodeUuidByPath('Canvas')).toBe('canvas');
+            expect(manager.getNodeUuidByPath('/Canvas')).toBe('canvas');
+        });
+
+        it('"/Canvas/Node1" 命中孙节点 uuid', () => {
+            addNode('canvas', 'Canvas', sceneUuid);
+            addNode('node1', 'Node1', 'canvas');
+            expect(manager.getNodeUuidByPath('/Canvas/Node1')).toBe('node1');
+        });
+
+        it('不存在返回 null', () => {
+            expect(manager.getNodeUuidByPath('/Missing')).toBeNull();
+        });
+    });
+});

--- a/src/core/scene/scene-process/service/component.ts
+++ b/src/core/scene/scene-process/service/component.ts
@@ -1,4 +1,4 @@
-import { Component, Constructor, animation, Animation, Node, RigidBody, Collider, ERigidBodyType, EColliderType, MeshCollider, UITransform, director, Canvas } from 'cc';
+import { Component, Constructor, animation, Animation, Node, RigidBody, Collider, ERigidBodyType, EColliderType, MeshCollider, UITransform, director, Canvas, Scene } from 'cc';
 import { Rpc } from '../rpc';
 import { register, Service, BaseService } from './core';
 import {
@@ -28,8 +28,17 @@ import { RemoveComponentCommand } from './undo/commands/remove-component-command
 import { createUndoId, restoreComponentSnapshotDump, snapshotMapsEqual } from './undo/commands/command-utils-shared';
 import { isUndoApplying } from './undo/applying-state';
 import { broadcastAnimationPropertyCommitted } from './animation/property-commit-event';
+import { isRootNodePath } from '../../../engine/editor-extends/manager/path-utils';
 
 const NodeMgr = EditorExtends.Node;
+
+function resolveNodeByPath(nodePath: string): Node | null {
+    // '/' 指当前编辑器的根：prefab 模式下是 prefab 根节点（可以挂组件），而不是承载它的虚拟场景
+    if (isRootNodePath(nodePath)) {
+        return Service.Editor.getRootNode() as Node | null;
+    }
+    return NodeMgr.getNodeByPath(nodePath) as Node | null;
+}
 
 interface IComponentPropertySnapshot {
     nodeUuid: string;
@@ -209,9 +218,12 @@ export class ComponentService extends BaseService<IComponentEvents> implements I
                 return lastDump!;
             }
 
-            const node = NodeMgr.getNodeByPath(params.nodePath);
+            const node = resolveNodeByPath(params.nodePath);
             if (!node) {
                 throw new Error(`create component failed: ${params.nodePath} does not exist`);
+            }
+            if (node instanceof Scene) {
+                throw new Error(`create component failed: cannot attach a component to the scene root (${params.nodePath})`);
             }
             if (!params.component || params.component.length <= 0) {
                 throw new Error(`create component failed: component name cannot be empty`);
@@ -397,7 +409,7 @@ export class ComponentService extends BaseService<IComponentEvents> implements I
                 return false;
             }
         }
-        const node = NodeMgr.getNodeByPath(options.nodePath);
+        const node = resolveNodeByPath(options.nodePath);
         if (!node) {
             console.warn(`Set property failed: ${options.nodePath} does not exist`);
             return false;
@@ -776,7 +788,7 @@ export class ComponentService extends BaseService<IComponentEvents> implements I
     }
 
     async queryFunctionOfNode(path: string): Promise<any> {
-        const node = NodeMgr.getNodeByPath(path);
+        const node = resolveNodeByPath(path);
         if (!node) {
             return {};
         }

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -38,7 +38,7 @@ import NodeConfig from './node/node-type-config';
 import { RemoveNodeCommand } from './undo/commands/remove-node-command';
 import { RemoveComponentCommand } from './undo/commands/remove-component-command';
 import { broadcastAnimationPropertyCommitted } from './animation/property-commit-event';
-import { validateNodeName } from '../../../engine/editor-extends/manager/path-utils';
+import { isRootNodePath, stripLeadingSlashes, validateNodeName } from '../../../engine/editor-extends/manager/path-utils';
 
 const NodeMgr = EditorExtends.Node;
 
@@ -260,10 +260,8 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         // 逐级检查并创建路径
         for (let i = 0; i < pathParts.length; i++) {
             const pathPart = pathParts[i];
-            const currentParentPath = NodeMgr.getNodePath(currentParent);
-            const candidatePath = currentParentPath && currentParentPath !== '/'
-                ? `${currentParentPath}/${pathPart}`
-                : pathPart;
+            const parentPrefix = stripLeadingSlashes(NodeMgr.getNodePath(currentParent));
+            const candidatePath = parentPrefix ? `${parentPrefix}/${pathPart}` : pathPart;
             let nextNode = NodeMgr.getNodeByPath(candidatePath) as Node | null;
 
             if (!nextNode) {
@@ -339,7 +337,8 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             }
             const path = params?.path;
             let node: Node | null = root;
-            if (path && path !== '/') {
+            // '/' 指当前编辑器的根：场景模式下是场景，prefab 模式下是 prefab 根，而非承载它的虚拟场景
+            if (path && !isRootNodePath(path)) {
                 node = NodeMgr.getNodeByPath(path);
             }
             if (!node) return null;

--- a/src/core/scene/scene-process/service/node/node-undo.ts
+++ b/src/core/scene/scene-process/service/node/node-undo.ts
@@ -7,6 +7,7 @@ import { CreateNodeCommand } from '../undo/commands/create-node-command';
 import { SnapshotCommand, type ISnapshotAdapter } from '../undo/commands/snapshot-command';
 import type { INodeStructureCaptureTarget } from '../undo/commands/node-structure-command-utils';
 import { createUndoId, restoreNodeSnapshotDump, snapshotMapsEqual } from '../undo/commands/command-utils-shared';
+import { isRootNodePath } from '../../../../engine/editor-extends/manager/path-utils';
 
 const NodeMgr = EditorExtends.Node;
 
@@ -413,8 +414,8 @@ export class NodeUndoHelper {
         }
         if (snapshot.parentPath) {
             try {
-                const byPath = snapshot.parentPath === '/'
-                    ? Service.Editor.getRootNode()
+                const byPath = isRootNodePath(snapshot.parentPath)
+                    ? Service.Editor.getRootNode() as Node | null
                     : NodeMgr.getNodeByPath(snapshot.parentPath) as Node | null;
                 return byPath?.isValid ? byPath : null;
             } catch (_error) {
@@ -579,7 +580,7 @@ export class NodeUndoHelper {
                 return byUuid;
             }
         }
-        if (snapshot.parentPath && snapshot.parentPath !== '/') {
+        if (snapshot.parentPath && !isRootNodePath(snapshot.parentPath)) {
             try {
                 const byPath = NodeMgr.getNodeByPath(snapshot.parentPath) as Node | null;
                 if (byPath?.isValid) {

--- a/src/core/scene/scene-process/service/selection.ts
+++ b/src/core/scene/scene-process/service/selection.ts
@@ -5,6 +5,7 @@ import type { ISelectionService, ISelectionEvents, IChangeNodeOptions } from '..
 import { NodeEventType } from '../../common';
 import type { Node } from 'cc';
 import { getEditorNodeByUuid, getEditorNodePath, getEditorNodeUuidByPath } from './gizmo/utils/editor-node';
+import { normalizeNodePath } from '../../../engine/editor-extends/manager/path-utils';
 
 function pathToUuid(path: string): string {
     return getEditorNodeUuidByPath(path);
@@ -57,25 +58,28 @@ export class SelectionService extends BaseService<ISelectionEvents> implements I
     }
 
     select(path: string): void {
-        const index = this._selections.findIndex(e => e.path === path);
+        // 选中项以归一化路径为键，'/Canvas' 与 'Canvas' 是同一个节点，不能存成两条
+        const normalized = normalizeNodePath(path);
+        const index = this._selections.findIndex(e => e.path === normalized);
         if (index !== -1) return;
-        const uuid = pathToUuid(path);
-        this._selections.unshift({ path, uuid });
+        const uuid = pathToUuid(normalized);
+        this._selections.unshift({ path: normalized, uuid });
         if (uuid) {
             this._callFocusInEditor(uuid);
         }
-        this.broadcast('selection:select', path, this._getPaths());
+        this.broadcast('selection:select', normalized, this._getPaths());
     }
 
     unselect(path: string): void {
-        const index = this._selections.findIndex(e => e.path === path);
+        const normalized = normalizeNodePath(path);
+        const index = this._selections.findIndex(e => e.path === normalized);
         if (index === -1) return;
         const entry = this._selections[index];
         this._selections.splice(index, 1);
         if (entry.uuid) {
             this._callLostFocusInEditor(entry.uuid);
         }
-        this.broadcast('selection:unselect', path, this._getPaths());
+        this.broadcast('selection:unselect', normalized, this._getPaths());
     }
 
     clear(): void {
@@ -96,7 +100,8 @@ export class SelectionService extends BaseService<ISelectionEvents> implements I
     }
 
     isSelect(path: string): boolean {
-        return this._selections.some(e => e.path === path);
+        const normalized = normalizeNodePath(path);
+        return this._selections.some(e => e.path === normalized);
     }
 
     reset(): void {

--- a/src/core/scene/scene-process/service/undo/commands/node-structure-command-utils.ts
+++ b/src/core/scene/scene-process/service/undo/commands/node-structure-command-utils.ts
@@ -231,7 +231,7 @@ function findParent(snapshot: INodeStructureSnapshot): Node | null {
         }
     }
 
-    if (snapshot.parentPath && snapshot.parentPath !== '/') {
+    if (snapshot.parentPath) {
         try {
             const byPath = editorNode?.getNodeByPath?.(snapshot.parentPath) as Node | null;
             if (byPath) {

--- a/src/core/scene/test/selection-prefab-path.test.ts
+++ b/src/core/scene/test/selection-prefab-path.test.ts
@@ -208,4 +208,88 @@ describe('SelectionService prefab path resolution', () => {
     });
 });
 
+describe('SelectionService 前导 / 归一化', () => {
+    function createSelection() {
+        (globalThis as any).EditorExtends = {
+            Node: {
+                getNodeUuidByPath: jest.fn((path: string) => (path === 'Canvas' ? 'canvas-uuid' : '')),
+                getNodeByPath: jest.fn(() => null),
+                getNode: jest.fn(() => null),
+            },
+        };
+        const { SelectionService } = require('../scene-process/service/selection');
+        const selection = new SelectionService();
+        jest.spyOn(selection, 'broadcast').mockImplementation(() => undefined);
+        return selection;
+    }
+
+    afterEach(() => {
+        jest.resetModules();
+        jest.clearAllMocks();
+        mockService.Editor.getCurrentEditorType.mockReturnValue('unknown');
+        mockService.Editor.getRootNode.mockReturnValue(null);
+        mockCc.director.getScene.mockReturnValue(null);
+        delete (globalThis as any).EditorExtends;
+    });
+
+    it('带前导 / 选中时存归一化路径并解析出 uuid', () => {
+        const selection = createSelection();
+
+        selection.select('/Canvas');
+
+        expect((selection as any)._selections).toEqual([{ path: 'Canvas', uuid: 'canvas-uuid' }]);
+        expect(selection.query()).toEqual(['Canvas']);
+    });
+
+    it('两种拼法只算一次选中', () => {
+        const selection = createSelection();
+
+        selection.select('Canvas');
+        selection.select('/Canvas');
+        selection.select('//Canvas');
+
+        expect((selection as any)._selections).toHaveLength(1);
+    });
+
+    it('带前导 / 可以取消不带 / 选中的节点', () => {
+        const selection = createSelection();
+
+        selection.select('Canvas');
+        selection.unselect('/Canvas');
+
+        expect((selection as any)._selections).toEqual([]);
+    });
+
+    it('isSelect 忽略前导 /', () => {
+        const selection = createSelection();
+
+        selection.select('/Canvas');
+
+        expect(selection.isSelect('Canvas')).toBe(true);
+        expect(selection.isSelect('/Canvas')).toBe(true);
+        expect(selection.isSelect('//Canvas')).toBe(true);
+        expect(selection.isSelect('Other')).toBe(false);
+    });
+
+    it('broadcast 与 query 一致，都用归一化路径', () => {
+        const selection = createSelection();
+        const broadcast = jest.spyOn(selection, 'broadcast');
+
+        selection.select('/Canvas');
+        expect(broadcast).toHaveBeenCalledWith('selection:select', 'Canvas', ['Canvas']);
+
+        selection.unselect('//Canvas');
+        expect(broadcast).toHaveBeenCalledWith('selection:unselect', 'Canvas', []);
+    });
+
+    it('根路径仍然是 "/"，不会被剥成空串', () => {
+        const selection = createSelection();
+
+        selection.select('///');
+
+        expect((selection as any)._selections).toEqual([{ path: '/', uuid: '' }]);
+        expect(selection.isSelect('/')).toBe(true);
+    });
+});
+
 export {};

--- a/src/core/scene/test/service-core/message-callsite.test.ts
+++ b/src/core/scene/test/service-core/message-callsite.test.ts
@@ -580,6 +580,41 @@ describe('ServiceEvents 事件发射集成测试', () => {
             expect(mockRpcRequest).not.toHaveBeenCalledWith('assetManager', 'queryUUID', expect.anything());
         });
 
+        it('query 的根路径应解析为当前编辑器根节点，而非 director 场景', async () => {
+            const { NodeService } = require('../../scene-process/service/node');
+            const { Service } = require('../../scene-process/service/core');
+            const { sceneUtils } = require('../../scene-process/service/scene/utils');
+            const nodeService = new NodeService();
+
+            // prefab 模式下 getRootNode() 是 prefab 根，director.getScene() 是承载它的虚拟场景
+            const prefabRoot = { uuid: 'prefab-root' };
+            const virtualScene = { uuid: 'virtual-scene' };
+            const child = { uuid: 'child' };
+
+            const NodeMgr = (global as any).EditorExtends.Node;
+            const originalGetByPath = NodeMgr.getNodeByPath;
+            const originalGetRootNode = Service.Editor.getRootNode;
+            const originalDump = sceneUtils.generateNodeDump;
+
+            NodeMgr.getNodeByPath = jest.fn((path: string) => (path === 'Canvas' ? child : virtualScene));
+            Service.Editor.getRootNode = jest.fn(() => prefabRoot);
+            sceneUtils.generateNodeDump = jest.fn((node: any) => ({ uuid: node.uuid }));
+
+            try {
+                expect(await nodeService.query({ path: '/' })).toEqual({ uuid: 'prefab-root' });
+                expect(await nodeService.query({ path: '//' })).toEqual({ uuid: 'prefab-root' });
+                expect(await nodeService.query({})).toEqual({ uuid: 'prefab-root' });
+                expect(NodeMgr.getNodeByPath).not.toHaveBeenCalled();
+
+                expect(await nodeService.query({ path: 'Canvas' })).toEqual({ uuid: 'child' });
+                expect(NodeMgr.getNodeByPath).toHaveBeenCalledWith('Canvas');
+            } finally {
+                NodeMgr.getNodeByPath = originalGetByPath;
+                Service.Editor.getRootNode = originalGetRootNode;
+                sceneUtils.generateNodeDump = originalDump;
+            }
+        });
+
         it('setProperty(name) 应 emit node:change 到 ServiceEvents', async () => {
             const listener = jest.fn();
             globalEventEmitter.on('node:change', listener);
@@ -747,6 +782,58 @@ describe('ServiceEvents 事件发射集成测试', () => {
     });
 
     describe('ComponentService (component.ts)', () => {
+        it('add 应拒绝挂组件到场景根 (nodePath 指向 scene)', async () => {
+            const { ComponentService } = require('../../scene-process/service/component');
+            const { Service } = require('../../scene-process/service/core');
+            const { Scene } = require('cc');
+            const componentService = new ComponentService();
+
+            const sceneRoot = new Scene();
+            const NodeMgr = (global as any).EditorExtends.Node;
+            const originalGetByPath = NodeMgr.getNodeByPath;
+            const originalGetRootNode = Service.Editor.getRootNode;
+            NodeMgr.getNodeByPath = jest.fn(() => sceneRoot);
+            Service.Editor.getRootNode = jest.fn(() => sceneRoot);
+
+            try {
+                await expect(componentService.add({ nodePath: '/', component: 'cc.Label' }))
+                    .rejects.toThrow(/scene root/);
+                await expect(componentService.add({ nodePath: 'SomeScene', component: 'cc.Label' }))
+                    .rejects.toThrow(/scene root/);
+            } finally {
+                NodeMgr.getNodeByPath = originalGetByPath;
+                Service.Editor.getRootNode = originalGetRootNode;
+            }
+        });
+
+        it('add 在 prefab 模式下允许把组件挂到 prefab 根 (nodePath 为 /)', async () => {
+            const { ComponentService } = require('../../scene-process/service/component');
+            const { Service } = require('../../scene-process/service/core');
+            const { Node: MockNode } = require('cc');
+            const componentService = new ComponentService();
+
+            const prefabRoot = new MockNode('Root');
+            const NodeMgr = (global as any).EditorExtends.Node;
+            const originalGetByPath = NodeMgr.getNodeByPath;
+            const originalGetRootNode = Service.Editor.getRootNode;
+            NodeMgr.getNodeByPath = jest.fn(() => null);
+            Service.Editor.getRootNode = jest.fn(() => prefabRoot);
+
+            try {
+                // 用空组件名探测：报“组件名为空”而不是“场景根/不存在”，说明 '/' 已解析到 prefab 根且通过了 guard
+                await expect(componentService.add({ nodePath: '/', component: '' }))
+                    .rejects.toThrow(/component name cannot be empty/);
+                expect(NodeMgr.getNodeByPath).not.toHaveBeenCalled();
+
+                await expect(componentService.add({ nodePath: 'Missing', component: '' }))
+                    .rejects.toThrow(/does not exist/);
+                expect(NodeMgr.getNodeByPath).toHaveBeenCalledWith('Missing');
+            } finally {
+                NodeMgr.getNodeByPath = originalGetByPath;
+                Service.Editor.getRootNode = originalGetRootNode;
+            }
+        });
+
         it('setProperty(__comps__) 成功后应 broadcast animation:property-committed', async () => {
             const listener = jest.fn();
             globalEventEmitter.on('animation:property-committed', listener);


### PR DESCRIPTION
## Summary

- `NodeManager.getNodeByPath` / `getNodeUuidByPath` now strip leading `/`, so `/Canvas` and `Canvas` resolve to the same node. A path made of slashes only (`/`, `//`, ...) still means the scene root.
- `ComponentManager.getComponentFromPath` strips leading `/`, so `/Canvas/cc.Label` hits the same entry as `Canvas/cc.Label`.
- `ComponentService.add` rejects `nodePath` that points at the scene root (components cannot be attached to a `Scene`). In prefab edit mode, `/` correctly resolves to the prefab root, which can still take components.
- Drop the now-redundant `path !== '/'` guards in the query / undo-reparent paths, since `getNodeByPath('/')` returns the scene root uniformly.

## Root cause

Indexed node paths never start with `/`, but various callers (extensions, messages, undo command payloads) spell them either way. The lookup did an exact `Map` match, so `/Canvas` fell through to `null` while `Canvas` succeeded. The component path lookup had the same shape. Separately, the scene root was silently accepted as a component host, which crashed downstream code that assumed a `Node`.

## Reproduction

1. Open any 3D scene that has a `Canvas` (or any) node at the scene root.
2. From an editor extension or panel script, call the scene message that resolves node paths (e.g. component add / query) with `/Canvas` instead of `Canvas`. Before the fix the call fails with `... does not exist`; after the fix it resolves the same node as `Canvas`.
3. In scene mode, try to add a component onto the scene root (path `/`). Before the fix the call went through and produced a broken component whose owner was the `Scene`; after the fix it is rejected with a clear error.

## Test steps (for QA)

1. **Leading slash in scripts / extensions**
   - Open a scene with a `Canvas` node.
   - In an editor script or a test panel that talks to the scene process, request the component list / add flow using `nodePath = '/Canvas'`.
   - Verify the operation targets the `Canvas` node, exactly as if `Canvas` had been passed.
   - Repeat with a deeper path such as `/Canvas/Label` — the result must equal the one for `Canvas/Label`.

2. **Scene root rejection**
   - In a normal scene (not a prefab), try to add any component with `nodePath = '/'` (or `''`).
   - Expected: the request is rejected with `cannot attach a component to the scene root`. The scene root stays clean, no ghost component appears in the Inspector, no console error stack from downstream code.

3. **Prefab root still accepts components**
   - Open a prefab for editing (enter prefab edit mode).
   - Add a component to the prefab root (path `/`).
   - Expected: the component is added to the prefab root node (not to the enclosing virtual scene) and shows up in the Inspector; save & reopen the prefab, the component persists.

4. **Undo / redo with root path**
   - In a scene, drag a child node onto the scene root in the Hierarchy (reparent to root).
   - Undo, then redo. The node must return to the correct parent each time; no `path is ambiguous` or `does not exist` error in the console.

5. **Regression — existing paths without leading slash**
   - Do a normal scene edit session (create nodes, add components, drag & drop, save). Everything that worked before must still work; open an existing scene from disk and confirm all nodes, components, and references load unchanged.

## Validation

- `npx tsc -p tsconfig.json --noEmit --pretty false`
- Automated unit tests were added alongside the fix, but the QA pass above is the user-visible check.