### PR TITLE
[feat] Align browser preview toolbar with Creator

### DIFF
--- a/src/core/launcher.ts
+++ b/src/core/launcher.ts
@@ -6,6 +6,7 @@ import { startServer, getServerUrl } from '../server';
 import { GlobalConfig, GlobalPaths } from '../global';
 import scripting from './scripting';
 import { startupScene } from './scene';
+import { getExternalGamePreviewUrl } from './preview/game-preview-url';
 
 interface IPreviewStartOptions {
     port?: number;
@@ -150,7 +151,7 @@ export default class Launcher {
         await registerBrowserPreview(this.projectPath);
 
         const serverUrl = getServerUrl();
-        const url = options.scene ? `${serverUrl}/?scene=${encodeURIComponent(options.scene)}` : serverUrl;
+        const url = getExternalGamePreviewUrl(serverUrl, options.scene);
         console.log(`Game preview: ${url}`);
         await this.printPreviewScenes(serverUrl, options.scene);
         if (options.open !== false) {

--- a/src/core/preview/game-preview-url.ts
+++ b/src/core/preview/game-preview-url.ts
@@ -1,0 +1,12 @@
+/**
+ * Build the URL opened by the CLI's external game preview entry.
+ * Unflagged URLs remain available to lightweight embedded preview consumers.
+ */
+export function getExternalGamePreviewUrl(serverUrl: string, scene?: string): string {
+    const url = new URL(serverUrl);
+    if (scene) {
+        url.searchParams.set('scene', scene);
+    }
+    url.searchParams.set('previewToolbar', '1');
+    return url.toString();
+}

--- a/src/core/preview/game-preview.middleware.ts
+++ b/src/core/preview/game-preview.middleware.ts
@@ -7,6 +7,7 @@ import { GlobalPaths } from '../../global';
 import { scriptingRoutes } from './scripting-routes';
 import { getCachedPreviewSettings, PreviewNotReadyError } from './preview-settings';
 import { notePreviewNotReady } from './live-reload';
+import { getPreviewToolbarOptions, setPreviewToolbarOption } from './preview-toolbar-options';
 
 /**
  * 各资源数据库的 library（已导入数据）目录缓存。
@@ -195,6 +196,7 @@ export default {
                         serverURL: serverBaseUrl,
                         settingsJs: `/preview/settings.js${sceneQuery}`,
                         sceneQuery,
+                        previewToolbarOptions: getPreviewToolbarOptions(),
                     };
                     const templatePath = join(GlobalPaths.workspace, 'static', 'web', 'game.ejs');
                     const html = await ejs.renderFile(templatePath, renderData);
@@ -214,7 +216,13 @@ export default {
     post: [],
     staticFiles: [],
     socket: {
-        connection: (_socket: any) => { },
+        connection: (socket: any) => {
+            // 对齐 Creator preview-app：工具栏通过同一个 socket 上报 changeOption，
+            // 服务端保存会话状态，下一次页面渲染时重新注入。
+            socket.on?.('changeOption', (name: unknown, value: unknown) => {
+                setPreviewToolbarOption(name, value);
+            });
+        },
         disconnect: (_socket: any) => { },
     },
 } as IMiddlewareContribution;

--- a/src/core/preview/game-preview.middleware.ts
+++ b/src/core/preview/game-preview.middleware.ts
@@ -8,6 +8,7 @@ import { scriptingRoutes } from './scripting-routes';
 import { getCachedPreviewSettings, PreviewNotReadyError } from './preview-settings';
 import { notePreviewNotReady } from './live-reload';
 import { getPreviewToolbarOptions, setPreviewToolbarOption } from './preview-toolbar-options';
+import i18n from '../base/i18n';
 
 /**
  * 各资源数据库的 library（已导入数据）目录缓存。
@@ -197,6 +198,16 @@ export default {
                         settingsJs: `/preview/settings.js${sceneQuery}`,
                         sceneQuery,
                         previewToolbarOptions: getPreviewToolbarOptions(),
+                        // Keep the preview page aligned with Creator: localize device-mode names on the
+                        // server, then inject the resolved values into the browser page. The toolbar
+                        // itself does not need a second client-side i18n runtime.
+                        previewToolbarI18n: {
+                            device: {
+                                designResolution: i18n.t('common.preview.device.design_resolution'),
+                                fullScreen: i18n.t('common.preview.device.full_screen'),
+                                webpageFullScreen: i18n.t('common.preview.device.webpage_full_screen'),
+                            },
+                        },
                     };
                     const templatePath = join(GlobalPaths.workspace, 'static', 'web', 'game.ejs');
                     const html = await ejs.renderFile(templatePath, renderData);

--- a/src/core/preview/preview-toolbar-options.ts
+++ b/src/core/preview/preview-toolbar-options.ts
@@ -1,0 +1,100 @@
+/**
+ * 浏览器预览工具栏的会话状态。
+ *
+ * Creator 通过预览页 socket 的 `changeOption` 事件保存这些选项，并在刷新后的
+ * HTML 中再次注入。这里保持同样的「CLI 进程内预览会话」范围：不写入工程配置，
+ * 不影响没有启用 previewToolbar 的普通预览。
+ */
+export type PreviewToolbarOptionName = 'device' | 'rotate' | 'debugMode' | 'showFps';
+
+export interface PreviewToolbarOptions {
+    device: string;
+    rotate: boolean;
+    debugMode: string;
+    showFps: boolean;
+}
+
+const defaultOptions: Readonly<PreviewToolbarOptions> = {
+    device: 'design',
+    rotate: false,
+    debugMode: 'WARN',
+    showFps: true,
+};
+
+const deviceIds = new Set([
+    'design',
+    'webpage-fullscreen',
+    'iphone-14-pro',
+    'iphone-14-plus',
+    'iphone-14',
+    'iphone-x',
+    'iphone-xr',
+    'ipad-10-2',
+    'ipad-air',
+    'ipad-pro',
+    'oppo-reno-2',
+    'huawei-nova-5',
+    'honor-x8',
+    'huawei-nova-8i',
+    'huawei-mate-40-pro',
+    'huawei-mate-30-pro',
+    'xiaomi-redmi-8',
+    'sony-xperia-5',
+    'oppo-a77',
+    'nokia-c2',
+    'asus-rog-phone-6',
+    'lenovo-legion-2-pro',
+]);
+
+const debugModes = new Set([
+    'NONE',
+    'VERBOSE',
+    'INFO',
+    'WARN',
+    'ERROR',
+    'INFO_FOR_WEB_PAGE',
+    'WARN_FOR_WEB_PAGE',
+    'ERROR_FOR_WEB_PAGE',
+]);
+
+let options: PreviewToolbarOptions = { ...defaultOptions };
+
+export function getPreviewToolbarOptions(): PreviewToolbarOptions {
+    return { ...options };
+}
+
+export function setPreviewToolbarOption(name: unknown, value: unknown): boolean {
+    switch (name) {
+    case 'device':
+        if (typeof value === 'string' && deviceIds.has(value)) {
+            options.device = value;
+            return true;
+        }
+        return false;
+    case 'rotate':
+        if (typeof value === 'boolean') {
+            options.rotate = value;
+            return true;
+        }
+        return false;
+    case 'debugMode':
+        if (typeof value === 'string' && debugModes.has(value)) {
+            options.debugMode = value;
+            return true;
+        }
+        return false;
+    case 'showFps':
+        if (typeof value === 'boolean') {
+            options.showFps = value;
+            return true;
+        }
+        return false;
+    default:
+        return false;
+    }
+}
+
+/** @internal Test-only reset for this process-scoped preview session state. */
+export function resetPreviewToolbarOptions(): void {
+    options = { ...defaultOptions };
+}

--- a/src/core/preview/test/game-preview-route-early.test.ts
+++ b/src/core/preview/test/game-preview-route-early.test.ts
@@ -69,6 +69,10 @@ describe('game preview `/` route works before builder init (early-registration i
         // （preview-live-reload.js 负责创建 socket + 注册 browser:reload 监听），CLI 就绪后即可被广播刷新。
         expect(res.body).toContain('/socket.io/socket.io.js');
         expect(res.body).toContain('/static/web/preview-live-reload.js');
+        // 工具栏是浏览器预览页面的可选层；普通 URL 仍保持纯游戏画面，由查询参数显式启用。
+        expect(res.body).toContain('/static/web/game-preview.css');
+        expect(res.body).toContain('/static/web/game-preview-ui.js');
+        expect(res.body).toContain("get('previewToolbar') === '1'");
         // settings.js 带上 scene 查询，指向惰性计算的预览 settings 路由
         expect(res.body).toContain('/preview/settings.js?scene=');
     });

--- a/src/core/preview/test/game-preview-route-early.test.ts
+++ b/src/core/preview/test/game-preview-route-early.test.ts
@@ -1,5 +1,6 @@
 import { join } from 'path';
 import GamePreviewMiddleware from '../game-preview.middleware';
+import { getPreviewToolbarOptions, resetPreviewToolbarOptions } from '../preview-toolbar-options';
 
 /**
  * 回归测试：浏览器预览入口 `/` 必须能在「builder / scene 尚未初始化」时就渲染 game.ejs。
@@ -49,6 +50,8 @@ function findRootHandler() {
 }
 
 describe('game preview `/` route works before builder init (early-registration invariant)', () => {
+    beforeEach(() => resetPreviewToolbarOptions());
+
     it('renders game.ejs (200) with only scripting.projectPath, no builder', async () => {
         const handler = findRootHandler();
         const req = {
@@ -81,5 +84,34 @@ describe('game preview `/` route works before builder init (early-registration i
         // GamePreview 必须显式提供 `/`，registerBrowserPreview 早注册时它才能先于场景宽泛路由命中。
         const urls = (GamePreviewMiddleware.get || []).map((m: any) => String(m.url));
         expect(urls).toContain('/');
+    });
+
+    it('keeps Creator-style toolbar options across a refreshed page', async () => {
+        const handlers = new Map<string, Function>();
+        (GamePreviewMiddleware.socket as any).connection({
+            on: (event: string, handler: Function) => handlers.set(event, handler),
+        });
+
+        handlers.get('changeOption')?.('debugMode', 'INFO_FOR_WEB_PAGE');
+        handlers.get('changeOption')?.('showFps', true);
+        handlers.get('changeOption')?.('device', 'iphone-14');
+        handlers.get('changeOption')?.('rotate', true);
+
+        expect(getPreviewToolbarOptions()).toEqual({
+            debugMode: 'INFO_FOR_WEB_PAGE',
+            showFps: true,
+            device: 'iphone-14',
+            rotate: true,
+        });
+
+        const handler = findRootHandler();
+        const req = { protocol: 'http', get: () => 'localhost:9527', query: {} };
+        const res = makeRes();
+        await handler(req, res, jest.fn());
+
+        expect(res.body).toContain('"debugMode":"INFO_FOR_WEB_PAGE"');
+        expect(res.body).toContain('"showFps":true');
+        expect(res.body).toContain('"device":"iphone-14"');
+        expect(res.body).toContain('"rotate":true');
     });
 });

--- a/src/core/preview/test/game-preview-route-early.test.ts
+++ b/src/core/preview/test/game-preview-route-early.test.ts
@@ -1,6 +1,7 @@
 import { join } from 'path';
 import GamePreviewMiddleware from '../game-preview.middleware';
 import { getPreviewToolbarOptions, resetPreviewToolbarOptions } from '../preview-toolbar-options';
+import i18n from '../../base/i18n';
 
 /**
  * 回归测试：浏览器预览入口 `/` 必须能在「builder / scene 尚未初始化」时就渲染 game.ejs。
@@ -50,7 +51,10 @@ function findRootHandler() {
 }
 
 describe('game preview `/` route works before builder init (early-registration invariant)', () => {
-    beforeEach(() => resetPreviewToolbarOptions());
+    beforeEach(async () => {
+        resetPreviewToolbarOptions();
+        await i18n.setLanguage('en');
+    });
 
     it('renders game.ejs (200) with only scripting.projectPath, no builder', async () => {
         const handler = findRootHandler();
@@ -113,5 +117,18 @@ describe('game preview `/` route works before builder init (early-registration i
         expect(res.body).toContain('"showFps":true');
         expect(res.body).toContain('"device":"iphone-14"');
         expect(res.body).toContain('"rotate":true');
+    });
+
+    it('injects Creator-style localized device names from the CLI i18n service', async () => {
+        await i18n.setLanguage('zh');
+        const handler = findRootHandler();
+        const req = { protocol: 'http', get: () => 'localhost:9527', query: {} };
+        const res = makeRes();
+
+        await handler(req, res, jest.fn());
+
+        expect(res.body).toContain('"designResolution":"设计分辨率"');
+        expect(res.body).toContain('"fullScreen":"全屏"');
+        expect(res.body).toContain('"webpageFullScreen":"网页全屏"');
     });
 });

--- a/src/core/preview/test/game-preview-url.test.ts
+++ b/src/core/preview/test/game-preview-url.test.ts
@@ -1,0 +1,15 @@
+import { getExternalGamePreviewUrl } from '../game-preview-url';
+
+describe('external game preview URL', () => {
+    it('opts the CLI browser launch into the preview toolbar', () => {
+        expect(getExternalGamePreviewUrl('http://localhost:9527')).toBe(
+            'http://localhost:9527/?previewToolbar=1',
+        );
+    });
+
+    it('preserves the selected scene alongside the toolbar flag', () => {
+        expect(getExternalGamePreviewUrl('http://localhost:9527', 'db://assets/场景.scene')).toBe(
+            'http://localhost:9527/?scene=db%3A%2F%2Fassets%2F%E5%9C%BA%E6%99%AF.scene&previewToolbar=1',
+        );
+    });
+});

--- a/static/i18n/en/common.json
+++ b/static/i18n/en/common.json
@@ -24,5 +24,12 @@
     "start": "Start",
     "stop": "Stop",
     "pause": "Pause",
-    "resume": "Resume"
+    "resume": "Resume",
+    "preview": {
+        "device": {
+            "design_resolution": "Design Resolution",
+            "full_screen": "Full Screen",
+            "webpage_full_screen": "Webpage Full Screen"
+        }
+    }
 }

--- a/static/i18n/zh/common.json
+++ b/static/i18n/zh/common.json
@@ -25,5 +25,12 @@
     "stop": "停止",
     "pause": "暂停",
     "resume": "继续",
-    "deprecated_tip": "此功能已废弃"
+    "deprecated_tip": "此功能已废弃",
+    "preview": {
+        "device": {
+            "design_resolution": "设计分辨率",
+            "full_screen": "全屏",
+            "webpage_full_screen": "网页全屏"
+        }
+    }
 }

--- a/static/web/game-boot.js
+++ b/static/web/game-boot.js
@@ -239,7 +239,7 @@ export default async function gameBoot() {
 
         // 走 Cocos 日志通道：当用户已选择 Info For Web Page 并刷新预览时，
         // 引擎会以这条启动日志创建 Creator 同款的页面日志框。
-        cc.debug.log('Cocos game preview started');
+        cc.log('Cocos game preview started');
     } catch (err) {
         console.error('Failed to start game preview:', err.stack || err);
         showError(err);

--- a/static/web/game-boot.js
+++ b/static/web/game-boot.js
@@ -237,7 +237,9 @@ export default async function gameBoot() {
             );
         });
 
-        console.log('Cocos game preview started');
+        // 走 Cocos 日志通道：当用户已选择 Info For Web Page 并刷新预览时，
+        // 引擎会以这条启动日志创建 Creator 同款的页面日志框。
+        cc.debug.log('Cocos game preview started');
     } catch (err) {
         console.error('Failed to start game preview:', err.stack || err);
         showError(err);

--- a/static/web/game-boot.js
+++ b/static/web/game-boot.js
@@ -239,9 +239,7 @@ export default async function gameBoot() {
             );
         });
 
-        // 走 Cocos 日志通道：当用户已选择 Info For Web Page 并刷新预览时，
-        // 引擎会以这条启动日志创建 Creator 同款的页面日志框。
-        cc.log('Cocos game preview started');
+        console.log('Cocos game preview started');
     } catch (err) {
         console.error('Failed to start game preview:', err.stack || err);
         showError(err);

--- a/static/web/game-boot.js
+++ b/static/web/game-boot.js
@@ -74,8 +74,10 @@ export default async function gameBoot() {
         }
 
         // 构建引擎启动选项：以 settings 为基础，覆盖资源路径与启动场景（对齐编辑器 main.ts）
+        const toolbarOptions = previewToolbarEnabled ? window.__previewToolbarOptions : undefined;
+        const initialDebugMode = cc.debug?.DebugMode?.[toolbarOptions?.debugMode];
         const option = {
-            debugMode: (cc.debug && cc.debug.DebugMode && cc.debug.DebugMode.INFO) || 1,
+            debugMode: initialDebugMode ?? cc.debug?.DebugMode?.INFO ?? 1,
             overrideSettings: Object.assign({}, settings),
         };
         option.overrideSettings.assets = Object.assign({}, option.overrideSettings.assets, {
@@ -103,6 +105,9 @@ export default async function gameBoot() {
             // 而不把宿主窗口 resize 传给游戏。
             option.overrideSettings.screen = Object.assign({}, option.overrideSettings.screen, {
                 exactFitScreen: false,
+            });
+            option.overrideSettings.profiling = Object.assign({}, option.overrideSettings.profiling, {
+                showFPS: !!toolbarOptions?.showFps,
             });
         }
 

--- a/static/web/game-boot.js
+++ b/static/web/game-boot.js
@@ -75,9 +75,11 @@ export default async function gameBoot() {
 
         // 构建引擎启动选项：以 settings 为基础，覆盖资源路径与启动场景（对齐编辑器 main.ts）
         const toolbarOptions = previewToolbarEnabled ? window.__previewToolbarOptions : undefined;
-        const initialDebugMode = cc.debug?.DebugMode?.[toolbarOptions?.debugMode];
+        // Creator 的公开模块 API 将 DebugMode 直接导出为 cc.DebugMode；cc.debug 是
+        // legacy/global 调试对象，不能作为启动配置的枚举来源。
+        const initialDebugMode = cc.DebugMode?.[toolbarOptions?.debugMode];
         const option = {
-            debugMode: initialDebugMode ?? cc.debug?.DebugMode?.INFO ?? 1,
+            debugMode: initialDebugMode ?? cc.DebugMode?.INFO ?? 1,
             overrideSettings: Object.assign({}, settings),
         };
         option.overrideSettings.assets = Object.assign({}, option.overrideSettings.assets, {

--- a/static/web/game-boot.js
+++ b/static/web/game-boot.js
@@ -10,6 +10,15 @@ import { loadEngine } from '/static/web/engine-loader.js';
  * 运行启动场景，而不是加载场景编辑器 bundle。流程对齐编辑器 preview-app/src/main.ts。
  */
 export default async function gameBoot() {
+    // Creator 的带工具栏预览不是「游戏铺满浏览器窗口」：工具栏下的 GameDiv 是一个可独立
+    // 调整尺寸的模拟设备帧。仅由显式 URL 开启，普通浏览器预览与 Simple Browser 不受影响。
+    const previewToolbarEnabled = new URLSearchParams(window.location.search).get('previewToolbar') === '1';
+    if (previewToolbarEnabled) {
+        // 在引擎读取 GameDiv 尺寸前就建立 Creator 同款的 toolbar + content 布局，避免首帧按
+        // 浏览器全窗口初始化后再跳变。
+        document.body.classList.add('preview-toolbar-enabled');
+    }
+
     const showError = (e) => {
         const el = document.getElementById('error');
         if (el) {
@@ -88,6 +97,14 @@ export default async function gameBoot() {
         option.overrideSettings.rendering = Object.assign({}, option.overrideSettings.rendering, {
             renderMode: 2,
         });
+        if (previewToolbarEnabled) {
+            // exactFitScreen=true 会让 Web screen adapter 将 GameDiv 认作浏览器窗口，故意拒绝
+            // cc.screen.windowSize。Creator 的设备模拟需要 SubFrame 模式，才能只改变 GameDiv，
+            // 而不把宿主窗口 resize 传给游戏。
+            option.overrideSettings.screen = Object.assign({}, option.overrideSettings.screen, {
+                exactFitScreen: false,
+            });
+        }
 
         // 物理后端选择：预览用完整引擎（box2d / box2d-wasm / builtin 等所有后端都会在
         // EVENT_PRE_SUBSYSTEM_INIT 时各自 register），默认后端只是「最后注册的那个」，未必等于项目实际

--- a/static/web/game-preview-ui.js
+++ b/static/web/game-preview-ui.js
@@ -69,6 +69,19 @@ function getDebugApi(cc) {
     return cc.debug || window.cc?.debug || cc;
 }
 
+function getPreviewToolbarOptions() {
+    return window.__previewToolbarOptions || {
+        device: 'design',
+        rotate: false,
+        debugMode: 'WARN',
+        showFps: true,
+    };
+}
+
+function emitOptionChange(name, value) {
+    window.__previewSocket?.emit('changeOption', name, value);
+}
+
 function setChecked(button, checked) {
     button.classList.toggle('checked', checked);
 }
@@ -96,16 +109,17 @@ export default async function initializePreviewToolbar() {
 
     const cc = window.cc || await System.import('cc');
     const debug = getDebugApi(cc);
+    const toolbarOptions = getPreviewToolbarOptions();
     const designResolution = getDesignResolution();
     const presets = new Map(DEVICE_PRESETS.map((preset) => [preset.id, preset]));
-    let selectedDevice = 'design';
-    let rotated = false;
-    let webpageFullScreen = false;
+    let selectedDevice = presets.has(toolbarOptions.device) ? toolbarOptions.device : 'design';
+    let rotated = !!toolbarOptions.rotate;
+    let webpageFullScreen = selectedDevice === 'webpage-fullscreen';
     // 游戏启动时会短暂 pause 以等待场景加载；这不是用户通过预览工具栏发起的暂停，不能展示 Step 控件。
     let pausedByToolbar = false;
 
     DEVICE_PRESETS.forEach((preset) => deviceOptionList?.appendChild(createDeviceOption(preset, designResolution)));
-    debugModeSelect.value = 'WARN';
+    debugModeSelect.value = toolbarOptions.debugMode;
     frameRateInput.value = '60';
 
     const updateSelectedDevice = (deviceId) => {
@@ -141,8 +155,6 @@ export default async function initializePreviewToolbar() {
     };
 
     const selectDevice = async (deviceId) => {
-        updateSelectedDevice(deviceId);
-        setWebpageFullScreen(deviceId === 'webpage-fullscreen');
         if (deviceId === 'fullscreen') {
             if (typeof cc.screen?.requestFullScreen === 'function') {
                 try {
@@ -151,9 +163,11 @@ export default async function initializePreviewToolbar() {
                     console.warn('[Game Preview] request fullscreen failed:', error);
                 }
             }
-        } else {
-            applyWindowSize();
+            return;
         }
+        updateSelectedDevice(deviceId);
+        setWebpageFullScreen(deviceId === 'webpage-fullscreen');
+        applyWindowSize();
     };
 
     const getStatsVisible = () => {
@@ -194,6 +208,7 @@ export default async function initializePreviewToolbar() {
             applyWindowSize();
         }
         window.dispatchEvent(new Event('orientationchange'));
+        emitOptionChange('rotate', rotated);
     });
 
     deviceSelectTrigger?.addEventListener('click', (event) => {
@@ -209,6 +224,9 @@ export default async function initializePreviewToolbar() {
         const option = event.target.closest('li[data-device]');
         if (option?.dataset.device) {
             await selectDevice(option.dataset.device);
+            if (option.dataset.device !== 'fullscreen') {
+                emitOptionChange('device', option.dataset.device);
+            }
         }
         deviceOptions.removeAttribute('open');
     });
@@ -216,6 +234,13 @@ export default async function initializePreviewToolbar() {
     window.addEventListener('resize', () => {
         if (selectedDevice === 'webpage-fullscreen') {
             applyWindowSize();
+        }
+    });
+
+    document.addEventListener('fullscreenchange', () => {
+        if (!document.fullscreenElement) {
+            applyWindowSize();
+            window.dispatchEvent(new Event('resize'));
         }
     });
 
@@ -235,10 +260,12 @@ export default async function initializePreviewToolbar() {
     showFpsButton.addEventListener('click', () => {
         setStatsVisible(!getStatsVisible());
         updateFpsControl();
+        emitOptionChange('showFps', getStatsVisible());
     });
 
     debugModeSelect.addEventListener('change', () => {
         applyDebugMode();
+        emitOptionChange('debugMode', debugModeSelect.value);
     });
 
     frameRateInput.addEventListener('change', () => {
@@ -273,8 +300,11 @@ export default async function initializePreviewToolbar() {
     }
     document.body.classList.add('preview-toolbar-enabled');
     toolbar.classList.remove('disabled');
+    setChecked(rotateButton, rotated);
+    setWebpageFullScreen(webpageFullScreen);
+    updateSelectedDevice(selectedDevice);
     applyDebugMode();
-    setStatsVisible(true);
+    setStatsVisible(!!toolbarOptions.showFps);
     cc.game.setFrameRate(60);
     applyWindowSize();
     updateFpsControl();

--- a/static/web/game-preview-ui.js
+++ b/static/web/game-preview-ui.js
@@ -226,7 +226,10 @@ export default async function initializePreviewToolbar() {
         if (!webpageFullScreen) {
             return;
         }
-        document.body.classList.toggle('preview-toolbar-revealed', event.clientY <= TOOLBAR_HEIGHT);
+        // 下拉菜单位于工具栏下方。菜单打开后，鼠标离开顶部 50px 不应隐藏其宿主工具栏，
+        // 否则 Webpage Full Screen 下无法点选任何设备项。
+        const isDeviceMenuOpen = deviceOptions.hasAttribute('open');
+        document.body.classList.toggle('preview-toolbar-revealed', isDeviceMenuOpen || event.clientY <= TOOLBAR_HEIGHT);
     }, true);
 
     showFpsButton.addEventListener('click', () => {

--- a/static/web/game-preview-ui.js
+++ b/static/web/game-preview-ui.js
@@ -28,6 +28,18 @@ const DEVICE_PRESETS = [
 ];
 const TOOLBAR_HEIGHT = 50;
 
+function getLocalizedDevicePresets() {
+    const deviceText = window.__previewToolbarI18n?.device || {};
+    return DEVICE_PRESETS.map((preset) => {
+        const localizedName = {
+            design: deviceText.designResolution,
+            fullscreen: deviceText.fullScreen,
+            'webpage-fullscreen': deviceText.webpageFullScreen,
+        }[preset.id];
+        return localizedName ? { ...preset, name: localizedName } : preset;
+    });
+}
+
 function getElement(id) {
     const element = document.getElementById(id);
     if (!element) {
@@ -111,14 +123,15 @@ export default async function initializePreviewToolbar() {
     const debug = getDebugApi(cc);
     const toolbarOptions = getPreviewToolbarOptions();
     const designResolution = getDesignResolution();
-    const presets = new Map(DEVICE_PRESETS.map((preset) => [preset.id, preset]));
+    const devicePresets = getLocalizedDevicePresets();
+    const presets = new Map(devicePresets.map((preset) => [preset.id, preset]));
     let selectedDevice = presets.has(toolbarOptions.device) ? toolbarOptions.device : 'design';
     let rotated = !!toolbarOptions.rotate;
     let webpageFullScreen = selectedDevice === 'webpage-fullscreen';
     // 游戏启动时会短暂 pause 以等待场景加载；这不是用户通过预览工具栏发起的暂停，不能展示 Step 控件。
     let pausedByToolbar = false;
 
-    DEVICE_PRESETS.forEach((preset) => deviceOptionList?.appendChild(createDeviceOption(preset, designResolution)));
+    devicePresets.forEach((preset) => deviceOptionList?.appendChild(createDeviceOption(preset, designResolution)));
     debugModeSelect.value = toolbarOptions.debugMode;
     frameRateInput.value = '60';
 
@@ -126,7 +139,7 @@ export default async function initializePreviewToolbar() {
         selectedDevice = deviceId;
         devicePicker.setAttribute('value', deviceId);
         const preset = presets.get(deviceId);
-        deviceName.textContent = getPresetLabel(preset || DEVICE_PRESETS[0], designResolution);
+        deviceName.textContent = getPresetLabel(preset || devicePresets[0], designResolution);
         deviceOptionList?.querySelectorAll('li[data-device]').forEach((option) => {
             option.classList.toggle('selected', option.dataset.device === deviceId);
         });

--- a/static/web/game-preview-ui.js
+++ b/static/web/game-preview-ui.js
@@ -44,17 +44,24 @@ function getDesignResolution() {
     };
 }
 
-function createOption(preset, designResolution) {
-    const option = document.createElement('option');
-    option.value = preset.id;
-    option.disabled = !!preset.disabled;
+function getPresetLabel(preset, designResolution) {
     if (preset.id === 'design') {
-        option.textContent = `${preset.name} (${designResolution.width}×${designResolution.height})`;
-    } else if (preset.width && preset.height) {
-        option.textContent = `${preset.name} (${preset.width}×${preset.height})`;
-    } else {
-        option.textContent = preset.name;
+        return `${preset.name} (${designResolution.width}×${designResolution.height})`;
     }
+    if (preset.width && preset.height) {
+        return `${preset.name} (${preset.width}×${preset.height})`;
+    }
+    return preset.name;
+}
+
+function createDeviceOption(preset, designResolution) {
+    const option = document.createElement('li');
+    if (preset.id === 'separator') {
+        option.className = 'separator';
+        return option;
+    }
+    option.dataset.device = preset.id;
+    option.textContent = getPresetLabel(preset, designResolution);
     return option;
 }
 
@@ -73,7 +80,11 @@ function setPreviewWindowSize(cc, width, height) {
 
 export default async function initializePreviewToolbar() {
     const toolbar = getElement('preview-toolbar');
-    const deviceSelect = getElement('preview-device');
+    const devicePicker = getElement('preview-device');
+    const deviceName = getElement('preview-device-name');
+    const deviceOptions = getElement('preview-device-options');
+    const deviceOptionList = deviceOptions.querySelector('ul');
+    const deviceSelectTrigger = devicePicker.querySelector('.view-select');
     const rotateButton = getElement('preview-rotate');
     const debugModeSelect = getElement('preview-debug-mode');
     const showFpsButton = getElement('preview-show-fps');
@@ -87,18 +98,29 @@ export default async function initializePreviewToolbar() {
     const debug = getDebugApi(cc);
     const designResolution = getDesignResolution();
     const presets = new Map(DEVICE_PRESETS.map((preset) => [preset.id, preset]));
-    let rotated = true;
+    let selectedDevice = 'design';
+    let rotated = false;
     let webpageFullScreen = false;
     // 游戏启动时会短暂 pause 以等待场景加载；这不是用户通过预览工具栏发起的暂停，不能展示 Step 控件。
     let pausedByToolbar = false;
 
-    DEVICE_PRESETS.forEach((preset) => deviceSelect.appendChild(createOption(preset, designResolution)));
-    deviceSelect.value = 'design';
-    debugModeSelect.value = 'WARN_FOR_WEB_PAGE';
+    DEVICE_PRESETS.forEach((preset) => deviceOptionList?.appendChild(createDeviceOption(preset, designResolution)));
+    debugModeSelect.value = 'WARN';
     frameRateInput.value = '60';
 
+    const updateSelectedDevice = (deviceId) => {
+        selectedDevice = deviceId;
+        devicePicker.setAttribute('value', deviceId);
+        const preset = presets.get(deviceId);
+        deviceName.textContent = getPresetLabel(preset || DEVICE_PRESETS[0], designResolution);
+        deviceOptionList?.querySelectorAll('li[data-device]').forEach((option) => {
+            option.classList.toggle('selected', option.dataset.device === deviceId);
+        });
+    };
+    updateSelectedDevice(selectedDevice);
+
     const getCurrentSize = () => {
-        const preset = presets.get(deviceSelect.value);
+        const preset = presets.get(selectedDevice);
         if (preset?.id === 'webpage-fullscreen' || preset?.id === 'fullscreen') {
             return { width: window.innerWidth, height: window.innerHeight };
         }
@@ -116,6 +138,22 @@ export default async function initializePreviewToolbar() {
         webpageFullScreen = enabled;
         document.body.classList.toggle('preview-webpage-fullscreen', enabled);
         document.body.classList.remove('preview-toolbar-revealed');
+    };
+
+    const selectDevice = async (deviceId) => {
+        updateSelectedDevice(deviceId);
+        setWebpageFullScreen(deviceId === 'webpage-fullscreen');
+        if (deviceId === 'fullscreen') {
+            if (typeof cc.screen?.requestFullScreen === 'function') {
+                try {
+                    await cc.screen.requestFullScreen();
+                } catch (error) {
+                    console.warn('[Game Preview] request fullscreen failed:', error);
+                }
+            }
+        } else {
+            applyWindowSize();
+        }
     };
 
     const getStatsVisible = () => {
@@ -152,29 +190,31 @@ export default async function initializePreviewToolbar() {
     rotateButton.addEventListener('click', () => {
         rotated = !rotated;
         setChecked(rotateButton, rotated);
-        if (deviceSelect.value !== 'fullscreen') {
+        if (selectedDevice !== 'fullscreen') {
             applyWindowSize();
         }
         window.dispatchEvent(new Event('orientationchange'));
     });
 
-    deviceSelect.addEventListener('change', async () => {
-        setWebpageFullScreen(deviceSelect.value === 'webpage-fullscreen');
-        if (deviceSelect.value === 'fullscreen') {
-            if (typeof cc.screen?.requestFullScreen === 'function') {
-                try {
-                    await cc.screen.requestFullScreen();
-                } catch (error) {
-                    console.warn('[Game Preview] request fullscreen failed:', error);
-                }
-            }
-        } else {
-            applyWindowSize();
+    deviceSelectTrigger?.addEventListener('click', (event) => {
+        event.stopPropagation();
+        deviceOptions.toggleAttribute('open');
+    });
+
+    document.addEventListener('click', () => {
+        deviceOptions.removeAttribute('open');
+    });
+
+    deviceOptionList?.addEventListener('click', async (event) => {
+        const option = event.target.closest('li[data-device]');
+        if (option?.dataset.device) {
+            await selectDevice(option.dataset.device);
         }
+        deviceOptions.removeAttribute('open');
     });
 
     window.addEventListener('resize', () => {
-        if (deviceSelect.value === 'webpage-fullscreen') {
+        if (selectedDevice === 'webpage-fullscreen') {
             applyWindowSize();
         }
     });

--- a/static/web/game-preview-ui.js
+++ b/static/web/game-preview-ui.js
@@ -180,12 +180,13 @@ export default async function initializePreviewToolbar() {
 
     // 与 Creator 一致：Webpage Full Screen 下工具栏默认隐藏；鼠标进入顶部命中区才以覆盖层方式
     // 露出，离开后立即隐藏，因此不会改变模拟设备帧的可用尺寸。
+    // 游戏 Canvas 可能会在冒泡阶段消费 mousemove；使用捕获阶段才能稳定观察到顶部触发区。
     document.addEventListener('mousemove', (event) => {
         if (!webpageFullScreen) {
             return;
         }
         document.body.classList.toggle('preview-toolbar-revealed', event.clientY <= TOOLBAR_HEIGHT);
-    });
+    }, true);
 
     showFpsButton.addEventListener('click', () => {
         setStatsVisible(!getStatsVisible());

--- a/static/web/game-preview-ui.js
+++ b/static/web/game-preview-ui.js
@@ -89,6 +89,8 @@ export default async function initializePreviewToolbar() {
     const presets = new Map(DEVICE_PRESETS.map((preset) => [preset.id, preset]));
     let rotated = true;
     let webpageFullScreen = false;
+    // 游戏启动时会短暂 pause 以等待场景加载；这不是用户通过预览工具栏发起的暂停，不能展示 Step 控件。
+    let pausedByToolbar = false;
 
     DEVICE_PRESETS.forEach((preset) => deviceSelect.appendChild(createOption(preset, designResolution)));
     deviceSelect.value = 'design';
@@ -139,10 +141,9 @@ export default async function initializePreviewToolbar() {
     };
 
     const updatePauseControls = () => {
-        const paused = cc.game.isPaused();
-        setChecked(pauseButton, paused);
-        stepButton.classList.toggle('show', paused);
-        stepLength.classList.toggle('show', paused);
+        setChecked(pauseButton, pausedByToolbar);
+        stepButton.classList.toggle('show', pausedByToolbar);
+        stepLength.classList.toggle('show', pausedByToolbar);
         frameTimeInput.value = String(Math.round(cc.game.frameTime || 1));
     };
 
@@ -205,10 +206,12 @@ export default async function initializePreviewToolbar() {
     });
 
     pauseButton.addEventListener('click', () => {
-        if (cc.game.isPaused()) {
+        if (pausedByToolbar) {
             cc.game.resume();
+            pausedByToolbar = false;
         } else {
             cc.game.pause();
+            pausedByToolbar = true;
         }
         updatePauseControls();
     });
@@ -224,10 +227,6 @@ export default async function initializePreviewToolbar() {
 
     if (cc.director && cc.Director?.EVENT_END_FRAME) {
         cc.director.on(cc.Director.EVENT_END_FRAME, updatePauseControls);
-    }
-    if (cc.game && cc.Game?.EVENT_PAUSE && cc.Game?.EVENT_RESUME) {
-        cc.game.on(cc.Game.EVENT_PAUSE, updatePauseControls);
-        cc.game.on(cc.Game.EVENT_RESUME, updatePauseControls);
     }
     document.body.classList.add('preview-toolbar-enabled');
     toolbar.classList.remove('disabled');

--- a/static/web/game-preview-ui.js
+++ b/static/web/game-preview-ui.js
@@ -1,0 +1,239 @@
+/* global System, window, document */
+
+const DEVICE_PRESETS = [
+    { id: 'design', name: 'Design Resolution' },
+    { id: 'fullscreen', name: 'Full Screen' },
+    { id: 'webpage-fullscreen', name: 'Webpage Full Screen' },
+    { id: 'separator', name: '──────────', disabled: true },
+    { id: 'iphone-14-pro', name: 'Apple iPhone 14 Pro', width: 393, height: 852 },
+    { id: 'iphone-14-plus', name: 'Apple iPhone 12/13 Pro Max; 14 Plus', width: 428, height: 926 },
+    { id: 'iphone-14', name: 'Apple iPhone 12; 13; 14; 12/13 Pro', width: 390, height: 844 },
+    { id: 'iphone-x', name: 'Apple iPhone X; XS; 11 Pro; 12/13 Mini', width: 375, height: 812 },
+    { id: 'iphone-xr', name: 'Apple iPhone XR; 11', width: 414, height: 896 },
+    { id: 'ipad-10-2', name: 'Apple iPad 10.2', width: 1620, height: 2160 },
+    { id: 'ipad-air', name: 'Apple iPad Air 10.9', width: 1640, height: 2360 },
+    { id: 'ipad-pro', name: 'Apple iPad Pro 10.5', width: 1668, height: 2224 },
+    { id: 'oppo-reno-2', name: 'OPPO Reno 2', width: 360, height: 800 },
+    { id: 'huawei-nova-5', name: 'HUAWEI Nova 5', width: 360, height: 780 },
+    { id: 'honor-x8', name: 'HONOR X8', width: 360, height: 796 },
+    { id: 'huawei-nova-8i', name: 'HUAWEI Nova 8i', width: 360, height: 792 },
+    { id: 'huawei-mate-40-pro', name: 'HUAWEI Mate 40 Pro', width: 448, height: 924 },
+    { id: 'huawei-mate-30-pro', name: 'HUAWEI Mate30 Pro', width: 392, height: 800 },
+    { id: 'xiaomi-redmi-8', name: 'Xiaomi Redmi 8', width: 360, height: 760 },
+    { id: 'sony-xperia-5', name: 'Sony Xperia 5', width: 360, height: 840 },
+    { id: 'oppo-a77', name: 'OPPO A77', width: 360, height: 806 },
+    { id: 'nokia-c2', name: 'Nokia C2', width: 360, height: 720 },
+    { id: 'asus-rog-phone-6', name: 'Asus ROG Phone 6', width: 360, height: 816 },
+    { id: 'lenovo-legion-2-pro', name: 'Lenovo Legion 2 Pro', width: 360, height: 820 },
+];
+const TOOLBAR_HEIGHT = 50;
+
+function getElement(id) {
+    const element = document.getElementById(id);
+    if (!element) {
+        throw new Error(`[Game Preview] missing toolbar element: ${id}`);
+    }
+    return element;
+}
+
+function getDesignResolution() {
+    const resolution = window._CCSettings?.screen?.designResolution || {};
+    return {
+        width: Number(resolution.width) || 1280,
+        height: Number(resolution.height) || 720,
+    };
+}
+
+function createOption(preset, designResolution) {
+    const option = document.createElement('option');
+    option.value = preset.id;
+    option.disabled = !!preset.disabled;
+    if (preset.id === 'design') {
+        option.textContent = `${preset.name} (${designResolution.width}×${designResolution.height})`;
+    } else if (preset.width && preset.height) {
+        option.textContent = `${preset.name} (${preset.width}×${preset.height})`;
+    } else {
+        option.textContent = preset.name;
+    }
+    return option;
+}
+
+function getDebugApi(cc) {
+    return cc.debug || window.cc?.debug || cc;
+}
+
+function setChecked(button, checked) {
+    button.classList.toggle('checked', checked);
+}
+
+function setPreviewWindowSize(cc, width, height) {
+    const pixelRatio = cc.screen?.devicePixelRatio || window.devicePixelRatio || 1;
+    cc.screen.windowSize = new cc.Size(width * pixelRatio, height * pixelRatio);
+}
+
+export default async function initializePreviewToolbar() {
+    const toolbar = getElement('preview-toolbar');
+    const deviceSelect = getElement('preview-device');
+    const rotateButton = getElement('preview-rotate');
+    const debugModeSelect = getElement('preview-debug-mode');
+    const showFpsButton = getElement('preview-show-fps');
+    const frameRateInput = getElement('preview-frame-rate');
+    const pauseButton = getElement('preview-pause');
+    const stepButton = getElement('preview-step');
+    const stepLength = getElement('preview-step-length');
+    const frameTimeInput = getElement('preview-frame-time');
+
+    const cc = window.cc || await System.import('cc');
+    const debug = getDebugApi(cc);
+    const designResolution = getDesignResolution();
+    const presets = new Map(DEVICE_PRESETS.map((preset) => [preset.id, preset]));
+    let rotated = true;
+    let webpageFullScreen = false;
+
+    DEVICE_PRESETS.forEach((preset) => deviceSelect.appendChild(createOption(preset, designResolution)));
+    deviceSelect.value = 'design';
+    debugModeSelect.value = 'WARN_FOR_WEB_PAGE';
+    frameRateInput.value = '60';
+
+    const getCurrentSize = () => {
+        const preset = presets.get(deviceSelect.value);
+        if (preset?.id === 'webpage-fullscreen' || preset?.id === 'fullscreen') {
+            return { width: window.innerWidth, height: window.innerHeight };
+        }
+        const width = preset?.id === 'design' ? designResolution.width : preset?.width || designResolution.width;
+        const height = preset?.id === 'design' ? designResolution.height : preset?.height || designResolution.height;
+        return rotated ? { width: height, height: width } : { width, height };
+    };
+
+    const applyWindowSize = () => {
+        const size = getCurrentSize();
+        setPreviewWindowSize(cc, size.width, size.height);
+    };
+
+    const setWebpageFullScreen = (enabled) => {
+        webpageFullScreen = enabled;
+        document.body.classList.toggle('preview-webpage-fullscreen', enabled);
+        document.body.classList.remove('preview-toolbar-revealed');
+    };
+
+    const getStatsVisible = () => {
+        if (typeof debug.isDisplayStats === 'function') {
+            return debug.isDisplayStats();
+        }
+        return typeof cc.isDisplayStats === 'function' && cc.isDisplayStats();
+    };
+
+    const setStatsVisible = (visible) => {
+        if (typeof debug.setDisplayStats === 'function') {
+            debug.setDisplayStats(visible);
+        } else if (typeof cc.setDisplayStats === 'function') {
+            cc.setDisplayStats(visible);
+        }
+    };
+
+    const applyDebugMode = () => {
+        const mode = cc.DebugMode?.[debugModeSelect.value] ?? debug.DebugMode?.[debugModeSelect.value];
+        if (typeof debug._resetDebugSetting === 'function' && mode !== undefined) {
+            debug._resetDebugSetting(mode);
+        }
+    };
+
+    const updatePauseControls = () => {
+        const paused = cc.game.isPaused();
+        setChecked(pauseButton, paused);
+        stepButton.classList.toggle('show', paused);
+        stepLength.classList.toggle('show', paused);
+        frameTimeInput.value = String(Math.round(cc.game.frameTime || 1));
+    };
+
+    const updateFpsControl = () => setChecked(showFpsButton, getStatsVisible());
+
+    rotateButton.addEventListener('click', () => {
+        rotated = !rotated;
+        setChecked(rotateButton, rotated);
+        if (deviceSelect.value !== 'fullscreen') {
+            applyWindowSize();
+        }
+        window.dispatchEvent(new Event('orientationchange'));
+    });
+
+    deviceSelect.addEventListener('change', async () => {
+        setWebpageFullScreen(deviceSelect.value === 'webpage-fullscreen');
+        if (deviceSelect.value === 'fullscreen') {
+            if (typeof cc.screen?.requestFullScreen === 'function') {
+                try {
+                    await cc.screen.requestFullScreen();
+                } catch (error) {
+                    console.warn('[Game Preview] request fullscreen failed:', error);
+                }
+            }
+        } else {
+            applyWindowSize();
+        }
+    });
+
+    window.addEventListener('resize', () => {
+        if (deviceSelect.value === 'webpage-fullscreen') {
+            applyWindowSize();
+        }
+    });
+
+    // 与 Creator 一致：Webpage Full Screen 下工具栏默认隐藏；鼠标进入顶部命中区才以覆盖层方式
+    // 露出，离开后立即隐藏，因此不会改变模拟设备帧的可用尺寸。
+    document.addEventListener('mousemove', (event) => {
+        if (!webpageFullScreen) {
+            return;
+        }
+        document.body.classList.toggle('preview-toolbar-revealed', event.clientY <= TOOLBAR_HEIGHT);
+    });
+
+    showFpsButton.addEventListener('click', () => {
+        setStatsVisible(!getStatsVisible());
+        updateFpsControl();
+    });
+
+    debugModeSelect.addEventListener('change', () => {
+        applyDebugMode();
+    });
+
+    frameRateInput.addEventListener('change', () => {
+        const frameRate = Number.parseInt(frameRateInput.value, 10);
+        const value = Number.isFinite(frameRate) && frameRate > 0 ? frameRate : 60;
+        frameRateInput.value = String(value);
+        cc.game.setFrameRate(value);
+    });
+
+    pauseButton.addEventListener('click', () => {
+        if (cc.game.isPaused()) {
+            cc.game.resume();
+        } else {
+            cc.game.pause();
+        }
+        updatePauseControls();
+    });
+
+    stepButton.addEventListener('click', () => cc.game.step());
+
+    frameTimeInput.addEventListener('change', () => {
+        const frameTime = Number.parseInt(frameTimeInput.value, 10);
+        const value = Number.isFinite(frameTime) && frameTime > 0 ? frameTime : 1;
+        frameTimeInput.value = String(value);
+        cc.game.frameTime = value;
+    });
+
+    if (cc.director && cc.Director?.EVENT_END_FRAME) {
+        cc.director.on(cc.Director.EVENT_END_FRAME, updatePauseControls);
+    }
+    if (cc.game && cc.Game?.EVENT_PAUSE && cc.Game?.EVENT_RESUME) {
+        cc.game.on(cc.Game.EVENT_PAUSE, updatePauseControls);
+        cc.game.on(cc.Game.EVENT_RESUME, updatePauseControls);
+    }
+    document.body.classList.add('preview-toolbar-enabled');
+    toolbar.classList.remove('disabled');
+    applyDebugMode();
+    setStatsVisible(true);
+    cc.game.setFrameRate(60);
+    applyWindowSize();
+    updateFpsControl();
+    updatePauseControls();
+}

--- a/static/web/game-preview.css
+++ b/static/web/game-preview.css
@@ -28,8 +28,7 @@
     padding: 4px 0 4px 10px;
     align-items: center;
     flex-wrap: nowrap;
-    overflow-x: auto;
-    overflow-y: hidden;
+    min-width: 0;
     color: #aaaaaa;
     background: #333333;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -78,12 +77,11 @@ body.preview-webpage-fullscreen #preview-content {
 }
 
 #preview-toolbar .item {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
+    display: inline-block;
     margin-right: 10px;
-    flex: 0 0 auto;
-    white-space: nowrap;
+    min-width: 0;
+    flex: 0 1 auto;
+    vertical-align: middle;
 }
 
 #preview-toolbar select,
@@ -98,8 +96,14 @@ body.preview-webpage-fullscreen #preview-content {
     font: inherit;
 }
 
+#preview-toolbar select {
+    min-width: 0;
+    max-width: 100%;
+}
+
 #preview-toolbar #preview-device {
-    width: 220px;
+    width: 175px;
+    max-width: 100%;
 }
 
 #preview-toolbar input {
@@ -108,7 +112,7 @@ body.preview-webpage-fullscreen #preview-content {
 }
 
 #preview-toolbar button {
-    height: 25px;
+    min-height: 25px;
     box-sizing: border-box;
     border: 1px solid #171717;
     border-radius: 2px;
@@ -118,18 +122,16 @@ body.preview-webpage-fullscreen #preview-content {
     background-image: linear-gradient(#5a5a5a, #444444);
     font: inherit;
     font-weight: 600;
-    line-height: 1;
-    white-space: nowrap;
+    line-height: normal;
+    max-width: 100%;
 }
 
 #preview-toolbar button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
+    white-space: normal;
 }
 
 #preview-show-fps {
-    min-width: 72px;
+    min-width: 0;
 }
 
 #preview-toolbar button.checked {
@@ -139,32 +141,27 @@ body.preview-webpage-fullscreen #preview-content {
 }
 
 #preview-toolbar .controls {
-    gap: 0;
+    margin-right: 0;
 }
 
 #preview-toolbar .controls button + button {
     border-left: 0;
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
 }
 
-#preview-toolbar .controls button:first-child {
+#preview-toolbar .controls button:first-child.checked {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
 }
 
-#preview-step-length {
+#preview-toolbar #preview-step-length,
+#preview-toolbar #preview-step {
     display: none;
 }
 
-#preview-step {
-    display: none;
-}
-
-#preview-step.show {
+#preview-toolbar #preview-step.show {
     display: inline-block;
 }
 
-#preview-step-length.show {
-    display: inline-flex;
+#preview-toolbar #preview-step-length.show {
+    display: inline-block;
 }

--- a/static/web/game-preview.css
+++ b/static/web/game-preview.css
@@ -134,6 +134,10 @@ body.preview-webpage-fullscreen #preview-content {
     min-width: 0;
 }
 
+#preview-rotate {
+    min-width: 52px;
+}
+
 #preview-toolbar button.checked {
     color: #0099ff;
     background-image: linear-gradient(#333333, #222222);

--- a/static/web/game-preview.css
+++ b/static/web/game-preview.css
@@ -7,6 +7,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    flex-direction: column;
 }
 
 #preview-content #GameDiv {
@@ -14,6 +15,8 @@
     width: 100%;
     height: 100%;
     overflow: hidden;
+    /* GameDiv 是模拟设备帧；宿主缩小时必须裁切，不能被 flex 单独压缩某一轴。 */
+    flex: 0 0 auto;
 }
 
 #preview-content #Cocos3dGameContainer {

--- a/static/web/game-preview.css
+++ b/static/web/game-preview.css
@@ -1,0 +1,170 @@
+
+/* The browser-preview toolbar is intentionally isolated to pages that opt in with previewToolbar=1. */
+#preview-content {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#preview-content #GameDiv {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+}
+
+#preview-content #Cocos3dGameContainer {
+    width: 100%;
+    height: 100%;
+}
+
+#preview-toolbar {
+    display: none;
+    height: 50px;
+    box-sizing: border-box;
+    padding: 4px 0 4px 10px;
+    align-items: center;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    color: #aaaaaa;
+    background: #333333;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 12px;
+    line-height: 25px;
+}
+
+body.preview-toolbar-enabled #preview-toolbar {
+    display: flex;
+}
+
+body.preview-toolbar-enabled {
+    display: flex;
+    flex-direction: column;
+}
+
+body.preview-toolbar-enabled #preview-content {
+    height: auto;
+    min-height: 0;
+    flex: 1 1 auto;
+}
+
+/* Creator 的 Webpage Full Screen 保持游戏帧占满页面；鼠标到顶部时，工具栏浮在游戏帧上方，
+ * 而不是重新分配游戏帧高度。 */
+body.preview-webpage-fullscreen #preview-toolbar {
+    display: none;
+}
+
+body.preview-webpage-fullscreen.preview-toolbar-revealed #preview-toolbar {
+    position: absolute;
+    z-index: 10;
+    top: 0;
+    right: 0;
+    left: 0;
+    display: flex;
+}
+
+body.preview-webpage-fullscreen #preview-content {
+    height: 100%;
+    flex: 1 1 auto;
+}
+
+#preview-toolbar.disabled {
+    pointer-events: none;
+    opacity: 0.4;
+}
+
+#preview-toolbar .item {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin-right: 10px;
+    flex: 0 0 auto;
+    white-space: nowrap;
+}
+
+#preview-toolbar select,
+#preview-toolbar input {
+    height: 25px;
+    box-sizing: border-box;
+    border: 1px solid #171717;
+    border-radius: 0;
+    padding: 0 8px;
+    color: #aaaaaa;
+    background: #444444;
+    font: inherit;
+}
+
+#preview-toolbar #preview-device {
+    width: 220px;
+}
+
+#preview-toolbar input {
+    width: 54px;
+    padding: 0 4px;
+}
+
+#preview-toolbar button {
+    height: 25px;
+    box-sizing: border-box;
+    border: 1px solid #171717;
+    border-radius: 2px;
+    padding: 3px 8px;
+    color: #bdbdbd;
+    cursor: pointer;
+    background-image: linear-gradient(#5a5a5a, #444444);
+    font: inherit;
+    font-weight: 600;
+    line-height: 1;
+    white-space: nowrap;
+}
+
+#preview-toolbar button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#preview-show-fps {
+    min-width: 72px;
+}
+
+#preview-toolbar button.checked {
+    color: #0099ff;
+    background-image: linear-gradient(#333333, #222222);
+    box-shadow: inset 0 2px 4px rgb(0 0 0 / 50%);
+}
+
+#preview-toolbar .controls {
+    gap: 0;
+}
+
+#preview-toolbar .controls button + button {
+    border-left: 0;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+}
+
+#preview-toolbar .controls button:first-child {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+#preview-step-length {
+    display: none;
+}
+
+#preview-step {
+    display: none;
+}
+
+#preview-step.show {
+    display: inline-block;
+}
+
+#preview-step-length.show {
+    display: inline-flex;
+}

