### PR TITLE
fix(scene): route root path to editor root in create flow.

### DIFF
--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -200,7 +200,7 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         materializesUITransform: boolean;
         canvasRequired: boolean;
     } {
-        if (path) {
+        if (path && !isRootNodePath(path)) {
             try {
                 const existingParent = NodeMgr.getNodeByPath(path);
                 if (existingParent) {
@@ -425,7 +425,9 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
      * 获取或创建路径节点
      */
     private async _getOrCreateNodeByPath(path: string | undefined, currentScene: Node, prefabCanvasHandling?: PrefabCanvasHandling): Promise<Node | null> {
-        if (!path) {
+        // '/' 指当前编辑器的根：prefab 模式下是 prefab 根节点，而不是承载它的虚拟场景。
+        // 交回 null 让上层 fallback 到 currentScene（= Service.Editor.getRootNode()）。
+        if (!path || isRootNodePath(path)) {
             return null;
         }
 

--- a/src/core/scene/test/service-core/node-create-root-path-prefab.test.ts
+++ b/src/core/scene/test/service-core/node-create-root-path-prefab.test.ts
@@ -1,0 +1,260 @@
+// _createNode('/', ...) 在 prefab 模式下的父级归属回归测试。
+//
+// NodeMgr.getNodeByPath('/') 在 prefab 模式下会返回承载 prefab 的 virtualScene，
+// 而不是 Service.Editor.getRootNode() 指向的预制体根。如果 _getOrCreateNodeByPath /
+// _getCreatePathPreflight 不显式识别根路径，就会让 virtualScene 短路成 parent，
+// 新节点最后挂在预制体根旁边而非其下（触发 "prefab 只允许一个根" 的清理）。
+//
+// 这里锁住入口层：调用方传 '/'（或 '//' 等前导斜杠变体）时，父级必须是
+// Service.Editor.getRootNode()——也就是 currentScene，而不是 director 场景。
+
+const mockLock = jest.fn(async () => undefined);
+const mockUnlock = jest.fn();
+const mockGetCurrentEditorType = jest.fn(() => 'prefab');
+const mockGetRootNode = jest.fn();
+const mockRemovePrefabInfoFromNode = jest.fn();
+const mockCreateNodeByAsset = jest.fn();
+const mockCreateShouldHideInHierarchyCanvasNode = jest.fn();
+const mockLoadAny = jest.fn();
+const mockQueryCanvasRequiredByAsset = jest.fn();
+const mockRpcRequest = jest.fn();
+const mockGetUICanvasNode = jest.fn<any, any[]>(() => null);
+const mockGetUITransformParentNode = jest.fn<any, any[]>(() => null);
+const mockInstantiate = jest.fn();
+const mockGenerateNodeDump = jest.fn();
+const mockScene = { name: 'VirtualScene', uuid: 'virtual-scene-uuid' };
+
+class MockCanvas {}
+class MockUITransform {}
+
+class MockNode {
+    uuid: string;
+    name: string;
+    parent: MockNode | null = null;
+    children: MockNode[] = [];
+    components: any[] = [];
+    layer = 0;
+    position = { z: 0 };
+    addChild = jest.fn((node: MockNode) => {
+        this.children.push(node);
+        node.parent = this;
+    });
+    addComponent = jest.fn((component: any) => {
+        const instance = component === 'cc.UITransform' ? new MockUITransform() : new component();
+        this.components.push(instance);
+        return instance;
+    });
+    setPosition = jest.fn();
+    setParent = jest.fn((parent: MockNode | null) => {
+        this.parent = parent;
+    });
+    getChildByName: (name: string) => MockNode | null = jest.fn((name: string): MockNode | null => (
+        this.children.find((child: MockNode): boolean => child.name === name) ?? null
+    ));
+    getSiblingIndex = jest.fn(() => this.parent?.children.indexOf(this) ?? 0);
+
+    constructor(name = 'Node') {
+        this.name = name;
+        this.uuid = `${name}-uuid`;
+    }
+
+    get isValid() {
+        return true;
+    }
+}
+
+(global as any).EditorExtends = {
+    Node: {
+        getNodeByPath: jest.fn(),
+        getNodePath: jest.fn((node: MockNode) => `/${node.name}`),
+    },
+};
+
+(global as any).cc = {
+    instantiate: mockInstantiate,
+    UITransform: MockUITransform,
+    Node: MockNode,
+};
+
+jest.mock('cc', () => ({
+    Canvas: MockCanvas,
+    CCClass: { getInheritanceChain: jest.fn(() => []) },
+    CCObject: { Flags: { HideInHierarchy: 1, LockedInEditor: 2 } },
+    Component: class Component {},
+    director: { getScene: jest.fn(() => mockScene) },
+    Node: MockNode,
+    Prefab: class Prefab {},
+    Quat: class Quat {},
+    UITransform: MockUITransform,
+    Vec3: class Vec3 {},
+}));
+
+jest.mock('../../scene-process/service/core', () => ({
+    BaseService: class BaseService {
+        emit = jest.fn();
+    },
+    register: () => () => undefined,
+    Service: {
+        Editor: {
+            lock: mockLock,
+            unlock: mockUnlock,
+            getCurrentEditorType: mockGetCurrentEditorType,
+            getRootNode: mockGetRootNode,
+        },
+        Prefab: {
+            removePrefabInfoFromNode: mockRemovePrefabInfoFromNode,
+        },
+        Undo: {
+            push: jest.fn(),
+        },
+    },
+}));
+
+jest.mock('../../scene-process/rpc', () => ({
+    Rpc: { getInstance: () => ({ request: mockRpcRequest }) },
+}));
+
+jest.mock('../../scene-process/service/node/node-create', () => ({
+    createNodeByAsset: mockCreateNodeByAsset,
+    createShouldHideInHierarchyCanvasNode: mockCreateShouldHideInHierarchyCanvasNode,
+    loadAny: mockLoadAny,
+    queryCanvasRequiredByAsset: mockQueryCanvasRequiredByAsset,
+}));
+
+jest.mock('../../scene-process/service/node/node-utils', () => ({
+    getUICanvasNode: mockGetUICanvasNode,
+    getUITransformParentNode: mockGetUITransformParentNode,
+    hasOneKindOfComponent: (node: MockNode, kind: any) => node.components.some((component) => component instanceof kind),
+    setLayer: jest.fn(),
+}));
+
+jest.mock('../../scene-process/service/node/node-undo', () => ({
+    NodeUndoHelper: jest.fn().mockImplementation(() => ({
+        shouldRecordStructureCommand: jest.fn(() => false),
+        collectSceneNodeUuids: jest.fn(() => new Set()),
+        getCreateRootPath: jest.fn(() => null),
+        recordCreateNodeCommand: jest.fn(),
+    })),
+}));
+
+jest.mock('../../scene-process/service/node/index', () => ({
+    __esModule: true,
+    default: {
+        ensureUITransformComponent: jest.fn((node: MockNode) => node.addComponent('cc.UITransform')),
+    },
+}));
+
+jest.mock('../../scene-process/service/prefab/utils', () => ({
+    prefabUtils: { getPrefabStateInfo: jest.fn(() => ({})) },
+}));
+
+jest.mock('../../scene-process/service/scene/utils', () => ({
+    sceneUtils: { generateNodeDump: mockGenerateNodeDump },
+}));
+
+jest.mock('../../scene-process/service/undo/commands/remove-node-command', () => ({
+    RemoveNodeCommand: {},
+}));
+
+jest.mock('../../scene-process/service/undo/commands/remove-component-command', () => ({
+    RemoveComponentCommand: {},
+}));
+
+jest.mock('../../scene-process/service/animation/property-commit-event', () => ({
+    broadcastAnimationPropertyCommitted: jest.fn(),
+}));
+
+import { NodeType } from '../../common';
+
+describe('NodeService prefab mode root-path parent resolution', () => {
+    let virtualScene: MockNode;
+    let prefabRoot: MockNode;
+    let capturedResultNode: MockNode | null;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        virtualScene = new MockNode('VirtualScene');
+        prefabRoot = new MockNode('PrefabRoot');
+        prefabRoot.parent = virtualScene;
+
+        mockGetCurrentEditorType.mockReturnValue('prefab');
+        mockGetRootNode.mockReturnValue(prefabRoot);
+        mockGetUICanvasNode.mockReturnValue(null);
+        mockGetUITransformParentNode.mockReturnValue(null);
+
+        // NodeMgr.getNodeByPath('/') 恒回 virtualScene——就是实机上的 bug 输入
+        (global as any).EditorExtends.Node.getNodeByPath.mockImplementation(
+            (path: string) => (path === '/' || path === '//' ? virtualScene : null),
+        );
+
+        capturedResultNode = null;
+        mockGenerateNodeDump.mockImplementation((node: MockNode) => {
+            capturedResultNode = node;
+            return { path: `/${node.name}` };
+        });
+    });
+
+    it('path="/" in prefab mode places new empty node under prefab root, not the virtual scene', async () => {
+        const { NodeService } = require('../../scene-process/service/node');
+        const service = new NodeService();
+
+        await service._createNode(null, false, false, {
+            path: '/',
+            nodeType: NodeType.EMPTY,
+            workMode: '2d',
+        });
+
+        expect(capturedResultNode).not.toBeNull();
+        expect(capturedResultNode!.setParent).toHaveBeenCalledTimes(1);
+        expect(capturedResultNode!.setParent).toHaveBeenCalledWith(prefabRoot, undefined);
+        expect(capturedResultNode!.parent).toBe(prefabRoot);
+        expect(capturedResultNode!.parent).not.toBe(virtualScene);
+    });
+
+    it('multiple leading slashes (e.g. "//") resolve to prefab root the same way', async () => {
+        const { NodeService } = require('../../scene-process/service/node');
+        const service = new NodeService();
+
+        await service._createNode(null, false, false, {
+            path: '//',
+            nodeType: NodeType.EMPTY,
+            workMode: '2d',
+        });
+
+        expect(capturedResultNode!.parent).toBe(prefabRoot);
+    });
+
+    it('preflight for path="/" in prefab mode plans parent as prefab root, not virtual scene', async () => {
+        prefabRoot.components.push(new MockUITransform());
+        mockGetUITransformParentNode.mockReturnValue(prefabRoot);
+
+        const { NodeService } = require('../../scene-process/service/node');
+
+        await expect(new NodeService().preflightCreate({
+            path: '/',
+            nodeType: NodeType.BUTTON,
+            workMode: '2d',
+        })).resolves.toMatchObject({
+            action: 'create',
+            uiTransformPath: '/PrefabRoot',
+        });
+    });
+
+    it('non-root paths still route through NodeMgr.getNodeByPath as before', async () => {
+        const existingChild = new MockNode('ExistingChild');
+        (global as any).EditorExtends.Node.getNodeByPath.mockImplementation(
+            (path: string) => (path === '/ExistingChild' ? existingChild : null),
+        );
+        const { NodeService } = require('../../scene-process/service/node');
+        const service = new NodeService();
+
+        await service._createNode(null, false, false, {
+            path: '/ExistingChild',
+            nodeType: NodeType.EMPTY,
+            workMode: '2d',
+        });
+
+        expect(capturedResultNode!.parent).toBe(existingChild);
+    });
+});


### PR DESCRIPTION
## Summary

In prefab edit mode, right-clicking with no selection (Pink sends `path: '/'` as parent) used to create the new node as a sibling of the prefab root, which the single-root constraint then discarded — the node "disappeared right after creation".

`NodeMgr.getNodeByPath('/')` returns `cc.director.getScene()`, which in prefab mode is the virtual scene hosting the prefab, not the prefab root. `_getOrCreateNodeByPath` and `_getCreatePathPreflight` accepted that as a truthy parent, bypassing the caller's `parent = currentScene` fallback (= `Service.Editor.getRootNode()` = the prefab root).

The `component.ts` add-component path already handles this with a `resolveNodeByPath` helper (#872). This aligns the node-create flow with the same convention.

## Changes

- `_getOrCreateNodeByPath` (`node.ts`): widen the early-return guard from `!path` to `!path || isRootNodePath(path)`, so root-like inputs (`/`, `//`, `///`) fall through to `parent = currentScene`.
- `_getCreatePathPreflight` (`node.ts`): same guard on the `NodeMgr.getNodeByPath` short-circuit; the existing empty-`pathParts` fallback already produces `parent: currentScene`, now unmasked for `/`.

## Tests

New file `src/core/scene/test/service-core/node-create-root-path-prefab.test.ts` (4 cases):

1. `path: '/'` in prefab mode: new empty node's `setParent` is called with the prefab root, not the virtual scene.
2. `path: '//'` normalizes to the same behaviour.
3. `preflightCreate({ path: '/' })` in prefab mode plans `uiTransformPath: '/PrefabRoot'` when the prefab root has a `UITransform` — i.e. preflight sees the prefab root as parent, not the virtual scene.
4. Non-root paths (e.g. `/ExistingChild`) still resolve via `NodeMgr.getNodeByPath` unchanged.

Verified the tests catch the regression: reverting either `isRootNodePath` guard in `node.ts` makes cases 1 and 2 fail with `capturedResultNode.parent` equal to the virtual scene instead of the prefab root.

`npx tsc --noEmit` clean. `jest src/core/scene/test/service-core/node-create-*` — 18/18 pass (14 existing + 4 new).

## QA notes

Reproduce on any prefab:

1. Open a prefab in Pink.
2. Deselect everything in the hierarchy.
3. Right-click on empty hierarchy area → create an empty node (or drag a prefab in).

Before this PR: the newly created node flashes and is gone. After: it appears as a direct child of the prefab root.
