### PR TITLE
fix(scene): preserve prefab root on delete

### DIFF
--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -532,6 +532,14 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
                 return null;
             }
 
+            // The root in prefab editing mode represents the prefab asset.
+            // A select-all delete may include it, but the asset root must stay
+            // in place so that it is not replaced with an anonymous Empty Node.
+            if (Service.Editor.getCurrentEditorType() === 'prefab' && node.uuid === root.uuid) {
+                console.warn('Cannot remove the root node of an opened prefab asset.');
+                return null;
+            }
+
             const uuids = Service.Prefab.filterChildOfPrefabAssetWhenRemoveNode(node.uuid);
             if (!uuids.length) {
                 return null;

--- a/src/core/scene/test/editor-proxy-prefab.testcase.ts
+++ b/src/core/scene/test/editor-proxy-prefab.testcase.ts
@@ -218,6 +218,28 @@ describe('EditorProxy Prefab 测试', () => {
             expect(content).toContain('abc-prefab');
         });
 
+        it('delete keeps the opened prefab root when a bulk selection includes it', async () => {
+            const root = await EditorProxy.queryCurrent() as INodeInfo;
+            expect(root).not.toBeNull();
+            const rootPath = root.path || root.name;
+            const rootName = root.name;
+
+            const child = await NodeProxy.createByType({
+                path: rootPath,
+                nodeType: NodeType.EMPTY,
+                name: 'prefab-root-delete-child',
+            });
+            expect(child).not.toBeNull();
+
+            await expect(NodeProxy.delete({ path: child!.path, keepWorldTransform: false })).resolves.not.toBeNull();
+            await expect(NodeProxy.delete({ path: rootPath, keepWorldTransform: false })).resolves.toBeNull();
+
+            const after = await NodeProxy.query({ path: rootPath, includeChildren: true });
+            expect(after).not.toBeNull();
+            expect(after?.name).toBe(rootName);
+            expect(after?.path).toBe(rootPath);
+        });
+
         it('reload - 重载当前预制体', async () => {
             const result = await EditorProxy.reload({});
 

--- a/src/core/scene/test/node-delete-prefab-filter.test.ts
+++ b/src/core/scene/test/node-delete-prefab-filter.test.ts
@@ -11,6 +11,7 @@ const mockService = {
         lock: jest.fn(async () => undefined),
         unlock: jest.fn(),
         getRootNode: jest.fn(() => ({ uuid: 'scene-root' })),
+        getCurrentEditorType: jest.fn(() => 'scene'),
     },
     Prefab: {
         filterChildOfPrefabAssetWhenRemoveNode: jest.fn(),
@@ -92,6 +93,7 @@ describe('NodeService delete prefab filtering', () => {
         jest.clearAllMocks();
         mockEditorNode.getNodeByPath.mockReturnValue(node);
         mockService.Editor.getRootNode.mockReturnValue({ uuid: 'scene-root' });
+        mockService.Editor.getCurrentEditorType.mockReturnValue('scene');
         mockShouldRecordStructureCommand.mockReturnValue(true);
     });
 


### PR DESCRIPTION
## Problem

Deleting a select-all hierarchy in prefab editing mode could include the prefab root. CLI removed that root together with the selected nodes, and the editor later displayed anonymous `Empty Node` entries instead of retaining the prefab root and its name.

Creator keeps the opened prefab asset root in this case.

## Cause

`NodeService.delete()` did not distinguish the current prefab editor root from regular nodes. A delete request targeting the root therefore removed the complete prefab hierarchy.

## Fix

- Reject deletion when the current editor is in prefab mode and the target node UUID matches the opened prefab root UUID.
- Continue allowing child nodes to be deleted normally.
- Add a regression test that deletes a child and then attempts to delete the prefab root, verifying that the root path and name remain unchanged.

## Validation

- `npx tsc --noEmit --pretty false` passes.
- The prefab integration suite could not start locally because the installed `gl` native module was built for a different Node ABI.