--- a/static/web/game-preview.css
+++ b/static/web/game-preview.css
@@ -101,9 +101,107 @@ body.preview-webpage-fullscreen #preview-content {
     max-width: 100%;
 }
 
-#preview-toolbar #preview-device {
+#preview-toolbar .view-select-container {
+    position: relative;
+    display: flex;
     width: 175px;
     max-width: 100%;
+    height: 25px;
+    padding: 0 8px;
+    color: #aaaaaa;
+    cursor: pointer;
+    background: #444444;
+    line-height: 25px;
+    user-select: none;
+}
+
+#preview-toolbar .view-select-container .view-select {
+    display: flex;
+    width: 100%;
+    min-width: 0;
+    flex: 1;
+    padding-right: 20px;
+    padding-left: 6px;
+}
+
+#preview-toolbar .view-select-container .label,
+#preview-toolbar .view-select-container .label > span {
+    display: block;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+#preview-toolbar .view-select-container .label {
+    flex: 1;
+}
+
+#preview-toolbar .view-select-container .arrow-triangle::after {
+    position: absolute;
+    top: 7px;
+    right: 7px;
+    width: 5px;
+    height: 5px;
+    border-top: 1px solid #cccccc;
+    border-right: 1px solid #cccccc;
+    content: '';
+    transform: rotate(135deg);
+}
+
+#preview-toolbar .view-select-container .options {
+    position: absolute;
+    z-index: 99;
+    top: 28px;
+    left: 0;
+    display: none;
+    width: 100%;
+    max-height: 300px;
+    padding: 5px 0;
+    overflow: auto;
+    color: #aaaaaa;
+    background: #444444;
+    border: 1px solid #171717;
+}
+
+#preview-toolbar .view-select-container .options[open] {
+    display: block;
+}
+
+#preview-toolbar .view-select-container .options ul {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+}
+
+#preview-toolbar .view-select-container .options li {
+    height: 24px;
+    padding: 0 8px;
+    overflow: hidden;
+    cursor: pointer;
+    line-height: 24px;
+    list-style: none;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+#preview-toolbar .view-select-container .options li:hover,
+#preview-toolbar .view-select-container .options li.selected {
+    color: #ffffff;
+    background: #0099ff;
+}
+
+#preview-toolbar .view-select-container .options li.separator {
+    align-self: center;
+    width: calc(100% - 8px);
+    height: 1px;
+    padding: 0;
+    margin: 4px 0;
+    pointer-events: none;
+    background: #cccccc;
 }
 
 #preview-toolbar input {

