### PR TITLE
feat(scene): support PolygonCollider2D point regeneration via Scene API and MCP

### DIFF
--- a/e2e/mcp/api/component.e2e.test.ts
+++ b/e2e/mcp/api/component.e2e.test.ts
@@ -342,4 +342,55 @@ describe('MCP Component API', () => {
             expect(eraseResult.data).toEqual(insertResult.data);
         });
     });
+
+    describe('PolygonCollider2D 专用操作', () => {
+        it('should regenerate rectangle fallback points through MCP', async () => {
+            const addResult = await mcpClient.callTool('scene-add-component', {
+                addComponentInfo: {
+                    nodePath: testNodePath,
+                    component: 'cc.PolygonCollider2D',
+                },
+            });
+            expect(addResult.code).toBe(200);
+            expect(addResult.data).toBeDefined();
+            if (!addResult.data) return;
+
+            const regenerateResult = await mcpClient.callTool('scene-regenerate-polygon-2d-points', {
+                options: {
+                    path: addResult.data.path,
+                    record: false,
+                },
+            });
+
+            expect(regenerateResult.code).toBe(200);
+            expect(regenerateResult.data).toEqual({
+                path: addResult.data.path,
+                changed: false,
+                pointCount: 4,
+                source: 'rect-fallback',
+            });
+        });
+
+        it('should reject a non-PolygonCollider2D component', async () => {
+            const addResult = await mcpClient.callTool('scene-add-component', {
+                addComponentInfo: {
+                    nodePath: testNodePath,
+                    component: 'cc.Label',
+                },
+            });
+            expect(addResult.code).toBe(200);
+            expect(addResult.data).toBeDefined();
+            if (!addResult.data) return;
+
+            const regenerateResult = await mcpClient.callTool('scene-regenerate-polygon-2d-points', {
+                options: {
+                    path: addResult.data.path,
+                    record: false,
+                },
+            });
+
+            expect(regenerateResult.code).toBe(400);
+            expect(regenerateResult.reason).toContain('component is not cc.PolygonCollider2D');
+        });
+    });
 });

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -6232,6 +6232,7 @@ export declare interface IComponentService extends IServiceEvents {
     add(params: IAddComponentOptions): Promise<IComponent>;
     remove(params: IRemoveComponentOptions): Promise<boolean>;
     setProperty(params: ISetPropertyOptions): Promise<boolean>;
+    regeneratePolygon2DPoints(options: IRegeneratePolygon2DPointsOptions): Promise<IRegeneratePolygon2DPointsResult>;
     query(params: IQueryComponentOptions | string): Promise<IComponent | null>;
     queryAll(): Promise<string[]>;
     recalculateLODGroupBounds(options: IRecalculateLODGroupBoundsOptions): Promise<ILODGroupBoundsResult>;
@@ -6707,6 +6708,16 @@ export declare interface IReferenceImageState {
 export declare interface IReferenceImageVisibilityOptions {
     desiredVisible: boolean;
 }
+export declare interface IRegeneratePolygon2DPointsOptions {
+    path: string;
+    record?: boolean;
+}
+export declare interface IRegeneratePolygon2DPointsResult {
+    path: string;
+    changed: boolean;
+    pointCount: number;
+    source: Polygon2DPointsSource;
+}
 export declare interface IReloadOptions {
     urlOrUUID?: string;
     preserveUndoHistory?: boolean;
@@ -7175,6 +7186,7 @@ export declare interface PluginScriptUserData {
     loadPluginInMiniGame?: boolean;
     loadPluginInNative?: boolean;
 }
+export declare type Polygon2DPointsSource = 'sprite-alpha' | 'rect-fallback';
 export declare interface PrefabAssetUserData {
     persistent?: boolean;
     syncNodeName?: string;

--- a/src/api/scene/component-schema.ts
+++ b/src/api/scene/component-schema.ts
@@ -119,6 +119,23 @@ export const SchemaComponent: z.ZodType<IComponentInfo> = SchemaComponentIdentif
 
 export const SchemaQueryAllComponentResult = z.array(z.string()).describe('Collection of all components, including built-in and custom components'); // 所有组件集合，包含内置与自定义组件
 
+// Regenerate PolygonCollider2D points // 重新生成 PolygonCollider2D 顶点
+export const SchemaRegeneratePolygon2DPointsOptions = z.object({
+    path: z.string().min(1)
+        .describe('cc.PolygonCollider2D component path, UUID, or db:// URL'),
+    record: z.boolean().optional().describe('Whether to record undo, defaults to true'),
+}).describe('Information required to regenerate cc.PolygonCollider2D points');
+
+export const SchemaPolygon2DPointsSource = z.enum(['sprite-alpha', 'rect-fallback'])
+    .describe('Source used to generate the PolygonCollider2D points');
+
+export const SchemaRegeneratePolygon2DPointsResult = z.object({
+    path: z.string().min(1).describe('PolygonCollider2D component identifier supplied for the operation'),
+    changed: z.boolean().describe('Whether the generated points changed the component'),
+    pointCount: z.number().int().min(3).describe('Number of generated polygon points'),
+    source: SchemaPolygon2DPointsSource,
+}).describe('Result of regenerating cc.PolygonCollider2D points');
+
 // Recalculate LODGroup bounds // 重新计算 LODGroup 包围盒
 export const SchemaRecalculateLODGroupBoundsOptions = z.object({
     path: z.string().min(1).describe('cc.LODGroup component path, e.g. "Root/LOD/cc.LODGroup"'), // cc.LODGroup 组件路径
@@ -170,6 +187,9 @@ export type TQueryComponentOptions = z.infer<typeof SchemaQueryComponent>;
 export type TSetPropertyOptions = z.infer<typeof SchemaSetPropertyOptions>;
 export type TComponentResult = z.infer<typeof SchemaComponentResult>;
 export type TQueryAllComponentResult = z.infer<typeof SchemaQueryAllComponentResult>;
+export type TRegeneratePolygon2DPointsOptions = z.infer<typeof SchemaRegeneratePolygon2DPointsOptions>;
+export type TPolygon2DPointsSource = z.infer<typeof SchemaPolygon2DPointsSource>;
+export type TRegeneratePolygon2DPointsResult = z.infer<typeof SchemaRegeneratePolygon2DPointsResult>;
 export type TRecalculateLODGroupBoundsOptions = z.infer<typeof SchemaRecalculateLODGroupBoundsOptions>;
 export type TLODGroupBoundsResult = z.infer<typeof SchemaLODGroupBoundsResult>;
 export type TInsertLODOptions = z.infer<typeof SchemaInsertLODOptions>;

--- a/src/api/scene/component.ts
+++ b/src/api/scene/component.ts
@@ -6,6 +6,8 @@ import {
     SchemaQueryAllComponentResult,
     SchemaQueryComponent,
     SchemaRemoveComponent,
+    SchemaRegeneratePolygon2DPointsOptions,
+    SchemaRegeneratePolygon2DPointsResult,
     SchemaRecalculateLODGroupBoundsOptions,
     SchemaLODGroupBoundsResult,
     SchemaInsertLODOptions,
@@ -20,6 +22,8 @@ import {
     TQueryAllComponentResult,
     TRemoveComponentOptions,
     TQueryComponentOptions,
+    TRegeneratePolygon2DPointsOptions,
+    TRegeneratePolygon2DPointsResult,
     TRecalculateLODGroupBoundsOptions,
     TLODGroupBoundsResult,
     TInsertLODOptions,
@@ -145,6 +149,30 @@ export class ComponentApi {
             return {
                 code: getCommonErrorStatus(e),
                 reason: e instanceof Error ? e.message : String(e)
+            };
+        }
+    }
+
+    /**
+     * Regenerate PolygonCollider2D points // 重新生成 PolygonCollider2D 顶点
+     */
+    @tool('scene-regenerate-polygon-2d-points')
+    @title('Regenerate PolygonCollider2D points')
+    @description('Regenerate cc.PolygonCollider2D points from the alpha contour of a Sprite on the same node. Falls back to the UITransform rectangle when no usable Sprite source exists. This overwrites the current points and records undo by default.')
+    @result(SchemaRegeneratePolygon2DPointsResult)
+    async regeneratePolygon2DPoints(
+        @param(SchemaRegeneratePolygon2DPointsOptions) options: TRegeneratePolygon2DPointsOptions,
+    ): Promise<CommonResultType<TRegeneratePolygon2DPointsResult>> {
+        try {
+            const result = await Scene.Component.regeneratePolygon2DPoints(options);
+            return {
+                code: COMMON_STATUS.SUCCESS,
+                data: result,
+            };
+        } catch (e) {
+            return {
+                code: getCommonErrorStatus(e),
+                reason: e instanceof Error ? e.message : String(e),
             };
         }
     }

--- a/src/core/assets/image-processing.ts
+++ b/src/core/assets/image-processing.ts
@@ -1,0 +1,76 @@
+import Sharp from 'sharp';
+
+export interface IImagePixelExtractionOptions {
+    rect: {
+        left: number;
+        top: number;
+        width: number;
+        height: number;
+    };
+    rotation?: 0 | 90;
+}
+
+export interface IExtractedImagePixels {
+    dataBase64: string;
+    width: number;
+    height: number;
+    channels: number;
+}
+
+/**
+ * 在 Node 进程中读取图片像素。
+ *
+ * Scene Runtime 可能运行在浏览器中，不能直接加载 Sharp 原生模块，因此只通过 RPC
+ * 调用此方法并接收可 JSON 序列化的 Base64 数据。
+ */
+export async function extractImagePixelsFromFile(
+    file: string,
+    options: IImagePixelExtractionOptions,
+): Promise<IExtractedImagePixels> {
+    if (!file) {
+        throw new Error('Image file path is required.');
+    }
+
+    validateExtractionOptions(options);
+
+    const { data, info } = await Sharp(file)
+        .extract(options.rect)
+        .rotate(options.rotation ?? 0)
+        .ensureAlpha()
+        .raw()
+        .toBuffer({ resolveWithObject: true });
+
+    if (info.channels !== 4) {
+        throw new Error(`Expected RGBA image data, but Sharp returned ${info.channels} channels.`);
+    }
+
+    return {
+        dataBase64: data.toString('base64'),
+        width: info.width,
+        height: info.height,
+        channels: info.channels,
+    };
+}
+
+function validateExtractionOptions(options: IImagePixelExtractionOptions): void {
+    if (!options || !options.rect) {
+        throw new Error('Image extraction rect is required.');
+    }
+
+    const { left, top, width, height } = options.rect;
+    assertInteger(left, 'rect.left', 0);
+    assertInteger(top, 'rect.top', 0);
+    assertInteger(width, 'rect.width', 1);
+    assertInteger(height, 'rect.height', 1);
+
+    const rotation = options.rotation ?? 0;
+    if (rotation !== 0 && rotation !== 90) {
+        throw new Error(`Image extraction rotation must be 0 or 90, but received ${rotation}.`);
+    }
+}
+
+function assertInteger(value: number, name: string, minimum: number): void {
+    if (!Number.isInteger(value) || value < minimum) {
+        throw new Error(`${name} must be an integer greater than or equal to ${minimum}.`);
+    }
+}

--- a/src/core/assets/manager/asset.ts
+++ b/src/core/assets/manager/asset.ts
@@ -10,6 +10,11 @@ import assetHandlerManager from './asset-handler';
 import animationGraphVariant from '../animation-graph-variant';
 import * as serializedData from '../serialized-data';
 import * as materialService from '../material-service';
+import {
+    extractImagePixelsFromFile,
+    type IExtractedImagePixels,
+    type IImagePixelExtractionOptions,
+} from '../image-processing';
 
 /**
  * 对外暴露一系列的资源查询、操作接口等
@@ -76,6 +81,18 @@ class AssetManager extends EventEmitter {
         if (!asset) { return null; }
         return assetHandlerManager.generateThumbnail(asset, size);
     }
+
+    async extractImagePixels(
+        urlOrUUIDOrPath: string,
+        options: IImagePixelExtractionOptions,
+    ): Promise<IExtractedImagePixels | null> {
+        const assetInfo = this.queryAssetInfo(urlOrUUIDOrPath);
+        if (!assetInfo?.file) {
+            return null;
+        }
+        return extractImagePixelsFromFile(assetInfo.file, options);
+    }
+
     getEffectBinPath() {
         return assetHandlerManager.getEffectBinPath();
     };
@@ -391,6 +408,10 @@ export interface TypedAssetManager extends EventEmitter {
     getEffectBinPath: typeof assetHandlerManager.getEffectBinPath;
 
     generateThumbnail(urlOrUUIDOrPath: string, size?: ThumbnailSize): Promise<ThumbnailInfo | null>;
+    extractImagePixels(
+        urlOrUUIDOrPath: string,
+        options: IImagePixelExtractionOptions,
+    ): Promise<IExtractedImagePixels | null>;
 
     onReady: typeof assetManager.onReady;
     onDBReady: typeof assetManager.onDBReady;

--- a/src/core/assets/test/image-processing.test.ts
+++ b/src/core/assets/test/image-processing.test.ts
@@ -1,0 +1,65 @@
+export {};
+
+jest.mock('sharp', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}));
+
+const mockSharp = require('sharp').default as jest.Mock;
+const imageProcessingModule = () => require('../image-processing') as typeof import('../image-processing');
+
+describe('asset image processing', () => {
+    beforeEach(() => {
+        mockSharp.mockReset();
+    });
+
+    it('extracts RGBA pixels in Node and returns JSON-safe Base64 data', async () => {
+        const data = Buffer.from([
+            255, 0, 0, 255,
+            0, 255, 0, 128,
+        ]);
+        const pipeline = {
+            extract: jest.fn().mockReturnThis(),
+            rotate: jest.fn().mockReturnThis(),
+            ensureAlpha: jest.fn().mockReturnThis(),
+            raw: jest.fn().mockReturnThis(),
+            toBuffer: jest.fn().mockResolvedValue({
+                data,
+                info: { width: 1, height: 2, channels: 4 },
+            }),
+        };
+        mockSharp.mockReturnValue(pipeline);
+
+        const result = await imageProcessingModule().extractImagePixelsFromFile(
+            'D:/project/assets/atlas.png',
+            {
+                rect: { left: 3, top: 4, width: 2, height: 1 },
+                rotation: 90,
+            },
+        );
+
+        expect(mockSharp).toHaveBeenCalledWith('D:/project/assets/atlas.png');
+        expect(pipeline.extract).toHaveBeenCalledWith({ left: 3, top: 4, width: 2, height: 1 });
+        expect(pipeline.rotate).toHaveBeenCalledWith(90);
+        expect(pipeline.ensureAlpha).toHaveBeenCalledTimes(1);
+        expect(pipeline.raw).toHaveBeenCalledTimes(1);
+        expect(result).toEqual({
+            dataBase64: data.toString('base64'),
+            width: 1,
+            height: 2,
+            channels: 4,
+        });
+    });
+
+    it('rejects invalid extraction rectangles before invoking Sharp', async () => {
+        await expect(imageProcessingModule().extractImagePixelsFromFile(
+            'D:/project/assets/atlas.png',
+            {
+                rect: { left: 0, top: 0, width: 0, height: 1 },
+                rotation: 0,
+            },
+        )).rejects.toThrow('rect.width must be an integer greater than or equal to 1');
+
+        expect(mockSharp).not.toHaveBeenCalled();
+    });
+});

--- a/src/core/scene/common/component.ts
+++ b/src/core/scene/common/component.ts
@@ -238,6 +238,20 @@ export interface IComponentService extends IServiceEvents {
      *
      * Sprite Alpha 轮廓生成、资源读取、校验或提交失败时抛出 Error，不会修改组件现有 points。
      * 没有 Sprite、SpriteFrame 或无法解析源图片时，使用 UITransform 矩形回退。
+     *
+     * @param options - 重新生成选项
+     * @param options.path - PolygonCollider2D 组件路径、UUID 或 db:// URL
+     * @param options.record - 是否记录 Undo，默认 true
+     * @returns 生成结果，包含是否变更、最终顶点数和顶点来源
+     * @throws 组件不存在或类型不正确，以及资源读取、轮廓生成、顶点校验或属性提交失败时抛出 Error
+     *
+     * @example
+     * ```ts
+     * const result = await regeneratePolygon2DPoints({
+     *     path: 'Canvas/MyNode/cc.PolygonCollider2D',
+     *     record: true,
+     * });
+     * ```
      */
     regeneratePolygon2DPoints(
         options: IRegeneratePolygon2DPointsOptions,

--- a/src/core/scene/common/component.ts
+++ b/src/core/scene/common/component.ts
@@ -125,6 +125,32 @@ export interface IExecuteComponentMethodOptions {
 }
 
 /**
+ * PolygonCollider2D 顶点重新生成的数据来源。
+ */
+export type Polygon2DPointsSource = 'sprite-alpha' | 'rect-fallback';
+
+/**
+ * 重新生成 PolygonCollider2D.points 的选项。
+ */
+export interface IRegeneratePolygon2DPointsOptions {
+    /** PolygonCollider2D 组件路径、UUID 或 URL。 */
+    path: string;
+    /** 是否记录 Undo；默认 true。 */
+    record?: boolean;
+}
+
+/**
+ * 重新生成 PolygonCollider2D.points 的成功结果。
+ * 失败通过 Error 抛出，由 RPC/API 边界决定如何呈现。
+ */
+export interface IRegeneratePolygon2DPointsResult {
+    path: string;
+    changed: boolean;
+    pointCount: number;
+    source: Polygon2DPointsSource;
+}
+
+/**
  * 查询注册类的过滤选项
  */
 export interface IQueryClassesOptions {
@@ -206,6 +232,16 @@ export interface IComponentService extends IServiceEvents {
      * ```
      */
     setProperty(params: ISetPropertyOptions): Promise<boolean>;
+
+    /**
+     * 根据同节点 Sprite 或 UITransform 重新生成 PolygonCollider2D.points。
+     *
+     * Sprite Alpha 轮廓生成、资源读取、校验或提交失败时抛出 Error，不会修改组件现有 points。
+     * 没有 Sprite、SpriteFrame 或无法解析源图片时，使用 UITransform 矩形回退。
+     */
+    regeneratePolygon2DPoints(
+        options: IRegeneratePolygon2DPointsOptions,
+    ): Promise<IRegeneratePolygon2DPointsResult>;
 
     /**
      * 查询组件信息

--- a/src/core/scene/main-process/proxy/component-proxy.ts
+++ b/src/core/scene/main-process/proxy/component-proxy.ts
@@ -1,5 +1,7 @@
 import {
     IAddComponentOptions,
+    IRegeneratePolygon2DPointsOptions,
+    IRegeneratePolygon2DPointsResult,
     IRemoveComponentOptions,
     IQueryComponentOptions,
     IPublicComponentService,
@@ -109,6 +111,12 @@ export const ComponentProxy: IComponentProxy = {
             }] as any);
         }
         return true;
+    },
+
+    regeneratePolygon2DPoints(
+        options: IRegeneratePolygon2DPointsOptions,
+    ): Promise<IRegeneratePolygon2DPointsResult> {
+        return Rpc.getInstance().request('Component', 'regeneratePolygon2DPoints', [options]);
     },
 
     queryAll(): Promise<string[]> {

--- a/src/core/scene/scene-process/service/component.ts
+++ b/src/core/scene/scene-process/service/component.ts
@@ -1,4 +1,4 @@
-import { Component, Constructor, animation, Animation, Node, RigidBody, Collider, ERigidBodyType, EColliderType, MeshCollider, UITransform, director, Canvas, Scene } from 'cc';
+import { Component, Constructor, animation, Animation, Node, RigidBody, Collider, ERigidBodyType, EColliderType, MeshCollider, UITransform, director, Canvas, Scene, PolygonCollider2D } from 'cc';
 import { Rpc } from '../rpc';
 import { register, Service, BaseService } from './core';
 import {
@@ -19,6 +19,8 @@ import {
     IEraseLODOptions,
     IQueryLODGroupRelativeHeightOptions,
     ILODGroupLevelsResult,
+    IRegeneratePolygon2DPointsOptions,
+    IRegeneratePolygon2DPointsResult,
 } from '../../common';
 import dumpUtil from './dump';
 import compMgr from './component/index';
@@ -43,6 +45,14 @@ import {
     validateLODErase,
     validateLODInsert,
 } from './component/lod-group';
+import {
+    arePolygonPointsEqual,
+    createPolygonPointsPropertyDump,
+    generatePolygonPoints,
+    initializePolygonCollider2DPoints,
+    requirePolygonCollider2D,
+    validatePolygonPoints,
+} from './component/polygon-collider-2d';
 
 const NodeMgr = EditorExtends.Node;
 
@@ -277,6 +287,9 @@ export class ComponentService extends BaseService<IComponentEvents> implements I
             this.checkDynamicBodyShape(node);
 
             compMgr.onComponentAddedFromEditor(comp);
+            if (comp instanceof PolygonCollider2D) {
+                await initializePolygonCollider2DPoints(comp);
+            }
             this.emit('node:change', node, { type: NodeEventType.CREATE_COMPONENT });
 
             const dump = dumpUtil.dumpComponent(comp as Component) as IComponent;
@@ -394,6 +407,69 @@ export class ComponentService extends BaseService<IComponentEvents> implements I
             return this.queryImpl({ path: params });
         } else {
             return this.queryImpl(params);
+        }
+    }
+
+    async regeneratePolygon2DPoints(
+        options: IRegeneratePolygon2DPointsOptions,
+    ): Promise<IRegeneratePolygon2DPointsResult> {
+        const path = options.path;
+
+        try {
+            await Service.Editor.lock();
+
+            const component = await this.findComponent(path);
+            const collider = requirePolygonCollider2D(component);
+            const generated = await generatePolygonPoints(collider);
+            validatePolygonPoints(generated.points);
+
+            if (arePolygonPointsEqual(collider.points, generated.points)) {
+                return {
+                    path,
+                    changed: false,
+                    pointCount: generated.points.length,
+                    source: generated.source,
+                };
+            }
+
+            const componentIndex = collider.node.components.indexOf(collider);
+            if (componentIndex < 0) {
+                throw new Error('PolygonCollider2D is no longer attached to its node.');
+            }
+
+            const componentDump = dumpUtil.dumpComponent(collider) as IComponent;
+            const pointsDump = createPolygonPointsPropertyDump(
+                componentDump.value?.points,
+                generated.points,
+            );
+            if (!pointsDump) {
+                throw new Error('Unable to encode PolygonCollider2D.points from the component dump.');
+            }
+
+            const nodePath = NodeMgr.getNodePath(collider.node)
+                || (collider.node === Service.Editor.getRootNode() ? '/' : '');
+            if (!nodePath) {
+                throw new Error('Unable to resolve the PolygonCollider2D node path.');
+            }
+
+            const committed = await this.setProperty({
+                nodePath,
+                path: `__comps__.${componentIndex}.points`,
+                dump: pointsDump,
+                record: options.record,
+            });
+            if (!committed) {
+                throw new Error('Failed to commit PolygonCollider2D.points through ComponentService.setProperty().');
+            }
+
+            return {
+                path,
+                changed: true,
+                pointCount: generated.points.length,
+                source: generated.source,
+            };
+        } finally {
+            Service.Editor.unlock();
         }
     }
 

--- a/src/core/scene/scene-process/service/component.ts
+++ b/src/core/scene/scene-process/service/component.ts
@@ -419,7 +419,7 @@ export class ComponentService extends BaseService<IComponentEvents> implements I
             await Service.Editor.lock();
 
             const component = await this.findComponent(path);
-            const collider = requirePolygonCollider2D(component);
+            const collider = requirePolygonCollider2D(component, path);
             const generated = await generatePolygonPoints(collider);
             validatePolygonPoints(generated.points);
 

--- a/src/core/scene/scene-process/service/component/polygon-collider-2d.ts
+++ b/src/core/scene/scene-process/service/component/polygon-collider-2d.ts
@@ -1,0 +1,270 @@
+import { Component, Physics2DUtils, PolygonCollider2D, Sprite, UITransform, Vec2, js } from 'cc';
+import type { IProperty } from '../../../@types/public';
+import type { Polygon2DPointsSource } from '../../../common/component';
+import type { IExtractedImagePixels } from '../../../../assets/image-processing';
+import { Rpc } from '../../rpc';
+import { traceAlphaContour } from './polygon-collider-2d/contour';
+import { simplifyContour } from './polygon-collider-2d/simplify';
+
+export interface IGeneratePolygonPointsResult {
+    source: Polygon2DPointsSource;
+    points: Vec2[];
+}
+
+const DEFAULT_RECT_SIZE = 100;
+
+/**
+ * 将通用组件收窄为 PolygonCollider2D。
+ */
+export function requirePolygonCollider2D(component: Component | null): PolygonCollider2D {
+    if (!component || !component.isValid) {
+        throw new Error('PolygonCollider2D component was not found or is no longer valid.');
+    }
+
+    if (!(component instanceof PolygonCollider2D)) {
+        const actualType = js.getClassName(component.constructor) || component.constructor?.name || 'unknown';
+        throw new Error(`Expected cc.PolygonCollider2D, but received ${actualType}.`);
+    }
+
+    return component;
+}
+
+/**
+ * 生成候选顶点，不直接修改组件。
+ *
+ * Sprite Alpha 分支异步读取源图片并生成轮廓；无有效 Sprite 来源时回退到节点矩形。
+ */
+export async function generatePolygonPoints(
+    collider: PolygonCollider2D,
+): Promise<IGeneratePolygonPointsResult> {
+    const transform = collider.node.getComponent(UITransform);
+    if (!hasUsableTransform(transform)) {
+        return {
+            source: 'rect-fallback',
+            points: generateRectFallbackPoints(collider),
+        };
+    }
+
+    const sprite = collider.node.getComponent(Sprite);
+    if (sprite?.spriteFrame) {
+        const points = await generateSpriteAlphaPolygonPoints(collider, sprite, transform);
+        if (points) {
+            return {
+                source: 'sprite-alpha',
+                points,
+            };
+        }
+    }
+
+    return {
+        source: 'rect-fallback',
+        points: generateRectFallbackPoints(collider),
+    };
+}
+
+/**
+ * 初始化新添加的 PolygonCollider2D，不参与通用组件新增生命周期。
+ * 生成失败时保留引擎默认 points，避免阻断 Add Component。
+ */
+export async function initializePolygonCollider2DPoints(collider: PolygonCollider2D): Promise<void> {
+    try {
+        const generated = await generatePolygonPoints(collider);
+        validatePolygonPoints(generated.points);
+        collider.points = generated.points;
+    } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        console.warn(
+            `Failed to initialize PolygonCollider2D.points; keeping the engine default points. ${reason}`,
+        );
+    }
+}
+
+/**
+ * 校验提交前的基础几何条件。
+ * 首版只覆盖数量、有限数值和环形相邻重复点；复杂自交校验留给算法阶段。
+ */
+export function validatePolygonPoints(points: readonly Readonly<Vec2>[]): void {
+    if (points.length < 3) {
+        throw new Error(`Polygon requires at least 3 points, but received ${points.length}.`);
+    }
+
+    for (let index = 0; index < points.length; index++) {
+        const point = points[index];
+        if (!Number.isFinite(point.x) || !Number.isFinite(point.y)) {
+            throw new Error(`Polygon point ${index} contains a non-finite coordinate.`);
+        }
+
+        const next = points[(index + 1) % points.length];
+        if (point.x === next.x && point.y === next.y) {
+            throw new Error(`Polygon points ${index} and ${(index + 1) % points.length} are adjacent duplicates.`);
+        }
+    }
+}
+
+/**
+ * 判断候选点是否会实际改变 points，避免产生空 Undo。
+ */
+export function arePolygonPointsEqual(
+    current: readonly Readonly<Vec2>[],
+    candidate: readonly Readonly<Vec2>[],
+): boolean {
+    return current.length === candidate.length && current.every((point, index) => {
+        const other = candidate[index];
+        return point.x === other.x && point.y === other.y;
+    });
+}
+
+/**
+ * 使用现有 points Dump 的元素模板编码候选 Vec2[]。
+ */
+export function createPolygonPointsPropertyDump(
+    pointsProperty: unknown,
+    points: readonly Readonly<Vec2>[],
+): IProperty | null {
+    if (!isProperty(pointsProperty) || !pointsProperty.isArray) {
+        return null;
+    }
+
+    const currentValues = Array.isArray(pointsProperty.value) ? pointsProperty.value : [];
+    const elementTemplate = pointsProperty.elementTypeData ?? currentValues[0];
+    if (!isProperty(elementTemplate)) {
+        return null;
+    }
+
+    const dump = cloneDump(pointsProperty);
+    dump.value = points.map((point, index) => {
+        const item = cloneDump(elementTemplate);
+        item.name = String(index);
+        item.value = { x: point.x, y: point.y };
+        return item;
+    });
+    return dump;
+}
+
+function generateRectFallbackPoints(collider: PolygonCollider2D): Vec2[] {
+    const transform = collider.node.getComponent(UITransform);
+    const usableTransform = hasUsableTransform(transform) ? transform : null;
+    const width = usableTransform?.contentSize.width ?? DEFAULT_RECT_SIZE;
+    const height = usableTransform?.contentSize.height ?? DEFAULT_RECT_SIZE;
+    const anchorX = usableTransform?.anchorX ?? 0.5;
+    const anchorY = usableTransform?.anchorY ?? 0.5;
+
+    const left = -anchorX * width;
+    const right = (1 - anchorX) * width;
+    const bottom = -anchorY * height;
+    const top = (1 - anchorY) * height;
+
+    return [
+        new Vec2(left, bottom),
+        new Vec2(left, top),
+        new Vec2(right, top),
+        new Vec2(right, bottom),
+    ];
+}
+
+async function generateSpriteAlphaPolygonPoints(
+    collider: PolygonCollider2D,
+    sprite: Sprite,
+    transform: UITransform,
+): Promise<Vec2[] | null> {
+    const spriteFrame = sprite.spriteFrame;
+    if (!spriteFrame) {
+        throw new Error('SpriteFrame was removed before PolygonCollider2D points could be generated.');
+    }
+
+    const spriteFrameUuid = (spriteFrame as { _uuid?: string })._uuid;
+    const sourceUuid = spriteFrameUuid?.split('@')[0];
+    if (!sourceUuid) {
+        return null;
+    }
+
+    const rect = spriteFrame.getRect();
+    const frameWidth = rect.width;
+    const frameHeight = rect.height;
+    const rotated = spriteFrame.isRotated();
+    let imagePixels: IExtractedImagePixels | null;
+    try {
+        imagePixels = await Rpc.getInstance().request('assetManager', 'extractImagePixels', [
+            sourceUuid,
+            {
+                rect: {
+                    left: rect.x,
+                    top: rect.y,
+                    width: rotated ? frameHeight : frameWidth,
+                    height: rotated ? frameWidth : frameHeight,
+                },
+                rotation: rotated ? 90 : 0,
+            },
+        ]) as IExtractedImagePixels | null;
+    } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        throw new Error(
+            `Failed to read source image pixels for SpriteFrame "${spriteFrameUuid}" from asset "${sourceUuid}": ${reason}`,
+        );
+    }
+    if (!imagePixels) {
+        return null;
+    }
+
+    const data = decodeImagePixels(imagePixels);
+
+    let points = traceAlphaContour(data, imagePixels.width, imagePixels.height, true);
+    points = simplifyContour(points, collider.threshold);
+
+    if (
+        points.length > 0
+        && points[0].x === points[points.length - 1].x
+        && points[0].y === points[points.length - 1].y
+    ) {
+        points.length -= 1;
+    }
+
+    const width = transform.contentSize.width;
+    const height = transform.contentSize.height;
+    const result = points.map((point) => new Vec2(
+        point.x * width / frameWidth - transform.anchorX * width,
+        (frameHeight - point.y) * height / frameHeight - transform.anchorY * height,
+    ));
+
+    Physics2DUtils.PolygonSeparator.ForceCounterClockWise(result);
+    return result;
+}
+
+function hasUsableTransform(transform: UITransform | null): transform is UITransform {
+    return !!transform && !(
+        transform.contentSize.width === 0
+        && transform.contentSize.height === 0
+    );
+}
+
+function decodeImagePixels(imagePixels: IExtractedImagePixels): Uint8Array {
+    if (
+        !Number.isInteger(imagePixels.width)
+        || imagePixels.width <= 0
+        || !Number.isInteger(imagePixels.height)
+        || imagePixels.height <= 0
+        || imagePixels.channels !== 4
+    ) {
+        throw new Error('Invalid RGBA image metadata returned by the asset image processor.');
+    }
+
+    const binary = atob(imagePixels.dataBase64);
+    const data = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index++) {
+        data[index] = binary.charCodeAt(index);
+    }
+
+    const expectedLength = imagePixels.width * imagePixels.height * imagePixels.channels;
+    if (data.length !== expectedLength) {
+        throw new Error(`Invalid RGBA image data length: expected ${expectedLength}, received ${data.length}.`);
+    }
+    return data;
+}
+
+function isProperty(value: unknown): value is IProperty {
+    return !!value && typeof value === 'object' && 'value' in value;
+}
+
+function cloneDump<T>(value: T): T {
+    return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/src/core/scene/scene-process/service/component/polygon-collider-2d.ts
+++ b/src/core/scene/scene-process/service/component/polygon-collider-2d.ts
@@ -16,14 +16,16 @@ const DEFAULT_RECT_SIZE = 100;
 /**
  * 将通用组件收窄为 PolygonCollider2D。
  */
-export function requirePolygonCollider2D(component: Component | null): PolygonCollider2D {
+export function requirePolygonCollider2D(component: Component | null, path: string): PolygonCollider2D {
     if (!component || !component.isValid) {
-        throw new Error('PolygonCollider2D component was not found or is no longer valid.');
+        throw new Error(`PolygonCollider2D component not found: ${path}`);
     }
 
     if (!(component instanceof PolygonCollider2D)) {
         const actualType = js.getClassName(component.constructor) || component.constructor?.name || 'unknown';
-        throw new Error(`Expected cc.PolygonCollider2D, but received ${actualType}.`);
+        throw new Error(
+            `Parameter error: component is not cc.PolygonCollider2D: ${path} (received ${actualType})`,
+        );
     }
 
     return component;

--- a/src/core/scene/scene-process/service/component/polygon-collider-2d/contour.ts
+++ b/src/core/scene/scene-process/service/component/polygon-collider-2d/contour.ts
@@ -1,0 +1,128 @@
+export interface IContourPoint {
+    x: number;
+    y: number;
+}
+
+enum StepDirection {
+    NONE,
+    UP,
+    LEFT,
+    DOWN,
+    RIGHT,
+}
+
+/**
+ * 提取 RGBA 数据中左上方第一个非透明连通区域的外轮廓。
+ */
+export function traceAlphaContour(
+    data: Uint8Array,
+    width: number,
+    height: number,
+    loop = true,
+): IContourPoint[] {
+    const start = findFirstOpaquePixel(data, width, height);
+    if (!start) {
+        return [];
+    }
+
+    let x = start.x;
+    let y = start.y;
+    let previousStep = StepDirection.NONE;
+    const points: IContourPoint[] = [{ x, y }];
+
+    do {
+        const nextStep = resolveNextStep(data, width, height, x, y, previousStep);
+        previousStep = nextStep;
+
+        switch (nextStep) {
+            case StepDirection.UP:
+                y--;
+                break;
+            case StepDirection.LEFT:
+                x--;
+                break;
+            case StepDirection.DOWN:
+                y++;
+                break;
+            case StepDirection.RIGHT:
+                x++;
+                break;
+            default:
+                return [];
+        }
+
+        if (x >= 0 && x <= width && y >= 0 && y <= height) {
+            points.push({ x, y });
+        }
+    } while (x !== start.x || y !== start.y);
+
+    if (loop) {
+        points.push({ x, y });
+    }
+
+    return points;
+}
+
+function findFirstOpaquePixel(data: Uint8Array, width: number, height: number): IContourPoint | null {
+    let offset = 0;
+    for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++, offset += 4) {
+            if (data[offset + 3] > 0) {
+                return { x, y };
+            }
+        }
+    }
+    return null;
+}
+
+function resolveNextStep(
+    data: Uint8Array,
+    width: number,
+    height: number,
+    x: number,
+    y: number,
+    previousStep: StepDirection,
+): StepDirection {
+    const width4 = width * 4;
+    const index = (y - 1) * width4 + (x - 1) * 4;
+    const canLeft = x > 0;
+    const canRight = x < width;
+    const canDown = y < height;
+    const canUp = y > 0;
+
+    const upLeft = canUp && canLeft && data[index + 3] > 0;
+    const upRight = canUp && canRight && data[index + 7] > 0;
+    const downLeft = canDown && canLeft && data[index + width4 + 3] > 0;
+    const downRight = canDown && canRight && data[index + width4 + 7] > 0;
+
+    let state = 0;
+    if (upLeft) state |= 1;
+    if (upRight) state |= 2;
+    if (downLeft) state |= 4;
+    if (downRight) state |= 8;
+
+    switch (state) {
+        case 1: return StepDirection.UP;
+        case 2:
+        case 3:
+        case 7:
+            return StepDirection.RIGHT;
+        case 4:
+        case 12:
+        case 14:
+            return StepDirection.LEFT;
+        case 5:
+        case 13:
+            return StepDirection.UP;
+        case 6:
+            return previousStep === StepDirection.UP ? StepDirection.LEFT : StepDirection.RIGHT;
+        case 8:
+        case 10:
+        case 11:
+            return StepDirection.DOWN;
+        case 9:
+            return previousStep === StepDirection.RIGHT ? StepDirection.UP : StepDirection.DOWN;
+        default:
+            return StepDirection.NONE;
+    }
+}

--- a/src/core/scene/scene-process/service/component/polygon-collider-2d/simplify.ts
+++ b/src/core/scene/scene-process/service/component/polygon-collider-2d/simplify.ts
@@ -1,0 +1,52 @@
+import type { IContourPoint } from './contour';
+
+/**
+ * 使用与 Creator Editor 相同的 Ramer-Douglas-Peucker 实现简化轮廓。
+ */
+export function simplifyContour(
+    points: readonly IContourPoint[],
+    epsilon: number,
+): IContourPoint[] {
+    if (points.length < 3) {
+        return points.map(clonePoint);
+    }
+
+    const firstPoint = points[0];
+    const lastPoint = points[points.length - 1];
+    let index = -1;
+    let distance = 0;
+
+    for (let i = 1; i < points.length - 1; i++) {
+        const currentDistance = findPerpendicularDistance(points[i], firstPoint, lastPoint);
+        if (currentDistance > distance) {
+            distance = currentDistance;
+            index = i;
+        }
+    }
+
+    if (distance > epsilon && index > 0) {
+        const left = simplifyContour(points.slice(0, index + 1), epsilon);
+        const right = simplifyContour(points.slice(index), epsilon);
+        return left.slice(0, left.length - 1).concat(right);
+    }
+
+    return [clonePoint(firstPoint), clonePoint(lastPoint)];
+}
+
+function findPerpendicularDistance(
+    point: IContourPoint,
+    lineStart: IContourPoint,
+    lineEnd: IContourPoint,
+): number {
+    if (lineStart.x === lineEnd.x) {
+        return Math.abs(point.x - lineStart.x);
+    }
+
+    const slope = (lineEnd.y - lineStart.y) / (lineEnd.x - lineStart.x);
+    const intercept = lineStart.y - slope * lineStart.x;
+    return Math.abs(slope * point.x - point.y + intercept) / Math.sqrt(slope * slope + 1);
+}
+
+function clonePoint(point: IContourPoint): IContourPoint {
+    return { x: point.x, y: point.y };
+}

--- a/src/core/scene/scene-process/service/component/utils.ts
+++ b/src/core/scene/scene-process/service/component/utils.ts
@@ -5,7 +5,6 @@ import {
     SphereCollider,
     BoxCollider,
     UITransformComponent,
-    PolygonCollider2D,
     MeshCollider,
     CapsuleCollider,
     CylinderCollider,
@@ -183,10 +182,6 @@ class ComponentUtils {
             if (radius !== 0) {
                 component.radius = radius;
             }
-        },
-
-        PolygonCollider2D(component: PolygonCollider2D, node: Node) {
-            //TODO: PhysicsUtils.resetPoints(component);
         },
 
         Camera(component: Camera, node: Node) {

--- a/src/core/scene/test/component-proxy-asset-validation.test.ts
+++ b/src/core/scene/test/component-proxy-asset-validation.test.ts
@@ -135,4 +135,24 @@ describe('ComponentProxy Asset validation', () => {
 
         expect(setPropertyRequests()).toHaveLength(0);
     });
+
+    it('forwards PolygonCollider2D regeneration to the scene process', async () => {
+        const expected = {
+            path: '/Canvas/Polygon/cc.PolygonCollider2D',
+            changed: true,
+            pointCount: 8,
+            source: 'sprite-alpha',
+        };
+        mockRequest.mockResolvedValue(expected);
+
+        await expect(ComponentProxy.regeneratePolygon2DPoints({
+            path: '/Canvas/Polygon/cc.PolygonCollider2D',
+            record: false,
+        })).resolves.toEqual(expected);
+
+        expect(mockRequest).toHaveBeenCalledWith('Component', 'regeneratePolygon2DPoints', [{
+            path: '/Canvas/Polygon/cc.PolygonCollider2D',
+            record: false,
+        }]);
+    });
 });

--- a/src/core/scene/test/polygon-collider-2d.test.ts
+++ b/src/core/scene/test/polygon-collider-2d.test.ts
@@ -343,7 +343,9 @@ describe('PolygonCollider2D regeneration helpers', () => {
         const { requirePolygonCollider2D } = polygonModule();
         const wrong = new MockComponent();
 
-        expect(() => requirePolygonCollider2D(null)).toThrow('was not found');
-        expect(() => requirePolygonCollider2D(wrong as any)).toThrow('Expected cc.PolygonCollider2D');
+        expect(() => requirePolygonCollider2D(null, '/PolygonNode/cc.PolygonCollider2D'))
+            .toThrow('PolygonCollider2D component not found');
+        expect(() => requirePolygonCollider2D(wrong as any, '/PolygonNode/cc.Label'))
+            .toThrow('Parameter error: component is not cc.PolygonCollider2D');
     });
 });

--- a/src/core/scene/test/polygon-collider-2d.test.ts
+++ b/src/core/scene/test/polygon-collider-2d.test.ts
@@ -1,0 +1,349 @@
+export {};
+
+const mockAssetRequest = jest.fn();
+
+class MockVec2 {
+    constructor(public x = 0, public y = 0) {}
+}
+
+class MockNode {
+    components: MockComponent[] = [];
+
+    attach<T extends MockComponent>(component: T): T {
+        component.node = this;
+        this.components.push(component);
+        return component;
+    }
+
+    getComponent<T>(type: new (...args: any[]) => T): T | null {
+        return (this.components.find(component => component instanceof type) as T | undefined) ?? null;
+    }
+}
+
+class MockComponent {
+    isValid = true;
+    node!: MockNode;
+}
+
+class MockPolygonCollider2D extends MockComponent {
+    threshold = 1;
+    points = [
+        new MockVec2(-1, -1),
+        new MockVec2(1, -1),
+        new MockVec2(1, 1),
+        new MockVec2(-1, 1),
+    ];
+}
+
+class MockSprite extends MockComponent {
+    spriteFrame: MockSpriteFrame | null = null;
+}
+
+class MockSpriteFrame {
+    _uuid = 'texture-uuid@spriteFrame';
+
+    constructor(
+        private readonly rect = { x: 0, y: 0, width: 2, height: 2 },
+        private readonly rotated = false,
+    ) {}
+
+    getRect() {
+        return this.rect;
+    }
+
+    isRotated() {
+        return this.rotated;
+    }
+}
+
+class MockUITransform extends MockComponent {
+    contentSize = { width: 100, height: 100 };
+    anchorX = 0.5;
+    anchorY = 0.5;
+}
+
+jest.mock('cc', () => ({
+    Component: MockComponent,
+    PolygonCollider2D: MockPolygonCollider2D,
+    Sprite: MockSprite,
+    UITransform: MockUITransform,
+    Vec2: MockVec2,
+    Physics2DUtils: {
+        PolygonSeparator: {
+            ForceCounterClockWise: jest.fn(),
+        },
+    },
+    js: {
+        getClassName: (ctor: { name?: string }) => ctor?.name || '',
+    },
+}));
+
+jest.mock('../scene-process/rpc', () => ({
+    Rpc: {
+        getInstance: () => ({ request: mockAssetRequest }),
+    },
+}));
+
+const polygonModule = () => require('../scene-process/service/component/polygon-collider-2d') as typeof import('../scene-process/service/component/polygon-collider-2d');
+
+describe('PolygonCollider2D regeneration helpers', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockAssetRequest.mockReset();
+    });
+
+    it('uses UITransform size and anchor for the rectangle fallback', async () => {
+        const node = new MockNode();
+        const transform = node.attach(new MockUITransform());
+        transform.contentSize = { width: 200, height: 80 };
+        transform.anchorX = 0.25;
+        transform.anchorY = 0.75;
+        const collider = node.attach(new MockPolygonCollider2D());
+
+        const result = await polygonModule().generatePolygonPoints(collider as any);
+
+        expect(result).toEqual({
+            source: 'rect-fallback',
+            points: [
+                { x: -50, y: -60 },
+                { x: -50, y: 20 },
+                { x: 150, y: 20 },
+                { x: 150, y: -60 },
+            ],
+        });
+    });
+
+    it('uses a centered 100x100 rectangle when UITransform is absent', async () => {
+        const node = new MockNode();
+        const collider = node.attach(new MockPolygonCollider2D());
+
+        const result = await polygonModule().generatePolygonPoints(collider as any);
+
+        expect(result).toMatchObject({
+            source: 'rect-fallback',
+            points: [
+                { x: -50, y: -50 },
+                { x: -50, y: 50 },
+                { x: 50, y: 50 },
+                { x: 50, y: -50 },
+            ],
+        });
+    });
+
+    it('initializes a newly added collider with generated points', async () => {
+        const node = new MockNode();
+        const transform = node.attach(new MockUITransform());
+        transform.contentSize = { width: 40, height: 20 };
+        const collider = node.attach(new MockPolygonCollider2D());
+
+        await polygonModule().initializePolygonCollider2DPoints(collider as any);
+
+        expect(collider.points).toEqual([
+            { x: -20, y: -10 },
+            { x: -20, y: 10 },
+            { x: 20, y: 10 },
+            { x: 20, y: -10 },
+        ]);
+    });
+
+    it('keeps engine defaults when add-time point generation fails', async () => {
+        const node = new MockNode();
+        node.attach(new MockUITransform());
+        const sprite = node.attach(new MockSprite());
+        sprite.spriteFrame = new MockSpriteFrame();
+        const collider = node.attach(new MockPolygonCollider2D());
+        const originalPoints = collider.points;
+        mockAssetRequest.mockRejectedValue(new Error('decode failed'));
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        await expect(polygonModule().initializePolygonCollider2DPoints(collider as any)).resolves.toBeUndefined();
+
+        expect(collider.points).toBe(originalPoints);
+        expect(warn).toHaveBeenCalledWith(
+            expect.stringContaining('keeping the engine default points'),
+        );
+        warn.mockRestore();
+    });
+
+    it('generates Sprite Alpha points through the Node image RPC without changing the component directly', async () => {
+        const node = new MockNode();
+        const transform = node.attach(new MockUITransform());
+        transform.contentSize = { width: 200, height: 100 };
+        transform.anchorX = 0.25;
+        transform.anchorY = 0.75;
+        const sprite = node.attach(new MockSprite());
+        sprite.spriteFrame = new MockSpriteFrame({ x: 10, y: 20, width: 2, height: 2 });
+        const collider = node.attach(new MockPolygonCollider2D());
+        collider.threshold = 0;
+        const oldPoints = collider.points.slice();
+
+        const rgba = new Uint8Array(2 * 2 * 4);
+        for (let index = 3; index < rgba.length; index += 4) {
+            rgba[index] = 255;
+        }
+        mockAssetRequest.mockResolvedValue({
+            dataBase64: Buffer.from(rgba).toString('base64'),
+            width: 2,
+            height: 2,
+            channels: 4,
+        });
+
+        const result = await polygonModule().generatePolygonPoints(collider as any);
+
+        expect(result.source).toBe('sprite-alpha');
+        expect(result.points.length).toBeGreaterThanOrEqual(3);
+        expect(mockAssetRequest).toHaveBeenCalledWith('assetManager', 'extractImagePixels', [
+            'texture-uuid',
+            {
+                rect: { left: 10, top: 20, width: 2, height: 2 },
+                rotation: 0,
+            },
+        ]);
+        expect(collider.points).toEqual(oldPoints);
+    });
+
+    it('keeps the Editor Marching Squares and RDP behavior in pure helpers', () => {
+        const { traceAlphaContour } = require('../scene-process/service/component/polygon-collider-2d/contour');
+        const { simplifyContour } = require('../scene-process/service/component/polygon-collider-2d/simplify');
+        const rgba = new Uint8Array(2 * 2 * 4);
+        for (let index = 3; index < rgba.length; index += 4) {
+            rgba[index] = 255;
+        }
+
+        const contour = traceAlphaContour(rgba, 2, 2, true);
+        const simplified = simplifyContour(contour, 0);
+
+        expect(contour[0]).toEqual(contour[contour.length - 1]);
+        expect(simplified.length).toBeGreaterThanOrEqual(4);
+    });
+
+    it('swaps the extraction size and rotates packed SpriteFrames', async () => {
+        const node = new MockNode();
+        node.attach(new MockUITransform());
+        const sprite = node.attach(new MockSprite());
+        sprite.spriteFrame = new MockSpriteFrame({ x: 3, y: 4, width: 2, height: 3 }, true);
+        const collider = node.attach(new MockPolygonCollider2D());
+        collider.threshold = 0;
+
+        const rgba = new Uint8Array(2 * 3 * 4);
+        for (let index = 3; index < rgba.length; index += 4) {
+            rgba[index] = 255;
+        }
+        mockAssetRequest.mockResolvedValue({
+            dataBase64: Buffer.from(rgba).toString('base64'),
+            width: 2,
+            height: 3,
+            channels: 4,
+        });
+
+        const result = await polygonModule().generatePolygonPoints(collider as any);
+
+        expect(result.source).toBe('sprite-alpha');
+        expect(mockAssetRequest).toHaveBeenCalledWith('assetManager', 'extractImagePixels', [
+            'texture-uuid',
+            {
+                rect: { left: 3, top: 4, width: 3, height: 2 },
+                rotation: 90,
+            },
+        ]);
+    });
+
+    it('falls back to the UITransform rectangle when the SpriteFrame source asset cannot be resolved', async () => {
+        const node = new MockNode();
+        node.attach(new MockUITransform());
+        const sprite = node.attach(new MockSprite());
+        sprite.spriteFrame = new MockSpriteFrame();
+        const collider = node.attach(new MockPolygonCollider2D());
+        const originalPoints = collider.points;
+        mockAssetRequest.mockResolvedValue(null);
+
+        await expect(polygonModule().generatePolygonPoints(collider as any)).resolves.toEqual({
+            source: 'rect-fallback',
+            points: [
+                { x: -50, y: -50 },
+                { x: -50, y: 50 },
+                { x: 50, y: 50 },
+                { x: 50, y: -50 },
+            ],
+        });
+
+        expect(collider.points).toBe(originalPoints);
+    });
+
+    it('adds SpriteFrame and source asset context when image extraction fails', async () => {
+        const node = new MockNode();
+        node.attach(new MockUITransform());
+        const sprite = node.attach(new MockSprite());
+        sprite.spriteFrame = new MockSpriteFrame();
+        const collider = node.attach(new MockPolygonCollider2D());
+        const originalPoints = collider.points;
+        mockAssetRequest.mockRejectedValue(new Error('decode failed'));
+
+        await expect(polygonModule().generatePolygonPoints(collider as any))
+            .rejects.toThrow(
+                'Failed to read source image pixels for SpriteFrame "texture-uuid@spriteFrame" from asset "texture-uuid": decode failed',
+            );
+
+        expect(collider.points).toBe(originalPoints);
+    });
+
+    it('validates point count, finite coordinates and cyclic adjacent duplicates', () => {
+        const { validatePolygonPoints } = polygonModule();
+
+        expect(() => validatePolygonPoints([new MockVec2(), new MockVec2(1, 0)] as any))
+            .toThrow('at least 3 points');
+        expect(() => validatePolygonPoints([
+            new MockVec2(0, 0),
+            new MockVec2(Number.NaN, 0),
+            new MockVec2(0, 1),
+        ] as any)).toThrow('non-finite coordinate');
+        expect(() => validatePolygonPoints([
+            new MockVec2(0, 0),
+            new MockVec2(1, 0),
+            new MockVec2(0, 0),
+        ] as any)).toThrow('adjacent duplicates');
+        expect(() => validatePolygonPoints([
+            new MockVec2(0, 0),
+            new MockVec2(1, 0),
+            new MockVec2(0, 1),
+        ] as any)).not.toThrow();
+    });
+
+    it('encodes candidate Vec2 values with the existing points element template', () => {
+        const { createPolygonPointsPropertyDump } = polygonModule();
+        const property = {
+            name: 'points',
+            path: '',
+            type: 'cc.Vec2',
+            isArray: true,
+            elementTypeData: {
+                name: '',
+                path: '',
+                type: 'cc.Vec2',
+                value: { x: 0, y: 0 },
+            },
+            value: [],
+        };
+
+        const result = createPolygonPointsPropertyDump(property, [
+            new MockVec2(-2, 3),
+            new MockVec2(4, 5),
+            new MockVec2(6, -7),
+        ] as any);
+
+        expect(result?.value).toEqual([
+            expect.objectContaining({ name: '0', type: 'cc.Vec2', value: { x: -2, y: 3 } }),
+            expect.objectContaining({ name: '1', type: 'cc.Vec2', value: { x: 4, y: 5 } }),
+            expect.objectContaining({ name: '2', type: 'cc.Vec2', value: { x: 6, y: -7 } }),
+        ]);
+        expect(property.value).toEqual([]);
+    });
+
+    it('distinguishes missing and wrong component types', () => {
+        const { requirePolygonCollider2D } = polygonModule();
+        const wrong = new MockComponent();
+
+        expect(() => requirePolygonCollider2D(null)).toThrow('was not found');
+        expect(() => requirePolygonCollider2D(wrong as any)).toThrow('Expected cc.PolygonCollider2D');
+    });
+});

--- a/src/core/scene/test/service-core/component-prefab-ui-handling.test.ts
+++ b/src/core/scene/test/service-core/component-prefab-ui-handling.test.ts
@@ -2,20 +2,63 @@ const mockLock = jest.fn(async () => undefined);
 const mockUnlock = jest.fn();
 const mockGetRootNode = jest.fn();
 const mockGetNodeByPath = jest.fn();
+const mockGetNodePath = jest.fn();
 const mockCreateShouldHideInHierarchyCanvasNode = jest.fn();
 const mockOnComponentAddedFromEditor = jest.fn();
+const mockQueryFromPath = jest.fn();
 const mockDumpComponent = jest.fn(() => ({ value: {} }));
 const mockCaptureMany = jest.fn(() => null);
 const mockGetClassById = jest.fn(() => null);
-const mockGetClassByName = jest.fn((name: string) => name === 'cc.UITransform' ? MockUITransform : null);
+const mockGetClassByName = jest.fn((name: string): any => {
+    if (name === 'cc.UITransform') {
+        return MockUITransform;
+    }
+    if (name === 'cc.PolygonCollider2D') {
+        return MockPolygonCollider2D;
+    }
+    return null;
+});
 const mockIsChildClassOf = jest.fn(() => true);
+const mockAssetRequest = jest.fn();
 const mockScene = { name: 'Scene' };
 
 class MockCanvas {}
 class MockComponent {
     uuid = `component-${Math.random()}`;
+    isValid = true;
+    node!: MockNode;
 }
-class MockUITransform extends MockComponent {}
+class MockUITransform extends MockComponent {
+    contentSize = { width: 100, height: 100 };
+    anchorX = 0.5;
+    anchorY = 0.5;
+}
+class MockVec2 {
+    constructor(public x = 0, public y = 0) {}
+}
+class MockSprite extends MockComponent {
+    spriteFrame: MockSpriteFrame | null = null;
+}
+class MockSpriteFrame {
+    _uuid = 'texture-uuid@spriteFrame';
+
+    getRect() {
+        return { x: 0, y: 0, width: 2, height: 2 };
+    }
+
+    isRotated() {
+        return false;
+    }
+}
+class MockPolygonCollider2D extends MockComponent {
+    threshold = 1;
+    points = [
+        new MockVec2(-1, -1),
+        new MockVec2(1, -1),
+        new MockVec2(1, 1),
+        new MockVec2(-1, 1),
+    ];
+}
 
 class MockNode {
     uuid: string;
@@ -25,6 +68,7 @@ class MockNode {
     components: any[] = [];
     addComponent = jest.fn((component: any) => {
         const instance = component === 'cc.UITransform' ? new MockUITransform() : new component();
+        instance.node = this;
         this.components.push(instance);
         return instance;
     });
@@ -47,6 +91,7 @@ class MockNode {
 (global as any).EditorExtends = {
     Node: {
         getNodeByPath: mockGetNodeByPath,
+        getNodePath: mockGetNodePath,
     },
 };
 
@@ -62,12 +107,21 @@ jest.mock('cc', () => ({
     EColliderType: {},
     MeshCollider: class MeshCollider {},
     Node: MockNode,
+    PolygonCollider2D: MockPolygonCollider2D,
     RigidBody: class RigidBody {},
     Scene: class Scene {},
+    Sprite: MockSprite,
     UITransform: MockUITransform,
+    Vec2: MockVec2,
+    Physics2DUtils: {
+        PolygonSeparator: {
+            ForceCounterClockWise: jest.fn(),
+        },
+    },
     js: {
         getClassById: mockGetClassById,
         getClassByName: mockGetClassByName,
+        getClassName: (ctor: { name?: string }) => ctor?.name || '',
         isChildClassOf: mockIsChildClassOf,
     },
 }));
@@ -95,17 +149,23 @@ jest.mock('../../scene-process/service/core', () => ({
 }));
 
 jest.mock('../../scene-process/rpc', () => ({
-    Rpc: { getInstance: () => ({ request: jest.fn() }) },
+    Rpc: { getInstance: () => ({ request: mockAssetRequest }) },
 }));
 
 jest.mock('../../scene-process/service/dump', () => ({
     __esModule: true,
-    default: { dumpComponent: mockDumpComponent },
+    default: {
+        dumpComponent: mockDumpComponent,
+        restoreProperty: jest.fn(async () => undefined),
+    },
 }));
 
 jest.mock('../../scene-process/service/component/index', () => ({
     __esModule: true,
-    default: { onComponentAddedFromEditor: mockOnComponentAddedFromEditor },
+    default: {
+        onComponentAddedFromEditor: mockOnComponentAddedFromEditor,
+        queryFromPath: mockQueryFromPath,
+    },
 }));
 
 jest.mock('../../scene-process/service/component/utils', () => ({
@@ -165,7 +225,9 @@ describe('ComponentService prefab UI handling', () => {
         root.parent = new MockNode('Scene');
         mockGetRootNode.mockReturnValue(root);
         mockGetNodeByPath.mockReturnValue(new MockNode('Target'));
+        mockGetNodePath.mockReturnValue('/Target');
         mockCreateShouldHideInHierarchyCanvasNode.mockResolvedValue(new MockNode('PreviewCanvas'));
+        mockAssetRequest.mockReset();
     });
 
     async function addUITransform(params: Record<string, unknown> = {}) {
@@ -189,6 +251,40 @@ describe('ComponentService prefab UI handling', () => {
         expect(mockCreateShouldHideInHierarchyCanvasNode).toHaveBeenCalledWith(mockScene);
         expect(root.parent?.name).toBe('PreviewCanvas');
         expect(mockOnComponentAddedFromEditor).toHaveBeenCalledTimes(1);
+    });
+
+    it('notifies component creation before waiting for PolygonCollider2D points, but delays dumping', async () => {
+        const target = new MockNode('Target');
+        target.addComponent(MockUITransform);
+        const sprite = target.addComponent(MockSprite) as MockSprite;
+        sprite.spriteFrame = new MockSpriteFrame();
+        mockGetNodeByPath.mockReturnValue(target);
+        let rejectImageExtraction!: (reason: Error) => void;
+        mockAssetRequest.mockImplementationOnce(() => new Promise((_resolve, reject) => {
+            rejectImageExtraction = reject;
+        }));
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const { ComponentService } = require('../../scene-process/service/component');
+        const service = new ComponentService();
+        const adding = service.add({
+            nodePath: '/Target',
+            component: 'cc.PolygonCollider2D',
+        });
+
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        expect(mockAssetRequest).toHaveBeenCalled();
+        expect(mockOnComponentAddedFromEditor).toHaveBeenCalledWith(expect.any(MockPolygonCollider2D));
+        expect(mockDumpComponent).not.toHaveBeenCalled();
+        expect(mockCaptureMany).not.toHaveBeenCalled();
+
+        rejectImageExtraction(new Error('decode failed'));
+        await expect(adding).resolves.toBeDefined();
+
+        expect(mockOnComponentAddedFromEditor).toHaveBeenCalledTimes(1);
+        expect(mockDumpComponent).toHaveBeenCalledTimes(1);
+        expect(mockCaptureMany).toHaveBeenCalledTimes(1);
+        warn.mockRestore();
     });
 
     it('does not create a hidden Canvas when the prefab root already has Canvas', async () => {
@@ -216,5 +312,122 @@ describe('ComponentService prefab UI handling', () => {
 
         expect(mockCreateShouldHideInHierarchyCanvasNode).toHaveBeenCalledTimes(2);
         expect(root.addComponent).not.toHaveBeenCalledWith('cc.UITransform');
+    });
+
+    describe('PolygonCollider2D regeneration', () => {
+        function createColliderFixture() {
+            const node = new MockNode('PolygonNode');
+            const transform = new MockUITransform();
+            transform.node = node;
+            transform.contentSize = { width: 200, height: 80 };
+            transform.anchorX = 0.25;
+            transform.anchorY = 0.75;
+            const collider = new MockPolygonCollider2D();
+            collider.node = node;
+            node.components.push(transform, collider);
+            return { node, collider };
+        }
+
+        it('commits the generated points through the real component index and setProperty', async () => {
+            const { node, collider } = createColliderFixture();
+            mockQueryFromPath.mockReturnValue(collider);
+            mockGetNodePath.mockReturnValue('/PolygonNode');
+            mockDumpComponent.mockReturnValue({
+                value: {
+                    points: {
+                        name: 'points',
+                        path: '',
+                        type: 'cc.Vec2',
+                        isArray: true,
+                        elementTypeData: {
+                            name: '',
+                            path: '',
+                            type: 'cc.Vec2',
+                            value: { x: 0, y: 0 },
+                        },
+                        value: [],
+                    },
+                },
+            });
+
+            const { ComponentService } = require('../../scene-process/service/component');
+            const service = new ComponentService();
+            const setProperty = jest.spyOn(service, 'setProperty').mockResolvedValue(true);
+
+            const result = await service.regeneratePolygon2DPoints({
+                path: '/PolygonNode/cc.PolygonCollider2D',
+                record: false,
+            });
+
+            expect(result).toEqual({
+                path: '/PolygonNode/cc.PolygonCollider2D',
+                changed: true,
+                pointCount: 4,
+                source: 'rect-fallback',
+            });
+            expect(setProperty).toHaveBeenCalledWith(expect.objectContaining({
+                nodePath: '/PolygonNode',
+                path: '__comps__.1.points',
+                record: false,
+                dump: expect.objectContaining({
+                    value: [
+                        expect.objectContaining({ value: { x: -50, y: -60 } }),
+                        expect.objectContaining({ value: { x: -50, y: 20 } }),
+                        expect.objectContaining({ value: { x: 150, y: 20 } }),
+                        expect.objectContaining({ value: { x: 150, y: -60 } }),
+                    ],
+                }),
+            }));
+            expect(node.components.indexOf(collider)).toBe(1);
+            expect(mockLock).toHaveBeenCalled();
+            expect(mockUnlock).toHaveBeenCalled();
+        });
+
+        it('does not call setProperty when the generated rectangle is unchanged', async () => {
+            const { collider } = createColliderFixture();
+            const transform = collider.node.components[0] as MockUITransform;
+            transform.contentSize = { width: 2, height: 2 };
+            transform.anchorX = 0.5;
+            transform.anchorY = 0.5;
+            collider.points = [
+                new MockVec2(-1, -1),
+                new MockVec2(-1, 1),
+                new MockVec2(1, 1),
+                new MockVec2(1, -1),
+            ];
+            mockQueryFromPath.mockReturnValue(collider);
+
+            const { ComponentService } = require('../../scene-process/service/component');
+            const service = new ComponentService();
+            const setProperty = jest.spyOn(service, 'setProperty').mockResolvedValue(true);
+
+            const result = await service.regeneratePolygon2DPoints({
+                path: '/PolygonNode/cc.PolygonCollider2D',
+            });
+
+            expect(result).toMatchObject({ changed: false, pointCount: 4 });
+            expect(setProperty).not.toHaveBeenCalled();
+        });
+
+        it('propagates generation errors and still releases the editor lock', async () => {
+            const { node, collider } = createColliderFixture();
+            const sprite = new MockSprite();
+            sprite.node = node;
+            sprite.spriteFrame = new MockSpriteFrame();
+            node.components.splice(1, 0, sprite);
+            mockQueryFromPath.mockReturnValue(collider);
+            mockAssetRequest.mockRejectedValue(new Error('decode failed'));
+
+            const { ComponentService } = require('../../scene-process/service/component');
+            const service = new ComponentService();
+            const setProperty = jest.spyOn(service, 'setProperty').mockResolvedValue(true);
+
+            await expect(service.regeneratePolygon2DPoints({
+                path: '/PolygonNode/cc.PolygonCollider2D',
+            })).rejects.toThrow('decode failed');
+
+            expect(setProperty).not.toHaveBeenCalled();
+            expect(mockUnlock).toHaveBeenCalled();
+        });
     });
 });

--- a/tests/component-polygon-regenerate-api.test.ts
+++ b/tests/component-polygon-regenerate-api.test.ts
@@ -1,0 +1,110 @@
+const mockRegeneratePolygon2DPoints = jest.fn();
+
+jest.mock('../src/api/decorator/decorator.js', () => ({
+    description: () => jest.fn(),
+    param: () => jest.fn(),
+    result: () => jest.fn(),
+    title: () => jest.fn(),
+    tool: () => jest.fn(),
+}), { virtual: true });
+
+jest.mock('../src/core/scene', () => ({
+    Scene: {
+        Component: {
+            regeneratePolygon2DPoints: (...args: unknown[]) => mockRegeneratePolygon2DPoints(...args),
+        },
+    },
+}));
+
+import { ComponentApi } from '../src/api/scene/component';
+import {
+    SchemaRegeneratePolygon2DPointsOptions,
+    SchemaRegeneratePolygon2DPointsResult,
+} from '../src/api/scene/component-schema';
+import { HTTP_STATUS } from '../src/api/base/schema-base';
+
+describe('PolygonCollider2D regeneration MCP API', () => {
+    beforeEach(() => {
+        mockRegeneratePolygon2DPoints.mockReset();
+    });
+
+    it('validates the dedicated input and result schemas', () => {
+        expect(SchemaRegeneratePolygon2DPointsOptions.parse({
+            path: 'Canvas/Polygon/cc.PolygonCollider2D',
+            record: false,
+        })).toEqual({
+            path: 'Canvas/Polygon/cc.PolygonCollider2D',
+            record: false,
+        });
+        expect(() => SchemaRegeneratePolygon2DPointsOptions.parse({ path: '' })).toThrow();
+
+        expect(SchemaRegeneratePolygon2DPointsResult.parse({
+            path: 'Canvas/Polygon/cc.PolygonCollider2D',
+            changed: true,
+            pointCount: 4,
+            source: 'rect-fallback',
+        })).toEqual({
+            path: 'Canvas/Polygon/cc.PolygonCollider2D',
+            changed: true,
+            pointCount: 4,
+            source: 'rect-fallback',
+        });
+        expect(() => SchemaRegeneratePolygon2DPointsResult.parse({
+            path: 'Canvas/Polygon/cc.PolygonCollider2D',
+            changed: true,
+            pointCount: 2,
+            source: 'unknown',
+        })).toThrow();
+    });
+
+    it('forwards to the public scene API and returns the regeneration result', async () => {
+        const options = { path: 'Canvas/Polygon/cc.PolygonCollider2D', record: false };
+        const regenerationResult = {
+            path: options.path,
+            changed: true,
+            pointCount: 8,
+            source: 'sprite-alpha' as const,
+        };
+        mockRegeneratePolygon2DPoints.mockResolvedValue(regenerationResult);
+
+        const result = await new ComponentApi().regeneratePolygon2DPoints(options);
+
+        expect(mockRegeneratePolygon2DPoints).toHaveBeenCalledWith(options);
+        expect(result).toEqual({ code: HTTP_STATUS.OK, data: regenerationResult });
+    });
+
+    it('maps an invalid component type to 400', async () => {
+        mockRegeneratePolygon2DPoints.mockRejectedValue(
+            new Error('Parameter error: component is not cc.PolygonCollider2D: Canvas/Polygon/cc.Label'),
+        );
+
+        const result = await new ComponentApi().regeneratePolygon2DPoints({
+            path: 'Canvas/Polygon/cc.Label',
+        });
+
+        expect(result.code).toBe(HTTP_STATUS.BAD_REQUEST);
+        expect(result.reason).toContain('component is not cc.PolygonCollider2D');
+    });
+
+    it('maps a missing component to 404', async () => {
+        mockRegeneratePolygon2DPoints.mockRejectedValue(
+            new Error('PolygonCollider2D component not found: Canvas/Polygon/cc.PolygonCollider2D'),
+        );
+
+        const result = await new ComponentApi().regeneratePolygon2DPoints({
+            path: 'Canvas/Polygon/cc.PolygonCollider2D',
+        });
+
+        expect(result.code).toBe(HTTP_STATUS.NOT_FOUND);
+    });
+
+    it('maps image processing failures to 500', async () => {
+        mockRegeneratePolygon2DPoints.mockRejectedValue(new Error('Failed to read source image pixels'));
+
+        const result = await new ComponentApi().regeneratePolygon2DPoints({
+            path: 'Canvas/Polygon/cc.PolygonCollider2D',
+        });
+
+        expect(result.code).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR);
+    });
+});


### PR DESCRIPTION
## Summary
Adds Creator-compatible PolygonCollider2D point regeneration to the public Scene API and exposes the same capability through MCP.
When a usable Sprite exists, the implementation generates points from its alpha contour. Otherwise, it falls back to an anchor-aware UITransform rectangle. Explicit regeneration supports Undo, skips no-op writes, and leaves existing points unchanged when generation fails.
## Changes
- src/core/assets/image-processing.ts, src/core/assets/manager/asset.ts: add Node-side Sharp pixel extraction over RPC, keeping native image processing out of the Scene Runtime.
- Polygon generation helpers:
  - Trace the Sprite alpha contour and simplify it with RDP.
  - Handle rotated packed SpriteFrames.
  - Convert pixels into anchored node-local coordinates.
  - Normalize polygon winding to counterclockwise.
  - Fall back to UITransform bounds or a centered 100 × 100 rectangle.
- ComponentService:
  - Add regeneratePolygon2DPoints().
  - Validate points before mutation.
  - Commit through setProperty() for Undo support.
  - Skip writes and empty Undo records when points are unchanged.
  - Initialize newly added PolygonCollider2D components automatically without blocking Add Component on failure.
- Public Scene types and proxy:
  - Add regeneration options, result, and source types.
  - Expose Scene.Component.regeneratePolygon2DPoints().
  - Update the generated DTS snapshot.
- MCP:
  - Add scene-regenerate-polygon-2d-points.
  - Return { path, changed, pointCount, source }.
  - Distinguish invalid component types (400), missing components (404), and processing failures (500).
## Tests
- Node-side Sharp extraction and argument validation.
- Alpha contour tracing, RDP simplification, rotated SpriteFrames, coordinate conversion, rectangle fallback, winding, and point validation.
- Fresh-add initialization, failure protection, Undo-aware property commits, no-op detection, and editor-lock release.
- Scene proxy forwarding and MCP schema/error mapping.
- MCP Component E2E coverage for successful regeneration and invalid component rejection.
- Public DTS snapshot coverage.