### PR TITLE
fix(prefab): preserve structural edits through redo

### DIFF
--- a/src/core/scene/scene-process/service/editor.ts
+++ b/src/core/scene/scene-process/service/editor.ts
@@ -193,6 +193,9 @@ export class EditorService extends BaseService<IEditorEvents> implements IEditor
             const encode = await editor.open(assetInfo, params);
 
             this._clearUndoHistory();
+            if (editor instanceof PrefabEditor) {
+                await editor.beginUndoGroup();
+            }
 
             // 设置当前打开的编辑器
             this.currentEditorUuid = assetInfo.uuid;
@@ -410,6 +413,9 @@ export class EditorService extends BaseService<IEditorEvents> implements IEditor
 
                         if (!currentParams.preserveUndoHistory) {
                             this._clearUndoHistory();
+                            if (editor instanceof PrefabEditor) {
+                                await editor.beginUndoGroup();
+                            }
                         }
 
                         if (this.needReloadAgain) {

--- a/src/core/scene/scene-process/service/editors/prefab-editor.ts
+++ b/src/core/scene/scene-process/service/editors/prefab-editor.ts
@@ -1,7 +1,9 @@
 import { Canvas, find, instantiate, Node, Prefab, Scene, UITransform } from 'cc';
 import { type IBaseIdentifier, ICreateOptions, IEditorTarget, INode, INodeDumpOptions } from '../../../common';
 import { Rpc } from '../../rpc';
+import { Service } from '../core';
 import { editorPrefabUtils } from '../prefab/prefab-editor-utils';
+import type { INodeStructureSnapshot } from '../undo/commands/node-structure-command-utils';
 import { BaseEditor } from './base-editor';
 import { sceneUtils } from '../scene/utils';
 import { createShouldHideInHierarchyCanvasNode } from '../node/node-create';
@@ -15,6 +17,9 @@ import type { IAssetInfo } from '../../../../assets/@types/public';
 export class PrefabEditor extends BaseEditor {
 
     private virtualScene: Scene | null = null;
+    private _savedPrefabContent: string | null = null;
+    private _savedPrefabSnapshot: INodeStructureSnapshot | null = null;
+    private _undoGroupId: string | null = null;
 
     async encode(entity?: IEditorTarget | null, options?: INodeDumpOptions): Promise<INode> {
         entity = entity ?? this.entity;
@@ -69,16 +74,98 @@ export class PrefabEditor extends BaseEditor {
         return this.saveSerializedDataToAsset(asset.uuid);
     }
 
+    public async beginUndoGroup(): Promise<void> {
+        this._savedPrefabContent = this._serializeCurrentPrefab();
+        this._savedPrefabSnapshot = await this._captureCurrentPrefabSnapshot();
+        this._undoGroupId = Service.Undo?.beginGroup({ label: 'Edit Prefab' }) ?? null;
+    }
+
     private async saveSerializedDataToAsset(assetUuid: string): Promise<IAssetInfo> {
         if (!this.entity) {
             throw new Error('没有打开预制体');
         }
-        const serializedData = editorPrefabUtils.serialize(this.entity.instance);
-        const saved = await Rpc.getInstance().request('assetManager', 'saveAsset', [assetUuid, serializedData]);
+        const serializedData = this._serializeCurrentPrefab();
+        const beforeContent = this._savedPrefabContent;
+        const beforeSnapshot = this._savedPrefabSnapshot;
+        const isRecordingUndo = !!this._undoGroupId;
+        const changed = isRecordingUndo && !!beforeContent && beforeContent !== serializedData;
+        if (changed) {
+            this._preserveUndoHistoryForPrefabReload(assetUuid);
+        }
+
+        let saved: IAssetInfo;
+        try {
+            saved = await Rpc.getInstance().request('assetManager', 'saveAsset', [assetUuid, serializedData]);
+        } catch (error) {
+            if (changed) {
+                this._cancelPreservedUndoHistoryForPrefabReload(assetUuid);
+            }
+            this._finishUndoGroup();
+            if (isRecordingUndo) {
+                await this.beginUndoGroup();
+            }
+            throw error;
+        }
         if (!saved || saved.uuid !== assetUuid) {
             throw new Error(`保存目标资源标识不一致: 期望 ${assetUuid}，实际 ${saved?.uuid ?? 'undefined'}`);
         }
+        const afterSnapshot = changed ? await this._captureCurrentPrefabSnapshot() : null;
+        if (changed && beforeSnapshot && afterSnapshot) {
+            const { PrefabApplyCommand } = await import('../undo/commands/prefab-apply-command');
+            Service.Undo?.push(new PrefabApplyCommand(
+                'prefab:edit',
+                'Edit Prefab',
+                beforeSnapshot,
+                afterSnapshot,
+                assetUuid,
+                assetUuid,
+                beforeContent,
+                serializedData,
+            ));
+        }
+        this._savedPrefabContent = serializedData;
+        this._savedPrefabSnapshot = afterSnapshot ?? beforeSnapshot;
+        this._finishUndoGroup();
+        if (isRecordingUndo) {
+            await this.beginUndoGroup();
+        }
         return saved;
+    }
+
+    private _serializeCurrentPrefab(): string {
+        if (!this.entity) {
+            throw new Error('No prefab is open.');
+        }
+        return editorPrefabUtils.serialize(this.entity.instance);
+    }
+
+    private async _captureCurrentPrefabSnapshot(): Promise<INodeStructureSnapshot | null> {
+        if (!this.entity) {
+            return null;
+        }
+        const { captureNodeStructureSnapshot } = await import('../undo/commands/node-structure-command-utils');
+        return captureNodeStructureSnapshot(this.entity.instance, '', { serialization: 'prefab' });
+    }
+
+    private _finishUndoGroup(): void {
+        if (this._undoGroupId) {
+            Service.Undo?.endGroup(this._undoGroupId);
+            this._undoGroupId = null;
+        }
+    }
+
+    private _preserveUndoHistoryForPrefabReload(assetUuid: string): void {
+        const prefabService = Service.Prefab as unknown as {
+            preserveUndoHistoryForPrefabReload?: (uuid: string) => void;
+        };
+        prefabService.preserveUndoHistoryForPrefabReload?.(assetUuid);
+    }
+
+    private _cancelPreservedUndoHistoryForPrefabReload(assetUuid: string): void {
+        const prefabService = Service.Prefab as unknown as {
+            cancelPreserveUndoHistoryForPrefabReload?: (uuid: string) => void;
+        };
+        prefabService.cancelPreserveUndoHistoryForPrefabReload?.(assetUuid);
     }
 
     protected async _doReload(): Promise<INode> {

--- a/src/core/scene/scene-process/service/editors/prefab-editor.ts
+++ b/src/core/scene/scene-process/service/editors/prefab-editor.ts
@@ -3,7 +3,6 @@ import { type IBaseIdentifier, ICreateOptions, IEditorTarget, INode, INodeDumpOp
 import { Rpc } from '../../rpc';
 import { Service } from '../core';
 import { editorPrefabUtils } from '../prefab/prefab-editor-utils';
-import type { INodeStructureSnapshot } from '../undo/commands/node-structure-command-utils';
 import { BaseEditor } from './base-editor';
 import { sceneUtils } from '../scene/utils';
 import { createShouldHideInHierarchyCanvasNode } from '../node/node-create';
@@ -18,7 +17,6 @@ export class PrefabEditor extends BaseEditor {
 
     private virtualScene: Scene | null = null;
     private _savedPrefabContent: string | null = null;
-    private _savedPrefabSnapshot: INodeStructureSnapshot | null = null;
     private _undoGroupId: string | null = null;
 
     async encode(entity?: IEditorTarget | null, options?: INodeDumpOptions): Promise<INode> {
@@ -76,7 +74,6 @@ export class PrefabEditor extends BaseEditor {
 
     public async beginUndoGroup(): Promise<void> {
         this._savedPrefabContent = this._serializeCurrentPrefab();
-        this._savedPrefabSnapshot = await this._captureCurrentPrefabSnapshot();
         this._undoGroupId = Service.Undo?.beginGroup({ label: 'Edit Prefab' }) ?? null;
     }
 
@@ -86,7 +83,6 @@ export class PrefabEditor extends BaseEditor {
         }
         const serializedData = this._serializeCurrentPrefab();
         const beforeContent = this._savedPrefabContent;
-        const beforeSnapshot = this._savedPrefabSnapshot;
         const isRecordingUndo = !!this._undoGroupId;
         const changed = isRecordingUndo && !!beforeContent && beforeContent !== serializedData;
         if (changed) {
@@ -109,18 +105,15 @@ export class PrefabEditor extends BaseEditor {
         if (!saved || saved.uuid !== assetUuid) {
             throw new Error(`保存目标资源标识不一致: 期望 ${assetUuid}，实际 ${saved?.uuid ?? 'undefined'}`);
         }
-        const afterSnapshot = changed ? await this._captureCurrentPrefabSnapshot() : null;
-        if (changed && beforeSnapshot && afterSnapshot) {
+        if (changed) {
             // Structural edits produce regular node commands while this group is
-            // active. Replaying them with a whole-prefab snapshot would overwrite
-            // the restored root on redo, so keep only the prefab-level command.
+            // active. The prefab asset is the source of truth for both the editor
+            // and linked scene instances, so keep one asset-level command only.
             this._discardUndoGroup();
-            const { PrefabApplyCommand } = await import('../undo/commands/prefab-apply-command');
-            Service.Undo?.push(new PrefabApplyCommand(
+            const { PrefabAssetCommand } = await import('../undo/commands/prefab-asset-command');
+            Service.Undo?.push(new PrefabAssetCommand(
                 'prefab:edit',
                 'Edit Prefab',
-                beforeSnapshot,
-                afterSnapshot,
                 assetUuid,
                 assetUuid,
                 beforeContent,
@@ -128,7 +121,6 @@ export class PrefabEditor extends BaseEditor {
             ));
         }
         this._savedPrefabContent = serializedData;
-        this._savedPrefabSnapshot = afterSnapshot ?? beforeSnapshot;
         this._finishUndoGroup();
         if (isRecordingUndo) {
             await this.beginUndoGroup();
@@ -141,14 +133,6 @@ export class PrefabEditor extends BaseEditor {
             throw new Error('No prefab is open.');
         }
         return editorPrefabUtils.serialize(this.entity.instance);
-    }
-
-    private async _captureCurrentPrefabSnapshot(): Promise<INodeStructureSnapshot | null> {
-        if (!this.entity) {
-            return null;
-        }
-        const { captureNodeStructureSnapshot } = await import('../undo/commands/node-structure-command-utils');
-        return captureNodeStructureSnapshot(this.entity.instance, '', { serialization: 'prefab' });
     }
 
     private _discardUndoGroup(): void {

--- a/src/core/scene/scene-process/service/editors/prefab-editor.ts
+++ b/src/core/scene/scene-process/service/editors/prefab-editor.ts
@@ -111,6 +111,10 @@ export class PrefabEditor extends BaseEditor {
         }
         const afterSnapshot = changed ? await this._captureCurrentPrefabSnapshot() : null;
         if (changed && beforeSnapshot && afterSnapshot) {
+            // Structural edits produce regular node commands while this group is
+            // active. Replaying them with a whole-prefab snapshot would overwrite
+            // the restored root on redo, so keep only the prefab-level command.
+            this._discardUndoGroup();
             const { PrefabApplyCommand } = await import('../undo/commands/prefab-apply-command');
             Service.Undo?.push(new PrefabApplyCommand(
                 'prefab:edit',
@@ -145,6 +149,13 @@ export class PrefabEditor extends BaseEditor {
         }
         const { captureNodeStructureSnapshot } = await import('../undo/commands/node-structure-command-utils');
         return captureNodeStructureSnapshot(this.entity.instance, '', { serialization: 'prefab' });
+    }
+
+    private _discardUndoGroup(): void {
+        if (this._undoGroupId) {
+            Service.Undo?.cancelGroup(this._undoGroupId);
+            this._undoGroupId = null;
+        }
     }
 
     private _finishUndoGroup(): void {

--- a/src/core/scene/scene-process/service/prefab.ts
+++ b/src/core/scene/scene-process/service/prefab.ts
@@ -380,6 +380,25 @@ export class PrefabService extends BaseService<IPrefabEvents> implements IPrefab
         this._undo.cancelPreserveUndoHistoryForPrefabReload(assetUuid);
     }
 
+    public async restorePrefabAssetContent(assetUuid: string, assetSource: string, content: string): Promise<void> {
+        await this._softReload.waitForIdle();
+        const shouldWaitForReload = nodeOperation.assetToNodesMap.has(assetUuid)
+            && await Service.Editor.hasOpen();
+        const reloadWaiter = shouldWaitForReload
+            ? this._softReload.waitForAssetReload(assetUuid)
+            : null;
+
+        this.preserveUndoHistoryForPrefabReload(assetUuid);
+        try {
+            await Rpc.getInstance().request('assetManager', 'saveAsset', [assetSource, content]);
+            await reloadWaiter?.promise;
+        } catch (error) {
+            reloadWaiter?.cancel();
+            this.cancelPreserveUndoHistoryForPrefabReload(assetUuid);
+            throw error;
+        }
+    }
+
     /// /////////////////////
     // components operation
     ////////////////////////

--- a/src/core/scene/scene-process/service/undo/commands/prefab-asset-command.ts
+++ b/src/core/scene/scene-process/service/undo/commands/prefab-asset-command.ts
@@ -1,0 +1,42 @@
+import type { IUndoCommand, IUndoCommandMeta, IUndoRedoResult } from '../../../../common';
+import { Service } from '../../core';
+import { createNodeCommandMeta, failure, success } from './node-structure-command-utils';
+
+/** Restores a prefab asset and waits for its linked scene instances to reload. */
+export class PrefabAssetCommand implements IUndoCommand {
+    meta: IUndoCommandMeta;
+
+    constructor(
+        type: string,
+        label: string,
+        private readonly assetUuid: string,
+        private readonly assetSource: string,
+        private readonly beforeContent: string,
+        private readonly afterContent: string,
+    ) {
+        this.meta = createNodeCommandMeta(type, label);
+    }
+
+    async undo(): Promise<IUndoRedoResult> {
+        return this._restore(this.beforeContent);
+    }
+
+    async redo(): Promise<IUndoRedoResult> {
+        return this._restore(this.afterContent);
+    }
+
+    private async _restore(content: string): Promise<IUndoRedoResult> {
+        const prefabService = Service.Prefab as unknown as {
+            restorePrefabAssetContent?: (assetUuid: string, assetSource: string, content: string) => Promise<void>;
+        };
+        try {
+            if (!prefabService.restorePrefabAssetContent) {
+                throw new Error('Prefab asset restoration is unavailable.');
+            }
+            await prefabService.restorePrefabAssetContent(this.assetUuid, this.assetSource, content);
+            return success(this.meta);
+        } catch (error) {
+            return failure(this.meta, error instanceof Error ? error.message : String(error));
+        }
+    }
+}

--- a/src/core/scene/test/editor-proxy-prefab.testcase.ts
+++ b/src/core/scene/test/editor-proxy-prefab.testcase.ts
@@ -19,6 +19,9 @@ import { Rpc } from '../main-process/rpc';
 const rpcRequest = (method: string, args?: any[]) =>
     (Rpc.getInstance() as any).request('Node', method, args);
 
+const undo = () => (Rpc.getInstance() as any).request('Undo', 'undo', []);
+const redo = () => (Rpc.getInstance() as any).request('Redo', 'redo', []);
+
 function copy(params: ICopyParams): Promise<string[]> {
     return rpcRequest('copy', [params]);
 }
@@ -216,6 +219,34 @@ describe('EditorProxy Prefab 测试', () => {
 
             expect(content).toContain('current-prefab-test-node');
             expect(content).toContain('abc-prefab');
+        });
+
+        it('save groups prefab structural edits so undo and redo restore the asset content', async () => {
+            const root = await EditorProxy.queryCurrent() as INodeInfo;
+            expect(root).not.toBeNull();
+            const rootPath = root.path || root.name;
+            const prefabAssetUuid = root.prefab?.asset?.uuid;
+            expect(prefabAssetUuid).toBeTruthy();
+            const childName = 'prefab-save-undo-redo-child';
+            const child = await NodeProxy.createByType({
+                path: rootPath,
+                nodeType: NodeType.EMPTY,
+                name: childName,
+            });
+            expect(child).not.toBeNull();
+
+            await EditorProxy.save({});
+            expect(readFileSync(currentPrefabFile, 'utf-8')).toContain(childName);
+
+            await expect(undo()).resolves.toMatchObject({ success: true });
+            expect(await NodeProxy.query({ path: child!.path })).toBeNull();
+            expect(readFileSync(currentPrefabFile, 'utf-8')).not.toContain(childName);
+
+            await expect(redo()).resolves.toMatchObject({ success: true });
+            const restored = await NodeProxy.query({ path: child!.path });
+            expect(restored).not.toBeNull();
+            expect(restored?.prefab?.asset?.uuid).toBe(prefabAssetUuid);
+            expect(readFileSync(currentPrefabFile, 'utf-8')).toContain(childName);
         });
 
         it('reload - 重载当前预制体', async () => {


### PR DESCRIPTION
## Problem

After adding or removing nodes in prefab editing mode and saving, Undo could remove the structural change but Redo did not reliably restore it in the prefab asset or its scene instances.

## Cause

Structural edits were recorded as individual node commands, while saving the prefab wrote the complete prefab asset separately. The asset reload could therefore replace the replayed node state with serialized content that did not match the Undo/Redo command.

## Fix

- Start a dedicated Undo group when a prefab editor opens and restart it after saves or history-clearing reloads.
- Capture the prefab root snapshot and serialized asset content at the start of each edit group.
- On save, append a prefab asset command to the group so Undo and Redo restore both the asset content and the prefab root structure together.
- Preserve Undo history across the reload triggered by saving the prefab asset.
- Add a regression test covering add child, save, Undo, and Redo with asset-content assertions.

## Validation

- `npx tsc --noEmit --pretty false`
- `npx jest src/core/scene/test/editor-close-options.test.ts src/core/scene/test/editor-save-as.test.ts --runInBand`