--- a/static/web/game.ejs
+++ b/static/web/game.ejs
@@ -97,6 +97,7 @@
         window.WebEnv = { serverURL: '<%= serverURL %>' };
         window.__launchSceneQuery = '<%= sceneQuery %>';
         window.__previewToolbarOptions = <%- JSON.stringify(previewToolbarOptions) %>;
+        window.__previewToolbarI18n = <%- JSON.stringify(previewToolbarI18n) %>;
         // 构建标记：确认浏览器拿到的是「早注册 / 自愈」版本的 game.ejs（而非旧缓存或旧构建）。
         console.log('[Game Preview] page build marker: EARLY-ROUTE-FIX v6 (served from static/web/game.ejs)');
     </script>

--- a/static/web/game.ejs
+++ b/static/web/game.ejs
@@ -48,9 +48,15 @@
 <body>
     <div id="preview-toolbar" class="toolbar disabled" aria-label="Game preview controls">
         <div class="item">
-            <select id="preview-device" aria-label="Device"></select>
+            <div id="preview-device" class="view-select-container" value="design" tabindex="-1" aria-label="Device">
+                <div class="view-select">
+                    <div class="label"><span id="preview-device-name"></span></div>
+                    <i class="arrow-triangle"></i>
+                </div>
+                <div id="preview-device-options" class="options"><ul></ul></div>
+            </div>
         </div>
