### PR TITLE
fix(assets): handle duplicate external imports

### DIFF
--- a/src/core/assets/manager/operation.ts
+++ b/src/core/assets/manager/operation.ts
@@ -232,6 +232,7 @@ function getSceneOrPrefabJsonError(asset: IAsset, content: string | Buffer): str
 class AssetOperation extends EventEmitter {
 
     private readonly _importTaskByTargetPath = new Map<string, Promise<void>>();
+    private readonly _reservedImportTargetPaths = new Map<string, number>();
 
     /**
      * 检查一个资源文件夹是否为只读
@@ -253,10 +254,10 @@ class AssetOperation extends EventEmitter {
      * @param option 
      * @returns 返回新的文件路径
      */
-    _checkOverwrite(path: string, option?: AssetOperationOption) {
-        if (existsSync(path) && !option?.overwrite) {
+    _checkOverwrite(path: string, option?: AssetOperationOption, isOccupied: (path: string) => boolean = existsSync) {
+        if (isOccupied(path) && !option?.overwrite) {
             if (option?.rename) {
-                return utils.File.getName(path);
+                return utils.File.getName(path, isOccupied);
             }
             throw new Error(`file ${path} already exists, please use overwrite option to overwrite it or use rename option to auto rename it first.`);
         }
@@ -480,7 +481,8 @@ class AssetOperation extends EventEmitter {
      * @param options 
      */
     async importAsset(source: string, target: string, options?: AssetOperationOption): Promise<IAssetInfo[]> {
-        const targetPath = target.startsWith('db://') ? url2path(target) : target;
+        const targetUrl = this._pathToDbUrlIfInsideAssetDB(target);
+        const targetPath = targetUrl.startsWith('db://') ? url2path(targetUrl) : target;
         return this._queueImportByTargetPath(targetPath, () => this._importAsset(source, targetPath, options));
     }
 
@@ -488,9 +490,14 @@ class AssetOperation extends EventEmitter {
         const isSamePath = this._isSameFilesystemPath(source, targetPath);
 
         if (!isSamePath) {
-            targetPath = this._checkOverwrite(targetPath, options);
-            const copyOptions = options?.overwrite === undefined ? undefined : { overwrite: options.overwrite };
-            await copyPath(source, targetPath, copyOptions);
+            const reservation = this._reserveImportTargetPath(targetPath, options);
+            targetPath = reservation.targetPath;
+            try {
+                const copyOptions = options?.overwrite === undefined ? undefined : { overwrite: options.overwrite };
+                await copyPath(source, targetPath, copyOptions);
+            } finally {
+                reservation.release();
+            }
         }
 
         const assetTarget = this._pathToDbUrlIfInsideAssetDB(targetPath);
@@ -508,10 +515,7 @@ class AssetOperation extends EventEmitter {
     }
 
     private _queueImportByTargetPath<T = unknown>(targetPath: string, task: () => Promise<T>): Promise<T> {
-        let targetKey = utils.Path.normalize(targetPath);
-        if (process.platform === 'win32') {
-            targetKey = targetKey.toLowerCase();
-        }
+        const targetKey = this._getImportTargetKey(targetPath);
 
         const previousTask = this._importTaskByTargetPath.get(targetKey) ?? Promise.resolve();
         const taskResult = previousTask.then(task);
@@ -523,6 +527,35 @@ class AssetOperation extends EventEmitter {
                 this._importTaskByTargetPath.delete(targetKey);
             }
         });
+    }
+
+    private _isPathOccupied = (path: string) => {
+        return existsSync(path) || this._reservedImportTargetPaths.has(this._getImportTargetKey(path));
+    };
+    private _reserveImportTargetPath(targetPath: string, options?: AssetOperationOption) {
+        const resolvedTargetPath = this._checkOverwrite(targetPath, options, this._isPathOccupied);
+        const targetKey = this._getImportTargetKey(resolvedTargetPath);
+        this._reservedImportTargetPaths.set(targetKey, (this._reservedImportTargetPaths.get(targetKey) ?? 0) + 1);
+
+        return {
+            targetPath: resolvedTargetPath,
+            release: () => {
+                const reservationCount = this._reservedImportTargetPaths.get(targetKey);
+                if (reservationCount === undefined || reservationCount <= 1) {
+                    this._reservedImportTargetPaths.delete(targetKey);
+                } else {
+                    this._reservedImportTargetPaths.set(targetKey, reservationCount - 1);
+                }
+            },
+        };
+    }
+
+    private _getImportTargetKey(targetPath: string) {
+        let targetKey = utils.Path.normalize(targetPath);
+        if (process.platform === 'win32') {
+            targetKey = targetKey.toLowerCase();
+        }
+        return targetKey;
     }
 
     /**

--- a/src/core/assets/manager/operation.ts
+++ b/src/core/assets/manager/operation.ts
@@ -231,6 +231,8 @@ function getSceneOrPrefabJsonError(asset: IAsset, content: string | Buffer): str
 
 class AssetOperation extends EventEmitter {
 
+    private readonly _importTaskByTargetPath = new Map<string, Promise<void>>();
+
     /**
      * 检查一个资源文件夹是否为只读
      */
@@ -479,11 +481,19 @@ class AssetOperation extends EventEmitter {
      */
     async importAsset(source: string, target: string, options?: AssetOperationOption): Promise<IAssetInfo[]> {
         const targetPath = target.startsWith('db://') ? url2path(target) : target;
-        const assetTarget = this._pathToDbUrlIfInsideAssetDB(target);
+        return this._queueImportByTargetPath(targetPath, () => this._importAsset(source, targetPath, options));
+    }
 
-        if (!this._isSameFilesystemPath(source, targetPath)) {
-            await copyPath(source, targetPath, options);
+    private async _importAsset(source: string, targetPath: string, options?: AssetOperationOption): Promise<IAssetInfo[]> {
+        const isSamePath = this._isSameFilesystemPath(source, targetPath);
+
+        if (!isSamePath) {
+            targetPath = this._checkOverwrite(targetPath, options);
+            const copyOptions = options?.overwrite === undefined ? undefined : { overwrite: options.overwrite };
+            await copyPath(source, targetPath, copyOptions);
         }
+
+        const assetTarget = this._pathToDbUrlIfInsideAssetDB(targetPath);
         await this.refreshAsset(assetTarget);
         const assetInfo = assetQuery.queryAssetInfo(assetTarget);
         if (!assetInfo) {
@@ -494,6 +504,24 @@ class AssetOperation extends EventEmitter {
         }
         return assetQuery.queryAssetInfos({
             pattern: `${assetInfo.url}/**/*`
+        });
+    }
+
+    private _queueImportByTargetPath<T = unknown>(targetPath: string, task: () => Promise<T>): Promise<T> {
+        let targetKey = utils.Path.normalize(targetPath);
+        if (process.platform === 'win32') {
+            targetKey = targetKey.toLowerCase();
+        }
+
+        const previousTask = this._importTaskByTargetPath.get(targetKey) ?? Promise.resolve();
+        const taskResult = previousTask.then(task);
+        const taskTail = taskResult.then(() => undefined, () => undefined); // never reject
+        this._importTaskByTargetPath.set(targetKey, taskTail);
+
+        return taskResult.finally(() => {
+            if (this._importTaskByTargetPath.get(targetKey) === taskTail) {
+                this._importTaskByTargetPath.delete(targetKey);
+            }
         });
     }
 

--- a/src/core/assets/test/operation-filesystem-bridge.test.ts
+++ b/src/core/assets/test/operation-filesystem-bridge.test.ts
@@ -23,7 +23,8 @@ const mockAddTask = jest.fn(async (func: Function, args: any[]) => await func(..
 const mockGetCreateMenuByName = jest.fn();
 const mockCreateAssetByHandler = jest.fn();
 const mockSaveAssetByHandler = jest.fn();
-const mockGetName = jest.fn((path: string) => path);
+type OccupancyCheck = (path: string) => boolean;
+const mockGetName = jest.fn((path: string, _isOccupied?: OccupancyCheck) => path);
 const mockAssetTreeInfoDataKeys = ['subAssets', 'displayName', 'extends'] as const;
 const { dirname, join } = require('path') as typeof import('path');
 
@@ -147,7 +148,7 @@ jest.mock('../../base/utils', () => {
             ...actual.default,
             File: {
                 ...actual.default.File,
-                getName: (...args: [string]) => mockGetName(...args),
+                getName: (path: string, isOccupied?: OccupancyCheck) => mockGetName(path, isOccupied),
             },
         },
     };
@@ -741,6 +742,126 @@ describe('asset operation filesystem bridge', () => {
         await expect(firstImport).rejects.toThrow(copyError);
         await expect(secondImport).resolves.toEqual([assetInfo]);
         expect(copyCount).toBe(2);
+    });
+
+    it('importAsset should queue equivalent AssetDB target paths together', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const source = 'D:/outside/snake_head.png';
+        const relativeTarget = 'assets/resources/Image/snake_head.png';
+        const dbTarget = 'db://assets/resources/Image/snake_head.png';
+        const physicalTarget = 'D:/project/assets/resources/Image/snake_head.png';
+        const assetInfo = {
+            isDirectory: false,
+            url: dbTarget,
+        };
+        let releaseFirstCopy: () => void;
+        const firstCopyCanFinish = new Promise<void>((resolve) => {
+            releaseFirstCopy = resolve;
+        });
+        let signalFirstCopyStarted: () => void;
+        const firstCopyStarted = new Promise<void>((resolve) => {
+            signalFirstCopyStarted = resolve;
+        });
+        let copyCount = 0;
+
+        setAssetDBInfo();
+        mockExistsSync.mockReturnValue(false);
+        mockCopyPath.mockImplementation(async () => {
+            copyCount += 1;
+            if (copyCount === 1) {
+                signalFirstCopyStarted();
+                await firstCopyCanFinish;
+            }
+        });
+        mockQueryAssetInfo.mockReturnValue(assetInfo);
+        jest.spyOn(assetOperation, 'refreshAsset').mockResolvedValue(0);
+
+        const imports = Promise.all([
+            assetOperation.importAsset(source, relativeTarget),
+            assetOperation.importAsset(source, dbTarget),
+            assetOperation.importAsset(source, physicalTarget),
+        ]);
+
+        await firstCopyStarted;
+        const copiesStartedBeforeRelease = copyCount;
+        releaseFirstCopy!();
+
+        await expect(imports).resolves.toEqual([[assetInfo], [assetInfo], [assetInfo]]);
+        expect(copiesStartedBeforeRelease).toBe(1);
+        expect(mockCopyPath.mock.calls).toEqual([
+            [source, physicalTarget, undefined],
+            [source, physicalTarget, undefined],
+            [source, physicalTarget, undefined],
+        ]);
+    });
+
+    it('importAsset should reserve distinct rename destinations for concurrent target names', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const source = 'D:/outside/snake_head.png';
+        const target = 'D:/project/assets/resources/Image/snake_head.png';
+        const renamedTarget = 'D:/project/assets/resources/Image/snake_head-001.png';
+        const firstAvailableTarget = 'D:/project/assets/resources/Image/snake_head-002.png';
+        const secondAvailableTarget = 'D:/project/assets/resources/Image/snake_head-003.png';
+        const occupiedTargets = new Set([target, renamedTarget]);
+        const inFlightTargets = new Set<string>();
+        const assetInfo = {
+            isDirectory: false,
+            url: 'db://assets/resources/Image/snake_head-002.png',
+        };
+        let releaseFirstCopy: () => void;
+        const firstCopyCanFinish = new Promise<void>((resolve) => {
+            releaseFirstCopy = resolve;
+        });
+        let signalFirstCopyStarted: () => void;
+        const firstCopyStarted = new Promise<void>((resolve) => {
+            signalFirstCopyStarted = resolve;
+        });
+        let copyCount = 0;
+
+        setAssetDBInfo();
+        mockExistsSync.mockImplementation((path: string) => occupiedTargets.has(path));
+        mockGetName.mockImplementation((_path: string, isOccupied?: OccupancyCheck) => (
+            isOccupied!(firstAvailableTarget) ? secondAvailableTarget : firstAvailableTarget
+        ));
+        mockCopyPath.mockImplementation(async (_source: string, destination: string) => {
+            if (occupiedTargets.has(destination) || inFlightTargets.has(destination)) {
+                throw new Error(
+                    `Unable to move/copy '${source}' because target '${destination}' already exists at destination.`,
+                );
+            }
+
+            inFlightTargets.add(destination);
+            copyCount += 1;
+            if (copyCount === 1) {
+                signalFirstCopyStarted();
+                await firstCopyCanFinish;
+            }
+            inFlightTargets.delete(destination);
+            occupiedTargets.add(destination);
+        });
+        mockQueryAssetInfo.mockReturnValue(assetInfo);
+        jest.spyOn(assetOperation, 'refreshAsset').mockResolvedValue(0);
+
+        const imports = Promise.all([
+            assetOperation.importAsset(source, target, { rename: true }),
+            assetOperation.importAsset(source, renamedTarget, { rename: true }),
+        ]);
+
+        await Promise.race([
+            firstCopyStarted,
+            imports.catch(error => {
+                throw error;
+            }),
+        ]);
+        const copiesStartedBeforeRelease = copyCount;
+        releaseFirstCopy!();
+
+        await expect(imports).resolves.toEqual([[assetInfo], [assetInfo]]);
+        expect(copiesStartedBeforeRelease).toBe(2);
+        expect(mockCopyPath.mock.calls).toEqual([
+            [source, firstAvailableTarget, undefined],
+            [source, secondAvailableTarget, undefined],
+        ]);
     });
 
     it('importAsset should not serialize independent targets in the same directory', async () => {

--- a/src/core/assets/test/operation-filesystem-bridge.test.ts
+++ b/src/core/assets/test/operation-filesystem-bridge.test.ts
@@ -23,6 +23,7 @@ const mockAddTask = jest.fn(async (func: Function, args: any[]) => await func(..
 const mockGetCreateMenuByName = jest.fn();
 const mockCreateAssetByHandler = jest.fn();
 const mockSaveAssetByHandler = jest.fn();
+const mockGetName = jest.fn((path: string) => path);
 const mockAssetTreeInfoDataKeys = ['subAssets', 'displayName', 'extends'] as const;
 const { dirname, join } = require('path') as typeof import('path');
 
@@ -56,6 +57,9 @@ jest.mock('../utils', () => ({
     pathToDbUrlIfAssetDBPath: jest.fn((value: string, assetDBInfo: Record<string, { name: string; target: string }>) => {
         if (!value || value.startsWith('db://')) {
             return value;
+        }
+        if (value.startsWith('D:/project/assets/')) {
+            return `db://assets/${value.slice('D:/project/assets/'.length)}`;
         }
         if (value.startsWith('assets/') || value === 'assets') {
             return value === 'assets' ? 'db://assets' : `db://assets/${value.slice('assets/'.length)}`;
@@ -134,6 +138,20 @@ jest.mock('../manager/query', () => ({
 jest.mock('../asset-handler/utils', () => ({
     mergeMeta: jest.fn(),
 }));
+
+jest.mock('../../base/utils', () => {
+    const actual = jest.requireActual('../../base/utils') as typeof import('../../base/utils');
+    return {
+        __esModule: true,
+        default: {
+            ...actual.default,
+            File: {
+                ...actual.default.File,
+                getName: (...args: [string]) => mockGetName(...args),
+            },
+        },
+    };
+});
 
 jest.mock('../../base/i18n', () => ({
     __esModule: true,
@@ -614,6 +632,160 @@ describe('asset operation filesystem bridge', () => {
         expect(mockRefresh).toHaveBeenCalledWith('db://assets/resources/Image/snake_head.png');
         expect(mockQueryAssetInfo).toHaveBeenCalledWith('db://assets/resources/Image/snake_head.png');
         expect(result).toEqual([assetInfo]);
+    });
+
+    it('importAsset should serialize repeated rename imports before the filesystem bridge', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const source = 'D:/outside/snake_head.png';
+        const target = 'D:/project/assets/resources/Image/snake_head.png';
+        const firstRenamedTarget = 'D:/project/assets/resources/Image/snake_head-001.png';
+        const secondRenamedTarget = 'D:/project/assets/resources/Image/snake_head-002.png';
+        const occupiedTargets = new Set([target]);
+        const inFlightTargets = new Set<string>();
+        const assetInfo = {
+            isDirectory: false,
+            url: 'db://assets/resources/Image/snake_head-001.png',
+        };
+        let releaseFirstCopy: () => void;
+        const firstCopyCanFinish = new Promise<void>((resolve) => {
+            releaseFirstCopy = resolve;
+        });
+        let signalFirstCopyStarted: () => void;
+        const firstCopyStarted = new Promise<void>((resolve) => {
+            signalFirstCopyStarted = resolve;
+        });
+        let copyCount = 0;
+
+        setAssetDBInfo();
+        mockExistsSync.mockImplementation((path: string) => occupiedTargets.has(path));
+        mockGetName.mockImplementation(() => (
+            occupiedTargets.has(firstRenamedTarget) ? secondRenamedTarget : firstRenamedTarget
+        ));
+        mockCopyPath.mockImplementation(async (_source: string, destination: string, options?: { overwrite?: boolean }) => {
+            if (occupiedTargets.has(destination) || inFlightTargets.has(destination)) {
+                throw new Error(
+                    `Unable to move/copy '${source}' because target '${destination}' already exists at destination.`,
+                );
+            }
+
+            inFlightTargets.add(destination);
+            copyCount += 1;
+            if (copyCount === 1) {
+                signalFirstCopyStarted();
+                await firstCopyCanFinish;
+            }
+            expect(options?.overwrite).not.toBe(true);
+            inFlightTargets.delete(destination);
+            occupiedTargets.add(destination);
+        });
+        mockQueryAssetInfo.mockReturnValue(assetInfo);
+        jest.spyOn(assetOperation, 'refreshAsset').mockResolvedValue(0);
+
+        const imports = Promise.all([
+            assetOperation.importAsset(source, target, { rename: true }),
+            assetOperation.importAsset(source, target, { rename: true }),
+        ]);
+
+        await Promise.race([
+            firstCopyStarted,
+            imports.catch(error => {
+                throw error;
+            }),
+        ]);
+        releaseFirstCopy!();
+
+        await expect(imports).resolves.toEqual([[assetInfo], [assetInfo]]);
+        expect(mockCopyPath.mock.calls).toEqual([
+            [source, firstRenamedTarget, undefined],
+            [source, secondRenamedTarget, undefined],
+        ]);
+    });
+
+    it('importAsset should continue a queued same-target import after the previous one fails', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const source = 'D:/outside/snake_head.png';
+        const target = 'D:/project/assets/resources/Image/snake_head.png';
+        const copyError = new Error('copy failed');
+        const assetInfo = {
+            isDirectory: false,
+            url: 'db://assets/resources/Image/snake_head.png',
+        };
+        let rejectFirstCopy: (error: Error) => void;
+        const firstCopy = new Promise<void>((_resolve, reject) => {
+            rejectFirstCopy = reject;
+        });
+        let signalFirstCopyStarted: () => void;
+        const firstCopyStarted = new Promise<void>((resolve) => {
+            signalFirstCopyStarted = resolve;
+        });
+        let copyCount = 0;
+
+        setAssetDBInfo();
+        mockExistsSync.mockReturnValue(false);
+        mockCopyPath.mockImplementation(() => {
+            copyCount += 1;
+            if (copyCount === 1) {
+                signalFirstCopyStarted();
+                return firstCopy;
+            }
+            return Promise.resolve();
+        });
+        mockQueryAssetInfo.mockReturnValue(assetInfo);
+        jest.spyOn(assetOperation, 'refreshAsset').mockResolvedValue(0);
+
+        const firstImport = assetOperation.importAsset(source, target);
+        await firstCopyStarted;
+        const secondImport = assetOperation.importAsset(source, target);
+        rejectFirstCopy!(copyError);
+
+        await expect(firstImport).rejects.toThrow(copyError);
+        await expect(secondImport).resolves.toEqual([assetInfo]);
+        expect(copyCount).toBe(2);
+    });
+
+    it('importAsset should not serialize independent targets in the same directory', async () => {
+        const { assetOperation } = require('../manager/operation') as typeof import('../manager/operation');
+        const sourceA = 'D:/outside/a.png';
+        const sourceB = 'D:/outside/b.png';
+        const targetA = 'D:/project/assets/resources/Image/a.png';
+        const targetB = 'D:/project/assets/resources/Image/b.png';
+        const assetInfo = {
+            isDirectory: false,
+            url: 'db://assets/resources/Image/imported.png',
+        };
+        let releaseCopies: () => void;
+        const copiesCanFinish = new Promise<void>((resolve) => {
+            releaseCopies = resolve;
+        });
+        let signalFirstCopyStarted: () => void;
+        const firstCopyStarted = new Promise<void>((resolve) => {
+            signalFirstCopyStarted = resolve;
+        });
+        let copyCount = 0;
+
+        setAssetDBInfo();
+        mockExistsSync.mockReturnValue(false);
+        mockCopyPath.mockImplementation(async () => {
+            copyCount += 1;
+            if (copyCount === 1) {
+                signalFirstCopyStarted();
+            }
+            await copiesCanFinish;
+        });
+        mockQueryAssetInfo.mockReturnValue(assetInfo);
+        jest.spyOn(assetOperation, 'refreshAsset').mockResolvedValue(0);
+
+        const imports = Promise.all([
+            assetOperation.importAsset(sourceA, targetA),
+            assetOperation.importAsset(sourceB, targetB),
+        ]);
+
+        await firstCopyStarted;
+        const copiesStartedBeforeRelease = copyCount;
+        releaseCopies!();
+
+        await expect(imports).resolves.toEqual([[assetInfo], [assetInfo]]);
+        expect(copiesStartedBeforeRelease).toBe(2);
     });
 
     it('createAsset should accept a Windows asset path after queryUrl normalizes its drive-letter case', async () => {

--- a/src/core/assets/test/operation.test.ts
+++ b/src/core/assets/test/operation.test.ts
@@ -708,7 +708,7 @@ describe('测试 db 的操作接口', function () {
             await outputFile(tempFilePath, 'new content');
 
             // 导入并覆盖
-            const assets = await assetManager.importAsset(tempFilePath, join(databasePath, targetName));
+            const assets = await assetManager.importAsset(tempFilePath, join(databasePath, targetName), { overwrite: true });
 
             // 验证返回的是数组
             expect(Array.isArray(assets)).toBeTruthy();

--- a/src/core/base/test/file.test.ts
+++ b/src/core/base/test/file.test.ts
@@ -1,0 +1,18 @@
+import { join } from 'path';
+import { getName } from '../utils/file';
+
+describe('file utilities', () => {
+    it('uses caller reservations when resolving an available name', () => {
+        const directory = '/virtual/assets';
+        const file = join(directory, 'snake_head.png');
+        const occupied = new Set([
+            file,
+            join(directory, 'snake_head-001.png'),
+            join(directory, 'snake_head-002.png'),
+        ]);
+
+        expect(getName(file, (candidate) => occupied.has(candidate))).toBe(
+            join(directory, 'snake_head-003.png'),
+        );
+    });
+});

--- a/src/core/base/utils/file.ts
+++ b/src/core/base/utils/file.ts
@@ -4,13 +4,16 @@ import { existsSync } from 'fs';
 import { remove } from 'fs-extra';
 import { basename, dirname, extname, join } from 'path';
 
+export type FileOccupancyCheck = (path: string) => boolean;
+
 /**
  * 检查文件在指定文件夹中是否存在，如果存在则通过追加数字后缀的方式生成一个唯一的文件名。
  * @param targetFolder 目标文件夹的路径。
  * @param fileName 需要检查存在的文件名。
+ * @param isOccupied 返回路径是否已被文件系统或调用方占用。
  * @returns 返回一个唯一的文件名字符串。
  */
-export const resolveFileNameConflict = (targetFolder: string, fileName: string): string => {
+export const resolveFileNameConflict = (targetFolder: string, fileName: string, isOccupied: FileOccupancyCheck = existsSync): string => {
     // 如果fileName为空，抛出错误
     if (!fileName) throw new Error(`fileName is empty`);
     // 获取文件扩展名
@@ -19,7 +22,7 @@ export const resolveFileNameConflict = (targetFolder: string, fileName: string):
     let fileBase = basename(fileName, fileExt);
 
     // 循环检查直到找到一个不存在的文件名
-    while (existsSync(join(targetFolder, `${fileBase}${fileExt}`))) {
+    while (isOccupied(join(targetFolder, `${fileBase}${fileExt}`))) {
         if ((/(\d+)$/.test(fileBase))) {
             fileBase = fileBase.replace(/^(.+?)(\d+)?$/, ($: string, $1: string, $2: string | undefined) => {
                 let num;
@@ -51,15 +54,16 @@ export const resolveFileNameConflict = (targetFolder: string, fileName: string):
  * Returns the file path with the available name
  * 
  * @param file 初始文件路径 Initial file path
+ * @param isOccupied 返回路径是否已被文件系统或调用方占用。
  */
-export function getName(file: string): string {
-    if (!existsSync(file)) {
+export function getName(file: string, isOccupied: FileOccupancyCheck = existsSync): string {
+    if (!isOccupied(file)) {
         return file;
     }
 
     const dir = dirname(file);
     const fileName = basename(file);
-    const newFileName = resolveFileNameConflict(dir, fileName);
+    const newFileName = resolveFileNameConflict(dir, fileName, isOccupied);
 
     return join(dir, newFileName);
 }
@@ -71,7 +75,7 @@ export async function trashItem(file: string) {
     await remove(file);
 }
 
-export function requireFile(file: string, options?: { root: string }) {
+export function requireFile(file: string, _options?: { root: string }) {
     // TODO
     return require(file);
 }


### PR DESCRIPTION
## Summary
- Resolve destination conflicts before copying external assets so `rename: true` selects a unique target.
- Serialize only repeated imports for the same target path; independent imports in one folder remain concurrent.
- Preserve caller-visible failures while allowing a queued same-target import to continue after an earlier failure.

## Test Plan
- [x] `npm rebuild gl`
- [x] `npm test -- --runInBand src/core/assets/test/operation-filesystem-bridge.test.ts`
- [x] `npm test -- --runInBand src/core/assets/test/operation.test.ts --testNamePattern=import-asset`
- [x] `npx tsc -p tsconfig.json --noEmit --pretty false`
- [x] `npx eslint src/core/assets/manager/operation.ts src/core/assets/test/operation.test.ts`
- [x] `git diff --check`

## Bug Tracking
- https://zentao.sud.center/index.php?m=bug&f=view&bugID=843