### PR TITLE
[fix] Restore plugin script global aliases

### DIFF
--- a/src/core/assets/asset-handler/assets/javascript.ts
+++ b/src/core/assets/asset-handler/assets/javascript.ts
@@ -19,7 +19,7 @@ export const JavascriptHandler: AssetHandlerBase = {
 
     importer: {
         // 版本号如果变更，则会强制重新导入
-        version: '4.0.25',
+        version: '4.0.24',
 
         /**
          * 实际导入流程

--- a/src/core/assets/asset-handler/assets/javascript.ts
+++ b/src/core/assets/asset-handler/assets/javascript.ts
@@ -1,6 +1,7 @@
 import { Asset, VirtualAsset } from '@cocos/asset-db';
 import { readFile } from 'fs-extra';
 import { transformPluginScript } from './utils/script-compiler';
+import { resolveSimulatedGlobals } from './utils/plugin-script-globals';
 import { openCode } from '../utils';
 import { AssetHandlerBase } from '../../@types/protected';
 import { JavaScriptAssetUserData, PluginScriptUserData } from '../../@types/userDatas';
@@ -18,7 +19,7 @@ export const JavascriptHandler: AssetHandlerBase = {
 
     importer: {
         // 版本号如果变更，则会强制重新导入
-        version: '4.0.24',
+        version: '4.0.25',
 
         /**
          * 实际导入流程
@@ -102,7 +103,7 @@ async function _importPluginScript(asset: Asset) {
         return true;
     }
 
-    const simulateGlobalNames: string[] = simulateGlobals === undefined ? ['self', 'window', 'global', 'globalThis'] : simulateGlobals;
+    const simulateGlobalNames = resolveSimulatedGlobals(simulateGlobals);
 
     const transformed = await transformPluginScript(code, {
         simulateGlobals: simulateGlobalNames,

--- a/src/core/assets/asset-handler/assets/utils/plugin-script-globals.ts
+++ b/src/core/assets/asset-handler/assets/utils/plugin-script-globals.ts
@@ -1,0 +1,13 @@
+/** Default aliases made available to enclosed plugin scripts. */
+export const DEFAULT_SIMULATED_GLOBALS = ['self', 'window', 'global', 'globalThis'] as const;
+
+/**
+ * Resolves persisted plugin aliases while tolerating metadata written by older PinK versions.
+ */
+export function resolveSimulatedGlobals(value: unknown): string[] {
+    const customGlobals = Array.isArray(value) ? value : [];
+    return Array.from(new Set([
+        ...DEFAULT_SIMULATED_GLOBALS,
+        ...customGlobals,
+    ]));
+}

--- a/src/core/assets/asset-handler/assets/utils/plugin-script-globals.ts
+++ b/src/core/assets/asset-handler/assets/utils/plugin-script-globals.ts
@@ -5,6 +5,10 @@ export const DEFAULT_SIMULATED_GLOBALS = ['self', 'window', 'global', 'globalThi
  * Resolves persisted plugin aliases while tolerating metadata written by older PinK versions.
  */
 export function resolveSimulatedGlobals(value: unknown): string[] {
+    if (value === false || (Array.isArray(value) && value.length === 0)) {
+        return [];
+    }
+
     const customGlobals = Array.isArray(value) ? value : [];
     return Array.from(new Set([
         ...DEFAULT_SIMULATED_GLOBALS,

--- a/src/core/assets/test/plugin-script-globals.test.ts
+++ b/src/core/assets/test/plugin-script-globals.test.ts
@@ -1,0 +1,25 @@
+import { DEFAULT_SIMULATED_GLOBALS, resolveSimulatedGlobals } from '../asset-handler/assets/utils/plugin-script-globals';
+
+describe('plugin script globals', () => {
+    test('uses the default aliases when no custom aliases are stored', () => {
+        expect(resolveSimulatedGlobals(undefined)).toEqual(DEFAULT_SIMULATED_GLOBALS);
+    });
+
+    test('appends custom aliases after the defaults', () => {
+        expect(resolveSimulatedGlobals(['PINK_PLUGIN_ALIAS'])).toEqual([
+            ...DEFAULT_SIMULATED_GLOBALS,
+            'PINK_PLUGIN_ALIAS',
+        ]);
+    });
+
+    test('treats legacy boolean metadata as no custom aliases', () => {
+        expect(resolveSimulatedGlobals(true)).toEqual(DEFAULT_SIMULATED_GLOBALS);
+    });
+
+    test('deduplicates default and custom aliases', () => {
+        expect(resolveSimulatedGlobals(['window', 'PINK_PLUGIN_ALIAS', 'PINK_PLUGIN_ALIAS'])).toEqual([
+            ...DEFAULT_SIMULATED_GLOBALS,
+            'PINK_PLUGIN_ALIAS',
+        ]);
+    });
+});

--- a/src/core/assets/test/plugin-script-globals.test.ts
+++ b/src/core/assets/test/plugin-script-globals.test.ts
@@ -16,6 +16,14 @@ describe('plugin script globals', () => {
         expect(resolveSimulatedGlobals(true)).toEqual(DEFAULT_SIMULATED_GLOBALS);
     });
 
+    test('preserves an empty alias array as disabled aliases', () => {
+        expect(resolveSimulatedGlobals([])).toEqual([]);
+    });
+
+    test('preserves legacy false metadata as disabled aliases', () => {
+        expect(resolveSimulatedGlobals(false)).toEqual([]);
+    });
+
     test('deduplicates default and custom aliases', () => {
         expect(resolveSimulatedGlobals(['window', 'PINK_PLUGIN_ALIAS', 'PINK_PLUGIN_ALIAS'])).toEqual([
             ...DEFAULT_SIMULATED_GLOBALS,


### PR DESCRIPTION
## Background

Older PinK versions could persist `simulateGlobals: true` when users cleared
the plugin script “Simulate Globals” field. cocos-cli later treats plugin
aliases as an array during enclosed-script import, so that legacy value can
make a reimport fail.

Valid custom aliases also need to extend the built-in enclosed-script aliases,
rather than replacing them.

## Root cause

The JavaScript importer consumed `simulateGlobals` as if it were always an
array, while existing project metadata may contain legacy boolean values.
Alias resolution was also split between the missing-value default and the
custom-value path.

## Changes

- Resolve plugin-script aliases at the importer boundary.
- Treat legacy `true` and other non-array invalid values as the default alias
  set, so a normal reimport can recover safely.
- Preserve historical disabled-alias values: `false` and an empty array still
  produce no simulated aliases.
- Merge non-empty custom alias arrays with the default aliases and remove
  duplicates.
- Add focused regression coverage for missing values, custom aliases, legacy
  booleans, disabled aliases, and duplicate aliases.

## Compatibility

This does not change the importer version and does not trigger an automatic
reimport of all JavaScript assets. Existing metadata and library artifacts are
not rewritten. The compatibility handling takes effect when a plugin script is
actually reimported.

Global execution scope, CommonJS/AMD isolation, and platform load flags are
unchanged.

## Test plan

1. Reimport an enclosed plugin script with legacy `simulateGlobals: true`; it
   should import successfully and expose the default aliases.
2. Reimport one with `simulateGlobals: false` or `[]`; no aliases should be
   simulated.
3. Configure a custom alias and run the plugin script; both the default and
   custom aliases should be available.
4. Configure repeated aliases; each generated alias should occur once.

## Verification

- Focused Jest coverage for plugin-script alias resolution passes.
- ESLint and `git diff --check` pass.
- The full TypeScript check remains blocked by the clean worktree missing the
  unrelated generated `src/i18n/types/generated` directory.