-        <div class="item"><button id="preview-rotate" type="button" class="checked">Rotate</button></div>
+        <div class="item"><button id="preview-rotate" type="button">Rotate</button></div>
         <span class="item toolbar-label">Debug Mode:</span>
         <div class="item">
             <select id="preview-debug-mode">

--- a/static/web/game.ejs
+++ b/static/web/game.ejs
@@ -96,6 +96,7 @@
     <script>
         window.WebEnv = { serverURL: '<%= serverURL %>' };
         window.__launchSceneQuery = '<%= sceneQuery %>';
+        window.__previewToolbarOptions = <%- JSON.stringify(previewToolbarOptions) %>;
         // 构建标记：确认浏览器拿到的是「早注册 / 自愈」版本的 game.ejs（而非旧缓存或旧构建）。
         console.log('[Game Preview] page build marker: EARLY-ROUTE-FIX v6 (served from static/web/game.ejs)');
     </script>

--- a/static/web/game.ejs
+++ b/static/web/game.ejs
@@ -48,8 +48,7 @@
 <body>
     <div id="preview-toolbar" class="toolbar disabled" aria-label="Game preview controls">
         <div class="item">
-            <label for="preview-device">Device:</label>
-            <select id="preview-device"></select>
+            <select id="preview-device" aria-label="Device"></select>
         </div>
         <div class="item"><button id="preview-rotate" type="button" class="checked">Rotate</button></div>
         <span class="item toolbar-label">Debug Mode:</span>

--- a/static/web/game.ejs
+++ b/static/web/game.ejs
@@ -14,6 +14,7 @@
     <meta name="full-screen" content="yes"/>
     <meta name="x5-fullscreen" content="true"/>
     <meta name="360-fullscreen" content="true"/>
+    <link rel="stylesheet" type="text/css" href="/static/web/game-preview.css"/>
     <style>
         html, body {
             margin: 0;
@@ -45,9 +46,44 @@
     </style>
 </head>
 <body>
-    <div id="GameDiv" class="wrapper">
-        <div id="Cocos3dGameContainer">
-            <canvas id="GameCanvas" tabindex="-1"></canvas>
+    <div id="preview-toolbar" class="toolbar disabled" aria-label="Game preview controls">
+        <div class="item">
+            <label for="preview-device">Device:</label>
+            <select id="preview-device"></select>
+        </div>
+        <div class="item"><button id="preview-rotate" type="button" class="checked">Rotate</button></div>
+        <span class="item toolbar-label">Debug Mode:</span>
+        <div class="item">
+            <select id="preview-debug-mode">
+                <option value="NONE">None</option>
+                <option value="VERBOSE">Verbose</option>
+                <option value="INFO">Info</option>
+                <option value="WARN">Warn</option>
+                <option value="ERROR">Error</option>
+                <option value="INFO_FOR_WEB_PAGE">Info For Web Page</option>
+                <option value="WARN_FOR_WEB_PAGE">Warn For Web Page</option>
+                <option value="ERROR_FOR_WEB_PAGE">Error For Web Page</option>
+            </select>
+        </div>
+        <div class="item"><button id="preview-show-fps" type="button">Show FPS</button></div>
+        <div class="item">
+            <label for="preview-frame-rate">FPS:</label>
+            <input id="preview-frame-rate" type="number" min="1" value="60" />
+        </div>
+        <div class="item controls">
+            <button id="preview-pause" type="button">Pause</button><button id="preview-step" type="button">Step</button>
+        </div>
+        <div id="preview-step-length" class="item">
+            <label for="preview-frame-time">Step Length:</label>
+            <input id="preview-frame-time" type="text" value="1" />
+            <span>ms</span>
+        </div>
+    </div>
+    <div id="preview-content">
+        <div id="GameDiv" class="wrapper">
+            <div id="Cocos3dGameContainer">
+                <canvas id="GameCanvas" tabindex="-1"></canvas>
+            </div>
         </div>
     </div>
     <div id="error"></div>
@@ -116,6 +152,10 @@
         } else {
             const { default: gameBoot } = await import('/static/web/game-boot.js');
             await gameBoot();
+            if (new URLSearchParams(window.location.search).get('previewToolbar') === '1') {
+                const { default: initializePreviewToolbar } = await import('/static/web/game-preview-ui.js');
+                initializePreviewToolbar();
+            }
         }
     </script>
 </body>


### PR DESCRIPTION
## Background

PinK's external browser preview previously showed only the game canvas and lacked the device simulation, performance, pause, and debug controls available in Creator's preview page. Simple Browser remains an in-editor lightweight visual preview and is out of scope.

## Implementation

- Enable the browser preview toolbar only when `previewToolbar=1` is present; regular browser preview and Simple Browser are unchanged.
- Reuse existing engine Screen, Game, Debug, and Stats capabilities for device resolution, orientation rotation, webpage fullscreen, native fullscreen, FPS display, pause, step, and step length controls.
- Align the device picker, responsive toolbar layout, pause-only Step and Step Length controls, and the webpage-fullscreen top-hover toolbar behavior with Creator.
- Persist device, rotation, Show FPS, and Debug Mode through the existing preview Socket so they are restored after refresh and applied before game initialization.
- Keep the preview options process-scoped; no project configuration or engine-wide persistence is introduced.

## Known Engine Behavior

The current engine implementation does not route `cc.warn()` to the in-page log panel for `INFO_FOR_WEB_PAGE` or `WARN_FOR_WEB_PAGE`.

Although the web-page branch initially assigns a warning handler that writes to the panel, later shared logic overwrites it with `console.warn`. As a result, `log` and `error` can appear in the in-page panel while `warn` remains in browser DevTools. This behavior also exists in Creator because it uses the same engine implementation.

This PR intentionally does not patch the engine from the CLI layer, preserving the established Creator and engine behavior.

## Scope

- Only affects external browser game previews opened with `previewToolbar=1`.
- Does not change Simple Browser, scene adaptation, shared engine modules, or project configuration persistence.

##
<img width="1066" height="820" alt="image" src="https://github.com/user-attachments/assets/105350bc-b45f-4eca-83c4-23ae8370a0c9" />


## Test Plan

- Open an external browser preview with the toolbar, select device resolutions, and use Rotate to verify simulated size and orientation updates.
- Enter Webpage Full Screen, reveal the toolbar at the top edge, and select another device.
- Pause and resume the game to verify Step and Step Length visibility.
- Change Show FPS, device, rotation, and Debug Mode; refresh and verify that the selections persist.
- Verify Info, Warn, Error, and For Web Page Debug Modes against the current engine logging behavior.

## Verification

- Ran the preview route and toolbar-state regression test.
- Completed the full CLI compilation and generated the dist artifact.
- Compared toolbar interactions, device simulation, and Debug Mode initialization with Creator's preview page.