### PR TITLE
[break] feat: Port terrain editor from cocos-creator with authoring API and fixes

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -7001,6 +7001,7 @@ export declare interface ITerrainService {
     setCurrentLayer(target: ITerrainTarget, currentLayer: number): TerrainReadResult;
     setSculptSession(target: ITerrainTarget, patch: ITerrainSculptSessionPatch): TerrainReadResult;
     setSculptBrushAsset(target: ITerrainTarget, assetUuid: string | null): Promise<TerrainReadResult>;
+    setPaintBrushAsset(target: ITerrainTarget, assetUuid: string | null): Promise<TerrainReadResult>;
     setPaintSession(target: ITerrainTarget, patch: ITerrainPaintSessionPatch): TerrainReadResult;
     saveManage(target: ITerrainTarget, manage: ITerrainManageState): Promise<TerrainReadResult>;
     addLayer(target: ITerrainTarget, layer: ITerrainLayerState): Promise<TerrainReadResult>;

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -7021,6 +7021,7 @@ export declare interface ITerrainService {
 }
 export declare interface ITerrainSnapshot extends ITerrainEditorState {
     target: ITerrainTarget;
+    assetUuid: string | null;
     valid: true;
 }
 export declare interface ITerrainTarget {

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -6917,12 +6917,16 @@ export declare interface ITerrainBlockData {
         x: number;
         y: number;
     };
-    layers: Array<string | null>;
+    layers: Array<ITerrainBlockLayerSlot | null>;
     weight: {
         width: number;
         height: number;
-        data: number[];
+        data: Uint8Array;
     } | null;
+}
+export declare interface ITerrainBlockLayerSlot {
+    layerIndex: number;
+    detailMapUuid: string | null;
 }
 export declare interface ITerrainBlockSnapshot {
     target: ITerrainTarget;

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -6924,7 +6924,6 @@ export declare interface ITerrainBlockSnapshot {
     block: ITerrainBlockData | null;
 }
 export declare interface ITerrainBrushPatch {
-    kind?: TerrainBrushKind;
     radius?: number;
     strength?: number;
     rotation?: number;
@@ -7001,6 +7000,7 @@ export declare interface ITerrainService {
     setMode(target: ITerrainTarget, mode: TerrainEditorMode): TerrainReadResult;
     setCurrentLayer(target: ITerrainTarget, currentLayer: number): TerrainReadResult;
     setSculptSession(target: ITerrainTarget, patch: ITerrainSculptSessionPatch): TerrainReadResult;
+    setSculptBrushAsset(target: ITerrainTarget, assetUuid: string | null): Promise<TerrainReadResult>;
     setPaintSession(target: ITerrainTarget, patch: ITerrainPaintSessionPatch): TerrainReadResult;
     saveManage(target: ITerrainTarget, manage: ITerrainManageState): Promise<TerrainReadResult>;
     addLayer(target: ITerrainTarget, layer: ITerrainLayerState): Promise<TerrainReadResult>;

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -6950,6 +6950,13 @@ export declare interface ITerrainInvalidSnapshot {
     target: ITerrainTarget;
     valid: false;
 }
+export declare interface ITerrainLayerPatch {
+    detailMapUuid?: string | null;
+    normalMapUuid?: string | null;
+    metallic?: number;
+    roughness?: number;
+    tileSize?: number;
+}
 export declare interface ITerrainLayerState {
     detailMapUuid: string | null;
     normalMapUuid: string | null;
@@ -6995,6 +7002,10 @@ export declare interface ITerrainService {
     setCurrentLayer(target: ITerrainTarget, currentLayer: number): TerrainReadResult;
     setSculptSession(target: ITerrainTarget, patch: ITerrainSculptSessionPatch): TerrainReadResult;
     setPaintSession(target: ITerrainTarget, patch: ITerrainPaintSessionPatch): TerrainReadResult;
+    saveManage(target: ITerrainTarget, manage: ITerrainManageState): Promise<TerrainReadResult>;
+    addLayer(target: ITerrainTarget, layer: ITerrainLayerState): Promise<TerrainReadResult>;
+    removeLayer(target: ITerrainTarget, index: number): Promise<TerrainReadResult>;
+    updateLayer(target: ITerrainTarget, index: number, patch: ITerrainLayerPatch): Promise<TerrainReadResult>;
     readBlock(target: ITerrainTarget): TerrainBlockReadResult;
 }
 export declare interface ITerrainSnapshot extends ITerrainEditorState {

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -5412,6 +5412,7 @@ exports[`DTS API compatibility cli.d.ts should match snapshot 1`] = `
 "import type { Component } from 'cc';
 import type { Node as Node_2 } from 'cc';
 import type { Scene } from 'cc';
+import type { Terrain } from 'cc';
 import type { Vec3 as Vec3_2 } from 'cc';
 export declare interface AnimationClipAssetUserData {
     name: string;
@@ -6367,6 +6368,7 @@ export declare interface IGizmoService {
     removeAllGizmoOfNode(node: any, recursive?: boolean): void;
     clearAllGizmos(): void;
     callAllGizmoFuncOfNode(node: any, funcName: string, ...params: any[]): boolean;
+    getComponentGizmo(component: any): any;
     onUpdate(deltaTime: number): void;
     queryToolsVisibility3d(): boolean;
     setToolsVisibility3d(value: boolean): void;
@@ -6867,6 +6869,7 @@ export declare interface IServiceManager {
     Preview: IPreviewService;
     UI: IUIService;
     ReferenceImage: IReferenceImageService;
+    Terrain: ITerrainService;
 }
 export declare interface ISetParentParams {
     paths: string[];
@@ -6902,6 +6905,105 @@ export declare interface ITargetOverrideInfo {
     propertyPath: string[];
     target: string;
     targetInfo?: string[];
+}
+export declare interface ITerrainBlockData {
+    index: {
+        x: number;
+        y: number;
+    };
+    layers: Array<string | null>;
+    weight: {
+        width: number;
+        height: number;
+        data: number[];
+    } | null;
+}
+export declare interface ITerrainBlockSnapshot {
+    target: ITerrainTarget;
+    valid: true;
+    block: ITerrainBlockData | null;
+}
+export declare interface ITerrainBrushPatch {
+    kind?: TerrainBrushKind;
+    radius?: number;
+    strength?: number;
+    rotation?: number;
+    setHeight?: number;
+}
+export declare interface ITerrainBrushState {
+    kind: TerrainBrushKind;
+    imageUuid: string | null;
+    radius: number;
+    strength: number;
+    rotation: number;
+    setHeight: number;
+}
+export declare interface ITerrainEditorState {
+    manage: ITerrainManageState;
+    layers: Array<ITerrainLayerState | null>;
+    mode: TerrainEditorMode;
+    currentLayer: number;
+    sculpt: ITerrainSculptState;
+    paint: ITerrainPaintState;
+}
+export declare interface ITerrainInvalidSnapshot {
+    target: ITerrainTarget;
+    valid: false;
+}
+export declare interface ITerrainLayerState {
+    detailMapUuid: string | null;
+    normalMapUuid: string | null;
+    metallic: number;
+    roughness: number;
+    tileSize: number;
+}
+export declare interface ITerrainManageState {
+    tileSize: number;
+    weightMapSize: number;
+    lightMapSize: number;
+    blockCount: [number, number];
+}
+export declare interface ITerrainPaintSessionPatch {
+    brush?: ITerrainBrushPatch;
+}
+export declare interface ITerrainPaintState {
+    brush: ITerrainBrushState;
+}
+export declare interface ITerrainSculptSessionPatch {
+    tool?: TerrainSculptTool;
+    brush?: ITerrainBrushPatch;
+}
+export declare interface ITerrainSculptState {
+    tool: TerrainSculptTool;
+    brush: ITerrainBrushState;
+}
+export declare interface ITerrainService {
+    readonly name: 'cc.Terrain';
+    readonly editedComponents: Terrain[];
+    readonly selectedComponents: Terrain[];
+    isTerrainChange: boolean;
+    select(nodeUuid: string): void;
+    unselect(nodeUuid: string): void;
+    close(): Promise<0 | 1 | 2>;
+    saveAsset(isClose?: boolean, component?: Terrain): Promise<0 | 1 | 2>;
+    saveAssetDialog(file?: string, isClose?: boolean): Promise<0 | 1 | 2>;
+    addAssetToComp(assetUuid: string): Promise<void>;
+    serialize(component: Terrain): Uint8Array;
+    onSculpt(node: any): void;
+    read(target: ITerrainTarget): TerrainReadResult;
+    setMode(target: ITerrainTarget, mode: TerrainEditorMode): TerrainReadResult;
+    setCurrentLayer(target: ITerrainTarget, currentLayer: number): TerrainReadResult;
+    setSculptSession(target: ITerrainTarget, patch: ITerrainSculptSessionPatch): TerrainReadResult;
+    setPaintSession(target: ITerrainTarget, patch: ITerrainPaintSessionPatch): TerrainReadResult;
+    readBlock(target: ITerrainTarget): TerrainBlockReadResult;
+}
+export declare interface ITerrainSnapshot extends ITerrainEditorState {
+    target: ITerrainTarget;
+    valid: true;
+}
+export declare interface ITerrainTarget {
+    nodeUuid: string;
+    componentUuid: string;
 }
 export declare interface IUIService {
     alignSelection(type: UIAlignType): Promise<void>;
@@ -7296,6 +7398,11 @@ export declare enum TangentImportSetting {
 }
 export declare type TEditorEntity = IScene | INode;
 export declare type TEditorInstance = Scene | Node_2;
+export declare type TerrainBlockReadResult = ITerrainBlockSnapshot | ITerrainInvalidSnapshot;
+export declare type TerrainBrushKind = 'circle' | 'image';
+export declare type TerrainEditorMode = 'manage' | 'sculpt' | 'paint' | 'block';
+export declare type TerrainReadResult = ITerrainSnapshot | ITerrainInvalidSnapshot;
+export declare type TerrainSculptTool = 'bulge' | 'sunken' | 'smooth' | 'flatten' | 'set-height';
 export declare interface Texture2DAssetUserData extends TextureBaseAssetUserData {
     isUuid?: boolean;
     imageUuidOrDatabaseUri?: string;

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -60,7 +60,7 @@ export declare interface AnimGraphVariantDump {
     clips: Record<string, string>;
     invalids?: Record<string, string>;
 }
-export declare const ASSET_HANDLER_TYPES: string[];
+export declare const ASSET_HANDLER_TYPES: readonly ["directory", "unknown", "text", "json", "spine-data", "dragonbones", "dragonbones-atlas", "terrain", "javascript", "typescript", "scene", "prefab", "sprite-frame", "tiled-map", "buffer", "image", "sign-image", "alpha-image", "texture", "texture-cube", "erp-texture-cube", "render-texture", "texture-cube-face", "rt-sprite-frame", "gltf", "gltf-mesh", "gltf-animation", "gltf-skeleton", "gltf-material", "gltf-scene", "gltf-embeded-image", "fbx", "material", "physics-material", "effect", "effect-header", "audio-clip", "animation-clip", "animation-graph", "animation-graph-variant", "animation-mask", "ttf-font", "bitmap-font", "particle", "sprite-atlas", "auto-atlas", "label-atlas", "render-pipeline", "render-stage", "render-flow", "instantiation-material", "instantiation-mesh", "instantiation-skeleton", "instantiation-animation", "video-clip", "*", "database"];
 export declare interface AssetDBOptions {
     name: string;
     target: string;
@@ -88,7 +88,9 @@ export declare interface AssetDBOptions_2 {
     };
     importConcurrency?: number;
 }
-export declare type AssetHandlerType = typeof ASSET_HANDLER_TYPES[number] | 'database';
+export declare type AssetHandlerType =
+| typeof ASSET_HANDLER_TYPES[number]
+| (string & {});
 export declare interface AssetInfo extends IAssetInfo {
     name: string;
     displayName: string;
@@ -1058,7 +1060,7 @@ export declare class Asset extends VirtualAsset {
     save(): Promise<boolean>;
     isDirectory(): boolean;
 }
-export declare const ASSET_HANDLER_TYPES: string[];
+export declare const ASSET_HANDLER_TYPES: readonly ["directory", "unknown", "text", "json", "spine-data", "dragonbones", "dragonbones-atlas", "terrain", "javascript", "typescript", "scene", "prefab", "sprite-frame", "tiled-map", "buffer", "image", "sign-image", "alpha-image", "texture", "texture-cube", "erp-texture-cube", "render-texture", "texture-cube-face", "rt-sprite-frame", "gltf", "gltf-mesh", "gltf-animation", "gltf-skeleton", "gltf-material", "gltf-scene", "gltf-embeded-image", "fbx", "material", "physics-material", "effect", "effect-header", "audio-clip", "animation-clip", "animation-graph", "animation-graph-variant", "animation-mask", "ttf-font", "bitmap-font", "particle", "sprite-atlas", "auto-atlas", "label-atlas", "render-pipeline", "render-stage", "render-flow", "instantiation-material", "instantiation-mesh", "instantiation-skeleton", "instantiation-animation", "video-clip", "*", "database"];
 export declare enum AssetActionEnum {
     'add' = 0,
     'change' = 1,
@@ -1149,7 +1151,9 @@ export declare interface AssetDBStartOptions {
 export declare namespace AssetHandlers {
     export type compressTextures = (tasks: ICompressConfig[]) => Promise<void>;
 }
-export declare type AssetHandlerType = typeof ASSET_HANDLER_TYPES[number] | 'database';
+export declare type AssetHandlerType =
+| typeof ASSET_HANDLER_TYPES[number]
+| (string & {});
 export declare type AssetInfoArr = Array<string | number>;
 export declare interface AssetSerializeOptions {
     'cc.EffectAsset': {
@@ -5445,8 +5449,10 @@ export declare interface AnimationImportSetting {
 export declare type AnimationMode = 'general' | 'prefab' | 'animation' | 'preview' | 'unknown';
 export declare type AnimationPlayOperation = 'play' | 'pause' | 'resume' | 'stop';
 export declare type AnimationPlayState_2 = 'stop' | 'playing' | 'pause';
-export declare const ASSET_HANDLER_TYPES: string[];
-export declare type AssetHandlerType = typeof ASSET_HANDLER_TYPES[number] | 'database';
+export declare const ASSET_HANDLER_TYPES: readonly ["directory", "unknown", "text", "json", "spine-data", "dragonbones", "dragonbones-atlas", "terrain", "javascript", "typescript", "scene", "prefab", "sprite-frame", "tiled-map", "buffer", "image", "sign-image", "alpha-image", "texture", "texture-cube", "erp-texture-cube", "render-texture", "texture-cube-face", "rt-sprite-frame", "gltf", "gltf-mesh", "gltf-animation", "gltf-skeleton", "gltf-material", "gltf-scene", "gltf-embeded-image", "fbx", "material", "physics-material", "effect", "effect-header", "audio-clip", "animation-clip", "animation-graph", "animation-graph-variant", "animation-mask", "ttf-font", "bitmap-font", "particle", "sprite-atlas", "auto-atlas", "label-atlas", "render-pipeline", "render-stage", "render-flow", "instantiation-material", "instantiation-mesh", "instantiation-skeleton", "instantiation-animation", "video-clip", "*", "database"];
+export declare type AssetHandlerType =
+| typeof ASSET_HANDLER_TYPES[number]
+| (string & {});
 export declare interface AssetUserDataMap {
     'animation-clip': AnimationClipAssetUserData;
     'auto-atlas': AutoAtlasAssetUserData;
@@ -7865,7 +7871,7 @@ export declare interface AnimGraphVariantDump {
     clips: Record<string, string>;
     invalids?: Record<string, string>;
 }
-export declare const ASSET_HANDLER_TYPES: string[];
+export declare const ASSET_HANDLER_TYPES: readonly ["directory", "unknown", "text", "json", "spine-data", "dragonbones", "dragonbones-atlas", "terrain", "javascript", "typescript", "scene", "prefab", "sprite-frame", "tiled-map", "buffer", "image", "sign-image", "alpha-image", "texture", "texture-cube", "erp-texture-cube", "render-texture", "texture-cube-face", "rt-sprite-frame", "gltf", "gltf-mesh", "gltf-animation", "gltf-skeleton", "gltf-material", "gltf-scene", "gltf-embeded-image", "fbx", "material", "physics-material", "effect", "effect-header", "audio-clip", "animation-clip", "animation-graph", "animation-graph-variant", "animation-mask", "ttf-font", "bitmap-font", "particle", "sprite-atlas", "auto-atlas", "label-atlas", "render-pipeline", "render-stage", "render-flow", "instantiation-material", "instantiation-mesh", "instantiation-skeleton", "instantiation-animation", "video-clip", "*", "database"];
 export declare enum AssetActionEnum {
     'add' = 0,
     'change' = 1,
@@ -7907,7 +7913,9 @@ export declare interface AssetDBOptions_2 {
     visible: boolean;
     ignoreGlob?: string;
 }
-export declare type AssetHandlerType = typeof ASSET_HANDLER_TYPES[number] | 'database';
+export declare type AssetHandlerType =
+| typeof ASSET_HANDLER_TYPES[number]
+| (string & {});
 export declare interface AssetInfo extends IAssetInfo {
     name: string;
     displayName: string;

--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -6529,6 +6529,20 @@ export declare interface IOriginAxesConfig {
     y: boolean;
     z: boolean;
 }
+export declare interface IParticlePlayInfo {
+    speed: number;
+    time: number;
+    particle: number;
+    isPlaying: boolean;
+}
+export declare interface IParticleService {
+    queryPlayInfo(uuid: string): IParticlePlayInfo | null;
+    setPlaySpeed(uuid: string, speed: number): void;
+    play(): void;
+    stop(): void;
+    pause(): void;
+    restart(): void;
+}
 export declare interface IPasteParams {
     parentPath?: string;
     keepWorldTransform?: boolean;
@@ -6875,6 +6889,7 @@ export declare interface IServiceManager {
     Preview: IPreviewService;
     UI: IUIService;
     ReferenceImage: IReferenceImageService;
+    Particle: IParticleService;
     Terrain: ITerrainService;
 }
 export declare interface ISetParentParams {

--- a/packages/cocos-cli-types/__tests__/dts-snapshot.test.ts
+++ b/packages/cocos-cli-types/__tests__/dts-snapshot.test.ts
@@ -38,4 +38,24 @@ describe('DTS API compatibility', () => {
             expect(content).toMatchSnapshot();
         });
     }
+
+    it('cli.d.ts preserves literal asset handler types', () => {
+        const filePath = path.join(dtsRoot, 'cli.d.ts');
+        const content = stripComments(fs.readFileSync(filePath, 'utf-8'));
+        const declaration = content.match(
+            /export declare const ASSET_HANDLER_TYPES: ([^;]+);/,
+        )?.[1];
+
+        if (!declaration) {
+            throw new Error('ASSET_HANDLER_TYPES declaration not found in cli.d.ts');
+        }
+
+        expect(declaration).toMatch(/^readonly \[/);
+        expect(declaration).toContain('"directory"');
+        expect(declaration).toContain('"database"');
+        expect(content).toMatch(
+            /export declare type AssetHandlerType =\s*\|?\s*typeof ASSET_HANDLER_TYPES\[number\]\s*\|\s*(?:\(string & \{\}\)|string & \{\});/,
+        );
+    });
+
 });

--- a/src/core/assets/@types/asset-types.d.ts
+++ b/src/core/assets/@types/asset-types.d.ts
@@ -75,8 +75,10 @@ export type IAssetType =
 export type ISupportCreateType = typeof SUPPORT_CREATE_TYPES[number];
 
 
-/** 资源处理器类型（从常量数组派生） */
-export type AssetHandlerType = typeof ASSET_HANDLER_TYPES[number] | 'database';
+/** Asset handler types include built-in values and extension-registered importer names. */
+export type AssetHandlerType =
+    | typeof ASSET_HANDLER_TYPES[number]
+    | (string & {});
 
 export interface AssetUserDataMap {
     'animation-clip': AnimationClipAssetUserData;

--- a/src/core/assets/@types/interface.ts
+++ b/src/core/assets/@types/interface.ts
@@ -58,7 +58,7 @@ export const ASSET_HANDLER_TYPES = [
     'video-clip',
     '*',
     'database',
-];
+] as const;
 
 /** 支持创建的资源类型常量数组（用于 Zod enum 和 TypeScript type） */
 export const SUPPORT_CREATE_TYPES = [

--- a/src/core/assets/manager/asset-handler.ts
+++ b/src/core/assets/manager/asset-handler.ts
@@ -425,7 +425,8 @@ class AssetHandlerManager {
             // content 不存在，新建一个文件夹
             await createDirectoryPath(options.target);
         } else {
-            if (typeof options.content === 'object') {
+            // Buffers are already a filesystem write type; serializing one would corrupt binary assets.
+            if (typeof options.content === 'object' && !Buffer.isBuffer(options.content)) {
                 options.content = JSON.stringify(options.content, null, 4);
             }
             // Normalize EOL for string content

--- a/src/core/assets/test/asset-handler-filesystem-bridge.test.ts
+++ b/src/core/assets/test/asset-handler-filesystem-bridge.test.ts
@@ -124,4 +124,14 @@ describe('asset handler filesystem bridge', () => {
         expect(mockWritePath.mock.calls[2][1]).toBe('world');
         expect(mockOutputJSON).not.toHaveBeenCalled();
     });
+
+    it('createAsset should preserve binary content for the filesystem bridge', async () => {
+        const assetHandlerManager = require('../manager/asset-handler').default as typeof import('../manager/asset-handler').default;
+        const target = 'D:/project/assets/new.terrain';
+        const content = Buffer.from([0, 1, 127, 255]);
+
+        await assetHandlerManager.createAsset({ target, content });
+
+        expect(mockWritePath).toHaveBeenCalledWith(target, content);
+    });
 });

--- a/src/core/scene/asset-binary-routes.ts
+++ b/src/core/scene/asset-binary-routes.ts
@@ -1,0 +1,204 @@
+import type { Request, Response } from 'express';
+import type { IGetPostConfig } from '../../server/interfaces';
+import type { IAssetInfo } from '../assets/@types/public';
+
+const BINARY_CONTENT_TYPE = 'application/octet-stream';
+export const ASSET_BINARY_MAX_BYTES = 50 * 1024 * 1024;
+
+interface AssetBinaryManager {
+    saveAsset(assetUuid: string, content: Buffer): Promise<IAssetInfo>;
+    createAsset(options: { target: string; overwrite: boolean; content: Buffer }): Promise<IAssetInfo>;
+}
+
+export interface AssetBinaryRouteDependencies {
+    loadAssetManager(): Promise<AssetBinaryManager>;
+}
+
+class HttpRequestError extends Error {
+    constructor(readonly status: number, message: string) {
+        super(message);
+    }
+}
+
+class RequestAbortedError extends Error {
+    constructor() {
+        super('Binary request was aborted');
+    }
+}
+
+function getHeaderValue(value: string | string[] | undefined): string | undefined {
+    return Array.isArray(value) ? value[0] : value;
+}
+
+function isOctetStreamRequest(req: Request): boolean {
+    const contentType = getHeaderValue(req.headers['content-type']);
+    return contentType?.split(';', 1)[0].trim().toLowerCase() === BINARY_CONTENT_TYPE;
+}
+
+function isAssetUuid(value: unknown): value is string {
+    return typeof value === 'string'
+        && /^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i.test(value);
+}
+
+function hasOnlyQueryKeys(req: Request, keys: readonly string[]): boolean {
+    const allowed = new Set(keys);
+    return Object.keys(req.query).every((key) => allowed.has(key));
+}
+
+function sendError(res: Response, status: number, error: string): void {
+    if (!res.headersSent && !res.destroyed) {
+        res.status(status).json({ error });
+    }
+}
+
+function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Aggregates a binary request body locally to the binary Asset routes.
+ * The helper keeps the 50 MiB transport policy out of the global JSON parser
+ * and checks chunks even when Content-Length is absent or untrusted.
+ */
+export function readBinaryBody(req: Request, limit = ASSET_BINARY_MAX_BYTES): Promise<Buffer> {
+    const contentLength = Number(getHeaderValue(req.headers?.['content-length']));
+    if (Number.isFinite(contentLength) && contentLength > limit) {
+        return Promise.reject(new HttpRequestError(413, 'Raw binary body exceeds 50 MiB'));
+    }
+
+    return new Promise<Buffer>((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        let length = 0;
+        let settled = false;
+
+        const cleanup = () => {
+            req.off('data', onData);
+            req.off('end', onEnd);
+            req.off('error', onError);
+            req.off('aborted', onAborted);
+        };
+        const fail = (error: Error) => {
+            if (settled) return;
+            settled = true;
+            cleanup();
+            reject(error);
+        };
+        const onData = (chunk: Buffer | Uint8Array | string) => {
+            const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+            length += buffer.length;
+            if (length > limit) {
+                fail(new HttpRequestError(413, 'Raw binary body exceeds 50 MiB'));
+                req.resume();
+                return;
+            }
+            chunks.push(buffer);
+        };
+        const onEnd = () => {
+            if (settled) return;
+            settled = true;
+            cleanup();
+            resolve(Buffer.concat(chunks, length));
+        };
+        const onError = (error: Error) => fail(error);
+        const onAborted = () => fail(new RequestAbortedError());
+
+        req.on('data', onData);
+        req.once('end', onEnd);
+        req.once('error', onError);
+        req.once('aborted', onAborted);
+    });
+}
+
+function createDefaultDependencies(): AssetBinaryRouteDependencies {
+    return {
+        async loadAssetManager() {
+            const { assetManager } = await import('../assets');
+            return assetManager;
+        },
+    };
+}
+
+function handleRouteError(error: unknown, res: Response): void {
+    if (error instanceof RequestAbortedError) {
+        return;
+    }
+    if (error instanceof HttpRequestError) {
+        sendError(res, error.status, error.message);
+        return;
+    }
+    sendError(res, 500, errorMessage(error));
+}
+
+/**
+ * Creates the narrow browser-facing binary Asset write routes.
+ * All identifier, metadata, body-size, and error translation rules stay here;
+ * callers only receive the stable save/create operations.
+ */
+export function createAssetBinaryRoutes(
+    dependencies: AssetBinaryRouteDependencies = createDefaultDependencies(),
+): IGetPostConfig[] {
+    return [
+        {
+            url: '/assets/binary/v1/save/:assetUuid',
+            async handler(req: Request, res: Response) {
+                if (!isOctetStreamRequest(req)) {
+                    sendError(res, 415, 'Content-Type must be application/octet-stream');
+                    return;
+                }
+                if (!hasOnlyQueryKeys(req, [])) {
+                    sendError(res, 400, 'save does not accept query parameters');
+                    return;
+                }
+                const { assetUuid } = req.params;
+                if (!isAssetUuid(assetUuid)) {
+                    sendError(res, 400, 'assetUuid must be a UUID');
+                    return;
+                }
+
+                try {
+                    const content = await readBinaryBody(req);
+                    const assetManager = await dependencies.loadAssetManager();
+                    const result = await assetManager.saveAsset(assetUuid, content);
+                    res.status(200).json(result);
+                } catch (error) {
+                    handleRouteError(error, res);
+                }
+            },
+        },
+        {
+            url: '/assets/binary/v1/create',
+            async handler(req: Request, res: Response) {
+                if (!isOctetStreamRequest(req)) {
+                    sendError(res, 415, 'Content-Type must be application/octet-stream');
+                    return;
+                }
+                if (!hasOnlyQueryKeys(req, ['target', 'overwrite'])) {
+                    sendError(res, 400, 'create accepts only target and overwrite query parameters');
+                    return;
+                }
+                const { target, overwrite } = req.query;
+                if (typeof target !== 'string' || !target.startsWith('db://')) {
+                    sendError(res, 400, 'target must be a db:// URL');
+                    return;
+                }
+                if (overwrite !== 'true' && overwrite !== 'false') {
+                    sendError(res, 400, 'overwrite must be true or false');
+                    return;
+                }
+
+                try {
+                    const content = await readBinaryBody(req);
+                    const assetManager = await dependencies.loadAssetManager();
+                    const result = await assetManager.createAsset({
+                        target,
+                        overwrite: overwrite === 'true',
+                        content,
+                    });
+                    res.status(200).json(result);
+                } catch (error) {
+                    handleRouteError(error, res);
+                }
+            },
+        },
+    ];
+}

--- a/src/core/scene/common/gizmo.ts
+++ b/src/core/scene/common/gizmo.ts
@@ -29,6 +29,7 @@ export interface IGizmoService {
     removeAllGizmoOfNode(node: any, recursive?: boolean): void;
     clearAllGizmos(): void;
     callAllGizmoFuncOfNode(node: any, funcName: string, ...params: any[]): boolean;
+    getComponentGizmo(component: any): any;
     onUpdate(deltaTime: number): void;
 
     // 与 cocos-editor GizmoManager 一致：GizmoConfig 方法

--- a/src/core/scene/common/index.ts
+++ b/src/core/scene/common/index.ts
@@ -16,6 +16,7 @@ export * from './gizmo';
 export * from './scene-view';
 export * from './preview';
 export * from './ui';
+export * from './terrain';
 export * from './message';
 export * from './reference-image';
 export * from './particle';

--- a/src/core/scene/common/terrain.ts
+++ b/src/core/scene/common/terrain.ts
@@ -1,6 +1,133 @@
 import type { Terrain } from 'cc';
 
-/** Terrain 编辑器的非 UI 接口；pink 只需要调用这些接口。 */
+/** Identifies one Terrain component without relying on the active gizmo selection. */
+export interface ITerrainTarget {
+    nodeUuid: string;
+    componentUuid: string;
+}
+
+/** The active non-asset Terrain editor view; `block` is read-only block inspection. */
+export type TerrainEditorMode = 'manage' | 'sculpt' | 'paint' | 'block';
+/** The Sculpt behavior applied while the editor is in `sculpt` mode. */
+export type TerrainSculptTool = 'bulge' | 'sunken' | 'smooth' | 'flatten' | 'set-height';
+/** The brush implementation currently selected for a Terrain editor session. */
+export type TerrainBrushKind = 'circle' | 'image';
+
+/** JSON-safe TerrainInfo values used to hydrate the Manage view. */
+export interface ITerrainManageState {
+    tileSize: number;
+    weightMapSize: number;
+    lightMapSize: number;
+    blockCount: [number, number];
+}
+
+/** JSON-safe Terrain layer data. Its array index is the Terrain layer slot. */
+export interface ITerrainLayerState {
+    detailMapUuid: string | null;
+    normalMapUuid: string | null;
+    metallic: number;
+    roughness: number;
+    tileSize: number;
+}
+
+/** JSON-safe, non-asset Terrain editor brush state. */
+export interface ITerrainBrushState {
+    kind: TerrainBrushKind;
+    imageUuid: string | null;
+    radius: number;
+    strength: number;
+    rotation: number;
+    setHeight: number;
+}
+
+/** Canonical Sculpt session state for a valid Terrain target. */
+export interface ITerrainSculptState {
+    tool: TerrainSculptTool;
+    brush: ITerrainBrushState;
+}
+
+/** Canonical Paint session state for a valid Terrain target. */
+export interface ITerrainPaintState {
+    brush: ITerrainBrushState;
+}
+
+/** The canonical editor-session state for one valid Terrain target. */
+export interface ITerrainEditorState {
+    manage: ITerrainManageState;
+    layers: Array<ITerrainLayerState | null>;
+    mode: TerrainEditorMode;
+    currentLayer: number;
+    sculpt: ITerrainSculptState;
+    paint: ITerrainPaintState;
+}
+
+/** A usable authoritative snapshot. Read its hydration state only after narrowing `valid` to `true`. */
+export interface ITerrainSnapshot extends ITerrainEditorState {
+    target: ITerrainTarget;
+    valid: true;
+}
+
+/** A rejected target has no usable Terrain state attached to it. */
+export interface ITerrainInvalidSnapshot {
+    target: ITerrainTarget;
+    valid: false;
+}
+
+/** Discriminated read result. Callers must replace cached state when `valid` is `false`. */
+export type TerrainReadResult = ITerrainSnapshot | ITerrainInvalidSnapshot;
+
+/** A partial, non-asset brush-session update. Omitted fields keep their current values. */
+export interface ITerrainBrushPatch {
+    kind?: TerrainBrushKind;
+    radius?: number;
+    strength?: number;
+    rotation?: number;
+    setHeight?: number;
+}
+
+/** A partial Sculpt session update that does not assign brush assets or create Scene Undo entries. */
+export interface ITerrainSculptSessionPatch {
+    tool?: TerrainSculptTool;
+    brush?: ITerrainBrushPatch;
+}
+
+/** A partial Paint session update that does not assign brush assets or create Scene Undo entries. */
+export interface ITerrainPaintSessionPatch {
+    brush?: ITerrainBrushPatch;
+}
+
+/**
+ * JSON-safe data for the currently inspected Terrain block.
+ *
+ * `layers` maps the block's RGBA channel slots to Terrain layer UUIDs. When present,
+ * `weight.data` is row-major RGBA bytes: four 0–255 values for every texel.
+ */
+export interface ITerrainBlockData {
+    index: { x: number; y: number };
+    layers: Array<string | null>;
+    weight: {
+        width: number;
+        height: number;
+        data: number[];
+    } | null;
+}
+
+/** A valid target may have no currently inspected block. */
+export interface ITerrainBlockSnapshot {
+    target: ITerrainTarget;
+    valid: true;
+    block: ITerrainBlockData | null;
+}
+
+/** A block-read result. A valid target may still have `block: null` when no block is selected. */
+export type TerrainBlockReadResult = ITerrainBlockSnapshot | ITerrainInvalidSnapshot;
+
+/**
+ * Terrain editor capability consumed by the Scene webview.
+ *
+ * Reads and commands always require an explicit node/component pair. Results are
+ * canonical snapshots; a `valid: false` result must replace any cached state.
+ */
 export interface ITerrainService {
     readonly name: 'cc.Terrain';
     readonly editedComponents: Terrain[];
@@ -14,15 +141,35 @@ export interface ITerrainService {
     addAssetToComp(assetUuid: string): Promise<void>;
     serialize(component: Terrain): Uint8Array;
     onSculpt(node: any): void;
+
+    /** Reads the canonical state for one explicit target without mutating Terrain. */
+    read(target: ITerrainTarget): TerrainReadResult;
+    /** Changes the active editor mode without mutating Terrain assets or creating Scene Undo. */
+    setMode(target: ITerrainTarget, mode: TerrainEditorMode): TerrainReadResult;
+    /** Changes the active Paint layer; pass `-1` to clear it without creating Scene Undo. */
+    setCurrentLayer(target: ITerrainTarget, currentLayer: number): TerrainReadResult;
+    /** Applies a partial Sculpt session update without assigning brush assets or creating Scene Undo. */
+    setSculptSession(target: ITerrainTarget, patch: ITerrainSculptSessionPatch): TerrainReadResult;
+    /** Applies a partial Paint session update without assigning brush assets or creating Scene Undo. */
+    setPaintSession(target: ITerrainTarget, patch: ITerrainPaintSessionPatch): TerrainReadResult;
+    /** Reads the current block without mutation or Scene Undo; `block` is null when no block is selected. */
+    readBlock(target: ITerrainTarget): TerrainBlockReadResult;
 }
 
 export type IPublicTerrainService = Pick<ITerrainService,
     'name' | 'isTerrainChange' | 'select' | 'unselect' | 'close' |
-    'saveAsset' | 'saveAssetDialog' | 'addAssetToComp'
+    'saveAsset' | 'saveAssetDialog' | 'addAssetToComp' |
+    'read' | 'setMode' | 'setCurrentLayer' | 'setSculptSession' |
+    'setPaintSession' | 'readBlock'
 >;
 
 export interface ITerrainEvents {
+    /** Invalidation only. Do not derive UI state from `component`; re-read the explicit target. */
     'terrain:changed': [component: Terrain];
+    /** Invalidation only. Do not derive UI state from `node`; re-read the explicit target. */
     'terrain:sculpt': [node: any];
+    /** Invalidation only. Re-read the explicit target's canonical block state. */
     'terrain:block-update': [];
+    /** Invalidation only. Re-read the explicit target's canonical Terrain state. */
+    'terrain:session-changed': [target: ITerrainTarget];
 }

--- a/src/core/scene/common/terrain.ts
+++ b/src/core/scene/common/terrain.ts
@@ -85,9 +85,8 @@ export interface ITerrainInvalidSnapshot {
 /** Discriminated read result. Callers must replace cached state when `valid` is `false`. */
 export type TerrainReadResult = ITerrainSnapshot | ITerrainInvalidSnapshot;
 
-/** A partial, non-asset brush-session update. Omitted fields keep their current values. */
+/** A partial, non-asset numeric brush-session update. Brush image selection is controlled by dedicated asset commands. */
 export interface ITerrainBrushPatch {
-    kind?: TerrainBrushKind;
     radius?: number;
     strength?: number;
     rotation?: number;
@@ -160,6 +159,8 @@ export interface ITerrainService {
     setCurrentLayer(target: ITerrainTarget, currentLayer: number): TerrainReadResult;
     /** Applies a partial Sculpt session update without assigning brush assets or creating Scene Undo. */
     setSculptSession(target: ITerrainTarget, patch: ITerrainSculptSessionPatch): TerrainReadResult;
+    /** Assigns a Texture2D asset UUID to Sculpt; pass null to clear it and restore the circle brush without creating Scene Undo. */
+    setSculptBrushAsset(target: ITerrainTarget, assetUuid: string | null): Promise<TerrainReadResult>;
     /** Applies a partial Paint session update without assigning brush assets or creating Scene Undo. */
     setPaintSession(target: ITerrainTarget, patch: ITerrainPaintSessionPatch): TerrainReadResult;
     /** Commits a complete Manage draft as one TerrainInfo/Undo mutation. */
@@ -178,7 +179,7 @@ export type IPublicTerrainService = Pick<ITerrainService,
     'name' | 'isTerrainChange' | 'select' | 'unselect' | 'close' |
     'saveAsset' | 'saveAssetDialog' | 'addAssetToComp' |
     'read' | 'setMode' | 'setCurrentLayer' | 'setSculptSession' |
-    'setPaintSession' | 'saveManage' | 'addLayer' | 'removeLayer' |
+    'setSculptBrushAsset' | 'setPaintSession' | 'saveManage' | 'addLayer' | 'removeLayer' |
     'updateLayer' | 'readBlock'
 >;
 

--- a/src/core/scene/common/terrain.ts
+++ b/src/core/scene/common/terrain.ts
@@ -161,6 +161,8 @@ export interface ITerrainService {
     setSculptSession(target: ITerrainTarget, patch: ITerrainSculptSessionPatch): TerrainReadResult;
     /** Assigns a Texture2D asset UUID to Sculpt; pass null to clear it and restore the circle brush without creating Scene Undo. */
     setSculptBrushAsset(target: ITerrainTarget, assetUuid: string | null): Promise<TerrainReadResult>;
+    /** Assigns a Texture2D asset UUID to Paint; pass null to clear it and restore the circle brush without creating Scene Undo. */
+    setPaintBrushAsset(target: ITerrainTarget, assetUuid: string | null): Promise<TerrainReadResult>;
     /** Applies a partial Paint session update without assigning brush assets or creating Scene Undo. */
     setPaintSession(target: ITerrainTarget, patch: ITerrainPaintSessionPatch): TerrainReadResult;
     /** Commits a complete Manage draft as one TerrainInfo/Undo mutation. */
@@ -179,7 +181,7 @@ export type IPublicTerrainService = Pick<ITerrainService,
     'name' | 'isTerrainChange' | 'select' | 'unselect' | 'close' |
     'saveAsset' | 'saveAssetDialog' | 'addAssetToComp' |
     'read' | 'setMode' | 'setCurrentLayer' | 'setSculptSession' |
-    'setSculptBrushAsset' | 'setPaintSession' | 'saveManage' | 'addLayer' | 'removeLayer' |
+    'setSculptBrushAsset' | 'setPaintBrushAsset' | 'setPaintSession' | 'saveManage' | 'addLayer' | 'removeLayer' |
     'updateLayer' | 'readBlock'
 >;
 

--- a/src/core/scene/common/terrain.ts
+++ b/src/core/scene/common/terrain.ts
@@ -73,6 +73,8 @@ export interface ITerrainEditorState {
 /** A usable authoritative snapshot. Read its hydration state only after narrowing `valid` to `true`. */
 export interface ITerrainSnapshot extends ITerrainEditorState {
     target: ITerrainTarget;
+    /** The persisted .terrain asset UUID, or null when this Terrain is not saveable yet. */
+    assetUuid: string | null;
     valid: true;
 }
 

--- a/src/core/scene/common/terrain.ts
+++ b/src/core/scene/common/terrain.ts
@@ -104,19 +104,30 @@ export interface ITerrainPaintSessionPatch {
     brush?: ITerrainBrushPatch;
 }
 
+/** One Terrain layer assigned to an RGBA channel in a selected Terrain block. */
+export interface ITerrainBlockLayerSlot {
+    /** The authoritative index into the selected Terrain component's layer list. */
+    layerIndex: number;
+    /** The assigned layer's detail map, when the layer has one. */
+    detailMapUuid: string | null;
+}
+
 /**
- * JSON-safe data for the currently inspected Terrain block.
+ * Direct Scene-webview binary data for the currently inspected Terrain block.
  *
- * `layers` maps the block's RGBA channel slots to Terrain layer UUIDs. When present,
- * `weight.data` is row-major RGBA bytes: four 0–255 values for every texel.
+ * `layers` maps the block's RGBA channel slots to Terrain layers. A null slot has no
+ * assigned Terrain layer; a non-null slot retains its layer index even without a detail map.
+ * When present, `weight.data` is a defensive, row-major RGBA8 snapshot: four bytes for every texel.
+ * It is intentionally not JSON-serializable; a future transport must encode it at
+ * that transport's seam rather than changing this direct webview interface.
  */
 export interface ITerrainBlockData {
     index: { x: number; y: number };
-    layers: Array<string | null>;
+    layers: Array<ITerrainBlockLayerSlot | null>;
     weight: {
         width: number;
         height: number;
-        data: number[];
+        data: Uint8Array;
     } | null;
 }
 

--- a/src/core/scene/common/terrain.ts
+++ b/src/core/scene/common/terrain.ts
@@ -13,7 +13,7 @@ export type TerrainSculptTool = 'bulge' | 'sunken' | 'smooth' | 'flatten' | 'set
 /** The brush implementation currently selected for a Terrain editor session. */
 export type TerrainBrushKind = 'circle' | 'image';
 
-/** JSON-safe TerrainInfo values used to hydrate the Manage view. */
+/** A complete JSON-safe TerrainInfo snapshot and `saveManage` payload; map sizes and block counts must be positive integers. */
 export interface ITerrainManageState {
     tileSize: number;
     weightMapSize: number;
@@ -28,6 +28,15 @@ export interface ITerrainLayerState {
     metallic: number;
     roughness: number;
     tileSize: number;
+}
+
+/** A partial JSON-safe Terrain layer update: omitted fields are unchanged, null texture UUIDs clear maps, and other UUIDs must resolve to compatible Texture2D assets. */
+export interface ITerrainLayerPatch {
+    detailMapUuid?: string | null;
+    normalMapUuid?: string | null;
+    metallic?: number;
+    roughness?: number;
+    tileSize?: number;
 }
 
 /** JSON-safe, non-asset Terrain editor brush state. */
@@ -123,10 +132,11 @@ export interface ITerrainBlockSnapshot {
 export type TerrainBlockReadResult = ITerrainBlockSnapshot | ITerrainInvalidSnapshot;
 
 /**
- * Terrain editor capability consumed by the Scene webview.
+ * Target-safe Terrain editor capability consumed by the Scene webview.
  *
  * Reads and commands always require an explicit node/component pair. Results are
  * canonical snapshots; a `valid: false` result must replace any cached state.
+ * A rejected target does not mutate Terrain or create a new Undo entry.
  */
 export interface ITerrainService {
     readonly name: 'cc.Terrain';
@@ -152,6 +162,14 @@ export interface ITerrainService {
     setSculptSession(target: ITerrainTarget, patch: ITerrainSculptSessionPatch): TerrainReadResult;
     /** Applies a partial Paint session update without assigning brush assets or creating Scene Undo. */
     setPaintSession(target: ITerrainTarget, patch: ITerrainPaintSessionPatch): TerrainReadResult;
+    /** Commits a complete Manage draft as one TerrainInfo/Undo mutation. */
+    saveManage(target: ITerrainTarget, manage: ITerrainManageState): Promise<TerrainReadResult>;
+    /** Adds a fully specified Terrain layer; `detailMapUuid` must identify a compatible Texture2D. */
+    addLayer(target: ITerrainTarget, layer: ITerrainLayerState): Promise<TerrainReadResult>;
+    /** Removes one Terrain layer slot and returns the authoritative state. */
+    removeLayer(target: ITerrainTarget, index: number): Promise<TerrainReadResult>;
+    /** Applies one explicit layer patch and returns the authoritative state. */
+    updateLayer(target: ITerrainTarget, index: number, patch: ITerrainLayerPatch): Promise<TerrainReadResult>;
     /** Reads the current block without mutation or Scene Undo; `block` is null when no block is selected. */
     readBlock(target: ITerrainTarget): TerrainBlockReadResult;
 }
@@ -160,7 +178,8 @@ export type IPublicTerrainService = Pick<ITerrainService,
     'name' | 'isTerrainChange' | 'select' | 'unselect' | 'close' |
     'saveAsset' | 'saveAssetDialog' | 'addAssetToComp' |
     'read' | 'setMode' | 'setCurrentLayer' | 'setSculptSession' |
-    'setPaintSession' | 'readBlock'
+    'setPaintSession' | 'saveManage' | 'addLayer' | 'removeLayer' |
+    'updateLayer' | 'readBlock'
 >;
 
 export interface ITerrainEvents {

--- a/src/core/scene/common/terrain.ts
+++ b/src/core/scene/common/terrain.ts
@@ -1,0 +1,28 @@
+import type { Terrain } from 'cc';
+
+/** Terrain 编辑器的非 UI 接口；pink 只需要调用这些接口。 */
+export interface ITerrainService {
+    readonly name: 'cc.Terrain';
+    readonly editedComponents: Terrain[];
+    readonly selectedComponents: Terrain[];
+    isTerrainChange: boolean;
+    select(nodeUuid: string): void;
+    unselect(nodeUuid: string): void;
+    close(): Promise<0 | 1 | 2>;
+    saveAsset(isClose?: boolean, component?: Terrain): Promise<0 | 1 | 2>;
+    saveAssetDialog(file?: string, isClose?: boolean): Promise<0 | 1 | 2>;
+    addAssetToComp(assetUuid: string): Promise<void>;
+    serialize(component: Terrain): Uint8Array;
+    onSculpt(node: any): void;
+}
+
+export type IPublicTerrainService = Pick<ITerrainService,
+    'name' | 'isTerrainChange' | 'select' | 'unselect' | 'close' |
+    'saveAsset' | 'saveAssetDialog' | 'addAssetToComp'
+>;
+
+export interface ITerrainEvents {
+    'terrain:changed': [component: Terrain];
+    'terrain:sculpt': [node: any];
+    'terrain:block-update': [];
+}

--- a/src/core/scene/scene-process/rpc.ts
+++ b/src/core/scene/scene-process/rpc.ts
@@ -3,6 +3,7 @@ import type { IMainModule } from '../main-process';
 
 export class RpcProxy {
     private rpcInstance: ProcessRPC<IMainModule> | null = null;
+    private webServerUrl: string | undefined;
 
     public getInstance() {
         if (!this.rpcInstance) {
@@ -11,11 +12,17 @@ export class RpcProxy {
         return this.rpcInstance;
     }
 
+    /** Returns a URL only when this proxy owns the browser Web RPC transport. */
+    public getWebServerUrl(): string | undefined {
+        return this.webServerUrl;
+    }
+
     async startup(options?: { serverURL: string }) {
         // 在创建新实例前，先清理旧实例，防止内存泄漏
         this.dispose();
         this.rpcInstance = new ProcessRPC<IMainModule>();
         if (options?.serverURL) {
+            this.webServerUrl = options.serverURL;
             this.rpcInstance.setWebTransport(options.serverURL);
             console.log('[Scene] Scene Process Web RPC ready');
         } else {
@@ -30,15 +37,19 @@ export class RpcProxy {
      * 清理 RPC 实例
      */
     dispose(): void {
-        if (this.rpcInstance) {
-            console.log('[Node] Disposing RPC instance');
-            try {
-                this.rpcInstance.dispose();
-            } catch (error) {
-                console.warn('[Node] Error disposing RPC instance:', error);
-            } finally {
-                this.rpcInstance = null;
-            }
+        if (!this.rpcInstance) {
+            this.webServerUrl = undefined;
+            return;
+        }
+
+        console.log('[Node] Disposing RPC instance');
+        try {
+            this.rpcInstance.dispose();
+        } catch (error) {
+            console.warn('[Node] Error disposing RPC instance:', error);
+        } finally {
+            this.rpcInstance = null;
+            this.webServerUrl = undefined;
         }
     }
 }

--- a/src/core/scene/scene-process/scene-asset-binary-client.ts
+++ b/src/core/scene/scene-process/scene-asset-binary-client.ts
@@ -1,0 +1,95 @@
+import type { IAssetInfo } from '../../assets/@types/public';
+import { Rpc } from './rpc';
+
+export interface SceneAssetBinaryCreateOptions {
+    target: string;
+    overwrite: boolean;
+    content: Uint8Array;
+}
+
+export interface SceneAssetBinaryClientDependencies {
+    getWebServerUrl(): string | undefined;
+    fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
+    saveLocally(assetUuid: string, content: Uint8Array): Promise<IAssetInfo>;
+    createLocally(options: SceneAssetBinaryCreateOptions): Promise<IAssetInfo>;
+}
+
+function errorMessage(responseBody: string): string {
+    try {
+        const parsed = JSON.parse(responseBody) as { error?: unknown };
+        if (typeof parsed.error === 'string' && parsed.error) {
+            return parsed.error;
+        }
+    } catch {
+        // The HTTP status remains useful even if an intermediary returned non-JSON.
+    }
+    return responseBody || 'Unknown error';
+}
+
+function parseAssetInfo(responseBody: string): IAssetInfo {
+    try {
+        return JSON.parse(responseBody) as IAssetInfo;
+    } catch (error) {
+        throw new Error(`Scene binary asset response is not valid JSON: ${errorMessage(error instanceof Error ? error.message : String(error))}`);
+    }
+}
+
+function createDefaultDependencies(): SceneAssetBinaryClientDependencies {
+    return {
+        getWebServerUrl: () => Rpc.getWebServerUrl(),
+        fetch: (...args) => fetch(...args),
+        saveLocally: (assetUuid, content) => Rpc.getInstance().request('assetManager', 'saveAsset', [
+            assetUuid,
+            Buffer.from(content),
+        ]) as Promise<IAssetInfo>,
+        createLocally: ({ target, overwrite, content }) => Rpc.getInstance().request('assetManager', 'createAsset', [{
+            target,
+            overwrite,
+            content: Buffer.from(content),
+        }]) as Promise<IAssetInfo>,
+    };
+}
+
+/**
+ * The only scene-process interface for binary Asset writes.
+ * It hides the web HTTP protocol while keeping native Scene workers on IPC.
+ */
+export class SceneAssetBinaryClient {
+    constructor(private readonly dependencies: SceneAssetBinaryClientDependencies = createDefaultDependencies()) {
+    }
+
+    async save(assetUuid: string, content: Uint8Array): Promise<IAssetInfo> {
+        const serverUrl = this.dependencies.getWebServerUrl();
+        if (!serverUrl) {
+            return this.dependencies.saveLocally(assetUuid, content);
+        }
+        return this.request(serverUrl, `/assets/binary/v1/save/${encodeURIComponent(assetUuid)}`, content);
+    }
+
+    async create(options: SceneAssetBinaryCreateOptions): Promise<IAssetInfo> {
+        const serverUrl = this.dependencies.getWebServerUrl();
+        if (!serverUrl) {
+            return this.dependencies.createLocally(options);
+        }
+        const query = new URLSearchParams({
+            target: options.target,
+            overwrite: String(options.overwrite),
+        });
+        return this.request(serverUrl, `/assets/binary/v1/create?${query.toString()}`, options.content);
+    }
+
+    private async request(serverUrl: string, path: string, content: Uint8Array): Promise<IAssetInfo> {
+        const response = await this.dependencies.fetch(`${serverUrl}${path}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/octet-stream' },
+            body: content as unknown as BodyInit,
+        });
+        const responseBody = await response.text();
+        if (!response.ok) {
+            throw new Error(`Scene binary asset request failed with status ${response.status}: ${errorMessage(responseBody)}`);
+        }
+        return parseAssetInfo(responseBody);
+    }
+}
+
+export const sceneAssetBinaryClient = new SceneAssetBinaryClient();

--- a/src/core/scene/scene-process/service/component/index.ts
+++ b/src/core/scene/scene-process/service/component/index.ts
@@ -8,6 +8,7 @@ import { Component, MissingScript } from 'cc';
 import { IProperty } from '../../../@types/public';
 import { type IComponentEvents } from '../../../common';
 import { ServiceEvents } from '../core/global-events';
+import { queryRegisteredService } from '../core/decorator';
 
 export class CompManager {
     protected _recycleComponent: Record<string, Component> = {};
@@ -213,6 +214,14 @@ export class CompManager {
 
         const pathKeys = (name || '').split('.');
         const methodName = pathKeys.pop() || '';
+        // 3.x terrain UI calls component methods through `gizmo.xxx`. Gizmos are
+        // held by GizmoService's WeakMap in CLI, so they cannot be resolved by lodash/get.
+        if (pathKeys.length === 1 && pathKeys[0] === 'gizmo') {
+            const gizmo = queryRegisteredService<any>('Gizmo')?.getComponentGizmo?.(comp);
+            if (gizmo && methodName && typeof gizmo[methodName] === 'function') {
+                return await gizmo[methodName](...(args || []));
+            }
+        }
         if (pathKeys.length > 0) {
             const methodObjPath = pathKeys.join('.');
             const methodObj = get(comp, methodObjPath);

--- a/src/core/scene/scene-process/service/editor.ts
+++ b/src/core/scene/scene-process/service/editor.ts
@@ -250,6 +250,9 @@ export class EditorService extends BaseService<IEditorEvents> implements IEditor
             }
 
             this.invalidateEditorSession();
+            if (params.save !== false) {
+                await this.saveTerrainAssets();
+            }
             const result = await editor.close({ save: params.save ?? true });
 
             if (editor === this.editorMap.get(currentEditorUuid)) {
@@ -286,6 +289,7 @@ export class EditorService extends BaseService<IEditorEvents> implements IEditor
         const urlOrUUID = params.urlOrUUID ?? this.currentEditorUuid;
         try {
             const { assetInfo, currentEditorUuid, editor } = await this.resolveSaveTarget(urlOrUUID);
+            await this.saveTerrainAssets();
             const result = assetInfo.uuid === currentEditorUuid
                 ? await editor.save()
                 : await this.recoverDeletedSourceTo(assetInfo, currentEditorUuid, editor);
@@ -299,6 +303,22 @@ export class EditorService extends BaseService<IEditorEvents> implements IEditor
         } catch (error) {
             console.error(`保存失败: [${urlOrUUID}]`, error);
             throw error;
+        }
+    }
+
+    /** Terrain data lives in .terrain assets, not in the scene JSON. */
+    private async saveTerrainAssets(): Promise<void> {
+        try {
+            const terrain = (Service as any).Terrain;
+            if (!terrain?.saveAsset) return;
+            const result = await terrain.saveAsset(false);
+            if (result === 2) {
+                throw new Error('Terrain asset save failed or requires a Save As target.');
+            }
+        } catch (error) {
+            // During early bootstrap or isolated editor tests TerrainService may
+            // not be registered. Real terrain save failures use the explicit error above.
+            if (error instanceof Error && error.message.includes('requires a Save As')) throw error;
         }
     }
 

--- a/src/core/scene/scene-process/service/gizmo.ts
+++ b/src/core/scene/scene-process/service/gizmo.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { Camera, Color, Component, gfx, js, Layers, Node, Rect, Vec3, director } from 'cc';
+import { Camera, Color, Component, gfx, js, Layers, Node, Rect, Terrain, Vec3, director } from 'cc';
 import { BaseService } from './core';
 import { register, Service } from './core/decorator';
 import { ServiceEvents } from './core/global-events';
@@ -50,16 +50,9 @@ import './gizmo/components/light-probe-group';
 import './gizmo/components/reflection-probe';
 import './gizmo/components/lod-group';
 import './gizmo/components/particle-system';
-
-// Terrain is available only in engine versions that expose the Terrain
-// component. Keep its registration conditional so lightweight CLI/test `cc`
-// mocks do not eagerly load the terrain controller's rendering dependencies.
-try {
-    if ((require('cc') as { Terrain?: unknown }).Terrain) {
-        require('./gizmo/components/terrain');
-    }
-} catch {
-    // Terrain registration is optional when the engine module is incomplete.
+// Avoid browser-runtime require('cc') while keeping lightweight cc mocks from loading Terrain dependencies.
+if (Terrain) {
+    require('./gizmo/components/terrain');
 }
 
 type TGizmoType = 'icon' | 'persistent' | 'component';
@@ -526,7 +519,11 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
                             if (gizmo.target !== component) {
                                 this._showGizmo('component', component, true);
                             }
-                            gizmo.checkVisible() ? gizmo.show() : gizmo.hide();
+                            const visible = gizmo.checkVisible();
+                            if (visible)
+                                gizmo.show();
+                            else
+                                gizmo.hide();
                         }
                     });
                 }

--- a/src/core/scene/scene-process/service/gizmo.ts
+++ b/src/core/scene/scene-process/service/gizmo.ts
@@ -51,6 +51,17 @@ import './gizmo/components/reflection-probe';
 import './gizmo/components/lod-group';
 import './gizmo/components/particle-system';
 
+// Terrain is available only in engine versions that expose the Terrain
+// component. Keep its registration conditional so lightweight CLI/test `cc`
+// mocks do not eagerly load the terrain controller's rendering dependencies.
+try {
+    if ((require('cc') as { Terrain?: unknown }).Terrain) {
+        require('./gizmo/components/terrain');
+    }
+} catch {
+    // Terrain registration is optional when the engine module is incomplete.
+}
+
 type TGizmoType = 'icon' | 'persistent' | 'component';
 
 // 与 cocos-editor GizmoConfig 一致：Gizmo 全局显示配置
@@ -828,6 +839,11 @@ export class GizmoService extends BaseService<IGizmoEvents> implements IGizmoSer
             }
         });
         return !stopped;
+    }
+
+    /** Returns the component gizmo without exposing the internal WeakMap to callers. */
+    getComponentGizmo(component: Component): GizmoBase | null {
+        return getGizmoProperty('component', component) ?? null;
     }
 
     // ── Selection integration (与 cocos-editor SelectionGizmoManager 一致) ─────

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/gizmo-persistent.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/gizmo-persistent.ts
@@ -1,0 +1,44 @@
+import { Terrain } from 'cc';
+import GizmoBase from '../../base/gizmo-base';
+import TerrainController from '../../controller/terrain';
+import type { GizmoMouseEvent } from '../../utils/defines';
+import { Service } from '../../../core/decorator';
+import { getEditorNodePath } from '../../utils/editor-node';
+import type TerrainGizmo from './gizmo-select';
+
+/** Persistent gizmo receiving mouse input over the non-raycast Terrain component. */
+export default class TerrainPersistentGizmo extends GizmoBase<Terrain> {
+    private _controller!: TerrainController;
+    private get selectGizmo(): TerrainGizmo | null {
+        return this.target ? Service.Gizmo.getComponentGizmo(this.target) as TerrainGizmo | null : null;
+    }
+    protected init() {
+        this._controller = new TerrainController(this.getGizmoRoot());
+        this._controller.onControllerMouseDown = this.onControllerMouseDown.bind(this);
+        this._controller.onControllerMouseMove = this.onControllerMouseMove.bind(this);
+        this._controller.onControllerMouseUp = this.onControllerMouseUp.bind(this);
+        this._controller.onControllerHoverOut = this.onControllerHoverOut.bind(this);
+        this.updateController();
+    }
+    private updateController() {
+        if (!this._controller) return;
+        if (!this.target) { this._controller.hide(); return; }
+        this._controller.updateWorldPosition(this.target.node.getWorldPosition());
+        const info = this.target.info;
+        this._controller.updateSize(info.size.width, info.size.height);
+        this._controller.show(); Service.Engine.repaintInEditMode();
+    }
+    public onTargetUpdate() { this.updateController(); }
+    public onNodeChanged() { this.updateController(); }
+    onControllerMouseDown(event: GizmoMouseEvent) {
+        if (!this.target) return;
+        const path = getEditorNodePath(this.target.node);
+        if (Service.Selection.query()[0] !== path) {
+            event.propagationStopped = true; Service.Selection.select(path); return;
+        }
+        const gizmo = this.selectGizmo; if (gizmo?.visible()) gizmo.onControllerMouseDown(event);
+    }
+    onControllerMouseMove(event: GizmoMouseEvent) { const gizmo = this.selectGizmo; if (gizmo?.visible()) gizmo.onControllerMouseMove(event); }
+    onControllerMouseUp(event: GizmoMouseEvent) { const gizmo = this.selectGizmo; if (gizmo?.visible()) gizmo.onControllerMouseUp(event); }
+    onControllerHoverOut() { const gizmo = this.selectGizmo; if (gizmo?.visible()) gizmo.onControllerHoverOut(); }
+}

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/gizmo-select.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/gizmo-select.ts
@@ -147,11 +147,11 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
         const weight = select.getCurrentWeightData();
         return {
             index: { x: index[0], y: index[1] },
-            layers: select.getCurrentLayerList().map((layer) => layer?._uuid ?? null),
+            layers: select.getCurrentBlockLayerSlots(),
             weight: weight ? {
                 width: weight.width,
                 height: weight.height,
-                data: Array.from(weight.data),
+                data: new Uint8Array(weight.data),
             } : null,
         };
     }

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/gizmo-select.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/gizmo-select.ts
@@ -1,4 +1,5 @@
 import { Terrain, TerrainInfo, TerrainLayer, TERRAIN_MAX_LAYER_COUNT } from 'cc';
+import type { Texture2D } from 'cc';
 import { Service } from '../../../core/decorator';
 import { loadAny } from '../../../node/node-create';
 import GizmoBase from '../../base/gizmo-base';
@@ -182,9 +183,6 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
     private updateTerrainBrush(mode: eTerrainEditorMode.SCULPT | eTerrainEditorMode.PAINT, patch: ITerrainBrushPatch): void {
         const editor = this.getTerrainBrushEditor(mode);
         const image = editor.getBrush(TerrainBrushType.IMAGE) as TerrainImageBrush;
-        if (patch.kind === 'circle') editor.setCurrentBrush(TerrainBrushType.CIRCLE);
-        else if (patch.kind === 'image' && image.image) editor.setCurrentBrush(TerrainBrushType.IMAGE);
-
         const brush = editor.getCurrentBrush();
         if (typeof patch.radius === 'number') brush.radius = patch.radius;
         if (typeof patch.strength === 'number') brush.strength = patch.strength;
@@ -205,15 +203,12 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
         const index = this.target.addLayer(layer); this.updateTerrainAsset(); this.isTerrainChange = true; this.emitNodeChange();
         Service.Engine.repaintInEditMode(); return index;
     }
-    async setSculptBrush(uuid: string) { return this.setBrushImage(eTerrainEditorMode.SCULPT, uuid); }
-    async setPaintBrush(uuid: string) { return this.setBrushImage(eTerrainEditorMode.PAINT, uuid); }
-    private async setBrushImage(mode: eTerrainEditorMode, uuid: string) {
-        const editMode: any = this._editor.getMode(mode);
-        if (!uuid) { editMode.setBrushImage(null); return true; }
-        const texture = await loadAny<any>(uuid);
-        const imageBrush = editMode.getBrush(TerrainBrushType.IMAGE) as TerrainImageBrush;
-        if (imageBrush.image !== texture) editMode.setBrushImage(texture);
-        this.isTerrainChange = true; Service.Engine.repaintInEditMode(); return true;
+
+    /** Applies a service-validated Sculpt brush texture without changing Terrain asset state. */
+    public setSculptBrushTexture(texture: Texture2D | null): void {
+        const sculpt = this.getTerrainBrushEditor(eTerrainEditorMode.SCULPT);
+        sculpt.setBrushImage(texture);
+        Service.Engine.repaintInEditMode();
     }
     async setSculptBrushRotation(rotation: number) {
         (this._editor.getMode(eTerrainEditorMode.SCULPT) as any).setSculptBrushRotation(rotation);

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/gizmo-select.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/gizmo-select.ts
@@ -56,13 +56,27 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
         this._editor?.clearBrush(); this._editor?.setEditTerrain(null); this._editor?.setCurrentLayer(0);
         Service.Engine.repaintInEditMode();
     }
-    public onTargetUpdate() { if (this._isInitialized) this.initEditor(); }
+    public onTargetUpdate() {
+        // Target clearing happens after onHide() while a pooled gizmo is detached.
+        // Never let the detached target consume the editor-initialized guard.
+        if (!this.target) {
+            this._isEditorInit = false;
+            return;
+        }
+        if (this._isInitialized) this.initEditor();
+    }
     public onNodeChanged() { if (this._isInitialized) this.initEditor(); }
     public onEditorCameraMoved() { this._editor?.updateBlockDepthOffset(); }
     private initEditor() {
-        if (!this._isEditorInit && this._editor) {
-            this._editor.setEditTerrain(this.target); this._isEditorInit = true; Service.Engine.repaintInEditMode();
+        const target = this.target;
+        if (!target || !this._editor) {
+            this._isEditorInit = false;
+            return;
         }
+        if (this._isEditorInit && this._editor.getEditTerrain() === target) return;
+        this._editor.setEditTerrain(target);
+        this._isEditorInit = true;
+        Service.Engine.repaintInEditMode();
     }
 
     /**

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/gizmo-select.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/gizmo-select.ts
@@ -1,10 +1,22 @@
-import { Terrain, TerrainInfo, TerrainLayer, TERRAIN_MAX_LAYER_COUNT, assetManager } from 'cc';
+import { Terrain, TerrainInfo, TerrainLayer, TERRAIN_MAX_LAYER_COUNT } from 'cc';
 import { Service } from '../../../core/decorator';
 import { loadAny } from '../../../node/node-create';
 import GizmoBase from '../../base/gizmo-base';
 import { TerrainEditor } from './terrain-editor';
+import { TerrainEditorPaint } from './terrain-editor-paint';
+import { TerrainEditorSculpt } from './terrain-editor-sculpt';
 import { eTerrainEditorMode } from './terrain-editor-mode';
 import { TerrainBrushType, TerrainImageBrush } from './terrain-brush';
+import type {
+    ITerrainBlockData,
+    ITerrainBrushPatch,
+    ITerrainBrushState,
+    ITerrainEditorState,
+    ITerrainPaintSessionPatch,
+    ITerrainSculptSessionPatch,
+    TerrainEditorMode,
+    TerrainSculptTool,
+} from '../../../../../common';
 import type { GizmoMouseEvent } from '../../utils/defines';
 
 interface IBrush { radius: number; strength: number; _setHeight: number; }
@@ -50,6 +62,140 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
         if (!this._isEditorInit && this._editor) {
             this._editor.setEditTerrain(this.target); this._isEditorInit = true; Service.Engine.repaintInEditMode();
         }
+    }
+
+    /**
+     * Internal adapter for TerrainService. It intentionally returns plain data
+     * instead of exposing this gizmo or its editor internals to Scene callers.
+     */
+    public readTerrainState(): ITerrainEditorState {
+        const info = this.queryTerrainInfo() ?? { tileSize: 0, weightMapSize: 0, lightMapSize: 0, blockCount: [0, 0] as [number, number] };
+        return {
+            manage: {
+                tileSize: info.tileSize,
+                weightMapSize: info.weightMapSize,
+                lightMapSize: info.lightMapSize,
+                blockCount: [info.blockCount[0] ?? 0, info.blockCount[1] ?? 0],
+            },
+            layers: this.getLayers().map((layer) => layer ? ({
+                detailMapUuid: layer.detailMap,
+                normalMapUuid: layer.normalMap,
+                metallic: layer.metallic,
+                roughness: layer.roughness,
+                tileSize: layer.tileSize,
+            }) : null),
+            mode: this.getTerrainMode(),
+            currentLayer: this._editor.getCurrentLayer(),
+            sculpt: {
+                tool: this.getTerrainSculptTool(),
+                brush: this.getTerrainBrushState(eTerrainEditorMode.SCULPT),
+            },
+            paint: {
+                brush: this.getTerrainBrushState(eTerrainEditorMode.PAINT),
+            },
+        };
+    }
+
+    public setTerrainMode(mode: TerrainEditorMode): void {
+        const internalMode: Record<TerrainEditorMode, eTerrainEditorMode> = {
+            manage: eTerrainEditorMode.MANAGE,
+            sculpt: eTerrainEditorMode.SCULPT,
+            paint: eTerrainEditorMode.PAINT,
+            block: eTerrainEditorMode.SELECT,
+        };
+        this._editor.setMode(internalMode[mode]);
+        Service.Engine.repaintInEditMode();
+    }
+
+    public setTerrainCurrentLayer(currentLayer: number): void {
+        if (!Number.isInteger(currentLayer) || currentLayer < -1) return;
+        if (currentLayer >= 0 && !this.target?.getLayer(currentLayer)) return;
+        this._editor.setCurrentLayer(currentLayer);
+        Service.Engine.repaintInEditMode();
+    }
+
+    public updateTerrainSculptSession(patch: ITerrainSculptSessionPatch): void {
+        if (patch.tool) this.setTerrainSculptTool(patch.tool);
+        if (patch.brush) this.updateTerrainBrush(eTerrainEditorMode.SCULPT, patch.brush);
+        Service.Engine.repaintInEditMode();
+    }
+
+    public updateTerrainPaintSession(patch: ITerrainPaintSessionPatch): void {
+        if (patch.brush) this.updateTerrainBrush(eTerrainEditorMode.PAINT, patch.brush);
+        Service.Engine.repaintInEditMode();
+    }
+
+    public readTerrainBlock(): ITerrainBlockData | null {
+        const select = this._editor.getMode(eTerrainEditorMode.SELECT);
+        const index = select.getCurrentBlockIndex();
+        if (!index) return null;
+        const weight = select.getCurrentWeightData();
+        return {
+            index: { x: index[0], y: index[1] },
+            layers: select.getCurrentLayerList().map((layer) => layer?._uuid ?? null),
+            weight: weight ? {
+                width: weight.width,
+                height: weight.height,
+                data: Array.from(weight.data),
+            } : null,
+        };
+    }
+
+    private getTerrainMode(): TerrainEditorMode {
+        switch (this._editor.getCurrentModeType()) {
+            case eTerrainEditorMode.MANAGE: return 'manage';
+            case eTerrainEditorMode.SCULPT: return 'sculpt';
+            case eTerrainEditorMode.PAINT: return 'paint';
+            default: return 'block';
+        }
+    }
+
+    private getTerrainSculptTool(): TerrainSculptTool {
+        if (this._isSmooth) return 'smooth';
+        if (this._isFlatten) return 'flatten';
+        if (this._isSetHeight) return 'set-height';
+        return this._isConcave ? 'sunken' : 'bulge';
+    }
+
+    private setTerrainSculptTool(tool: TerrainSculptTool): void {
+        this._isConcave = tool === 'sunken';
+        this._isShiftDown = this._isConcave;
+        this._isSmooth = tool === 'smooth';
+        this._isFlatten = tool === 'flatten';
+        this._isSetHeight = tool === 'set-height';
+    }
+
+    private getTerrainBrushState(mode: eTerrainEditorMode.SCULPT | eTerrainEditorMode.PAINT): ITerrainBrushState {
+        const editor = this.getTerrainBrushEditor(mode);
+        const brush = editor.getCurrentBrush();
+        const image = editor.getBrush(TerrainBrushType.IMAGE) as TerrainImageBrush;
+        return {
+            kind: brush === image ? 'image' : 'circle',
+            imageUuid: image.image?._uuid ?? null,
+            radius: brush.radius,
+            strength: brush.strength,
+            rotation: image._rotation,
+            setHeight: brush._setHeight,
+        };
+    }
+
+    private updateTerrainBrush(mode: eTerrainEditorMode.SCULPT | eTerrainEditorMode.PAINT, patch: ITerrainBrushPatch): void {
+        const editor = this.getTerrainBrushEditor(mode);
+        const image = editor.getBrush(TerrainBrushType.IMAGE) as TerrainImageBrush;
+        if (patch.kind === 'circle') editor.setCurrentBrush(TerrainBrushType.CIRCLE);
+        else if (patch.kind === 'image' && image.image) editor.setCurrentBrush(TerrainBrushType.IMAGE);
+
+        const brush = editor.getCurrentBrush();
+        if (typeof patch.radius === 'number') brush.radius = patch.radius;
+        if (typeof patch.strength === 'number') brush.strength = patch.strength;
+        if (typeof patch.rotation === 'number') image._rotation = patch.rotation;
+        if (typeof patch.setHeight === 'number') brush._setHeight = patch.setHeight;
+    }
+
+    private getTerrainBrushEditor(mode: eTerrainEditorMode.SCULPT | eTerrainEditorMode.PAINT): TerrainEditorSculpt | TerrainEditorPaint {
+        return mode === eTerrainEditorMode.SCULPT
+            ? this._editor.getMode(eTerrainEditorMode.SCULPT)
+            : this._editor.getMode(eTerrainEditorMode.PAINT);
     }
 
     async addLayerByUuid(uuid: string) {

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/gizmo-select.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/gizmo-select.ts
@@ -1,0 +1,150 @@
+import { Terrain, TerrainInfo, TerrainLayer, TERRAIN_MAX_LAYER_COUNT, assetManager } from 'cc';
+import { Service } from '../../../core/decorator';
+import { loadAny } from '../../../node/node-create';
+import GizmoBase from '../../base/gizmo-base';
+import { TerrainEditor } from './terrain-editor';
+import { eTerrainEditorMode } from './terrain-editor-mode';
+import { TerrainBrushType, TerrainImageBrush } from './terrain-brush';
+import type { GizmoMouseEvent } from '../../utils/defines';
+
+interface IBrush { radius: number; strength: number; _setHeight: number; }
+interface ITerrainInfo { tileSize: number; weightMapSize: number; lightMapSize: number; blockCount: number[]; }
+
+/** Component gizmo containing all Terrain editing operations. */
+export default class TerrainGizmo extends GizmoBase<Terrain> {
+    private _editor!: TerrainEditor;
+    private _isEditorInit = false;
+    private _isShiftDown = false;
+    private _isConcave = false;
+    private _isSmooth = false;
+    private _isFlatten = false;
+    private _isSetHeight = false;
+
+    public get editor() { return this._editor; }
+    public get isConcave() { return this._isConcave; }
+    public get isSmooth() { return this._isSmooth; }
+    public get isFlatten() { return this._isFlatten; }
+    public get isSetHeight() { return this._isSetHeight; }
+    public applySmooth(value: boolean) { this._isSmooth = value; }
+    public get isTerrainChange() { return !!this.target && Service.Terrain.isTerrainChange; }
+    public set isTerrainChange(value: boolean) {
+        if (this.target) { (this.target as any).manager = Service.Terrain; (this.target as any).isTerrainChange = value; }
+        if (value && this.target) Service.Terrain.select(this.target.node.uuid);
+    }
+
+    protected init() {
+        this._editor = new TerrainEditor((Service.Camera as any).getCamera?.() ?? null, this);
+    }
+    protected onShow() {
+        this.registerCameraMovedEvent(); this.initEditor(); this._editor.updateBlockDepthOffset();
+    }
+    protected onHide() {
+        this._isEditorInit = false; this.unregisterCameraMoveEvent();
+        this._editor?.clearBrush(); this._editor?.setEditTerrain(null); this._editor?.setCurrentLayer(0);
+        Service.Engine.repaintInEditMode();
+    }
+    public onTargetUpdate() { if (this._isInitialized) this.initEditor(); }
+    public onNodeChanged() { if (this._isInitialized) this.initEditor(); }
+    public onEditorCameraMoved() { this._editor?.updateBlockDepthOffset(); }
+    private initEditor() {
+        if (!this._isEditorInit && this._editor) {
+            this._editor.setEditTerrain(this.target); this._isEditorInit = true; Service.Engine.repaintInEditMode();
+        }
+    }
+
+    async addLayerByUuid(uuid: string) {
+        if (!this.target) return -1;
+        const texture = await loadAny<any>(uuid);
+        const layer = new TerrainLayer(); layer.detailMap = texture; layer.tileSize = 1;
+        const index = this.target.addLayer(layer); this.updateTerrainAsset(); this.isTerrainChange = true; this.emitNodeChange();
+        Service.Engine.repaintInEditMode(); return index;
+    }
+    async setSculptBrush(uuid: string) { return this.setBrushImage(eTerrainEditorMode.SCULPT, uuid); }
+    async setPaintBrush(uuid: string) { return this.setBrushImage(eTerrainEditorMode.PAINT, uuid); }
+    private async setBrushImage(mode: eTerrainEditorMode, uuid: string) {
+        const editMode: any = this._editor.getMode(mode);
+        if (!uuid) { editMode.setBrushImage(null); return true; }
+        const texture = await loadAny<any>(uuid);
+        const imageBrush = editMode.getBrush(TerrainBrushType.IMAGE) as TerrainImageBrush;
+        if (imageBrush.image !== texture) editMode.setBrushImage(texture);
+        this.isTerrainChange = true; Service.Engine.repaintInEditMode(); return true;
+    }
+    async setSculptBrushRotation(rotation: number) {
+        (this._editor.getMode(eTerrainEditorMode.SCULPT) as any).setSculptBrushRotation(rotation);
+    }
+    async setLayerValue(index: number, uuid: string, extVal: any) {
+        if (!this.target) return null;
+        const layer = this.target.getLayer(index); if (!layer) return null;
+        if (extVal) {
+            if ('tileSize' in extVal) layer.tileSize = extVal.tileSize;
+            if ('metallic' in extVal) layer.metallic = extVal.metallic;
+            if ('roughness' in extVal) layer.roughness = extVal.roughness;
+            if ('normalMap' in extVal) layer.normalMap = extVal.normalMap ? await loadAny<any>(extVal.normalMap) : null;
+        }
+        if (uuid) layer.detailMap = await loadAny<any>(uuid);
+        this.updateTerrainAsset(); this.isTerrainChange = true; this.emitNodeChange(); Service.Engine.repaintInEditMode();
+        return index;
+    }
+    removeLayerByIndex(index: number) {
+        if (!this.target) return;
+        this.target.removeLayer(index); this.updateTerrainAsset(); this.isTerrainChange = true; this.emitNodeChange(); Service.Engine.repaintInEditMode();
+    }
+    setCurrentEditLayer(index: number) { this._editor.setCurrentLayer(index); Service.Engine.repaintInEditMode(); }
+    getLayers() {
+        if (!this.target) return [];
+        return Array.from({ length: TERRAIN_MAX_LAYER_COUNT }, (_, index) => {
+            const layer = this.target!.getLayer(index);
+            return layer ? {
+                detailMap: layer.detailMap?._uuid ?? null, metallic: layer.metallic,
+                normalMap: layer.normalMap?._uuid ?? null, roughness: layer.roughness, tileSize: layer.tileSize,
+            } : null;
+        });
+    }
+    getCurrentEditLayer() { return this._editor.getCurrentLayer(); }
+    setCurrentEditMode(mode: eTerrainEditorMode, option?: any) {
+        const config = Object.assign({ isSculptDown: false, isSmooth: false, isFlatten: false, isSetHeight: false }, option || {});
+        this._isConcave = this._isShiftDown = !!config.isSculptDown; this._isSmooth = !!config.isSmooth;
+        this._isFlatten = !!config.isFlatten; this._isSetHeight = !!config.isSetHeight;
+        this._editor.setMode(mode); Service.Engine.repaintInEditMode();
+    }
+    queryTerrainInfo(): ITerrainInfo | null {
+        const info = this.target?.info; return info ? {
+            tileSize: info.tileSize, weightMapSize: info.weightMapSize, lightMapSize: info.lightMapSize, blockCount: [...info.blockCount],
+        } : null;
+    }
+    changeTerrainInfo(info: any) {
+        if (!this.target) return;
+        const terrainInfo = new TerrainInfo(); Object.assign(terrainInfo, info); this.target.rebuild(terrainInfo);
+        this.isTerrainChange = true; this.emitNodeChange(); Service.Engine.repaintInEditMode();
+    }
+    queryBrushOfMode(mode: eTerrainEditorMode): IBrush | null {
+        if (mode !== eTerrainEditorMode.SCULPT && mode !== eTerrainEditorMode.PAINT) return null;
+        const brush = (this._editor.getMode(mode) as any).getCurrentBrush();
+        return { radius: brush.radius, strength: brush.strength, _setHeight: brush._setHeight };
+    }
+    setBrushOfMode(mode: eTerrainEditorMode, setting: any) {
+        if (mode !== eTerrainEditorMode.SCULPT && mode !== eTerrainEditorMode.PAINT) return;
+        const brush = (this._editor.getMode(mode) as any).getCurrentBrush();
+        for (const key of Object.keys(setting || {})) if (key !== 'material' && setting[key] !== undefined) brush[key] = setting[key];
+    }
+    getBlockInfo() {
+        const mode = this._editor.getMode(eTerrainEditorMode.SELECT); const index = mode.getCurrentBlockIndex() ?? [0, 0];
+        const weight = mode.getCurrentWeightData();
+        return {
+            index: { x: index[0], y: index[1] },
+            weight: weight ? { data: Array.from(weight.data), width: weight.width, height: weight.height } : null,
+            layers: mode.getCurrentLayerList().map((layer: any) => layer?._uuid ?? ''),
+        };
+    }
+    emitNodeChange() { if (this.target) this.onComponentChanged(this.target.node); }
+    onKeyDown(event: any) { if (event.shiftKey) this._isShiftDown = true; }
+    onKeyUp(event: any) { if (event.keyCode === 16) this._isShiftDown = this._isConcave; }
+    onUpdate(deltaTime: number) { this._editor?.update(deltaTime, this._isShiftDown); }
+    onCameraControlModeChanged(mode: number) { if (mode !== 0 && this._editor?.isChanged) this.emitNodeChange(); }
+    updateTerrainAsset() { if (this.target?._asset) this.target.exportLayerListToAsset(this.target._asset); }
+
+    public onControllerMouseDown(event: GizmoMouseEvent) { event.propagationStopped = true; this._isShiftDown = event.shiftKey; this._editor.onMouseDown(event.x, event.y); }
+    public onControllerMouseMove(event: GizmoMouseEvent) { event.propagationStopped = true; this._editor.onMouseMove(event.x, event.y); }
+    public onControllerMouseUp(event: GizmoMouseEvent) { event.propagationStopped = true; if (this._editor.isChanged) this.emitNodeChange(); this._editor.onMouseUp(); }
+    public onControllerHoverOut() { this._editor.onHoverOut(); }
+}

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/gizmo-select.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/gizmo-select.ts
@@ -210,6 +210,13 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
         sculpt.setBrushImage(texture);
         Service.Engine.repaintInEditMode();
     }
+
+    /** Applies a service-validated Paint brush texture without changing Terrain asset state. */
+    public setPaintBrushTexture(texture: Texture2D | null): void {
+        const paint = this.getTerrainBrushEditor(eTerrainEditorMode.PAINT);
+        paint.setBrushImage(texture);
+        Service.Engine.repaintInEditMode();
+    }
     async setSculptBrushRotation(rotation: number) {
         (this._editor.getMode(eTerrainEditorMode.SCULPT) as any).setSculptBrushRotation(rotation);
     }

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/index.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/index.ts
@@ -1,0 +1,13 @@
+'use strict';
+
+import { js, Terrain } from 'cc';
+import { registerGizmo } from '../../gizmo-defines';
+import TerrainGizmo from './gizmo-select';
+import TerrainPersistentGizmo from './gizmo-persistent';
+
+export const name = js.getClassName(Terrain);
+export const SelectGizmo = TerrainGizmo;
+export const IconGizmo = null;
+export const PersistentGizmo = TerrainPersistentGizmo;
+
+registerGizmo(name, { SelectGizmo, PersistentGizmo });

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-brush.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-brush.ts
@@ -1,0 +1,204 @@
+import { Material, Terrain, Texture2D, Vec2, Vec3, Vec4, builtinResMgr, clamp } from 'cc';
+
+export enum TerrainBrushType { CIRCLE, IMAGE, _MAX }
+
+export class TerrainEdModifierKeyState { public siftPressed = false; }
+
+const brushDepthOffsetDefaultRatios = 0.001;
+let brushDepthOffset = 0.05;
+
+/** Shared brush math and the editor brush preview material state. */
+export class TerrainBrush {
+    public static updateBrushDepthOffset(cameraDistanceFactor: number) {
+        const ratios = brushDepthOffsetDefaultRatios + (cameraDistanceFactor / 300) * 0.00025;
+        brushDepthOffset = Math.max(0.05, cameraDistanceFactor * ratios);
+    }
+
+    public static updateBrushDepthOffsetToMaterial(material: Material | null) {
+        material?.setProperty('BrushDepthOffset', brushDepthOffset);
+    }
+
+    public material: Material | null = null;
+    public position = new Vec3();
+    public radius = 5;
+    public strength = 1;
+    public _setHeight = 0;
+    public _rotation = 0;
+
+    public get rotation() { return this._rotation / 180 * Math.PI; }
+    public getDelta(_x: number, _z: number) { return 0; }
+    public getBound(bbmin: Vec2, bbmax: Vec2) {
+        bbmin.set(this.position.x - this.radius, this.position.z - this.radius);
+        bbmax.set(this.position.x + this.radius, this.position.z + this.radius);
+    }
+    public update(_terrain: Terrain, pos: Vec3) { this.position.set(pos); }
+}
+
+export class TerrainBrushData {
+    public bmin: number[] = [0, 0];
+    public bmax: number[] = [0, 0];
+    public width() { return this.bmax[0] - this.bmin[0] + 1; }
+    public height() { return this.bmax[1] - this.bmin[1] + 1; }
+}
+
+export enum eTerrainCircleBrushType { Linear, Smooth, Spherical, Tip }
+
+export class TerrainCircleBrush extends TerrainBrush {
+    protected type = eTerrainCircleBrushType.Linear;
+    protected falloff = 0.5;
+
+    constructor() { super(); this._updateMaterial(); }
+
+    public setType(type: eTerrainCircleBrushType) {
+        if (this.type !== type) { this.type = type; this._updateMaterial(); }
+    }
+    public getType() { return this.type; }
+    public _updateMaterial() {
+        const effect = (cc as any).EffectAsset?.get?.('internal/editor/terrain-circle-brush');
+        if (effect) {
+            this.material = new Material();
+            this.material.initialize({ effectAsset: effect, defines: this._getTypeDefine() });
+        }
+    }
+    public _getTypeDefine(): Record<string, number> {
+        return [{ LINEAR: 1 }, { SMOOTH: 1 }, { SPHERICAL: 1 }, { TIP: 1 }][this.type];
+    }
+    public static _calculateFalloff_Linear(distance: number, radius: number, falloff: number) {
+        if (distance <= radius) return 1;
+        if (distance > radius + falloff || falloff <= 0) return 0;
+        return Math.max(0, 1 - (distance - radius) / falloff);
+    }
+    public static _calculateFalloff_Spherical(distance: number, radius: number, falloff: number) {
+        const y = this._calculateFalloff_Linear(distance, radius, falloff);
+        return y * y * (3 - 2 * y);
+    }
+    public static _calculateFalloff_Smooth(distance: number, radius: number, falloff: number) {
+        if (distance <= radius) return 1;
+        if (distance > radius + falloff || falloff <= 0) return 0;
+        const y = (distance - radius) / falloff;
+        return Math.sqrt(Math.max(0, 1 - y * y));
+    }
+    public static _calculateFalloff_Tip(distance: number, radius: number, falloff: number) {
+        if (distance <= radius) return 1;
+        if (distance > radius + falloff || falloff <= 0) return 0;
+        const y = (falloff + radius - distance) / falloff;
+        return 1 - Math.sqrt(Math.max(0, 1 - y * y));
+    }
+    public getDelta(x: number, z: number) {
+        const distance = Math.hypot(x - this.position.x, z - this.position.z);
+        const radius = (1 - this.falloff) * this.radius;
+        const falloff = this.falloff * this.radius;
+        let value = 0;
+        switch (this.type) {
+            case eTerrainCircleBrushType.Linear: value = TerrainCircleBrush._calculateFalloff_Linear(distance, radius, falloff); break;
+            case eTerrainCircleBrushType.Smooth: value = TerrainCircleBrush._calculateFalloff_Smooth(distance, radius, falloff); break;
+            case eTerrainCircleBrushType.Spherical: value = TerrainCircleBrush._calculateFalloff_Spherical(distance, radius, falloff); break;
+            case eTerrainCircleBrushType.Tip: value = TerrainCircleBrush._calculateFalloff_Tip(distance, radius, falloff); break;
+        }
+        return value * this.strength;
+    }
+    public update(terrain: Terrain, pos: Vec3) {
+        super.update(terrain, pos);
+        if (!this.material) return;
+        const terrainPos = terrain.node.getWorldPosition();
+        const brushPos = new Vec4(terrainPos.x + pos.x, terrainPos.y + pos.y, terrainPos.z + pos.z, 0);
+        const brushParams = new Vec4((1 - this.falloff) * this.radius, this.falloff * this.radius, 0, 0);
+        for (const block of terrain.getBlocks()) {
+            if (block._getBrushMaterial() !== this.material || !block._getBrushPass() || !block.material) continue;
+            block.material.setProperty('BrushPos', brushPos);
+            block.material.setProperty('BrushParams', brushParams);
+            TerrainBrush.updateBrushDepthOffsetToMaterial(block.material);
+        }
+    }
+}
+
+export class TerrainImageBrush extends TerrainBrush {
+    private _image: Texture2D | null = null;
+    private _pixelData: number[] | null = null;
+
+    constructor() {
+        super();
+        const effect = (cc as any).EffectAsset?.get?.('internal/editor/terrain-image-brush');
+        if (effect) {
+            this.material = new Material();
+            this.material.initialize({ effectAsset: effect });
+        }
+    }
+
+    public set image(value: Texture2D | null) {
+        if (this._image === value) return;
+        this._image = value;
+        this._pixelData = null;
+        if (!value || typeof document === 'undefined') return;
+        const nativeData: any = value.mipmaps?.[0]?.data;
+        const source = nativeData?._src;
+        const readImage = (image: CanvasImageSource, width: number, height: number) => {
+            const canvas = document.createElement('canvas');
+            canvas.width = width; canvas.height = height;
+            const context = canvas.getContext('2d');
+            if (!context) return;
+            context.drawImage(image, 0, 0, width, height);
+            const data = context.getImageData(0, 0, width, height).data;
+            this._pixelData = new Array(width * height);
+            for (let i = 0; i < this._pixelData.length; ++i) this._pixelData[i] = data[i * 4] / 255;
+        };
+        if (source) {
+            const image = document.createElement('img');
+            image.onload = () => readImage(image, value.width, value.height);
+            image.src = `file://${source}`;
+        } else if (nativeData) {
+            readImage(nativeData as CanvasImageSource, value.width, value.height);
+        }
+    }
+    public get image() { return this._image; }
+    public static getColor(pixels: number[], width: number, height: number, u: number, v: number) {
+        u = clamp(u, 0, width - 1); v = clamp(v, 0, height - 1);
+        return pixels[v * width + u];
+    }
+    public static sampleImage(pixels: number[], width: number, height: number, u: number, v: number) {
+        u *= width - 1; v *= height - 1;
+        const u0 = Math.floor(u), v0 = Math.floor(v), u1 = u0 + 1, v1 = v0 + 1;
+        const du = u - u0, dv = v - v0;
+        const c00 = this.getColor(pixels, width, height, u0, v0);
+        const c10 = this.getColor(pixels, width, height, u1, v0);
+        const c01 = this.getColor(pixels, width, height, u0, v1);
+        const c11 = this.getColor(pixels, width, height, u1, v1);
+        return (c00 + (c10 - c00) * du) * (1 - dv) + (c01 + (c11 - c01) * du) * dv;
+    }
+    public sample(u: number, v: number) {
+        return this._pixelData && this._image
+            ? TerrainImageBrush.sampleImage(this._pixelData, this._image.width, this._image.height, u, v)
+            : 1;
+    }
+    public getDelta(x: number, z: number) {
+        let dx = this.position.x - x, dz = this.position.z - z;
+        if (this.rotation) {
+            const sine = Math.sin(this.rotation), cosine = Math.cos(this.rotation);
+            const tx = dx * cosine + dz * sine;
+            dz = -dx * sine + dz * cosine; dx = tx;
+        }
+        const u = dx / this.radius * 0.5 + 0.5, v = dz / this.radius * 0.5 + 0.5;
+        return u < 0 || u > 1 || v < 0 || v > 1 ? 0 : this.sample(u, v) * this.strength;
+    }
+    public getBound(bbmin: Vec2, bbmax: Vec2) {
+        const c = Math.abs(Math.cos(this.rotation)), s = Math.abs(Math.sin(this.rotation));
+        const halfX = this.radius * (c + s), halfZ = this.radius * (c + s);
+        bbmin.set(this.position.x - halfX, this.position.z - halfZ);
+        bbmax.set(this.position.x + halfX, this.position.z + halfZ);
+    }
+    public update(terrain: Terrain, pos: Vec3) {
+        super.update(terrain, pos);
+        if (!this.material) return;
+        const terrainPos = terrain.node.getWorldPosition();
+        const brushPos = new Vec4(terrainPos.x + pos.x, terrainPos.y + pos.y, terrainPos.z + pos.z, 0);
+        const brushParams = new Vec4(this.radius, 1, this.rotation, 0);
+        const fallback = builtinResMgr.get<Texture2D>('grey-texture');
+        for (const block of terrain.getBlocks()) {
+            if (block._getBrushMaterial() !== this.material || !block._getBrushPass() || !block.material) continue;
+            block.material.setProperty('BrushPos', brushPos);
+            block.material.setProperty('BrushParams', brushParams);
+            block.material.setProperty('BrushImage', this._image ?? fallback);
+            TerrainBrush.updateBrushDepthOffsetToMaterial(block.material);
+        }
+    }
+}

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-manage.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-manage.ts
@@ -1,0 +1,2 @@
+import { TerrainEditorMode } from './terrain-editor-mode';
+export class TerrainEditorManage extends TerrainEditorMode {}

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-mode.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-mode.ts
@@ -1,0 +1,13 @@
+import type { Terrain } from 'cc';
+
+export enum eTerrainEditorMode { MANAGE, SCULPT, PAINT, SELECT }
+
+export class TerrainEditorMode {
+    protected _gizmo: any;
+    constructor(gizmo: any) { this._gizmo = gizmo; }
+    get gizmo() { return this._gizmo; }
+    public onUpdate(_terrain: Terrain, _dTime: number, _isShiftDown: boolean) {}
+    public onActivate() {}
+    public onDeactivate() {}
+    public forceUpdate() {}
+}

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-paint.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-paint.ts
@@ -1,0 +1,107 @@
+import { Rect, Terrain, TERRAIN_BLOCK_TILE_COMPLEXITY, Texture2D, Vec3, Vec4, math } from 'cc';
+import { Service } from '../../../core/decorator';
+import { TerrainBrush, TerrainBrushType, TerrainCircleBrush, TerrainImageBrush } from './terrain-brush';
+import { TerrainEditorMode } from './terrain-editor-mode';
+import { TerrainWeightOperation, TerrainWeightUndoRedo } from './terrain-operation';
+
+const clamp = math.clamp;
+
+export class TerrainEditorPaint extends TerrainEditorMode {
+    public _brushes: TerrainBrush[];
+    public _undo: TerrainWeightUndoRedo | null = null;
+    public _currentLayer = -1;
+    public _currentBrush: TerrainBrush;
+
+    constructor(gizmo: any) {
+        super(gizmo);
+        const circle = new TerrainCircleBrush(); circle.strength = 5;
+        const image = new TerrainImageBrush(); image.strength = 5;
+        this._brushes = [circle, image]; this._currentBrush = circle;
+    }
+    public setCurrentBrush(type: TerrainBrushType) {
+        const old = this._currentBrush; this._currentBrush = this._brushes[type];
+        this._currentBrush.position.set(old.position); this._currentBrush.radius = old.radius;
+        this._currentBrush.strength = old.strength; this._currentBrush._setHeight = old._setHeight;
+        this._currentBrush._rotation = old._rotation;
+    }
+    public getCurrentBrush() { return this._currentBrush; }
+    public getBrush(type: TerrainBrushType) { return this._brushes[type]; }
+    public setBrushImage(texture: Texture2D | null) {
+        const image = this.getBrush(TerrainBrushType.IMAGE) as TerrainImageBrush;
+        image.image = texture; this.setCurrentBrush(texture ? TerrainBrushType.IMAGE : TerrainBrushType.CIRCLE);
+    }
+    public setCurrentLayer(layer: number) { this._currentLayer = layer; }
+    public getCurrentLayer() { return this._currentLayer; }
+
+    public onUpdate(terrain: Terrain, deltaTime: number) {
+        if (!this._undo) return;
+        this._updateWeight(terrain, deltaTime); this.gizmo.isTerrainChange = true;
+    }
+    public onUpdateBrushPosition(terrain: Terrain, position: Vec3) {
+        const brush = this._currentBrush; brush.update(terrain, position);
+        const brushRect = new Rect(position.x - brush.radius, position.z - brush.radius, brush.radius * 2, brush.radius * 2);
+        for (const block of terrain.getBlocks()) {
+            const index = block.getIndex();
+            const bound = new Rect(
+                index[0] * TERRAIN_BLOCK_TILE_COMPLEXITY * terrain.info.tileSize,
+                index[1] * TERRAIN_BLOCK_TILE_COMPLEXITY * terrain.info.tileSize,
+                TERRAIN_BLOCK_TILE_COMPLEXITY * terrain.info.tileSize,
+                TERRAIN_BLOCK_TILE_COMPLEXITY * terrain.info.tileSize,
+            );
+            block.setBrushMaterial(bound.intersects(brushRect) ? brush.material : null);
+        }
+    }
+    public onMouseDown(terrain: Terrain) {
+        if (this._currentLayer !== -1) this._undo = new TerrainWeightUndoRedo(terrain);
+    }
+    public onMouseUp() {
+        if (this._undo?.data.length || this._undo?.redoOperations.length) Service.Undo.push(this._undo);
+        this._undo = null;
+    }
+    public forceUpdate() { TerrainBrush.updateBrushDepthOffsetToMaterial(this._currentBrush.material); }
+    public onDeactivate() {
+        if (!this.gizmo.editor.getEditTerrain()?._asset) this._currentLayer = -1;
+    }
+
+    private _updateWeight(terrain: Terrain, deltaTime: number) {
+        const width = terrain.info.weightMapSize * terrain.info.blockCount[0];
+        const height = terrain.info.weightMapSize * terrain.info.blockCount[1];
+        if (!width || !height) return;
+        const brush = this._currentBrush;
+        let x1 = Math.floor((brush.position.x - brush.radius) / terrain.info.size.width * (width - 1));
+        let y1 = Math.floor((brush.position.z - brush.radius) / terrain.info.size.height * (height - 1));
+        let x2 = Math.floor((brush.position.x + brush.radius) / terrain.info.size.width * (width - 1));
+        let y2 = Math.floor((brush.position.z + brush.radius) / terrain.info.size.height * (height - 1));
+        if (x1 > width - 1 || x2 < 0 || y1 > height - 1 || y2 < 0) return;
+        x1 = clamp(x1, 0, width - 1); y1 = clamp(y1, 0, height - 1); x2 = clamp(x2, 0, width - 1); y2 = clamp(y2, 0, height - 1);
+        const operation = new TerrainWeightOperation(terrain); this._undo?.redoOperations.push(operation);
+        for (let y = y1; y <= y2; ++y) {
+            for (let x = x1; x <= x2; ++x) {
+                const weight = terrain.getWeight(x, y);
+                const block = terrain.getBlock(Math.floor(x / terrain.info.weightMapSize), Math.floor(y / terrain.info.weightMapSize));
+                if (!block) continue;
+                const layers = [...block.layers];
+                const delta = brush.getDelta(
+                    x / (width - 1) * terrain.info.size.width,
+                    y / (height - 1) * terrain.info.size.height,
+                ) * deltaTime;
+                if (!delta) continue;
+                const layerSlot = layers.indexOf(this._currentLayer);
+                if (layerSlot >= 0) {
+                    (weight as any)[['x', 'y', 'z', 'w'][layerSlot]] += delta;
+                } else {
+                    const emptySlot = layers.indexOf(-1);
+                    if (emptySlot < 0) continue;
+                    block.setLayer(emptySlot, this._currentLayer);
+                    (weight as any)[['x', 'y', 'z', 'w'][emptySlot]] += delta;
+                }
+                const sum = weight.x + weight.y + weight.z + weight.w;
+                if (sum > 0) weight.multiplyScalar(1 / sum);
+                this._undo?.push(x, y, terrain.getWeight(x, y));
+                this._undo?.pushBlock(block, layers, [...block.layers]);
+                operation.push(x, y, weight);
+            }
+        }
+        operation.apply();
+    }
+}

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-sculpt-tools.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-sculpt-tools.ts
@@ -1,0 +1,32 @@
+import type { Terrain } from 'cc';
+import { TerrainEdModifierKeyState } from './terrain-brush';
+
+export enum eTerrainTerrainEditorSculptToolMode { SCULPT, SMOOTH, FLATTEN, SET_HEIGHT }
+
+export class TerrainEditorSculptTool {
+    start(_terrain: Terrain, _x: number, _y: number) {}
+    apply(_terrain: Terrain, _x: number, _y: number, h: number, _delta: number, _modifiers: TerrainEdModifierKeyState) { return h; }
+}
+export class TerrainEditorSculptTool_Sculpt extends TerrainEditorSculptTool {
+    constructor(public _concave: boolean) { super(); }
+    apply(_terrain: Terrain, _x: number, _y: number, h: number, delta: number, modifiers: TerrainEdModifierKeyState) {
+        return h + (this._concave || modifiers.siftPressed ? -delta : delta);
+    }
+}
+export class TerrainEditorSculptTool_Smooth extends TerrainEditorSculptTool {
+    apply(terrain: Terrain, x: number, y: number, h: number, delta: number) {
+        const average = (terrain.getHeightClamp(x - 1, y - 1) + h + terrain.getHeightClamp(x + 1, y + 1)) / 3;
+        return h + delta * 3 * (average - h);
+    }
+}
+export class TerrainEditorSculptTool_Flatten extends TerrainEditorSculptTool {
+    protected _height = 0;
+    start(terrain: Terrain, x: number, y: number) { this._height = terrain.getHeightClamp(x, y); }
+    apply(_terrain: Terrain, _x: number, _y: number, h: number, delta: number) {
+        return h > this._height ? Math.max(h - delta, this._height) : Math.min(h + delta, this._height);
+    }
+}
+export class TerrainEditorSculptTool_SetHeight extends TerrainEditorSculptTool_Flatten {
+    constructor(height: number) { super(); this._height = height; }
+    start(_terrain: Terrain, _x: number, _y: number) {}
+}

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-sculpt.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-sculpt.ts
@@ -1,0 +1,111 @@
+import { Rect, Terrain, TERRAIN_BLOCK_TILE_COMPLEXITY, Texture2D, Vec2, Vec3, math } from 'cc';
+import { Service } from '../../../core/decorator';
+import {
+    TerrainBrush, TerrainBrushType, TerrainCircleBrush, TerrainEdModifierKeyState, TerrainImageBrush,
+} from './terrain-brush';
+import { TerrainEditorMode } from './terrain-editor-mode';
+import {
+    eTerrainTerrainEditorSculptToolMode, TerrainEditorSculptTool, TerrainEditorSculptTool_Flatten,
+    TerrainEditorSculptTool_Sculpt, TerrainEditorSculptTool_SetHeight, TerrainEditorSculptTool_Smooth,
+} from './terrain-editor-sculpt-tools';
+import { TerrainHeightOperation, TerrainHeightUndoRedo } from './terrain-operation';
+
+const clamp = math.clamp;
+
+export class TerrainEditorSculpt extends TerrainEditorMode {
+    public _brushes: TerrainBrush[];
+    public _undo: TerrainHeightUndoRedo | null = null;
+    public _currentBrush: TerrainBrush;
+    private _currentTool: TerrainEditorSculptTool | null = null;
+
+    constructor(gizmo: any) {
+        super(gizmo);
+        const circle = new TerrainCircleBrush(); circle.strength = 5;
+        const image = new TerrainImageBrush(); image.strength = 5;
+        this._brushes = [circle, image]; this._currentBrush = circle;
+    }
+
+    public setCurrentBrush(type: TerrainBrushType) {
+        const old = this._currentBrush;
+        this._currentBrush = this._brushes[type];
+        this._currentBrush.position.set(old.position);
+        this._currentBrush.radius = old.radius;
+        this._currentBrush.strength = old.strength;
+        this._currentBrush._setHeight = old._setHeight;
+    }
+    public getCurrentBrush() { return this._currentBrush; }
+    public getBrush(type: TerrainBrushType) { return this._brushes[type]; }
+    public setBrushImage(texture: Texture2D | null) {
+        const imageBrush = this.getBrush(TerrainBrushType.IMAGE) as TerrainImageBrush;
+        imageBrush.image = texture; this.setCurrentBrush(texture ? TerrainBrushType.IMAGE : TerrainBrushType.CIRCLE);
+    }
+    public setSculptBrushRotation(rotation: number) { (this.getBrush(TerrainBrushType.IMAGE) as TerrainImageBrush)._rotation = rotation; }
+
+    public onUpdate(terrain: Terrain, deltaTime: number, isShiftDown: boolean) {
+        if (!this._currentTool) return;
+        const modifiers = new TerrainEdModifierKeyState(); modifiers.siftPressed = isShiftDown;
+        this._updateHeight(terrain, deltaTime, modifiers);
+        this.gizmo.isTerrainChange = true;
+    }
+    public forceUpdate() { TerrainBrush.updateBrushDepthOffsetToMaterial(this._currentBrush.material); }
+
+    public onUpdateBrushPosition(terrain: Terrain, position: Vec3) {
+        const brush = this._currentBrush; brush.update(terrain, position);
+        const bbmin = new Vec2(), bbmax = new Vec2(); brush.getBound(bbmin, bbmax);
+        const brushRect = new Rect(bbmin.x, bbmin.y, bbmax.x - bbmin.x, bbmax.y - bbmin.y);
+        for (const block of terrain.getBlocks()) {
+            const index = block.getIndex();
+            const bound = new Rect(
+                index[0] * TERRAIN_BLOCK_TILE_COMPLEXITY * terrain.info.tileSize,
+                index[1] * TERRAIN_BLOCK_TILE_COMPLEXITY * terrain.info.tileSize,
+                TERRAIN_BLOCK_TILE_COMPLEXITY * terrain.info.tileSize,
+                TERRAIN_BLOCK_TILE_COMPLEXITY * terrain.info.tileSize,
+            );
+            block.setBrushMaterial(bound.intersects(brushRect) ? brush.material : null);
+        }
+    }
+
+    public onMouseDown(terrain: Terrain) {
+        this._undo = new TerrainHeightUndoRedo(terrain);
+        let mode = eTerrainTerrainEditorSculptToolMode.SCULPT;
+        if (this.gizmo.isSmooth) mode = eTerrainTerrainEditorSculptToolMode.SMOOTH;
+        else if (this.gizmo.isFlatten) mode = eTerrainTerrainEditorSculptToolMode.FLATTEN;
+        else if (this.gizmo.isSetHeight) mode = eTerrainTerrainEditorSculptToolMode.SET_HEIGHT;
+        switch (mode) {
+            case eTerrainTerrainEditorSculptToolMode.SMOOTH: this._currentTool = new TerrainEditorSculptTool_Smooth(); break;
+            case eTerrainTerrainEditorSculptToolMode.FLATTEN: this._currentTool = new TerrainEditorSculptTool_Flatten(); break;
+            case eTerrainTerrainEditorSculptToolMode.SET_HEIGHT: this._currentTool = new TerrainEditorSculptTool_SetHeight(this._currentBrush._setHeight); break;
+            default: this._currentTool = new TerrainEditorSculptTool_Sculpt(this.gizmo.isConcave); break;
+        }
+        const x = Math.floor(this._currentBrush.position.x / terrain.info.tileSize);
+        const y = Math.floor(this._currentBrush.position.z / terrain.info.tileSize);
+        this._currentTool.start(terrain, x, y);
+    }
+
+    public onMouseUp() {
+        if (this._undo?.data.length || this._undo?.redoOperations.length) Service.Undo.push(this._undo);
+        this._undo = null; this._currentTool = null;
+    }
+
+    public _updateHeight(terrain: Terrain, deltaTime: number, modifiers: TerrainEdModifierKeyState) {
+        if (!this._currentTool) return;
+        const bbmin = new Vec2(), bbmax = new Vec2(); this._currentBrush.getBound(bbmin, bbmax);
+        let x1 = Math.floor(bbmin.x / terrain.info.tileSize), y1 = Math.floor(bbmin.y / terrain.info.tileSize);
+        let x2 = Math.floor(bbmax.x / terrain.info.tileSize), y2 = Math.floor(bbmax.y / terrain.info.tileSize);
+        const maxX = terrain.info.vertexCount[0] - 1, maxY = terrain.info.vertexCount[1] - 1;
+        if (x1 > maxX || x2 < 0 || y1 > maxY || y2 < 0) return;
+        x1 = clamp(x1, 0, maxX); y1 = clamp(y1, 0, maxY); x2 = clamp(x2, 0, maxX); y2 = clamp(y2, 0, maxY);
+        const operation = new TerrainHeightOperation(terrain); this._undo?.redoOperations.push(operation);
+        for (let y = y1; y <= y2; ++y) {
+            for (let x = x1; x <= x2; ++x) {
+                let height = terrain.getHeightClamp(x, y);
+                this._undo?.push(x, y, height);
+                const delta = this._currentBrush.getDelta(x * terrain.info.tileSize, y * terrain.info.tileSize) * deltaTime;
+                height = this._currentTool.apply(terrain, x, y, height, delta, modifiers);
+                operation.push(x, y, height);
+            }
+        }
+        operation.apply();
+        Service.Terrain?.onSculpt(terrain.node);
+    }
+}

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-select.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-select.ts
@@ -2,6 +2,7 @@ import {
     Camera, Material, Rect, Terrain, TerrainBlock, TERRAIN_BLOCK_TILE_COMPLEXITY, Texture2D, Vec2, Vec3, clamp,
 } from 'cc';
 import { ServiceEvents } from '../../../core/global-events';
+import type { ITerrainBlockLayerSlot } from '../../../../../common';
 import { TerrainBrush } from './terrain-brush';
 import { TerrainEditorMode } from './terrain-editor-mode';
 
@@ -56,6 +57,19 @@ export class TerrainEditorSelect extends TerrainEditorMode {
     public getCurrentWeightMap() { return this._weightMap; }
     public getCurrentWeightData() { return this._weightData; }
     public getCurrentLayerList() { return this._layerList; }
+    /** Returns the Terrain-layer identity behind each RGBA slot without changing the legacy texture list. */
+    public getCurrentBlockLayerSlots(): Array<ITerrainBlockLayerSlot | null> {
+        const block = this._selectBlock;
+        if (!block) return [];
+        const terrain = block.getTerrain();
+        return block.layers.map((layerIndex) => {
+            if (layerIndex < 0) return null;
+            return {
+                layerIndex,
+                detailMapUuid: terrain.getLayer(layerIndex)?.detailMap?.uuid ?? null,
+            };
+        });
+    }
     public onDeactivate() { this.setSelectBlock(null); }
     public forceUpdate() {
         if (!this._selectBlock) return;

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-select.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-select.ts
@@ -1,0 +1,87 @@
+import {
+    Camera, Material, Rect, Terrain, TerrainBlock, TERRAIN_BLOCK_TILE_COMPLEXITY, Texture2D, Vec2, Vec3, clamp,
+} from 'cc';
+import { ServiceEvents } from '../../../core/global-events';
+import { TerrainBrush } from './terrain-brush';
+import { TerrainEditorMode } from './terrain-editor-mode';
+
+export class TerrainEditorWeightMapData {
+    public data = new Uint8Array();
+    public width = 0;
+    public height = 0;
+}
+
+/** Block picker and read-only data provider for the terrain float window. */
+export class TerrainEditorSelect extends TerrainEditorMode {
+    private _selectMaterial: Material | null = null;
+    private _selectBlock: TerrainBlock | null = null;
+    private _weightMap: Texture2D | null = null;
+    private _weightData: TerrainEditorWeightMapData | null = null;
+    private _layerList: Array<Texture2D | null> = [];
+
+    constructor(gizmo: any) {
+        super(gizmo);
+        const effect = (cc as any).EffectAsset?.get?.('internal/editor/terrain-select-brush');
+        if (effect) { this._selectMaterial = new Material(); this._selectMaterial.initialize({ effectAsset: effect }); }
+    }
+    public setSelectBlock(block: TerrainBlock | null) {
+        if (this._selectBlock === block) return;
+        ServiceEvents.emit('terrain:block-update');
+        if (this._selectBlock) this._updateBlockSelectMaterial(this._selectBlock, null);
+        this._selectBlock = block;
+        this._weightMap = null; this._weightData = null; this._layerList = [];
+        if (!block) return;
+        const terrain = block.getTerrain(); this._weightMap = block.weightmap;
+        if (this._weightMap) {
+            const size = terrain.info.weightMapSize;
+            this._weightData = new TerrainEditorWeightMapData();
+            this._weightData.width = size; this._weightData.height = size;
+            this._weightData.data = new Uint8Array(size * size * 4);
+            const index = block.getIndex(); let offset = 0;
+            for (let y = index[1] * size; y < (index[1] + 1) * size; ++y) {
+                for (let x = index[0] * size; x < (index[0] + 1) * size; ++x) {
+                    const weight = terrain.getWeight(x, y);
+                    this._weightData.data[offset++] = clamp(weight.x * 255, 0, 255);
+                    this._weightData.data[offset++] = clamp(weight.y * 255, 0, 255);
+                    this._weightData.data[offset++] = clamp(weight.z * 255, 0, 255);
+                    this._weightData.data[offset++] = clamp(weight.w * 255, 0, 255);
+                }
+            }
+        }
+        this._layerList = block.layers.map((layerId) => layerId >= 0 ? terrain.getLayer(layerId)?.detailMap ?? null : null);
+        this._updateBlockSelectMaterial(block, this._selectMaterial);
+    }
+    public getSelectBlock() { return this._selectBlock; }
+    public getCurrentBlockIndex() { return this._selectBlock?.getIndex() ?? null; }
+    public getCurrentWeightMap() { return this._weightMap; }
+    public getCurrentWeightData() { return this._weightData; }
+    public getCurrentLayerList() { return this._layerList; }
+    public onDeactivate() { this.setSelectBlock(null); }
+    public forceUpdate() {
+        if (!this._selectBlock) return;
+        TerrainBrush.updateBrushDepthOffsetToMaterial(this._selectMaterial);
+        this._selectBlock.setBrushMaterial(this._selectMaterial); this._selectBlock._invalidMaterial();
+    }
+    public onMouseDown(terrain: Terrain, camera: Camera, x: number, y: number) {
+        const from = camera.node.getWorldPosition(); const screen = new Vec3(x, y, 0); const to = new Vec3();
+        camera.screenToWorld(screen, to); const direction = new Vec3(); Vec3.subtract(direction, to, from).normalize();
+        const hit = terrain.rayCheck(from, direction, 0.35, true);
+        if (!hit) return;
+        // Terrain.rayCheck returns coordinates in Terrain local space even when
+        // the input ray is world-space.
+        const picked = new Vec2(hit.x, hit.z);
+        const block = terrain.getBlocks().find((candidate) => {
+            const index = candidate.getIndex();
+            return new Rect(
+                index[0] * TERRAIN_BLOCK_TILE_COMPLEXITY * terrain.info.tileSize,
+                index[1] * TERRAIN_BLOCK_TILE_COMPLEXITY * terrain.info.tileSize,
+                TERRAIN_BLOCK_TILE_COMPLEXITY * terrain.info.tileSize,
+                TERRAIN_BLOCK_TILE_COMPLEXITY * terrain.info.tileSize,
+            ).contains(picked);
+        }) ?? null;
+        this.setSelectBlock(this._selectBlock === block ? null : block);
+    }
+    private _updateBlockSelectMaterial(block: TerrainBlock, material: Material | null) {
+        TerrainBrush.updateBrushDepthOffsetToMaterial(material); block.setBrushMaterial(material);
+    }
+}

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor.ts
@@ -1,0 +1,91 @@
+import { Camera, Terrain, Vec3 } from 'cc';
+import { Service } from '../../../core/decorator';
+import ControllerUtils from '../../utils/controller-utils';
+import { TerrainBrush } from './terrain-brush';
+import { TerrainEditorManage } from './terrain-editor-manage';
+import { TerrainEditorMode, eTerrainEditorMode } from './terrain-editor-mode';
+import { TerrainEditorPaint } from './terrain-editor-paint';
+import { TerrainEditorSculpt } from './terrain-editor-sculpt';
+import { TerrainEditorSelect } from './terrain-editor-select';
+import type TerrainGizmo from './gizmo-select';
+
+const tempVec3_1 = new Vec3();
+const tempVec3_2 = new Vec3();
+const tempVec3_3 = new Vec3();
+
+export class TerrainEditor {
+    private _terrain: Terrain | null = null;
+    private _modes: [TerrainEditorManage, TerrainEditorSculpt, TerrainEditorPaint, TerrainEditorSelect];
+    private _currentMode: TerrainEditorMode | null = null;
+    private _cameraComp: Camera | null;
+    public isChanged = false;
+    private _gizmo: TerrainGizmo;
+
+    constructor(camera: Camera | null, gizmo: TerrainGizmo) {
+        this._cameraComp = camera;
+        this._gizmo = gizmo;
+        this._modes = [
+            new TerrainEditorManage(gizmo), new TerrainEditorSculpt(gizmo),
+            new TerrainEditorPaint(gizmo), new TerrainEditorSelect(gizmo),
+        ];
+        this.setMode(eTerrainEditorMode.MANAGE);
+    }
+    public setEditTerrain(terrain: Terrain | null) { this._terrain = terrain; }
+    public getEditTerrain() { return this._terrain; }
+    public setMode(mode: eTerrainEditorMode) {
+        this._currentMode?.onDeactivate(); this._currentMode = this._modes[mode]; this._currentMode.onActivate(); this.clearBrush();
+    }
+    public clearBrush() {
+        this._terrain?.getBlocks().forEach((block) => block.setBrushMaterial(null));
+        this._currentMode?.onDeactivate();
+    }
+    public getMode<T extends eTerrainEditorMode>(mode: T) { return this._modes[mode] as [TerrainEditorManage, TerrainEditorSculpt, TerrainEditorPaint, TerrainEditorSelect][T]; }
+    public getCurrentMode() { return this._currentMode; }
+    public getCurrentModeType() {
+        const index = this._modes.indexOf(this._currentMode as any);
+        return index < 0 ? eTerrainEditorMode.SCULPT : index as eTerrainEditorMode;
+    }
+    public setCurrentLayer(layer: number) { this.getMode(eTerrainEditorMode.PAINT).setCurrentLayer(layer); }
+    public getCurrentLayer() { return this.getMode(eTerrainEditorMode.PAINT).getCurrentLayer(); }
+    public update(deltaTime: number, shiftDown: boolean) {
+        if (!this._currentMode || !this._terrain) return;
+        this._currentMode.onUpdate(this._terrain, deltaTime, shiftDown);
+        Service.Engine.repaintInEditMode();
+    }
+    public onMouseDown(x: number, y: number) {
+        if (!this._terrain) return;
+        this.isChanged = false;
+        const sculpt = this.getMode(eTerrainEditorMode.SCULPT), paint = this.getMode(eTerrainEditorMode.PAINT), select = this.getMode(eTerrainEditorMode.SELECT);
+        if (this._currentMode === sculpt) { sculpt.onMouseDown(this._terrain); this.isChanged = true; }
+        else if (this._currentMode === paint) { paint.onMouseDown(this._terrain); this.isChanged = true; }
+        else if (this._currentMode === select && this._cameraComp) select.onMouseDown(this._terrain, this._cameraComp, x, y);
+        Service.Engine.repaintInEditMode();
+    }
+    public onMouseUp() {
+        if (!this._terrain) return;
+        const sculpt = this.getMode(eTerrainEditorMode.SCULPT), paint = this.getMode(eTerrainEditorMode.PAINT);
+        if (this._currentMode === sculpt) sculpt.onMouseUp(); else if (this._currentMode === paint) paint.onMouseUp();
+        this.isChanged = false; Service.Engine.repaintInEditMode();
+    }
+    public onMouseMove(x: number, y: number) {
+        if (!this._terrain || !this._cameraComp) return;
+        const from = this._cameraComp.node.getWorldPosition();
+        tempVec3_2.set(x, y, 0); this._cameraComp.screenToWorld(tempVec3_2, tempVec3_1);
+        Vec3.subtract(tempVec3_3, tempVec3_1, from).normalize();
+        const hit = this._terrain.rayCheck(from, tempVec3_3, 0.35, true);
+        if (!hit) return;
+        const sculpt = this.getMode(eTerrainEditorMode.SCULPT), paint = this.getMode(eTerrainEditorMode.PAINT);
+        if (this._currentMode === sculpt) { sculpt.onUpdateBrushPosition(this._terrain, hit); this.isChanged = true; }
+        else if (this._currentMode === paint) { paint.onUpdateBrushPosition(this._terrain, hit); this.isChanged = true; }
+        Service.Engine.repaintInEditMode();
+    }
+    public onHoverOut() {
+        if (this._currentMode !== this.getMode(eTerrainEditorMode.SELECT)) { this.clearBrush(); Service.Engine.repaintInEditMode(); }
+    }
+    public updateBlockDepthOffset() {
+        const node = this._gizmo.target?.node, camera = this._cameraComp;
+        if (!node || !camera) return;
+        TerrainBrush.updateBrushDepthOffset(ControllerUtils.getCameraDistanceFactor(node.position, camera.node));
+        if (this._currentMode === this.getMode(eTerrainEditorMode.SELECT)) { this.getMode(eTerrainEditorMode.SELECT).forceUpdate(); Service.Engine.repaintInEditMode(); }
+    }
+}

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-operation.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-operation.ts
@@ -1,0 +1,136 @@
+import { Rect, Terrain, TerrainBlock, Vec2, Vec3, Vec4 } from 'cc';
+import type { IUndoCommand, IUndoCommandMeta, IUndoRedoResult } from '../../../../../common';
+
+function commandMeta(type: string, terrain: Terrain): IUndoCommandMeta {
+    return {
+        id: `terrain-${type}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        label: type === 'height' ? 'Terrain Sculpt' : 'Terrain Paint',
+        type: `terrain.${type}`,
+        scope: { editorType: 'scene', nodePath: terrain.node.uuid },
+        timestamp: Date.now(),
+    };
+}
+
+export class TerrainHeightData { public x = 0; public y = 0; public value = 0; }
+
+/** A single height delta applied during one brush update. */
+export class TerrainHeightOperation {
+    protected _terrain: Terrain;
+    public data: TerrainHeightData[] = [];
+    constructor(terrain: Terrain) { this._terrain = terrain; }
+    set terrain(value: Terrain) { this._terrain = value; }
+    get terrain() { return this._terrain; }
+    public push(x: number, y: number, value: number) {
+        if (this.data.some((item) => item.x === x && item.y === y)) return;
+        this.data.push(Object.assign(new TerrainHeightData(), { x, y, value }));
+    }
+    public apply() {
+        const terrain = this._terrain;
+        if (!terrain || !this.data.length) return;
+        let xmin = this.data[0].x, xmax = xmin, ymin = this.data[0].y, ymax = ymin;
+        for (const item of this.data) {
+            terrain.setHeight(item.x, item.y, item.value);
+            xmin = Math.min(xmin, item.x); xmax = Math.max(xmax, item.x);
+            ymin = Math.min(ymin, item.y); ymax = Math.max(ymax, item.y);
+        }
+        xmin = Math.max(0, xmin - 1); ymin = Math.max(0, ymin - 1);
+        xmax = Math.min(terrain.info.vertexCount[0] - 1, xmax + 1);
+        ymax = Math.min(terrain.info.vertexCount[1] - 1, ymax + 1);
+        for (let y = ymin; y <= ymax; ++y) {
+            for (let x = xmin; x <= xmax; ++x) terrain._setNormal(x, y, terrain._calcNormal(x, y));
+        }
+        const range = new Rect(xmin, ymin, xmax - xmin + 1, ymax - ymin + 1);
+        for (const block of terrain.getBlocks()) {
+            if (block.getRect().intersects(range)) { block._updateHeight(); block.update(); }
+        }
+    }
+}
+
+export class TerrainHeightUndoRedo extends TerrainHeightOperation implements IUndoCommand {
+    public readonly meta: IUndoCommandMeta;
+    public redoOperations: TerrainHeightOperation[] = [];
+    constructor(terrain: Terrain) { super(terrain); this.meta = commandMeta('height', terrain); }
+    async undo(): Promise<IUndoRedoResult> { this.apply(); return { success: true, commandId: this.meta.id, label: this.meta.label }; }
+    async redo(): Promise<IUndoRedoResult> {
+        for (const operation of this.redoOperations) operation.apply();
+        return { success: true, commandId: this.meta.id, label: this.meta.label };
+    }
+}
+
+export class TerrainWeightData { public x = 0; public y = 0; public value = new Vec4(); }
+
+export class TerrainWeightOperation {
+    protected _terrain: Terrain;
+    public data: TerrainWeightData[] = [];
+    constructor(terrain: Terrain) { this._terrain = terrain; }
+    set terrain(value: Terrain) { this._terrain = value; }
+    get terrain() { return this._terrain; }
+    public push(x: number, y: number, value: Vec4) {
+        if (this.data.some((item) => item.x === x && item.y === y)) return;
+        const item = new TerrainWeightData(); item.x = x; item.y = y; item.value.set(value); this.data.push(item);
+    }
+    public apply() {
+        const terrain = this._terrain;
+        if (!terrain) return;
+        const changed = new Set<TerrainBlock>();
+        for (const item of this.data) {
+            terrain.setWeight(item.x, item.y, item.value);
+            const block = terrain.getBlock(
+                Math.floor(item.x / terrain.info.weightMapSize),
+                Math.floor(item.y / terrain.info.weightMapSize),
+            );
+            if (block) changed.add(block);
+        }
+        for (const block of changed) { block._updateWeightMap(); block.update(); }
+    }
+}
+
+export class TerrainBlockLayerData {
+    public readonly block: TerrainBlock;
+    public readonly layers: number[];
+    constructor(block: TerrainBlock, layers: number[]) { this.block = block; this.layers = [...layers]; }
+}
+
+export class TerrainWeightUndoRedo extends TerrainWeightOperation implements IUndoCommand {
+    public readonly meta: IUndoCommandMeta;
+    public readonly undoBlockLayers: TerrainBlockLayerData[] = [];
+    public readonly redoBlockLayers: TerrainBlockLayerData[] = [];
+    public readonly redoOperations: TerrainWeightOperation[] = [];
+    constructor(terrain: Terrain) { super(terrain); this.meta = commandMeta('weight', terrain); }
+    private applyLayers(items: TerrainBlockLayerData[]) {
+        for (const item of items) item.layers.forEach((layer, index) => item.block.setLayer(index, layer));
+    }
+    async undo(): Promise<IUndoRedoResult> {
+        this.applyLayers(this.undoBlockLayers); this.apply();
+        return { success: true, commandId: this.meta.id, label: this.meta.label };
+    }
+    async redo(): Promise<IUndoRedoResult> {
+        this.applyLayers(this.redoBlockLayers); for (const operation of this.redoOperations) operation.apply();
+        return { success: true, commandId: this.meta.id, label: this.meta.label };
+    }
+    public pushBlock(block: TerrainBlock, undoLayers: number[], redoLayers: number[]) {
+        const redo = this.redoBlockLayers.find((item) => item.block === block);
+        if (redo) redo.layers.splice(0, redo.layers.length, ...redoLayers);
+        else this.redoBlockLayers.push(new TerrainBlockLayerData(block, redoLayers));
+        if (!this.undoBlockLayers.some((item) => item.block === block)) {
+            this.undoBlockLayers.push(new TerrainBlockLayerData(block, undoLayers));
+        }
+    }
+}
+
+/** Kept for API compatibility with the 3.x layer operation implementation. */
+export class TerrainLayerOperation {
+    protected _terrain: Terrain;
+    protected _layers: (any)[] = [];
+    constructor(terrain: Terrain) { this._terrain = terrain; }
+    set terrain(value: Terrain) { this._terrain = value; }
+    get terrain() { return this._terrain; }
+    setLayers() { this._layers = (this._terrain as any)._layerList?.slice?.() ?? []; }
+    apply() { this._layers.forEach((layer, index) => (this._terrain as any).setLayer(index, layer)); }
+}
+
+export class TerrainLayerUndoRedo extends TerrainLayerOperation {
+    public redoOperations: TerrainLayerOperation[] = [];
+    undo() { this.apply(); }
+    redo() { this.redoOperations.forEach((operation) => operation.apply()); }
+}

--- a/src/core/scene/scene-process/service/gizmo/controller/terrain.ts
+++ b/src/core/scene/scene-process/service/gizmo/controller/terrain.ts
@@ -1,0 +1,39 @@
+import { MeshRenderer, Node, Vec3 } from 'cc';
+import ControllerBase from './base';
+import ControllerShape from '../utils/controller-shape';
+import ControllerUtils from '../utils/controller-utils';
+import type { GizmoMouseEvent } from '../utils/defines';
+import { getModel, setNodeOpacity, updateBoundingBox, updatePositions } from '../utils/engine-utils';
+
+/** Invisible quad used because TerrainBlock geometry is not a raycast target. */
+export default class TerrainController extends ControllerBase {
+    private _quadNode: Node | null = null;
+    private _quadMR: MeshRenderer | null = null;
+    private _size = 10;
+
+    constructor(rootNode: Node, opts: any = {}) {
+        super(rootNode); this.initShape(opts);
+    }
+    initShape(opts: any) {
+        this.createShapeNode('TerrainController');
+        const quad = ControllerUtils.quad(new Vec3(), this._size, this._size, new Vec3(0, 1, 0), undefined, opts);
+        quad.parent = this.shape; this._quadNode = quad; this._quadMR = getModel(quad);
+        setNodeOpacity(quad, 0); this.registerMouseEvents(quad, 'quad');
+    }
+    onMouseDown(event: GizmoMouseEvent) { this.onControllerMouseDown?.(event); }
+    onMouseMove(event: GizmoMouseEvent) { this.onControllerMouseMove?.(event); }
+    onMouseUp(event: GizmoMouseEvent) { this.onControllerMouseUp?.(event); }
+    onHoverIn(_event: GizmoMouseEvent) {}
+    onHoverOut(event: GizmoMouseEvent<{ hoverInNodeMap: Map<Node, boolean> }>) { this.onControllerHoverOut?.(event); }
+    onShow() {
+        if (!this._eventsRegistered) { this.registerCameraMovedEvent(); this._eventsRegistered = true; }
+    }
+    onHide() {
+        if (this._eventsRegistered) { this.unregisterCameraMoveEvent(); this._eventsRegistered = false; }
+    }
+    updateWorldPosition(value: Vec3) { this._quadNode?.setWorldPosition(value); }
+    updateSize(width: number, height: number) {
+        const data = ControllerShape.calcQuadData(new Vec3(width / 2, 0, height / 2), width, height, new Vec3(0, 1, 0));
+        if (this._quadMR) { updatePositions(this._quadMR, data.positions); updateBoundingBox(this._quadMR, data.minPos, data.maxPos); }
+    }
+}

--- a/src/core/scene/scene-process/service/gizmo/utils/defines.ts
+++ b/src/core/scene/scene-process/service/gizmo/utils/defines.ts
@@ -1,5 +1,12 @@
 import { Vec3, Vec2, primitives, Node, Color, MeshRenderer, IVec3Like, Event as CCEvent } from 'cc';
 
+// Some CLI unit tests intentionally provide a minimal `cc` mock without Event.
+// Keep the data-only mouse event usable in that environment while using the
+// engine Event implementation whenever it is available.
+const GizmoMouseEventBase = (CCEvent ?? class {
+    constructor(_type?: string, _bubbles?: boolean) {}
+}) as typeof CCEvent;
+
 export interface IMeshPrimitive {
     primitiveType?: number; // 图元类型
     positions: Readonly<IVec3Like>[]; // 顶点坐标
@@ -118,7 +125,7 @@ export interface IHandleData {
  * 简化版 GizmoMouseEvent
  * 编辑器版本继承自 CCEvent，此处作为独立的纯数据类
  */
-export class GizmoMouseEvent<T extends Record<string, any> = {}> extends CCEvent {
+export class GizmoMouseEvent<T extends Record<string, any> = {}> extends GizmoMouseEventBase {
     ctrlKey = false;
     shiftKey = false;
     altKey = false;

--- a/src/core/scene/scene-process/service/index.ts
+++ b/src/core/scene/scene-process/service/index.ts
@@ -3,6 +3,7 @@ export * from './editor';
 export * from './node';
 export * from './script';
 export * from './asset';
+export * from './terrain';
 import './effect';
 export * from './component';
 export * from './engine';

--- a/src/core/scene/scene-process/service/interfaces.ts
+++ b/src/core/scene/scene-process/service/interfaces.ts
@@ -34,15 +34,10 @@ import {
     IAnimationService,
     IPublicReferenceImageService,
     IReferenceImageService,
-<<<<<<< HEAD
     IParticleService,
     IPublicParticleService,
     IPublicTerrainService,
     ITerrainService,
-=======
-    IPublicTerrainService,
-    ITerrainService,
->>>>>>> dba13ebb (Porting the terrain editor from cocos-creator)
 } from '../../common';
 
 /**
@@ -66,12 +61,8 @@ export interface IPublicServiceManager {
     Preview: IPublicPreviewService,
     UI: IPublicUIService,
     ReferenceImage: IPublicReferenceImageService,
-<<<<<<< HEAD
     Particle: IPublicParticleService,
     Terrain: IPublicTerrainService,
-=======
-    Terrain: IPublicTerrainService,
->>>>>>> dba13ebb (Porting the terrain editor from cocos-creator)
 }
 
 export interface IServiceManager {
@@ -93,10 +84,6 @@ export interface IServiceManager {
     Preview: IPreviewService,
     UI: IUIService,
     ReferenceImage: IReferenceImageService,
-<<<<<<< HEAD
     Particle: IParticleService,
     Terrain: ITerrainService,
-=======
-    Terrain: ITerrainService,
->>>>>>> dba13ebb (Porting the terrain editor from cocos-creator)
 }

--- a/src/core/scene/scene-process/service/interfaces.ts
+++ b/src/core/scene/scene-process/service/interfaces.ts
@@ -34,8 +34,15 @@ import {
     IAnimationService,
     IPublicReferenceImageService,
     IReferenceImageService,
+<<<<<<< HEAD
     IParticleService,
     IPublicParticleService,
+    IPublicTerrainService,
+    ITerrainService,
+=======
+    IPublicTerrainService,
+    ITerrainService,
+>>>>>>> dba13ebb (Porting the terrain editor from cocos-creator)
 } from '../../common';
 
 /**
@@ -59,7 +66,12 @@ export interface IPublicServiceManager {
     Preview: IPublicPreviewService,
     UI: IPublicUIService,
     ReferenceImage: IPublicReferenceImageService,
+<<<<<<< HEAD
     Particle: IPublicParticleService,
+    Terrain: IPublicTerrainService,
+=======
+    Terrain: IPublicTerrainService,
+>>>>>>> dba13ebb (Porting the terrain editor from cocos-creator)
 }
 
 export interface IServiceManager {
@@ -81,5 +93,10 @@ export interface IServiceManager {
     Preview: IPreviewService,
     UI: IUIService,
     ReferenceImage: IReferenceImageService,
+<<<<<<< HEAD
     Particle: IParticleService,
+    Terrain: ITerrainService,
+=======
+    Terrain: ITerrainService,
+>>>>>>> dba13ebb (Porting the terrain editor from cocos-creator)
 }

--- a/src/core/scene/scene-process/service/service-manager.ts
+++ b/src/core/scene/scene-process/service/service-manager.ts
@@ -32,6 +32,7 @@ const MESSAGE_ONLY_EVENTS = [
     'terrain:changed',
     'terrain:sculpt',
     'terrain:block-update',
+    'terrain:session-changed',
 ] as const;
 
 // 定义事件分组映射

--- a/src/core/scene/scene-process/service/service-manager.ts
+++ b/src/core/scene/scene-process/service/service-manager.ts
@@ -29,6 +29,9 @@ const MESSAGE_ONLY_EVENTS = [
     'camera:fov-changed',
     'scene-view:visibility-changed',
     'scene-view:light-changed',
+    'terrain:changed',
+    'terrain:sculpt',
+    'terrain:block-update',
 ] as const;
 
 // 定义事件分组映射

--- a/src/core/scene/scene-process/service/terrain.ts
+++ b/src/core/scene/scene-process/service/terrain.ts
@@ -3,7 +3,7 @@ import { BaseService, queryRegisteredService, register } from './core';
 import { ServiceEvents } from './core/global-events';
 import { getEditorNodeByUuid, getEditorNodeByPath } from './gizmo/utils/editor-node';
 import { loadAny } from './node/node-create';
-import { Rpc } from '../rpc';
+import { sceneAssetBinaryClient } from '../scene-asset-binary-client';
 import type {
     ITerrainBlockData,
     ITerrainBrushPatch,
@@ -668,10 +668,7 @@ export class TerrainService extends BaseService<ITerrainEvents> implements ITerr
                 continue;
             }
             try {
-                const saved = await Rpc.getInstance().request('assetManager', 'saveAsset', [
-                    uuid,
-                    Buffer.from(this.serialize(terrain)),
-                ]);
+                const saved = await sceneAssetBinaryClient.save(uuid, this.serialize(terrain));
                 if (!saved || saved.uuid !== uuid) {
                     result = 2;
                     continue;
@@ -705,11 +702,11 @@ export class TerrainService extends BaseService<ITerrainEvents> implements ITerr
                 continue;
             }
             try {
-                const created = await Rpc.getInstance().request('assetManager', 'createAsset', [{
+                const created = await sceneAssetBinaryClient.create({
                     target: file,
-                    content: Buffer.from(this.serialize(terrain)),
                     overwrite: true,
-                }]);
+                    content: this.serialize(terrain),
+                });
                 if (created) {
                     (terrain as any)._asset = await loadAny<TerrainAsset>(created.uuid ?? created);
                     this.setDirty(terrain, false);

--- a/src/core/scene/scene-process/service/terrain.ts
+++ b/src/core/scene/scene-process/service/terrain.ts
@@ -1,4 +1,4 @@
-import { Component, Terrain, TerrainAsset } from 'cc';
+import { Component, Terrain, TerrainAsset, TerrainInfo, TerrainLayer, Texture2D, TERRAIN_MAX_LAYER_COUNT } from 'cc';
 import { BaseService, queryRegisteredService, register } from './core';
 import { ServiceEvents } from './core/global-events';
 import { getEditorNodeByUuid, getEditorNodeByPath } from './gizmo/utils/editor-node';
@@ -10,6 +10,9 @@ import type {
     ITerrainEditorState,
     ITerrainEvents,
     ITerrainInvalidSnapshot,
+    ITerrainLayerPatch,
+    ITerrainLayerState,
+    ITerrainManageState,
     ITerrainPaintSessionPatch,
     ITerrainService,
     ITerrainSculptSessionPatch,
@@ -17,6 +20,9 @@ import type {
     TerrainBlockReadResult,
     TerrainEditorMode,
     TerrainReadResult,
+    IUndoCommand,
+    IUndoRedoResult,
+    IUndoService,
 } from '../../common';
 
 interface ITerrainSessionGizmo {
@@ -89,6 +95,106 @@ function normalizePaintPatch(value: unknown): ITerrainPaintSessionPatch | undefi
     return brush ? { brush } : undefined;
 }
 
+
+interface ITerrainLayerAssets {
+    detailMap?: Texture2D | null;
+    normalMap?: Texture2D | null;
+}
+
+function copyManageState(value: ITerrainManageState): ITerrainManageState {
+    return {
+        tileSize: value.tileSize,
+        weightMapSize: value.weightMapSize,
+        lightMapSize: value.lightMapSize,
+        blockCount: [value.blockCount[0], value.blockCount[1]],
+    };
+}
+
+function copyLayerState(value: ITerrainLayerState): ITerrainLayerState {
+    return {
+        detailMapUuid: value.detailMapUuid,
+        normalMapUuid: value.normalMapUuid,
+        metallic: value.metallic,
+        roughness: value.roughness,
+        tileSize: value.tileSize,
+    };
+}
+
+function copyLayerStates(values: Array<ITerrainLayerState | null>): Array<ITerrainLayerState | null> {
+    return values.map((value) => value ? copyLayerState(value) : null);
+}
+
+function isFinitePositive(value: unknown): value is number {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+function isPositiveInteger(value: unknown, maximum = Number.MAX_SAFE_INTEGER): value is number {
+    return typeof value === 'number' && Number.isInteger(value) && value > 0 && value <= maximum;
+}
+
+function isUuidOrNull(value: unknown): value is string | null {
+    return value === null || (typeof value === 'string' && value.length > 0);
+}
+
+function normalizeManageState(value: unknown): ITerrainManageState | null {
+    if (!value || typeof value !== 'object') return null;
+    const source = value as Partial<ITerrainManageState>;
+    if (!isFinitePositive(source.tileSize)
+        || !isPositiveInteger(source.weightMapSize, 0x7fff)
+        || !isPositiveInteger(source.lightMapSize, 0x7fff)
+        || !Array.isArray(source.blockCount)
+        || source.blockCount.length !== 2
+        || !isPositiveInteger(source.blockCount[0])
+        || !isPositiveInteger(source.blockCount[1])) {
+        return null;
+    }
+    return {
+        tileSize: source.tileSize,
+        weightMapSize: source.weightMapSize,
+        lightMapSize: source.lightMapSize,
+        blockCount: [source.blockCount[0], source.blockCount[1]],
+    };
+}
+
+function normalizeLayerState(value: unknown): ITerrainLayerState | null {
+    if (!value || typeof value !== 'object') return null;
+    const source = value as Partial<ITerrainLayerState>;
+    const { detailMapUuid, normalMapUuid, metallic, roughness, tileSize } = source;
+    if (!isUuidOrNull(detailMapUuid)
+        || !isUuidOrNull(normalMapUuid)
+        || typeof metallic !== 'number' || !Number.isFinite(metallic)
+        || typeof roughness !== 'number' || !Number.isFinite(roughness)
+        || !isFinitePositive(tileSize)) {
+        return null;
+    }
+    return { detailMapUuid, normalMapUuid, metallic, roughness, tileSize };
+}
+
+function normalizeLayerPatch(value: unknown): ITerrainLayerPatch | null {
+    if (!value || typeof value !== 'object') return null;
+    const source = value as ITerrainLayerPatch;
+    const patch: ITerrainLayerPatch = {};
+    for (const key of ['detailMapUuid', 'normalMapUuid'] as const) {
+        if (!Object.hasOwn(source, key)) continue;
+        if (!isUuidOrNull(source[key])) return null;
+        patch[key] = source[key];
+    }
+    for (const key of ['metallic', 'roughness'] as const) {
+        if (!Object.hasOwn(source, key)) continue;
+        if (!Number.isFinite(source[key])) return null;
+        patch[key] = source[key];
+    }
+    if (Object.hasOwn(source, 'tileSize')) {
+        if (!isFinitePositive(source.tileSize)) return null;
+        patch.tileSize = source.tileSize;
+    }
+    return Object.keys(patch).length ? patch : null;
+}
+
+function statesEqual(left: unknown, right: unknown): boolean {
+    return JSON.stringify(left) === JSON.stringify(right);
+}
+
 /**
  * Terrain asset lifecycle and target-safe editor-session access.
  *
@@ -101,6 +207,7 @@ export class TerrainService extends BaseService<ITerrainEvents> implements ITerr
     public readonly name = 'cc.Terrain' as const;
     public readonly editedComponents: Terrain[] = [];
     public readonly selectedComponents: Terrain[] = [];
+    private _terrainUndoSequence = 0;
 
     init() {
         // SelectionService broadcasts paths, while the old manager received node UUIDs.
@@ -194,6 +301,244 @@ export class TerrainService extends BaseService<ITerrainEvents> implements ITerr
         const resolved = this.resolveTarget(target);
         if (!resolved) return this.invalidResult(target);
         return { target: copyTarget(target), valid: true, block: resolved.gizmo.readTerrainBlock() };
+    }
+
+    /** Commits a full Manage draft as one CLI-owned Terrain mutation and Undo command. */
+    public async saveManage(target: ITerrainTarget, manage: ITerrainManageState): Promise<TerrainReadResult> {
+        const next = normalizeManageState(manage);
+        if (!next) return this.read(target);
+        const resolved = this.resolveTarget(target);
+        if (!resolved) return isTerrainTarget(target) ? this.invalidResult(target) : this.read(target);
+        const undoService = this.getTerrainUndoService();
+        if (!undoService) return this.readResolved(target, resolved.gizmo);
+
+        const before = copyManageState(resolved.gizmo.readTerrainState().manage);
+        if (statesEqual(before, next)) return this.readResolved(target, resolved.gizmo);
+        if (!this.applyTerrainManageState(resolved.component, next)) return this.read(target);
+
+        const result = this.read(target);
+        if (!result.valid) return result;
+        const after = copyManageState(result.manage);
+        this.pushTerrainUndo(undoService, resolved.component, 'Save Terrain Manage', 'terrain:save-manage',
+            () => this.applyTerrainManageState(resolved.component, before),
+            () => this.applyTerrainManageState(resolved.component, after));
+        return result;
+    }
+
+    /** Adds one complete layer; incompatible or unavailable textures leave Terrain untouched. */
+    public async addLayer(target: ITerrainTarget, layer: ITerrainLayerState): Promise<TerrainReadResult> {
+        const next = normalizeLayerState(layer);
+        if (!next || !next.detailMapUuid) return this.read(target);
+        const initial = this.resolveTarget(target);
+        if (!initial) return isTerrainTarget(target) ? this.invalidResult(target) : this.read(target);
+        const undoService = this.getTerrainUndoService();
+        if (!undoService) return this.readResolved(target, initial.gizmo);
+        const assets = await this.loadLayerAssets(next);
+        if (!assets?.detailMap) return this.read(target);
+
+        const resolved = this.resolveTarget(target);
+        if (!resolved) return isTerrainTarget(target) ? this.invalidResult(target) : this.read(target);
+        const before = copyLayerStates(resolved.gizmo.readTerrainState().layers);
+        if (!this.addTerrainLayer(resolved.component, next, assets)) return this.read(target);
+
+        const result = this.read(target);
+        if (!result.valid) return result;
+        const after = copyLayerStates(result.layers);
+        this.pushTerrainUndo(undoService, resolved.component, 'Add Terrain Layer', 'terrain:add-layer',
+            () => this.applyTerrainLayerStates(resolved.component, before),
+            () => this.applyTerrainLayerStates(resolved.component, after));
+        return result;
+    }
+
+    /** Removes a single layer slot as one CLI-owned Terrain mutation and Undo command. */
+    public async removeLayer(target: ITerrainTarget, index: number): Promise<TerrainReadResult> {
+        if (!this.isLayerIndex(index)) return this.read(target);
+        const resolved = this.resolveTarget(target);
+        if (!resolved) return isTerrainTarget(target) ? this.invalidResult(target) : this.read(target);
+        const undoService = this.getTerrainUndoService();
+        if (!undoService) return this.readResolved(target, resolved.gizmo);
+        const before = copyLayerStates(resolved.gizmo.readTerrainState().layers);
+        if (!this.removeTerrainLayer(resolved.component, index)) return this.read(target);
+
+        const result = this.read(target);
+        if (!result.valid) return result;
+        const after = copyLayerStates(result.layers);
+        this.pushTerrainUndo(undoService, resolved.component, 'Remove Terrain Layer', 'terrain:remove-layer',
+            () => this.applyTerrainLayerStates(resolved.component, before),
+            () => this.applyTerrainLayerStates(resolved.component, after));
+        return result;
+    }
+
+    /** Updates one layer slot; texture references are resolved before the target can mutate. */
+    public async updateLayer(target: ITerrainTarget, index: number, patch: ITerrainLayerPatch): Promise<TerrainReadResult> {
+        if (!this.isLayerIndex(index)) return this.read(target);
+        const next = normalizeLayerPatch(patch);
+        if (!next) return this.read(target);
+        const initial = this.resolveTarget(target);
+        if (!initial) return isTerrainTarget(target) ? this.invalidResult(target) : this.read(target);
+        const undoService = this.getTerrainUndoService();
+        if (!undoService) return this.readResolved(target, initial.gizmo);
+        const assets = await this.loadLayerAssets(next);
+        if (!assets) return this.read(target);
+
+        const resolved = this.resolveTarget(target);
+        if (!resolved) return isTerrainTarget(target) ? this.invalidResult(target) : this.read(target);
+        const before = copyLayerStates(resolved.gizmo.readTerrainState().layers);
+        if (!this.updateTerrainLayer(resolved.component, index, next, assets)) return this.read(target);
+
+        const result = this.read(target);
+        if (!result.valid) return result;
+        const after = copyLayerStates(result.layers);
+        this.pushTerrainUndo(undoService, resolved.component, 'Update Terrain Layer', 'terrain:update-layer',
+            () => this.applyTerrainLayerStates(resolved.component, before),
+            () => this.applyTerrainLayerStates(resolved.component, after));
+        return result;
+    }
+
+    private isLayerIndex(index: number): boolean {
+        return Number.isInteger(index) && index >= 0 && index < TERRAIN_MAX_LAYER_COUNT;
+    }
+
+    private isAttachedTerrain(component: Terrain): boolean {
+        return this.isTerrainComponent(component)
+            && (component as any).isValid !== false
+            && Array.isArray(component.node?.components)
+            && component.node.components.includes(component);
+    }
+
+    private createTerrainInfo(state: ITerrainManageState): TerrainInfo {
+        const info = new TerrainInfo();
+        info.tileSize = state.tileSize;
+        info.weightMapSize = state.weightMapSize;
+        info.lightMapSize = state.lightMapSize;
+        info.blockCount = [state.blockCount[0], state.blockCount[1]];
+        return info;
+    }
+
+    private createTerrainLayer(state: ITerrainLayerState, assets: ITerrainLayerAssets): TerrainLayer {
+        const layer = new TerrainLayer();
+        layer.detailMap = assets.detailMap ?? null;
+        layer.normalMap = assets.normalMap ?? null;
+        layer.metallic = state.metallic;
+        layer.roughness = state.roughness;
+        layer.tileSize = state.tileSize;
+        return layer;
+    }
+
+    private async loadTerrainTexture(uuid: string): Promise<Texture2D | null> {
+        try {
+            const texture = await loadAny<Texture2D>(uuid);
+            return texture instanceof Texture2D ? texture : null;
+        } catch (error) {
+            console.warn(`[Terrain] load layer texture failed: ${uuid}`, error);
+            return null;
+        }
+    }
+
+    private async loadLayerAssets(value: Pick<ITerrainLayerState, 'detailMapUuid' | 'normalMapUuid'> | ITerrainLayerPatch): Promise<ITerrainLayerAssets | null> {
+        const assets: ITerrainLayerAssets = {};
+        for (const key of ['detailMapUuid', 'normalMapUuid'] as const) {
+            if (!Object.hasOwn(value, key)) continue;
+            const uuid = value[key];
+            const assetKey = key === 'detailMapUuid' ? 'detailMap' : 'normalMap';
+            if (uuid === null) {
+                assets[assetKey] = null;
+                continue;
+            }
+            if (typeof uuid !== 'string') return null;
+            const texture = await this.loadTerrainTexture(uuid);
+            if (!texture) return null;
+            assets[assetKey] = texture;
+        }
+        return assets;
+    }
+
+    private applyTerrainManageState(component: Terrain, state: ITerrainManageState): boolean {
+        if (!this.isAttachedTerrain(component)) return false;
+        component.rebuild(this.createTerrainInfo(state));
+        this.reportTerrainAuthoringChange(component);
+        return true;
+    }
+
+    private addTerrainLayer(component: Terrain, state: ITerrainLayerState, assets: ITerrainLayerAssets): boolean {
+        if (!this.isAttachedTerrain(component) || !assets.detailMap) return false;
+        if (component.addLayer(this.createTerrainLayer(state, assets)) < 0) return false;
+        this.reportTerrainAuthoringChange(component);
+        return true;
+    }
+
+    private removeTerrainLayer(component: Terrain, index: number): boolean {
+        if (!this.isAttachedTerrain(component) || !component.getLayer(index)) return false;
+        component.removeLayer(index);
+        this.reportTerrainAuthoringChange(component);
+        return true;
+    }
+
+    private updateTerrainLayer(component: Terrain, index: number, patch: ITerrainLayerPatch, assets: ITerrainLayerAssets): boolean {
+        if (!this.isAttachedTerrain(component)) return false;
+        const layer = component.getLayer(index);
+        if (!layer) return false;
+        if (Object.hasOwn(patch, 'detailMapUuid')) layer.detailMap = assets.detailMap ?? null;
+        if (Object.hasOwn(patch, 'normalMapUuid')) layer.normalMap = assets.normalMap ?? null;
+        if (typeof patch.metallic === 'number') layer.metallic = patch.metallic;
+        if (typeof patch.roughness === 'number') layer.roughness = patch.roughness;
+        if (typeof patch.tileSize === 'number') layer.tileSize = patch.tileSize;
+        this.reportTerrainAuthoringChange(component);
+        return true;
+    }
+
+    private async applyTerrainLayerStates(component: Terrain, states: Array<ITerrainLayerState | null>): Promise<boolean> {
+        const loaded = await Promise.all(states.map(async (state) => {
+            if (!state) return null;
+            const assets = await this.loadLayerAssets(state);
+            return assets ? { state, assets } : undefined;
+        }));
+        if (loaded.some((value, index) => states[index] !== null && value === undefined) || !this.isAttachedTerrain(component)) {
+            return false;
+        }
+
+        for (let index = 0; index < TERRAIN_MAX_LAYER_COUNT; index++) {
+            const layer = loaded[index];
+            if (layer) component.setLayer(index, this.createTerrainLayer(layer.state, layer.assets));
+            else component.removeLayer(index);
+        }
+        this.reportTerrainAuthoringChange(component);
+        return true;
+    }
+
+    private reportTerrainAuthoringChange(component: Terrain): void {
+        if (component._asset) component.exportLayerListToAsset(component._asset);
+        this.setDirty(component, true);
+        ServiceEvents.emit('node:change', component.node, { type: 'component-changed' });
+        queryRegisteredService<{ repaintInEditMode(): void }>('Engine')?.repaintInEditMode();
+    }
+
+    private getTerrainUndoService(): IUndoService | null {
+        const undoService = queryRegisteredService<IUndoService>('Undo');
+        return undoService && !undoService.isApplying() ? undoService : null;
+    }
+
+    private pushTerrainUndo(
+        undoService: IUndoService,
+        component: Terrain,
+        label: string,
+        type: string,
+        undo: () => boolean | Promise<boolean>,
+        redo: () => boolean | Promise<boolean>,
+    ): void {
+        const id = `${type}:${++this._terrainUndoSequence}`;
+        const result = async (apply: () => boolean | Promise<boolean>): Promise<IUndoRedoResult> => {
+            const success = await apply();
+            return success
+                ? { success: true, commandId: id, label }
+                : { success: false, commandId: id, label, reason: 'Terrain target or texture is unavailable' };
+        };
+        const command: IUndoCommand = {
+            meta: { id, label, type, scope: { editorType: 'scene' }, timestamp: Date.now() },
+            undo: () => result(undo),
+            redo: () => result(redo),
+        };
+        undoService.push(command);
     }
 
     private setManager(component: Terrain, value: any) {

--- a/src/core/scene/scene-process/service/terrain.ts
+++ b/src/core/scene/scene-process/service/terrain.ts
@@ -1,0 +1,221 @@
+import { Component, Terrain, TerrainAsset } from 'cc';
+import { BaseService, register } from './core';
+import { ServiceEvents } from './core/global-events';
+import { getEditorNodeByUuid, getEditorNodeByPath } from './gizmo/utils/editor-node';
+import { loadAny } from './node/node-create';
+import { Rpc } from '../rpc';
+import type { ITerrainEvents, ITerrainService } from '../../common';
+
+/**
+ * Terrain 资源生命周期管理。
+ *
+ * 3.x 的 terrain manager 依赖 Editor.Dialog/Plugin；CLI 只保留其数据和资产接口，
+ * 将“是否询问用户”交给 pink。已有 .terrain 资源直接 saveAsset，未绑定资源时返回 2，
+ * 由 UI 决定 Save As 的目标 URL。
+ */
+@register('Terrain')
+export class TerrainService extends BaseService<ITerrainEvents> implements ITerrainService {
+    public readonly name = 'cc.Terrain' as const;
+    public readonly editedComponents: Terrain[] = [];
+    public readonly selectedComponents: Terrain[] = [];
+
+    init() {
+        // SelectionService broadcasts paths, while the old manager received node UUIDs.
+        // Keep both entry points so pink can use either protocol.
+        ServiceEvents.on('selection:select', (path: string) => this.onSelectionSelect(path));
+        ServiceEvents.on('selection:unselect', (path: string) => this.onSelectionUnselect(path));
+        ServiceEvents.on('selection:clear', () => this.onSelectionClear());
+    }
+
+    private terrainOfNode(node: any): Terrain | null {
+        return node?.components?.find((component: Component) => component instanceof Terrain
+            || (component as any).__classname__ === 'cc.Terrain') as Terrain | null ?? null;
+    }
+
+    private terrainOfUuid(uuid: string): Terrain | null {
+        return this.terrainOfNode(getEditorNodeByUuid(uuid));
+    }
+
+    private setManager(component: Terrain, value: any) {
+        (component as any).manager = value;
+    }
+
+    private setDirty(component: Terrain, value: boolean) {
+        (component as any).isTerrainChange = value;
+        if (value) {
+            this.emit('terrain:changed', component);
+        }
+    }
+
+    public get isTerrainChange(): boolean {
+        return this.editedComponents.some((component) => (component as any).isTerrainChange === true);
+    }
+
+    public set isTerrainChange(value: boolean) {
+        for (const component of this.selectedComponents) {
+            this.setDirty(component, value);
+        }
+    }
+
+    public select(nodeUuid: string): void {
+        const component = this.terrainOfUuid(nodeUuid);
+        if (!component) return;
+        this.setManager(component, this);
+        if (!this.selectedComponents.includes(component)) this.selectedComponents.push(component);
+        if (!this.editedComponents.includes(component)) this.editedComponents.push(component);
+    }
+
+    public unselect(nodeUuid: string): void {
+        const component = this.terrainOfUuid(nodeUuid);
+        if (!component) return;
+        this.setManager(component, null);
+        const selectedIndex = this.selectedComponents.indexOf(component);
+        if (selectedIndex >= 0) this.selectedComponents.splice(selectedIndex, 1);
+        // Keep editedComponents until the node is removed, like the 3.x manager.
+    }
+
+    public onSelectionSelect(path: string): void {
+        const node = getEditorNodeByPath(path);
+        if (node) this.select(node.uuid);
+    }
+
+    public onSelectionUnselect(path: string): void {
+        const node = getEditorNodeByPath(path);
+        if (node) this.unselect(node.uuid);
+    }
+
+    public onSelectionClear(): void {
+        for (const component of this.selectedComponents) this.setManager(component, null);
+        this.selectedComponents.length = 0;
+    }
+
+    public onNodeRemoved(node: any): void {
+        const component = this.terrainOfNode(node);
+        if (!component) return;
+        this.removeComponent(component);
+    }
+
+    public onComponentRemoved(component: Component): void {
+        if (component instanceof Terrain) this.removeComponent(component);
+    }
+
+    private removeComponent(component: Terrain) {
+        this.setManager(component, null);
+        const selected = this.selectedComponents.indexOf(component);
+        if (selected >= 0) this.selectedComponents.splice(selected, 1);
+        const edited = this.editedComponents.indexOf(component);
+        if (edited >= 0) this.editedComponents.splice(edited, 1);
+    }
+
+    public onSculpt(node: any): void {
+        this.emit('terrain:sculpt', node);
+    }
+
+    public serialize(component: Terrain): Uint8Array {
+        const asset = component.exportAsset();
+        // TerrainAsset's binary export is the canonical .terrain native payload.
+        return asset._exportNativeData();
+    }
+
+    public async saveAsset(isClose = false, component?: Terrain): Promise<0 | 1 | 2> {
+        const targets = component ? [component] : this.editedComponents;
+        let result: 0 | 1 | 2 = 1;
+        for (const terrain of targets) {
+            if (!(terrain as any).isTerrainChange) continue;
+            const uuid = terrain._asset?._uuid;
+            if (!uuid) {
+                result = 2;
+                continue;
+            }
+            try {
+                const saved = await Rpc.getInstance().request('assetManager', 'saveAsset', [
+                    uuid,
+                    Buffer.from(this.serialize(terrain)),
+                ]);
+                if (!saved || saved.uuid !== uuid) {
+                    result = 2;
+                    continue;
+                }
+                this.setDirty(terrain, false);
+                result = 0;
+            } catch (error) {
+                console.error('[Terrain] saveAsset failed:', error);
+                result = 2;
+            }
+        }
+        return result;
+    }
+
+    public async saveAssetDialog(file?: string, isClose = false): Promise<0 | 1 | 2> {
+        let result: 0 | 1 | 2 = 1;
+        for (const terrain of this.editedComponents) {
+            if (!(terrain as any).isTerrainChange) continue;
+            const uuid = terrain._asset?._uuid;
+            if (uuid) {
+                const code = await this.saveAsset(isClose, terrain);
+                if (code === 2) result = 2;
+                else if (code === 0) result = 0;
+                continue;
+            }
+
+            // No UI is intentionally implemented here. pink can pass a db:// target
+            // through `file` to create the asset, or use its own Save As dialog.
+            if (!file) {
+                result = 2;
+                continue;
+            }
+            try {
+                const created = await Rpc.getInstance().request('assetManager', 'createAsset', [{
+                    target: file,
+                    content: Buffer.from(this.serialize(terrain)),
+                    overwrite: true,
+                }]);
+                if (created) {
+                    (terrain as any)._asset = await loadAny<TerrainAsset>(created.uuid ?? created);
+                    this.setDirty(terrain, false);
+                    result = 0;
+                } else {
+                    result = 2;
+                }
+            } catch (error) {
+                console.error('[Terrain] create terrain asset failed:', error);
+                result = 2;
+            }
+        }
+        return result;
+    }
+
+    public async close(): Promise<0 | 1 | 2> {
+        if (!this.isTerrainChange) return 1;
+        return this.saveAssetDialog(undefined, true);
+    }
+
+    public async addAssetToComp(assetUuid: string): Promise<void> {
+        for (const terrain of this.selectedComponents) {
+            if (assetUuid) {
+                try {
+                    (terrain as any)._asset = await loadAny<TerrainAsset>(assetUuid);
+                } catch {
+                    (terrain as any)._asset = null;
+                }
+            } else if (!(terrain as any)._asset) {
+                (terrain as any)._asset = new TerrainAsset();
+                this.setDirty(terrain, false);
+            }
+            ServiceEvents.emit('node:change', terrain.node, { type: 'component-changed' });
+        }
+    }
+
+    public onAssetDeleted(uuid: string): void {
+        for (const terrain of this.editedComponents) {
+            if (terrain._asset?._uuid === uuid) {
+                ServiceEvents.emit('node:change', terrain.node, { type: 'component-changed' });
+            }
+        }
+    }
+
+    public onEditorClosed(): void {
+        this.onSelectionClear();
+        this.editedComponents.length = 0;
+    }
+}

--- a/src/core/scene/scene-process/service/terrain.ts
+++ b/src/core/scene/scene-process/service/terrain.ts
@@ -31,6 +31,7 @@ interface ITerrainSessionGizmo {
     setTerrainMode(mode: TerrainEditorMode): void;
     setTerrainCurrentLayer(currentLayer: number): void;
     updateTerrainSculptSession(patch: ITerrainSculptSessionPatch): void;
+    setSculptBrushTexture(texture: Texture2D | null): void;
     updateTerrainPaintSession(patch: ITerrainPaintSessionPatch): void;
     readTerrainBlock(): ITerrainBlockData | null;
 }
@@ -43,7 +44,6 @@ const terrainEditorModes = new Set<TerrainEditorMode>(['manage', 'sculpt', 'pain
 const terrainSculptTools = new Set<NonNullable<ITerrainSculptSessionPatch['tool']>>([
     'bulge', 'sunken', 'smooth', 'flatten', 'set-height',
 ]);
-const terrainBrushKinds = new Set<NonNullable<ITerrainBrushPatch['kind']>>(['circle', 'image']);
 
 function copyTarget(target: ITerrainTarget): ITerrainTarget {
     return { nodeUuid: target.nodeUuid, componentUuid: target.componentUuid };
@@ -64,6 +64,7 @@ function isTerrainSessionGizmo(value: unknown): value is ITerrainSessionGizmo {
         && typeof gizmo.setTerrainMode === 'function'
         && typeof gizmo.setTerrainCurrentLayer === 'function'
         && typeof gizmo.updateTerrainSculptSession === 'function'
+        && typeof gizmo.setSculptBrushTexture === 'function'
         && typeof gizmo.updateTerrainPaintSession === 'function'
         && typeof gizmo.readTerrainBlock === 'function';
 }
@@ -72,7 +73,6 @@ function normalizeBrushPatch(value: unknown): ITerrainBrushPatch | undefined {
     if (!value || typeof value !== 'object') return undefined;
     const source = value as ITerrainBrushPatch;
     const patch: ITerrainBrushPatch = {};
-    if (source.kind && terrainBrushKinds.has(source.kind)) patch.kind = source.kind;
     for (const key of ['radius', 'strength', 'rotation', 'setHeight'] as const) {
         if (typeof source[key] === 'number' && Number.isFinite(source[key])) patch[key] = source[key];
     }
@@ -285,6 +285,24 @@ export class TerrainService extends BaseService<ITerrainEvents> implements ITerr
         return this.read(target);
     }
 
+    /** Assigns a validated Texture2D asset to Sculpt, or clears it to restore the circle brush, without creating Scene Undo. */
+    public async setSculptBrushAsset(target: ITerrainTarget, assetUuid: string | null): Promise<TerrainReadResult> {
+        if (assetUuid !== null && (typeof assetUuid !== 'string' || assetUuid.length === 0)) {
+            return this.read(target);
+        }
+        const initial = this.resolveTarget(target);
+        if (!initial) return isTerrainTarget(target) ? this.invalidResult(target) : this.read(target);
+
+        const texture = assetUuid === null ? null : await this.loadTerrainTexture(assetUuid, 'sculpt brush');
+        if (assetUuid !== null && !texture) return this.read(target);
+
+        const resolved = this.resolveTarget(target);
+        if (!resolved) return isTerrainTarget(target) ? this.invalidResult(target) : this.read(target);
+        resolved.gizmo.setSculptBrushTexture(texture);
+        this.emit('terrain:session-changed', copyTarget(target));
+        return this.read(target);
+    }
+
     public setPaintSession(target: ITerrainTarget, patch: ITerrainPaintSessionPatch): TerrainReadResult {
         const resolved = this.resolveTarget(target);
         if (!resolved) return isTerrainTarget(target) ? this.invalidResult(target) : this.read(target);
@@ -425,12 +443,12 @@ export class TerrainService extends BaseService<ITerrainEvents> implements ITerr
         return layer;
     }
 
-    private async loadTerrainTexture(uuid: string): Promise<Texture2D | null> {
+    private async loadTerrainTexture(uuid: string, usage = 'layer'): Promise<Texture2D | null> {
         try {
             const texture = await loadAny<Texture2D>(uuid);
             return texture instanceof Texture2D ? texture : null;
         } catch (error) {
-            console.warn(`[Terrain] load layer texture failed: ${uuid}`, error);
+            console.warn(`[Terrain] load ${usage} texture failed: ${uuid}`, error);
             return null;
         }
     }

--- a/src/core/scene/scene-process/service/terrain.ts
+++ b/src/core/scene/scene-process/service/terrain.ts
@@ -32,6 +32,7 @@ interface ITerrainSessionGizmo {
     setTerrainCurrentLayer(currentLayer: number): void;
     updateTerrainSculptSession(patch: ITerrainSculptSessionPatch): void;
     setSculptBrushTexture(texture: Texture2D | null): void;
+    setPaintBrushTexture(texture: Texture2D | null): void;
     updateTerrainPaintSession(patch: ITerrainPaintSessionPatch): void;
     readTerrainBlock(): ITerrainBlockData | null;
 }
@@ -65,6 +66,7 @@ function isTerrainSessionGizmo(value: unknown): value is ITerrainSessionGizmo {
         && typeof gizmo.setTerrainCurrentLayer === 'function'
         && typeof gizmo.updateTerrainSculptSession === 'function'
         && typeof gizmo.setSculptBrushTexture === 'function'
+        && typeof gizmo.setPaintBrushTexture === 'function'
         && typeof gizmo.updateTerrainPaintSession === 'function'
         && typeof gizmo.readTerrainBlock === 'function';
 }
@@ -287,18 +289,32 @@ export class TerrainService extends BaseService<ITerrainEvents> implements ITerr
 
     /** Assigns a validated Texture2D asset to Sculpt, or clears it to restore the circle brush, without creating Scene Undo. */
     public async setSculptBrushAsset(target: ITerrainTarget, assetUuid: string | null): Promise<TerrainReadResult> {
+        return this.setBrushAsset(target, assetUuid, 'sculpt brush', (gizmo, texture) => gizmo.setSculptBrushTexture(texture));
+    }
+
+    /** Assigns a validated Texture2D asset to Paint, or clears it to restore the circle brush, without creating Scene Undo. */
+    public async setPaintBrushAsset(target: ITerrainTarget, assetUuid: string | null): Promise<TerrainReadResult> {
+        return this.setBrushAsset(target, assetUuid, 'paint brush', (gizmo, texture) => gizmo.setPaintBrushTexture(texture));
+    }
+
+    private async setBrushAsset(
+        target: ITerrainTarget,
+        assetUuid: string | null,
+        usage: string,
+        apply: (gizmo: ITerrainSessionGizmo, texture: Texture2D | null) => void,
+    ): Promise<TerrainReadResult> {
         if (assetUuid !== null && (typeof assetUuid !== 'string' || assetUuid.length === 0)) {
             return this.read(target);
         }
         const initial = this.resolveTarget(target);
         if (!initial) return isTerrainTarget(target) ? this.invalidResult(target) : this.read(target);
 
-        const texture = assetUuid === null ? null : await this.loadTerrainTexture(assetUuid, 'sculpt brush');
+        const texture = assetUuid === null ? null : await this.loadTerrainTexture(assetUuid, usage);
         if (assetUuid !== null && !texture) return this.read(target);
 
         const resolved = this.resolveTarget(target);
         if (!resolved) return isTerrainTarget(target) ? this.invalidResult(target) : this.read(target);
-        resolved.gizmo.setSculptBrushTexture(texture);
+        apply(resolved.gizmo, texture);
         this.emit('terrain:session-changed', copyTarget(target));
         return this.read(target);
     }

--- a/src/core/scene/scene-process/service/terrain.ts
+++ b/src/core/scene/scene-process/service/terrain.ts
@@ -202,7 +202,7 @@ function statesEqual(left: unknown, right: unknown): boolean {
  *
  * The public Terrain capability never exposes gizmos. This service validates the
  * requested node/component pair, adapts the matching internal gizmo, and returns
- * JSON-safe canonical snapshots for the Scene webview.
+ * canonical snapshots for direct Scene-webview access.
  */
 @register('Terrain')
 export class TerrainService extends BaseService<ITerrainEvents> implements ITerrainService {

--- a/src/core/scene/scene-process/service/terrain.ts
+++ b/src/core/scene/scene-process/service/terrain.ts
@@ -1,17 +1,100 @@
 import { Component, Terrain, TerrainAsset } from 'cc';
-import { BaseService, register } from './core';
+import { BaseService, queryRegisteredService, register } from './core';
 import { ServiceEvents } from './core/global-events';
 import { getEditorNodeByUuid, getEditorNodeByPath } from './gizmo/utils/editor-node';
 import { loadAny } from './node/node-create';
 import { Rpc } from '../rpc';
-import type { ITerrainEvents, ITerrainService } from '../../common';
+import type {
+    ITerrainBlockData,
+    ITerrainBrushPatch,
+    ITerrainEditorState,
+    ITerrainEvents,
+    ITerrainInvalidSnapshot,
+    ITerrainPaintSessionPatch,
+    ITerrainService,
+    ITerrainSculptSessionPatch,
+    ITerrainTarget,
+    TerrainBlockReadResult,
+    TerrainEditorMode,
+    TerrainReadResult,
+} from '../../common';
+
+interface ITerrainSessionGizmo {
+    target: Terrain | null;
+    readTerrainState(): ITerrainEditorState;
+    setTerrainMode(mode: TerrainEditorMode): void;
+    setTerrainCurrentLayer(currentLayer: number): void;
+    updateTerrainSculptSession(patch: ITerrainSculptSessionPatch): void;
+    updateTerrainPaintSession(patch: ITerrainPaintSessionPatch): void;
+    readTerrainBlock(): ITerrainBlockData | null;
+}
+
+interface IGizmoServiceLookup {
+    getComponentGizmo(component: Component): unknown;
+}
+
+const terrainEditorModes = new Set<TerrainEditorMode>(['manage', 'sculpt', 'paint', 'block']);
+const terrainSculptTools = new Set<NonNullable<ITerrainSculptSessionPatch['tool']>>([
+    'bulge', 'sunken', 'smooth', 'flatten', 'set-height',
+]);
+const terrainBrushKinds = new Set<NonNullable<ITerrainBrushPatch['kind']>>(['circle', 'image']);
+
+function copyTarget(target: ITerrainTarget): ITerrainTarget {
+    return { nodeUuid: target.nodeUuid, componentUuid: target.componentUuid };
+}
+
+function isTerrainTarget(value: unknown): value is ITerrainTarget {
+    if (!value || typeof value !== 'object') return false;
+    const target = value as Partial<ITerrainTarget>;
+    return typeof target.nodeUuid === 'string' && target.nodeUuid.length > 0
+        && typeof target.componentUuid === 'string' && target.componentUuid.length > 0;
+}
+
+function isTerrainSessionGizmo(value: unknown): value is ITerrainSessionGizmo {
+    if (!value || typeof value !== 'object') return false;
+    const gizmo = value as Partial<ITerrainSessionGizmo>;
+    return 'target' in gizmo
+        && typeof gizmo.readTerrainState === 'function'
+        && typeof gizmo.setTerrainMode === 'function'
+        && typeof gizmo.setTerrainCurrentLayer === 'function'
+        && typeof gizmo.updateTerrainSculptSession === 'function'
+        && typeof gizmo.updateTerrainPaintSession === 'function'
+        && typeof gizmo.readTerrainBlock === 'function';
+}
+
+function normalizeBrushPatch(value: unknown): ITerrainBrushPatch | undefined {
+    if (!value || typeof value !== 'object') return undefined;
+    const source = value as ITerrainBrushPatch;
+    const patch: ITerrainBrushPatch = {};
+    if (source.kind && terrainBrushKinds.has(source.kind)) patch.kind = source.kind;
+    for (const key of ['radius', 'strength', 'rotation', 'setHeight'] as const) {
+        if (typeof source[key] === 'number' && Number.isFinite(source[key])) patch[key] = source[key];
+    }
+    return Object.keys(patch).length ? patch : undefined;
+}
+
+function normalizeSculptPatch(value: unknown): ITerrainSculptSessionPatch | undefined {
+    if (!value || typeof value !== 'object') return undefined;
+    const source = value as ITerrainSculptSessionPatch;
+    const patch: ITerrainSculptSessionPatch = {};
+    if (source.tool && terrainSculptTools.has(source.tool)) patch.tool = source.tool;
+    const brush = normalizeBrushPatch(source.brush);
+    if (brush) patch.brush = brush;
+    return Object.keys(patch).length ? patch : undefined;
+}
+
+function normalizePaintPatch(value: unknown): ITerrainPaintSessionPatch | undefined {
+    if (!value || typeof value !== 'object') return undefined;
+    const brush = normalizeBrushPatch((value as ITerrainPaintSessionPatch).brush);
+    return brush ? { brush } : undefined;
+}
 
 /**
- * Terrain 资源生命周期管理。
+ * Terrain asset lifecycle and target-safe editor-session access.
  *
- * 3.x 的 terrain manager 依赖 Editor.Dialog/Plugin；CLI 只保留其数据和资产接口，
- * 将“是否询问用户”交给 pink。已有 .terrain 资源直接 saveAsset，未绑定资源时返回 2，
- * 由 UI 决定 Save As 的目标 URL。
+ * The public Terrain capability never exposes gizmos. This service validates the
+ * requested node/component pair, adapts the matching internal gizmo, and returns
+ * JSON-safe canonical snapshots for the Scene webview.
  */
 @register('Terrain')
 export class TerrainService extends BaseService<ITerrainEvents> implements ITerrainService {
@@ -27,13 +110,90 @@ export class TerrainService extends BaseService<ITerrainEvents> implements ITerr
         ServiceEvents.on('selection:clear', () => this.onSelectionClear());
     }
 
+    private isTerrainComponent(component: Component | null | undefined): component is Terrain {
+        return component instanceof Terrain || (component as any)?.__classname__ === 'cc.Terrain';
+    }
+
     private terrainOfNode(node: any): Terrain | null {
-        return node?.components?.find((component: Component) => component instanceof Terrain
-            || (component as any).__classname__ === 'cc.Terrain') as Terrain | null ?? null;
+        return node?.components?.find((component: Component) => this.isTerrainComponent(component)) as Terrain | null ?? null;
     }
 
     private terrainOfUuid(uuid: string): Terrain | null {
         return this.terrainOfNode(getEditorNodeByUuid(uuid));
+    }
+
+    private resolveTarget(target: ITerrainTarget): { component: Terrain; gizmo: ITerrainSessionGizmo } | null {
+        if (!isTerrainTarget(target)) return null;
+        const node = getEditorNodeByUuid(target.nodeUuid);
+        const component = node?.components?.find((candidate: Component) => candidate.uuid === target.componentUuid
+            && this.isTerrainComponent(candidate)) as Terrain | undefined;
+        if (!component || component.node !== node || !this.selectedComponents.includes(component)) return null;
+
+        const gizmoService = queryRegisteredService<IGizmoServiceLookup>('Gizmo');
+        const gizmo = gizmoService?.getComponentGizmo(component);
+        if (!isTerrainSessionGizmo(gizmo) || gizmo.target !== component) return null;
+        return { component, gizmo };
+    }
+
+    private invalidResult(target: ITerrainTarget): ITerrainInvalidSnapshot {
+        return { target: copyTarget(target), valid: false };
+    }
+
+    private readResolved(target: ITerrainTarget, gizmo: ITerrainSessionGizmo): TerrainReadResult {
+        return { target: copyTarget(target), valid: true, ...gizmo.readTerrainState() };
+    }
+
+    /** Returns a canonical snapshot or `valid: false`; it never falls back to another Terrain. */
+    public read(target: ITerrainTarget): TerrainReadResult {
+        if (!isTerrainTarget(target)) return { target: { nodeUuid: '', componentUuid: '' }, valid: false };
+        const resolved = this.resolveTarget(target);
+        return resolved ? this.readResolved(target, resolved.gizmo) : this.invalidResult(target);
+    }
+
+    public setMode(target: ITerrainTarget, mode: TerrainEditorMode): TerrainReadResult {
+        const resolved = this.resolveTarget(target);
+        if (!resolved) return isTerrainTarget(target) ? this.invalidResult(target) : this.read(target);
+        if (!terrainEditorModes.has(mode)) return this.readResolved(target, resolved.gizmo);
+        resolved.gizmo.setTerrainMode(mode);
+        this.emit('terrain:session-changed', copyTarget(target));
+        return this.read(target);
+    }
+
+    public setCurrentLayer(target: ITerrainTarget, currentLayer: number): TerrainReadResult {
+        const resolved = this.resolveTarget(target);
+        if (!resolved) return isTerrainTarget(target) ? this.invalidResult(target) : this.read(target);
+        if (!Number.isInteger(currentLayer) || currentLayer < -1) return this.readResolved(target, resolved.gizmo);
+        resolved.gizmo.setTerrainCurrentLayer(currentLayer);
+        this.emit('terrain:session-changed', copyTarget(target));
+        return this.read(target);
+    }
+
+    public setSculptSession(target: ITerrainTarget, patch: ITerrainSculptSessionPatch): TerrainReadResult {
+        const resolved = this.resolveTarget(target);
+        if (!resolved) return isTerrainTarget(target) ? this.invalidResult(target) : this.read(target);
+        const normalized = normalizeSculptPatch(patch);
+        if (!normalized) return this.readResolved(target, resolved.gizmo);
+        resolved.gizmo.updateTerrainSculptSession(normalized);
+        this.emit('terrain:session-changed', copyTarget(target));
+        return this.read(target);
+    }
+
+    public setPaintSession(target: ITerrainTarget, patch: ITerrainPaintSessionPatch): TerrainReadResult {
+        const resolved = this.resolveTarget(target);
+        if (!resolved) return isTerrainTarget(target) ? this.invalidResult(target) : this.read(target);
+        const normalized = normalizePaintPatch(patch);
+        if (!normalized) return this.readResolved(target, resolved.gizmo);
+        resolved.gizmo.updateTerrainPaintSession(normalized);
+        this.emit('terrain:session-changed', copyTarget(target));
+        return this.read(target);
+    }
+
+    /** Reads the currently inspected block only; no Terrain mutation or Undo occurs. */
+    public readBlock(target: ITerrainTarget): TerrainBlockReadResult {
+        if (!isTerrainTarget(target)) return { target: { nodeUuid: '', componentUuid: '' }, valid: false };
+        const resolved = this.resolveTarget(target);
+        if (!resolved) return this.invalidResult(target);
+        return { target: copyTarget(target), valid: true, block: resolved.gizmo.readTerrainBlock() };
     }
 
     private setManager(component: Terrain, value: any) {
@@ -96,7 +256,7 @@ export class TerrainService extends BaseService<ITerrainEvents> implements ITerr
     }
 
     public onComponentRemoved(component: Component): void {
-        if (component instanceof Terrain) this.removeComponent(component);
+        if (this.isTerrainComponent(component)) this.removeComponent(component);
     }
 
     private removeComponent(component: Terrain) {
@@ -118,6 +278,7 @@ export class TerrainService extends BaseService<ITerrainEvents> implements ITerr
     }
 
     public async saveAsset(isClose = false, component?: Terrain): Promise<0 | 1 | 2> {
+        void isClose;
         const targets = component ? [component] : this.editedComponents;
         let result: 0 | 1 | 2 = 1;
         for (const terrain of targets) {
@@ -217,5 +378,9 @@ export class TerrainService extends BaseService<ITerrainEvents> implements ITerr
     public onEditorClosed(): void {
         this.onSelectionClear();
         this.editedComponents.length = 0;
+    }
+
+    public onEditorDisposed(): void {
+        this.onEditorClosed();
     }
 }

--- a/src/core/scene/scene-process/service/terrain.ts
+++ b/src/core/scene/scene-process/service/terrain.ts
@@ -248,8 +248,19 @@ export class TerrainService extends BaseService<ITerrainEvents> implements ITerr
         return { target: copyTarget(target), valid: false };
     }
 
+    /** Returns only the public UUID of the persisted Terrain asset, never the engine asset object. */
+    private getTerrainAssetUuid(component: Terrain | null): string | null {
+        const uuid = component?._asset?.uuid;
+        return typeof uuid === 'string' && uuid.length > 0 ? uuid : null;
+    }
+
     private readResolved(target: ITerrainTarget, gizmo: ITerrainSessionGizmo): TerrainReadResult {
-        return { target: copyTarget(target), valid: true, ...gizmo.readTerrainState() };
+        return {
+            target: copyTarget(target),
+            valid: true,
+            assetUuid: this.getTerrainAssetUuid(gizmo.target),
+            ...gizmo.readTerrainState(),
+        };
     }
 
     /** Returns a canonical snapshot or `valid: false`; it never falls back to another Terrain. */

--- a/src/core/scene/scene.middleware.ts
+++ b/src/core/scene/scene.middleware.ts
@@ -2,6 +2,7 @@ import type { IMiddlewareContribution } from '../../server/interfaces';
 import { Request, Response, NextFunction } from 'express';
 import path from 'path';
 import fse from 'fs-extra';
+import { createAssetBinaryRoutes } from './asset-binary-routes';
 
 /**
  * 各资源数据库的 library（已导入数据）目录缓存。
@@ -281,6 +282,7 @@ export default {
         }
     ],
     post: [
+        ...createAssetBinaryRoutes(),
         {
             // Preview in Editor：写入「当前编辑场景」快照。
             // 约定 body 为 { data: <serialize 输出的 JSON 字符串> }：serialize 交付的是字符串，

--- a/src/core/scene/test/asset-binary-routes.test.ts
+++ b/src/core/scene/test/asset-binary-routes.test.ts
@@ -1,0 +1,147 @@
+import { PassThrough, Readable } from 'stream';
+import type { Request, Response } from 'express';
+import {
+    createAssetBinaryRoutes,
+    readBinaryBody,
+} from '../asset-binary-routes';
+
+const assetInfo = { uuid: '10f83b52-8786-4de7-89e1-92e34e3176fc' } as any;
+
+function createRequest(options: {
+    params?: Record<string, string>;
+    query?: Record<string, unknown>;
+    contentType?: string;
+} = {}) {
+    const request = new PassThrough() as PassThrough & Partial<Request>;
+    request.params = options.params ?? {};
+    request.query = (options.query ?? {}) as any;
+    request.headers = options.contentType === undefined
+        ? {}
+        : { 'content-type': options.contentType };
+    return request as unknown as Request & PassThrough;
+}
+
+function createResponse() {
+    const response = {
+        status: jest.fn(),
+        json: jest.fn(),
+        destroyed: false,
+        headersSent: false,
+    };
+    response.status.mockReturnValue(response);
+    return response as unknown as Response & { status: jest.Mock; json: jest.Mock };
+}
+
+function routesFor(assetManager: { saveAsset: jest.Mock; createAsset: jest.Mock }) {
+    return createAssetBinaryRoutes({ loadAssetManager: async () => assetManager as any });
+}
+
+describe('Asset binary routes', () => {
+    it('passes the save body as a Node Buffer and returns the encoded asset info', async () => {
+        const assetManager = {
+            saveAsset: jest.fn().mockResolvedValue(assetInfo),
+            createAsset: jest.fn(),
+        };
+        const route = routesFor(assetManager).find((entry) => entry.url === '/assets/binary/v1/save/:assetUuid');
+        const req = createRequest({
+            params: { assetUuid: assetInfo.uuid },
+            contentType: 'application/octet-stream',
+        });
+        const res = createResponse();
+
+        const handled = route!.handler(req, res);
+        req.end(Buffer.from([0, 1, 127, 255]));
+        await handled;
+
+        expect(assetManager.saveAsset).toHaveBeenCalledWith(assetInfo.uuid, expect.any(Buffer));
+        expect(assetManager.saveAsset.mock.calls[0][1]).toEqual(Buffer.from([0, 1, 127, 255]));
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith(assetInfo);
+    });
+
+    it('accepts only db:// targets and explicit overwrite metadata for create', async () => {
+        const assetManager = {
+            saveAsset: jest.fn(),
+            createAsset: jest.fn().mockResolvedValue(assetInfo),
+        };
+        const route = routesFor(assetManager).find((entry) => entry.url === '/assets/binary/v1/create');
+        const req = createRequest({
+            query: { target: 'db://assets/terrain/New.terrain', overwrite: 'true' },
+            contentType: 'application/octet-stream; charset=binary',
+        });
+        const res = createResponse();
+
+        const handled = route!.handler(req, res);
+        req.end(Buffer.from([4, 5, 6]));
+        await handled;
+
+        expect(assetManager.createAsset).toHaveBeenCalledWith({
+            target: 'db://assets/terrain/New.terrain',
+            overwrite: true,
+            content: Buffer.from([4, 5, 6]),
+        });
+        expect(res.json).toHaveBeenCalledWith(assetInfo);
+    });
+
+    it('rejects an unsupported media type before loading the Asset Manager', async () => {
+        const assetManager = {
+            saveAsset: jest.fn(),
+            createAsset: jest.fn(),
+        };
+        const route = routesFor(assetManager).find((entry) => entry.url === '/assets/binary/v1/save/:assetUuid');
+        const res = createResponse();
+
+        await route!.handler(createRequest({
+            params: { assetUuid: assetInfo.uuid },
+            contentType: 'application/json',
+        }), res);
+
+        expect(res.status).toHaveBeenCalledWith(415);
+        expect(res.json).toHaveBeenCalledWith({ error: 'Content-Type must be application/octet-stream' });
+        expect(assetManager.saveAsset).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-db targets and non-boolean overwrite values before reading the body', async () => {
+        const assetManager = {
+            saveAsset: jest.fn(),
+            createAsset: jest.fn(),
+        };
+        const route = routesFor(assetManager).find((entry) => entry.url === '/assets/binary/v1/create');
+        const res = createResponse();
+
+        await route!.handler(createRequest({
+            query: { target: '/project/assets/New.terrain', overwrite: 'yes' },
+            contentType: 'application/octet-stream',
+        }), res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ error: 'target must be a db:// URL' });
+        expect(assetManager.createAsset).not.toHaveBeenCalled();
+    });
+
+    it('enforces the configured raw-body limit while reading chunks', async () => {
+        const req = Readable.from([Buffer.from([1, 2]), Buffer.from([3, 4])]) as Request;
+
+        await expect(readBinaryBody(req, 3)).rejects.toMatchObject({ status: 413 });
+    });
+
+    it('maps Asset Manager failures to a JSON HTTP error', async () => {
+        const assetManager = {
+            saveAsset: jest.fn().mockRejectedValue(new Error('asset is readonly')),
+            createAsset: jest.fn(),
+        };
+        const route = routesFor(assetManager).find((entry) => entry.url === '/assets/binary/v1/save/:assetUuid');
+        const req = createRequest({
+            params: { assetUuid: assetInfo.uuid },
+            contentType: 'application/octet-stream',
+        });
+        const res = createResponse();
+
+        const handled = route!.handler(req, res);
+        req.end(Buffer.from([1]));
+        await handled;
+
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.json).toHaveBeenCalledWith({ error: 'asset is readonly' });
+    });
+});

--- a/src/core/scene/test/scene-asset-binary-client.test.ts
+++ b/src/core/scene/test/scene-asset-binary-client.test.ts
@@ -1,0 +1,100 @@
+import type { IAssetInfo } from '../../assets/@types/public';
+import {
+    SceneAssetBinaryClient,
+    type SceneAssetBinaryClientDependencies,
+} from '../scene-process/scene-asset-binary-client';
+
+const assetInfo = { uuid: '10f83b52-8786-4de7-89e1-92e34e3176fc' } as IAssetInfo;
+
+function createClient(overrides: Partial<SceneAssetBinaryClientDependencies> = {}) {
+    const dependencies: SceneAssetBinaryClientDependencies = {
+        getWebServerUrl: () => 'http://localhost:7456',
+        fetch: jest.fn() as unknown as typeof fetch,
+        saveLocally: jest.fn(),
+        createLocally: jest.fn(),
+        ...overrides,
+    };
+    return {
+        client: new SceneAssetBinaryClient(dependencies),
+        dependencies,
+    };
+}
+
+function response(status: number, body: unknown) {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        text: jest.fn().mockResolvedValue(JSON.stringify(body)),
+    } as unknown as Response;
+}
+
+describe('SceneAssetBinaryClient', () => {
+    it('posts existing Terrain bytes unchanged to the dedicated save endpoint in web mode', async () => {
+        const { client, dependencies } = createClient();
+        const bytes = new Uint8Array([0, 1, 127, 255]);
+        (dependencies.fetch as jest.Mock).mockResolvedValue(response(200, assetInfo));
+
+        await expect(client.save(assetInfo.uuid, bytes)).resolves.toStrictEqual(assetInfo);
+
+        expect(dependencies.fetch).toHaveBeenCalledWith(
+            `http://localhost:7456/assets/binary/v1/save/${assetInfo.uuid}`,
+            expect.objectContaining({
+                method: 'POST',
+                headers: { 'Content-Type': 'application/octet-stream' },
+                body: bytes,
+            }),
+        );
+        expect(dependencies.saveLocally).not.toHaveBeenCalled();
+    });
+
+    it('encodes create metadata in the URL while keeping the content as the raw body', async () => {
+        const { client, dependencies } = createClient();
+        const bytes = new Uint8Array([3, 2, 1]);
+        (dependencies.fetch as jest.Mock).mockResolvedValue(response(200, assetInfo));
+
+        await expect(client.create({
+            target: 'db://assets/terrain/New terrain.terrain',
+            overwrite: true,
+            content: bytes,
+        })).resolves.toStrictEqual(assetInfo);
+
+        expect(dependencies.fetch).toHaveBeenCalledWith(
+            'http://localhost:7456/assets/binary/v1/create?target=db%3A%2F%2Fassets%2Fterrain%2FNew+terrain.terrain&overwrite=true',
+            expect.objectContaining({ body: bytes }),
+        );
+    });
+
+    it('keeps native Scene workers on their existing Asset Manager transport', async () => {
+        const saveLocally = jest.fn().mockResolvedValue(assetInfo);
+        const createLocally = jest.fn().mockResolvedValue(assetInfo);
+        const { client, dependencies } = createClient({
+            getWebServerUrl: () => undefined,
+            saveLocally,
+            createLocally,
+        });
+        const bytes = new Uint8Array([5, 6]);
+
+        await expect(client.save(assetInfo.uuid, bytes)).resolves.toBe(assetInfo);
+        await expect(client.create({
+            target: 'db://assets/terrain/New.terrain',
+            overwrite: false,
+            content: bytes,
+        })).resolves.toBe(assetInfo);
+
+        expect(saveLocally).toHaveBeenCalledWith(assetInfo.uuid, bytes);
+        expect(createLocally).toHaveBeenCalledWith({
+            target: 'db://assets/terrain/New.terrain',
+            overwrite: false,
+            content: bytes,
+        });
+        expect(dependencies.fetch).not.toHaveBeenCalled();
+    });
+
+    it('surfaces the route error body together with the HTTP status', async () => {
+        const { client, dependencies } = createClient();
+        (dependencies.fetch as jest.Mock).mockResolvedValue(response(413, { error: 'Raw binary body exceeds 50 MiB' }));
+
+        await expect(client.save(assetInfo.uuid, new Uint8Array())).rejects
+            .toThrow('Scene binary asset request failed with status 413: Raw binary body exceeds 50 MiB');
+    });
+});

--- a/src/core/scene/test/scene-rpc-web-transport.test.ts
+++ b/src/core/scene/test/scene-rpc-web-transport.test.ts
@@ -1,0 +1,49 @@
+const mockSetWebTransport = jest.fn();
+const mockAttach = jest.fn();
+const mockDispose = jest.fn();
+const mockRegister = jest.fn();
+
+jest.mock('../process-rpc', () => ({
+    ProcessRPC: jest.fn().mockImplementation(() => ({
+        setWebTransport: mockSetWebTransport,
+        attach: mockAttach,
+        dispose: mockDispose,
+        register: mockRegister,
+    })),
+}));
+
+jest.mock('../scene-process/service/core/decorator', () => ({
+    Service: {},
+}));
+
+import { RpcProxy } from '../scene-process/rpc';
+
+describe('RpcProxy Web transport state', () => {
+    beforeEach(() => {
+        mockSetWebTransport.mockReset();
+        mockAttach.mockReset();
+        mockDispose.mockReset();
+        mockRegister.mockReset();
+    });
+
+    it('exposes a server URL only when it initialized Web RPC', async () => {
+        const proxy = new RpcProxy();
+
+        await proxy.startup({ serverURL: 'http://localhost:7456' });
+
+        expect(proxy.getWebServerUrl()).toBe('http://localhost:7456');
+        expect(mockSetWebTransport).toHaveBeenCalledWith('http://localhost:7456');
+
+        proxy.dispose();
+        expect(proxy.getWebServerUrl()).toBeUndefined();
+    });
+
+    it('does not treat an IPC Scene worker as Web RPC', async () => {
+        const proxy = new RpcProxy();
+
+        await proxy.startup();
+
+        expect(proxy.getWebServerUrl()).toBeUndefined();
+        expect(mockAttach).toHaveBeenCalledWith(process);
+    });
+});

--- a/src/core/scene/test/service-core/service-manager-forwarding.test.ts
+++ b/src/core/scene/test/service-core/service-manager-forwarding.test.ts
@@ -47,6 +47,7 @@ const MESSAGE_ONLY_EVENTS = [
     'scene:dimension-changed',
     'camera:mode-change', 'camera:projection-changed', 'camera:fov-changed',
     'scene-view:visibility-changed', 'scene-view:light-changed',
+    'terrain:changed', 'terrain:sculpt', 'terrain:block-update', 'terrain:session-changed',
 ];
 
 const ALL_FORWARDED_EVENTS = [...SERVICE_MAP_EVENTS, ...MESSAGE_ONLY_EVENTS];

--- a/src/core/scene/test/terrain-gizmo-lifecycle.test.ts
+++ b/src/core/scene/test/terrain-gizmo-lifecycle.test.ts
@@ -1,0 +1,86 @@
+const mockRepaintInEditMode = jest.fn();
+
+jest.mock('cc', () => {
+    class Component {
+        public node: any = null;
+    }
+
+    class Terrain extends Component {
+        public getBlocks() {
+            return [];
+        }
+    }
+
+    class TerrainInfo { }
+    class TerrainLayer { }
+
+    return {
+        Component,
+        Terrain,
+        TerrainInfo,
+        TerrainLayer,
+        TERRAIN_MAX_LAYER_COUNT: 4,
+    };
+});
+
+jest.mock('../scene-process/service/core/decorator', () => ({
+    Service: {
+        Camera: { getCamera: jest.fn(() => null) },
+        Engine: { repaintInEditMode: mockRepaintInEditMode },
+    },
+}));
+
+jest.mock('../scene-process/service/node/node-create', () => ({
+    loadAny: jest.fn(),
+}));
+
+jest.mock('../scene-process/service/gizmo/components/terrain/terrain-editor', () => ({
+    TerrainEditor: class {
+        private _terrain: any = null;
+
+        setEditTerrain(terrain: any) {
+            this._terrain = terrain;
+        }
+
+        getEditTerrain() {
+            return this._terrain;
+        }
+
+        clearBrush = jest.fn();
+        setCurrentLayer = jest.fn();
+        updateBlockDepthOffset = jest.fn();
+    },
+}));
+
+jest.mock('../scene-process/service/gizmo/components/terrain/terrain-brush', () => ({
+    TerrainBrushType: { IMAGE: 1 },
+    TerrainImageBrush: class { },
+}));
+
+import { Terrain } from 'cc';
+import TerrainGizmo from '../scene-process/service/gizmo/components/terrain/gizmo-select';
+
+describe('TerrainGizmo lifecycle', () => {
+    it('rebinds its editor after target clear and pooled-gizmo reuse', () => {
+        const terrain = new Terrain() as Terrain & { node: any };
+        terrain.node = { on: jest.fn(), off: jest.fn() };
+        const gizmo = new TerrainGizmo(null);
+
+        gizmo.target = terrain;
+        gizmo.show();
+        expect(gizmo.editor.getEditTerrain()).toBe(terrain);
+
+        // GizmoService removes a component gizmo by hiding it first, then clearing target.
+        gizmo.hide();
+        gizmo.target = null;
+        expect((gizmo as any)._isEditorInit).toBe(false);
+        expect(gizmo.editor.getEditTerrain()).toBeNull();
+
+        // A later selection reuses this hidden instance and must attach the new target.
+        gizmo.target = terrain;
+        gizmo.show();
+
+        expect(gizmo.editor.getEditTerrain()).toBe(terrain);
+        expect((gizmo as any)._isEditorInit).toBe(true);
+    });
+});

--- a/src/core/scene/test/terrain-gizmo-lifecycle.test.ts
+++ b/src/core/scene/test/terrain-gizmo-lifecycle.test.ts
@@ -125,7 +125,7 @@ describe('TerrainGizmo lifecycle', () => {
 
     it('reads Block layer detail maps from the current Terrain state instead of the selection cache', () => {
         const terrain = {
-            getLayer: jest.fn(() => ({ detailMap: { _uuid: 'detail-current' } })),
+            getLayer: jest.fn(() => ({ detailMap: { uuid: 'detail-current' } })),
         };
         const select = Object.create(TerrainEditorSelect.prototype) as TerrainEditorSelect;
         (select as any)._selectBlock = {

--- a/src/core/scene/test/terrain-gizmo-lifecycle.test.ts
+++ b/src/core/scene/test/terrain-gizmo-lifecycle.test.ts
@@ -30,6 +30,10 @@ jest.mock('../scene-process/service/core/decorator', () => ({
     },
 }));
 
+jest.mock('../scene-process/service/core/global-events', () => ({
+    ServiceEvents: { emit: jest.fn() },
+}));
+
 jest.mock('../scene-process/service/node/node-create', () => ({
     loadAny: jest.fn(),
 }));
@@ -59,6 +63,7 @@ jest.mock('../scene-process/service/gizmo/components/terrain/terrain-brush', () 
 
 import { Terrain } from 'cc';
 import TerrainGizmo from '../scene-process/service/gizmo/components/terrain/gizmo-select';
+import { TerrainEditorSelect } from '../scene-process/service/gizmo/components/terrain/terrain-editor-select';
 
 describe('TerrainGizmo lifecycle', () => {
     it('rebinds its editor after target clear and pooled-gizmo reuse', () => {
@@ -82,5 +87,56 @@ describe('TerrainGizmo lifecycle', () => {
 
         expect(gizmo.editor.getEditTerrain()).toBe(terrain);
         expect((gizmo as any)._isEditorInit).toBe(true);
+    });
+
+    it('returns a defensive binary snapshot for the selected block weight map', () => {
+        const source = new Uint8Array([255, 0, 0, 0, 128, 127, 0, 0]);
+        const gizmo = new TerrainGizmo(null);
+        (gizmo as any)._editor = {
+            getMode: () => ({
+                getCurrentBlockIndex: () => [1, 2],
+                getCurrentWeightData: () => ({ width: 2, height: 1, data: source }),
+                getCurrentBlockLayerSlots: () => [
+                    { layerIndex: 3, detailMapUuid: 'detail-a' },
+                    null,
+                    { layerIndex: 7, detailMapUuid: null },
+                    null,
+                ],
+            }),
+        };
+
+        const block = gizmo.readTerrainBlock();
+
+        expect(block).toEqual({
+            index: { x: 1, y: 2 },
+            layers: [
+                { layerIndex: 3, detailMapUuid: 'detail-a' },
+                null,
+                { layerIndex: 7, detailMapUuid: null },
+                null,
+            ],
+            weight: { width: 2, height: 1, data: new Uint8Array(source) },
+        });
+        expect(block?.weight?.data).not.toBe(source);
+
+        block?.weight?.data.fill(0);
+        expect(source).toEqual(new Uint8Array([255, 0, 0, 0, 128, 127, 0, 0]));
+    });
+
+    it('reads Block layer detail maps from the current Terrain state instead of the selection cache', () => {
+        const terrain = {
+            getLayer: jest.fn(() => ({ detailMap: { _uuid: 'detail-current' } })),
+        };
+        const select = Object.create(TerrainEditorSelect.prototype) as TerrainEditorSelect;
+        (select as any)._selectBlock = {
+            layers: [2],
+            getTerrain: () => terrain,
+        };
+        (select as any)._layerList = [{ _uuid: 'detail-stale' }];
+
+        expect(select.getCurrentBlockLayerSlots()).toEqual([
+            { layerIndex: 2, detailMapUuid: 'detail-current' },
+        ]);
+        expect(terrain.getLayer).toHaveBeenCalledWith(2);
     });
 });

--- a/src/core/scene/test/terrain-service.test.ts
+++ b/src/core/scene/test/terrain-service.test.ts
@@ -1,6 +1,13 @@
 const mockNodesByUuid = new Map<string, any>();
 const mockEmit = jest.fn();
 const mockQueryRegisteredService = jest.fn();
+const mockLoadAny = jest.fn();
+const mockServiceEventEmit = jest.fn();
+const mockUndo = {
+    push: jest.fn(),
+    isApplying: jest.fn(() => false),
+};
+const mockConsoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
 
 jest.mock('cc', () => {
     class Component {
@@ -10,8 +17,24 @@ jest.mock('cc', () => {
 
     class Terrain extends Component { }
     class TerrainAsset { }
+    class TerrainLayer {
+        public detailMap: any = null;
+        public normalMap: any = null;
+        public metallic = 0;
+        public roughness = 1;
+        public tileSize = 1;
+    }
+    class TerrainInfo {
+        public tileSize = 1;
+        public weightMapSize = 128;
+        public lightMapSize = 128;
+        public blockCount = [1, 1];
+    }
+    class Texture2D {
+        constructor(public _uuid = '') { }
+    }
 
-    return { Component, Terrain, TerrainAsset };
+    return { Component, Terrain, TerrainAsset, TerrainInfo, TerrainLayer, Texture2D, TERRAIN_MAX_LAYER_COUNT: 4 };
 });
 
 jest.mock('../scene-process/service/core', () => ({
@@ -30,14 +53,21 @@ jest.mock('../scene-process/service/gizmo/utils/editor-node', () => ({
 }));
 
 jest.mock('../scene-process/service/node/node-create', () => ({
-    loadAny: jest.fn(),
+    loadAny: mockLoadAny,
+}));
+
+jest.mock('../scene-process/service/core/global-events', () => ({
+    ServiceEvents: {
+        emit: mockServiceEventEmit,
+        on: jest.fn(),
+    },
 }));
 
 jest.mock('../scene-process/rpc', () => ({
     Rpc: { getInstance: () => ({ request: jest.fn() }) },
 }));
 
-import { Terrain } from 'cc';
+import { Terrain, Texture2D } from 'cc';
 import type {
     IPublicTerrainService,
     ITerrainEditorState,
@@ -84,6 +114,59 @@ function createFixture(nodeUuid = 'node-a', componentUuid = 'terrain-a') {
         weight: { width: 2, height: 1, data: [255, 0, 0, 0, 128, 127, 0, 0] },
     };
 
+    Object.assign(terrain as any, {
+        _asset: {},
+        rebuild: jest.fn((info: any) => {
+            state.manage = {
+                tileSize: info.tileSize,
+                weightMapSize: info.weightMapSize,
+                lightMapSize: info.lightMapSize,
+                blockCount: [info.blockCount[0], info.blockCount[1]],
+            };
+        }),
+        getLayer: jest.fn((index: number) => {
+            const layer = state.layers[index];
+            if (!layer) return null;
+            return {
+                get detailMap() { return layer.detailMapUuid ? new Texture2D(layer.detailMapUuid) : null; },
+                set detailMap(value: any) { layer.detailMapUuid = value?._uuid ?? null; },
+                get normalMap() { return layer.normalMapUuid ? new Texture2D(layer.normalMapUuid) : null; },
+                set normalMap(value: any) { layer.normalMapUuid = value?._uuid ?? null; },
+                get metallic() { return layer.metallic; },
+                set metallic(value: number) { layer.metallic = value; },
+                get roughness() { return layer.roughness; },
+                set roughness(value: number) { layer.roughness = value; },
+                get tileSize() { return layer.tileSize; },
+                set tileSize(value: number) { layer.tileSize = value; },
+            };
+        }),
+        setLayer: jest.fn((index: number, layer: any) => {
+            state.layers[index] = {
+                detailMapUuid: layer.detailMap?._uuid ?? null,
+                normalMapUuid: layer.normalMap?._uuid ?? null,
+                metallic: layer.metallic,
+                roughness: layer.roughness,
+                tileSize: layer.tileSize,
+            };
+        }),
+        removeLayer: jest.fn((index: number) => {
+            state.layers[index] = null;
+        }),
+        addLayer: jest.fn((layer: any) => {
+            const index = state.layers.findIndex((item) => item === null);
+            if (index < 0) return -1;
+            state.layers[index] = {
+                detailMapUuid: layer.detailMap?._uuid ?? null,
+                normalMapUuid: layer.normalMap?._uuid ?? null,
+                metallic: layer.metallic,
+                roughness: layer.roughness,
+                tileSize: layer.tileSize,
+            };
+            return index;
+        }),
+        exportLayerListToAsset: jest.fn(),
+    });
+
     const gizmo = {
         target: terrain,
         readTerrainState: jest.fn(() => clone(state)),
@@ -118,6 +201,12 @@ describe('TerrainService target-safe public capability', () => {
         mockNodesByUuid.clear();
         mockEmit.mockReset();
         mockQueryRegisteredService.mockReset();
+        mockLoadAny.mockReset();
+        mockServiceEventEmit.mockReset();
+        mockUndo.push.mockReset();
+        mockUndo.isApplying.mockReset();
+        mockUndo.isApplying.mockReturnValue(false);
+        mockConsoleWarn.mockReset();
     });
 
     it('publishes only typed target-safe reads and editor-session commands', () => {
@@ -129,7 +218,13 @@ describe('TerrainService target-safe public capability', () => {
             service.setCurrentLayer(target, 0);
             service.setSculptSession(target, { tool: 'set-height', brush: { radius: 8, setHeight: 12 } });
             service.setPaintSession(target, { brush: { kind: 'circle', strength: 7 } });
-            return { read, block };
+            const manage = service.saveManage(target, { tileSize: 1, weightMapSize: 128, lightMapSize: 128, blockCount: [1, 1] });
+            const add = service.addLayer(target, {
+                detailMapUuid: 'detail', normalMapUuid: null, metallic: 0, roughness: 1, tileSize: 1,
+            });
+            const update = service.updateLayer(target, 0, { roughness: 0.5 });
+            const remove = service.removeLayer(target, 0);
+            return { read, block, manage, add, update, remove };
         };
 
         expect(assertPublicTerrainInterface).toBeDefined();
@@ -231,4 +326,218 @@ describe('TerrainService target-safe public capability', () => {
         fixture.node.components = [Object.assign(new Terrain(), { uuid: 'replacement-terrain', node: fixture.node })];
         expect(service.read(fixture.target)).toEqual({ target: fixture.target, valid: false });
     });
+
+    it('rejects every authoring command before it touches a missing, non-Terrain, or mismatched target', async () => {
+        const fixture = createFixture();
+        const nonTerrainNode: { uuid: string; components: Array<{ uuid: string; node?: any }> } = {
+            uuid: 'node-non-terrain', components: [{ uuid: 'component-non-terrain' }],
+        };
+        nonTerrainNode.components[0].node = nonTerrainNode;
+        mockNodesByUuid.set(nonTerrainNode.uuid, nonTerrainNode);
+        mockQueryRegisteredService.mockImplementation((name: string) => {
+            if (name === 'Gizmo') return { getComponentGizmo: () => fixture.gizmo };
+            if (name === 'Undo') return mockUndo;
+            return null;
+        });
+        const service = new TerrainService();
+        service.select(fixture.target.nodeUuid);
+        const before = clone(fixture.state);
+        const missing: ITerrainTarget = { nodeUuid: 'missing-node', componentUuid: 'missing-terrain' };
+        const nonTerrain: ITerrainTarget = { nodeUuid: nonTerrainNode.uuid, componentUuid: 'component-non-terrain' };
+        const mismatched: ITerrainTarget = { nodeUuid: fixture.target.nodeUuid, componentUuid: 'wrong-terrain' };
+        const layer = { detailMapUuid: 'detail-rejected', normalMapUuid: null, metallic: 0, roughness: 1, tileSize: 1 };
+
+        await expect(service.saveManage(missing, fixture.state.manage)).resolves.toEqual({ target: missing, valid: false });
+        await expect(service.addLayer(nonTerrain, layer)).resolves.toEqual({ target: nonTerrain, valid: false });
+        await expect(service.removeLayer(mismatched, 0)).resolves.toEqual({ target: mismatched, valid: false });
+        await expect(service.updateLayer(missing, 0, { roughness: 0.5 })).resolves.toEqual({ target: missing, valid: false });
+
+        expect(fixture.state).toEqual(before);
+        expect(mockLoadAny).not.toHaveBeenCalled();
+        expect(mockUndo.push).not.toHaveBeenCalled();
+    });
+
+    it('leaves authoring state untouched when the CLI Undo service is unavailable', async () => {
+        const fixture = createFixture();
+        mockQueryRegisteredService.mockImplementation((name: string) => name === 'Gizmo'
+            ? { getComponentGizmo: () => fixture.gizmo }
+            : null);
+        const service = new TerrainService();
+        service.select(fixture.target.nodeUuid);
+        const before = clone(fixture.state);
+        const layer = { detailMapUuid: 'detail-without-undo', normalMapUuid: null, metallic: 0, roughness: 1, tileSize: 1 };
+
+        await expect(service.saveManage(fixture.target, { ...fixture.state.manage, tileSize: 3 })).resolves.toEqual({
+            target: fixture.target,
+            valid: true,
+            ...before,
+        });
+        await expect(service.addLayer(fixture.target, layer)).resolves.toEqual({ target: fixture.target, valid: true, ...before });
+        await expect(service.removeLayer(fixture.target, 0)).resolves.toEqual({ target: fixture.target, valid: true, ...before });
+        await expect(service.updateLayer(fixture.target, 0, { roughness: 0.5 })).resolves.toEqual({ target: fixture.target, valid: true, ...before });
+
+        expect(fixture.state).toEqual(before);
+        expect(mockLoadAny).not.toHaveBeenCalled();
+    });
+
+    it('reports a texture-load error while leaving the explicit Terrain unchanged', async () => {
+        const fixture = createFixture();
+        mockQueryRegisteredService.mockImplementation((name: string) => {
+            if (name === 'Gizmo') return { getComponentGizmo: () => fixture.gizmo };
+            if (name === 'Undo') return mockUndo;
+            return null;
+        });
+        const error = new Error('asset database unavailable');
+        mockLoadAny.mockRejectedValue(error);
+
+        const service = new TerrainService();
+        service.select(fixture.target.nodeUuid);
+        const before = clone(fixture.state);
+        await expect(service.addLayer(fixture.target, {
+            detailMapUuid: 'detail-load-error', normalMapUuid: null, metallic: 0, roughness: 1, tileSize: 1,
+        })).resolves.toEqual({ target: fixture.target, valid: true, ...before });
+
+        expect(mockConsoleWarn).toHaveBeenCalledWith('[Terrain] load layer texture failed: detail-load-error', error);
+        expect(fixture.state).toEqual(before);
+        expect(mockUndo.push).not.toHaveBeenCalled();
+    });
+
+    it('rejects a target invalidated while a layer texture is loading', async () => {
+        const fixture = createFixture();
+        mockQueryRegisteredService.mockImplementation((name: string) => {
+            if (name === 'Gizmo') return { getComponentGizmo: () => fixture.gizmo };
+            if (name === 'Undo') return mockUndo;
+            return null;
+        });
+        let finishLoad: ((texture: Texture2D) => void) | undefined;
+        mockLoadAny.mockImplementation(() => new Promise<Texture2D>((resolve) => {
+            finishLoad = resolve;
+        }));
+
+        const service = new TerrainService();
+        service.select(fixture.target.nodeUuid);
+        const before = clone(fixture.state);
+        const pending = service.addLayer(fixture.target, {
+            detailMapUuid: 'detail-delayed', normalMapUuid: null, metallic: 0, roughness: 1, tileSize: 1,
+        });
+        service.onSelectionClear();
+        finishLoad?.(new Texture2D('detail-delayed'));
+
+        await expect(pending).resolves.toEqual({ target: fixture.target, valid: false });
+        expect(fixture.state).toEqual(before);
+        expect(mockUndo.push).not.toHaveBeenCalled();
+    });
+
+    it('commits target-safe Manage and layer mutations as one authoritative Undo command each', async () => {
+        const fixture = createFixture();
+        const other = createFixture('node-b', 'terrain-b');
+        const gizmoService = {
+            getComponentGizmo: jest.fn((component) => component === fixture.terrain ? fixture.gizmo : other.gizmo),
+        };
+        const engine = { repaintInEditMode: jest.fn() };
+        mockQueryRegisteredService.mockImplementation((name: string) => {
+            if (name === 'Gizmo') return gizmoService;
+            if (name === 'Undo') return mockUndo;
+            if (name === 'Engine') return engine;
+            return null;
+        });
+        mockLoadAny.mockImplementation(async (uuid: string) => new Texture2D(uuid));
+
+        const service = new TerrainService();
+        service.select(fixture.target.nodeUuid);
+        const initialManage = clone(fixture.state.manage);
+        const initialLayers = clone(fixture.state.layers);
+
+        const managed = await service.saveManage(fixture.target, {
+            tileSize: 3,
+            weightMapSize: 128,
+            lightMapSize: 64,
+            blockCount: [4, 2],
+        });
+        expect(managed).toMatchObject({
+            valid: true,
+            manage: { tileSize: 3, weightMapSize: 128, lightMapSize: 64, blockCount: [4, 2] },
+        });
+
+        const added = await service.addLayer(fixture.target, {
+            detailMapUuid: 'detail-b',
+            normalMapUuid: 'normal-b',
+            metallic: 0.4,
+            roughness: 0.6,
+            tileSize: 8,
+        });
+        expect(added).toMatchObject({ valid: true });
+        expect((added as any).layers[0]).toMatchObject({ detailMapUuid: 'detail-a' });
+        expect((added as any).layers[1]).toMatchObject({ detailMapUuid: 'detail-b', normalMapUuid: 'normal-b' });
+
+        const updated = await service.updateLayer(fixture.target, 1, {
+            detailMapUuid: 'detail-c',
+            roughness: 0.25,
+        });
+        expect(updated).toMatchObject({ valid: true });
+        expect((updated as any).layers[0]).toMatchObject({ detailMapUuid: 'detail-a' });
+        expect((updated as any).layers[1]).toMatchObject({ detailMapUuid: 'detail-c', roughness: 0.25 });
+
+        const removed = await service.removeLayer(fixture.target, 1);
+        expect(removed).toMatchObject({ valid: true });
+        expect((removed as any).layers[0]).toMatchObject({ detailMapUuid: 'detail-a' });
+        expect((removed as any).layers[1]).toBeNull();
+
+        // Current-layer selection is a session control, not an asset mutation or an Undo entry.
+        service.setCurrentLayer(fixture.target, 0);
+        expect(mockUndo.push).toHaveBeenCalledTimes(4);
+        expect(mockUndo.push.mock.calls.map(([command]) => command.meta.type)).toEqual([
+            'terrain:save-manage',
+            'terrain:add-layer',
+            'terrain:update-layer',
+            'terrain:remove-layer',
+        ]);
+        expect(mockUndo.push.mock.calls.every(([command]) => command.meta.scope.editorType === 'scene')).toBe(true);
+        expect((fixture.terrain as any).exportLayerListToAsset).toHaveBeenCalled();
+        expect(mockServiceEventEmit).toHaveBeenCalledWith('node:change', fixture.node, { type: 'component-changed' });
+        expect(engine.repaintInEditMode).toHaveBeenCalledTimes(4);
+
+        const [manageCommand, addCommand, updateCommand, removeCommand] = mockUndo.push.mock.calls.map(([command]) => command);
+        expect(mockEmit).toHaveBeenCalledWith('terrain:changed', fixture.terrain);
+        await manageCommand.undo();
+        expect(fixture.state.manage).toEqual(initialManage);
+        await manageCommand.redo();
+        expect(fixture.state.manage).toEqual({ tileSize: 3, weightMapSize: 128, lightMapSize: 64, blockCount: [4, 2] });
+
+        const assetSyncCallsBeforeLayerUndo = (fixture.terrain as any).exportLayerListToAsset.mock.calls.length;
+        await addCommand.undo();
+        expect(fixture.state.layers).toEqual(initialLayers);
+        expect((fixture.terrain as any).exportLayerListToAsset).toHaveBeenCalledTimes(assetSyncCallsBeforeLayerUndo + 1);
+        await addCommand.redo();
+        expect(fixture.state.layers[1]).toMatchObject({ detailMapUuid: 'detail-b', normalMapUuid: 'normal-b' });
+        expect((fixture.terrain as any).exportLayerListToAsset).toHaveBeenCalledTimes(assetSyncCallsBeforeLayerUndo + 2);
+        expect(mockEmit).toHaveBeenCalledWith('terrain:changed', fixture.terrain);
+
+        await updateCommand.undo();
+        expect(fixture.state.layers[1]).toMatchObject({ detailMapUuid: 'detail-b', roughness: 0.6 });
+        await updateCommand.redo();
+        expect(fixture.state.layers[1]).toMatchObject({ detailMapUuid: 'detail-c', roughness: 0.25 });
+
+        await removeCommand.undo();
+        expect(fixture.state.layers[1]).toMatchObject({ detailMapUuid: 'detail-c', roughness: 0.25 });
+        await removeCommand.redo();
+        expect(fixture.state.layers[1]).toBeNull();
+
+        const beforeRejectedDrop = clone(fixture.state);
+        mockLoadAny.mockResolvedValueOnce({ _uuid: 'not-a-texture' });
+        expect(await service.addLayer(fixture.target, {
+            detailMapUuid: 'not-a-texture', normalMapUuid: null, metallic: 0, roughness: 1, tileSize: 1,
+        })).toEqual({ target: fixture.target, valid: true, ...beforeRejectedDrop });
+        expect(mockUndo.push).toHaveBeenCalledTimes(4);
+
+        expect(await service.updateLayer(other.target, 0, { roughness: 0.5 })).toEqual({ target: other.target, valid: false });
+        const textureLoadsBeforeRejectedTarget = mockLoadAny.mock.calls.length;
+        expect(await service.addLayer(other.target, {
+            detailMapUuid: 'detail-on-stale-target', normalMapUuid: null, metallic: 0, roughness: 1, tileSize: 1,
+        })).toEqual({ target: other.target, valid: false });
+        expect(mockLoadAny).toHaveBeenCalledTimes(textureLoadsBeforeRejectedTarget);
+        expect(mockUndo.push).toHaveBeenCalledTimes(4);
+        expect(other.state).not.toEqual(fixture.state);
+    });
+
 });

--- a/src/core/scene/test/terrain-service.test.ts
+++ b/src/core/scene/test/terrain-service.test.ts
@@ -1,0 +1,234 @@
+const mockNodesByUuid = new Map<string, any>();
+const mockEmit = jest.fn();
+const mockQueryRegisteredService = jest.fn();
+
+jest.mock('cc', () => {
+    class Component {
+        public node: any;
+        public uuid = '';
+    }
+
+    class Terrain extends Component { }
+    class TerrainAsset { }
+
+    return { Component, Terrain, TerrainAsset };
+});
+
+jest.mock('../scene-process/service/core', () => ({
+    BaseService: class {
+        emit(...args: unknown[]) {
+            mockEmit(...args);
+        }
+    },
+    register: () => () => undefined,
+    queryRegisteredService: mockQueryRegisteredService,
+}));
+
+jest.mock('../scene-process/service/gizmo/utils/editor-node', () => ({
+    getEditorNodeByUuid: (uuid: string) => mockNodesByUuid.get(uuid) ?? null,
+    getEditorNodeByPath: () => null,
+}));
+
+jest.mock('../scene-process/service/node/node-create', () => ({
+    loadAny: jest.fn(),
+}));
+
+jest.mock('../scene-process/rpc', () => ({
+    Rpc: { getInstance: () => ({ request: jest.fn() }) },
+}));
+
+import { Terrain } from 'cc';
+import type {
+    IPublicTerrainService,
+    ITerrainEditorState,
+    ITerrainTarget,
+    TerrainBlockReadResult,
+    TerrainReadResult,
+} from '../common/terrain';
+import { TerrainService } from '../scene-process/service/terrain';
+
+function clone<T>(value: T): T {
+    return JSON.parse(JSON.stringify(value));
+}
+
+function createFixture(nodeUuid = 'node-a', componentUuid = 'terrain-a') {
+    const terrain = new Terrain() as Terrain & { node: any; uuid: string };
+    terrain.uuid = componentUuid;
+
+    const node = { uuid: nodeUuid, components: [terrain] };
+    terrain.node = node;
+    mockNodesByUuid.set(nodeUuid, node);
+
+    const state: ITerrainEditorState = {
+        manage: { tileSize: 2, weightMapSize: 64, lightMapSize: 32, blockCount: [2, 3] },
+        layers: [
+            { detailMapUuid: 'detail-a', normalMapUuid: 'normal-a', metallic: 0.2, roughness: 0.7, tileSize: 4 },
+            null,
+            null,
+            null,
+        ],
+        mode: 'manage',
+        currentLayer: 0,
+        sculpt: {
+            tool: 'bulge',
+            brush: { kind: 'image', imageUuid: 'sculpt-brush', radius: 3, strength: 5, rotation: 15, setHeight: 9 },
+        },
+        paint: {
+            brush: { kind: 'circle', imageUuid: null, radius: 6, strength: 4, rotation: 0, setHeight: 0 },
+        },
+    };
+
+    const block = {
+        index: { x: 1, y: 2 },
+        layers: ['detail-a', null, 'detail-c', null],
+        weight: { width: 2, height: 1, data: [255, 0, 0, 0, 128, 127, 0, 0] },
+    };
+
+    const gizmo = {
+        target: terrain,
+        readTerrainState: jest.fn(() => clone(state)),
+        setTerrainMode: jest.fn((mode: ITerrainEditorState['mode']) => {
+            state.mode = mode;
+        }),
+        setTerrainCurrentLayer: jest.fn((currentLayer: number) => {
+            state.currentLayer = currentLayer;
+        }),
+        updateTerrainSculptSession: jest.fn((patch: any) => {
+            if (patch.tool) state.sculpt.tool = patch.tool;
+            if (patch.brush) Object.assign(state.sculpt.brush, patch.brush);
+        }),
+        updateTerrainPaintSession: jest.fn((patch: any) => {
+            if (patch.brush) Object.assign(state.paint.brush, patch.brush);
+        }),
+        readTerrainBlock: jest.fn(() => clone(block)),
+    };
+
+    return {
+        terrain,
+        node,
+        state,
+        gizmo,
+        target: { nodeUuid, componentUuid } satisfies ITerrainTarget,
+    };
+}
+
+
+describe('TerrainService target-safe public capability', () => {
+    beforeEach(() => {
+        mockNodesByUuid.clear();
+        mockEmit.mockReset();
+        mockQueryRegisteredService.mockReset();
+    });
+
+    it('publishes only typed target-safe reads and editor-session commands', () => {
+        const assertPublicTerrainInterface = (service: IPublicTerrainService) => {
+            const target: ITerrainTarget = { nodeUuid: 'node', componentUuid: 'terrain' };
+            const read: TerrainReadResult = service.read(target);
+            const block: TerrainBlockReadResult = service.readBlock(target);
+            service.setMode(target, 'sculpt');
+            service.setCurrentLayer(target, 0);
+            service.setSculptSession(target, { tool: 'set-height', brush: { radius: 8, setHeight: 12 } });
+            service.setPaintSession(target, { brush: { kind: 'circle', strength: 7 } });
+            return { read, block };
+        };
+
+        expect(assertPublicTerrainInterface).toBeDefined();
+    });
+
+    it('returns one complete, JSON-safe hydration snapshot only for the explicitly selected Terrain', () => {
+        const fixture = createFixture();
+        const other = createFixture('node-b', 'terrain-b');
+        const gizmoService = { getComponentGizmo: jest.fn((component) => component === fixture.terrain ? fixture.gizmo : other.gizmo) };
+        mockQueryRegisteredService.mockReturnValue(gizmoService);
+
+        const service = new TerrainService();
+        service.select(fixture.target.nodeUuid);
+
+        expect(service.read(fixture.target)).toEqual({
+            target: fixture.target,
+            valid: true,
+            ...fixture.state,
+        });
+        expect(service.read(other.target)).toEqual({ target: other.target, valid: false });
+        expect(service.read({ nodeUuid: fixture.target.nodeUuid, componentUuid: other.target.componentUuid })).toEqual({
+            target: { nodeUuid: fixture.target.nodeUuid, componentUuid: other.target.componentUuid },
+            valid: false,
+        });
+        expect(gizmoService.getComponentGizmo).toHaveBeenCalledTimes(1);
+    });
+
+    it('updates only the explicit target editor session, returns its canonical state, and emits invalidation', () => {
+        const fixture = createFixture();
+        mockQueryRegisteredService.mockReturnValue({ getComponentGizmo: () => fixture.gizmo });
+        const service = new TerrainService();
+        service.select(fixture.target.nodeUuid);
+
+        expect(service.setMode(fixture.target, 'paint')).toMatchObject({ valid: true, mode: 'paint' });
+        expect(service.setCurrentLayer(fixture.target, 0)).toMatchObject({ valid: true, currentLayer: 0 });
+        expect(service.setSculptSession(fixture.target, {
+            tool: 'set-height',
+            brush: { radius: 8, strength: 6, rotation: 30, setHeight: 12 },
+        })).toMatchObject({
+            valid: true,
+            sculpt: { tool: 'set-height', brush: { radius: 8, strength: 6, rotation: 30, setHeight: 12 } },
+        });
+        expect(service.setPaintSession(fixture.target, { brush: { kind: 'image', strength: 7 } })).toMatchObject({
+            valid: true,
+            paint: { brush: { kind: 'image', strength: 7 } },
+        });
+
+        expect(fixture.gizmo.setTerrainMode).toHaveBeenCalledWith('paint');
+        expect(fixture.gizmo.setTerrainCurrentLayer).toHaveBeenCalledWith(0);
+        expect(fixture.gizmo.updateTerrainSculptSession).toHaveBeenCalledWith({
+            tool: 'set-height',
+            brush: { radius: 8, strength: 6, rotation: 30, setHeight: 12 },
+        });
+        expect(fixture.gizmo.updateTerrainPaintSession).toHaveBeenCalledWith({ brush: { kind: 'image', strength: 7 } });
+        expect(mockEmit).toHaveBeenCalledWith('terrain:session-changed', fixture.target);
+    });
+
+    it('reads the currently selected block without exposing the gizmo or mutating Terrain state', () => {
+        const fixture = createFixture();
+        mockQueryRegisteredService.mockReturnValue({ getComponentGizmo: () => fixture.gizmo });
+        const service = new TerrainService();
+        service.select(fixture.target.nodeUuid);
+
+        expect(service.readBlock(fixture.target)).toEqual({
+            target: fixture.target,
+            valid: true,
+            block: {
+                index: { x: 1, y: 2 },
+                layers: ['detail-a', null, 'detail-c', null],
+                weight: { width: 2, height: 1, data: [255, 0, 0, 0, 128, 127, 0, 0] },
+            },
+        });
+        expect(fixture.gizmo.readTerrainBlock).toHaveBeenCalledTimes(1);
+    });
+
+    it('invalidates stale targets after selection clear, component removal, reload close, disposal, and node replacement', () => {
+        const fixture = createFixture();
+        mockQueryRegisteredService.mockReturnValue({ getComponentGizmo: () => fixture.gizmo });
+        const service = new TerrainService();
+        service.select(fixture.target.nodeUuid);
+
+        service.onSelectionClear();
+        expect(service.read(fixture.target)).toEqual({ target: fixture.target, valid: false });
+
+        service.select(fixture.target.nodeUuid);
+        service.onComponentRemoved(fixture.terrain);
+        expect(service.read(fixture.target)).toEqual({ target: fixture.target, valid: false });
+
+        // ServiceManager maps the internal reload-close event to onEditorClosed.
+        service.select(fixture.target.nodeUuid);
+        service.onEditorClosed();
+        expect(service.read(fixture.target)).toEqual({ target: fixture.target, valid: false });
+
+        service.select(fixture.target.nodeUuid);
+        service.onEditorDisposed();
+        expect(service.read(fixture.target)).toEqual({ target: fixture.target, valid: false });
+
+        service.select(fixture.target.nodeUuid);
+        fixture.node.components = [Object.assign(new Terrain(), { uuid: 'replacement-terrain', node: fixture.node })];
+        expect(service.read(fixture.target)).toEqual({ target: fixture.target, valid: false });
+    });
+});

--- a/src/core/scene/test/terrain-service.test.ts
+++ b/src/core/scene/test/terrain-service.test.ts
@@ -180,6 +180,10 @@ function createFixture(nodeUuid = 'node-a', componentUuid = 'terrain-a') {
             if (patch.tool) state.sculpt.tool = patch.tool;
             if (patch.brush) Object.assign(state.sculpt.brush, patch.brush);
         }),
+        setSculptBrushTexture: jest.fn((texture: Texture2D | null) => {
+            state.sculpt.brush.imageUuid = texture?._uuid ?? null;
+            state.sculpt.brush.kind = texture ? 'image' : 'circle';
+        }),
         updateTerrainPaintSession: jest.fn((patch: any) => {
             if (patch.brush) Object.assign(state.paint.brush, patch.brush);
         }),
@@ -217,14 +221,15 @@ describe('TerrainService target-safe public capability', () => {
             service.setMode(target, 'sculpt');
             service.setCurrentLayer(target, 0);
             service.setSculptSession(target, { tool: 'set-height', brush: { radius: 8, setHeight: 12 } });
-            service.setPaintSession(target, { brush: { kind: 'circle', strength: 7 } });
+            const brush = service.setSculptBrushAsset(target, 'brush');
+            service.setPaintSession(target, { brush: { strength: 7 } });
             const manage = service.saveManage(target, { tileSize: 1, weightMapSize: 128, lightMapSize: 128, blockCount: [1, 1] });
             const add = service.addLayer(target, {
                 detailMapUuid: 'detail', normalMapUuid: null, metallic: 0, roughness: 1, tileSize: 1,
             });
             const update = service.updateLayer(target, 0, { roughness: 0.5 });
             const remove = service.removeLayer(target, 0);
-            return { read, block, manage, add, update, remove };
+            return { read, block, brush, manage, add, update, remove };
         };
 
         expect(assertPublicTerrainInterface).toBeDefined();
@@ -267,9 +272,9 @@ describe('TerrainService target-safe public capability', () => {
             valid: true,
             sculpt: { tool: 'set-height', brush: { radius: 8, strength: 6, rotation: 30, setHeight: 12 } },
         });
-        expect(service.setPaintSession(fixture.target, { brush: { kind: 'image', strength: 7 } })).toMatchObject({
+        expect(service.setPaintSession(fixture.target, { brush: { strength: 7 } })).toMatchObject({
             valid: true,
-            paint: { brush: { kind: 'image', strength: 7 } },
+            paint: { brush: { kind: 'circle', strength: 7 } },
         });
 
         expect(fixture.gizmo.setTerrainMode).toHaveBeenCalledWith('paint');
@@ -278,8 +283,87 @@ describe('TerrainService target-safe public capability', () => {
             tool: 'set-height',
             brush: { radius: 8, strength: 6, rotation: 30, setHeight: 12 },
         });
-        expect(fixture.gizmo.updateTerrainPaintSession).toHaveBeenCalledWith({ brush: { kind: 'image', strength: 7 } });
+        expect(fixture.gizmo.updateTerrainPaintSession).toHaveBeenCalledWith({ brush: { strength: 7 } });
         expect(mockEmit).toHaveBeenCalledWith('terrain:session-changed', fixture.target);
+    });
+
+    it('assigns or clears only the explicit target Sculpt image brush and emits invalidation', async () => {
+        const fixture = createFixture();
+        const other = createFixture('node-b', 'terrain-b');
+        mockQueryRegisteredService.mockReturnValue({
+            getComponentGizmo: (component: Terrain) => component === fixture.terrain ? fixture.gizmo : other.gizmo,
+        });
+        mockLoadAny.mockImplementation(async (uuid: string) => new Texture2D(uuid));
+        const service = new TerrainService();
+        service.select(fixture.target.nodeUuid);
+
+        await expect(service.setSculptBrushAsset(fixture.target, 'new-brush')).resolves.toMatchObject({
+            valid: true,
+            sculpt: { brush: { kind: 'image', imageUuid: 'new-brush' } },
+        });
+        await expect(service.setSculptBrushAsset(fixture.target, null)).resolves.toMatchObject({
+            valid: true,
+            sculpt: { brush: { kind: 'circle', imageUuid: null } },
+        });
+        await expect(service.setSculptBrushAsset(other.target, 'other-brush')).resolves.toEqual({
+            target: other.target,
+            valid: false,
+        });
+
+        expect(fixture.gizmo.setSculptBrushTexture).toHaveBeenNthCalledWith(1, expect.objectContaining({ _uuid: 'new-brush' }));
+        expect(fixture.gizmo.setSculptBrushTexture).toHaveBeenNthCalledWith(2, null);
+        expect(other.gizmo.setSculptBrushTexture).not.toHaveBeenCalled();
+        expect(mockEmit).toHaveBeenCalledWith('terrain:session-changed', fixture.target);
+        expect((fixture.terrain as any).isTerrainChange).not.toBe(true);
+    });
+
+    it('rejects failed or incompatible Sculpt brush assets without mutating the session', async () => {
+        const fixture = createFixture();
+        mockQueryRegisteredService.mockReturnValue({ getComponentGizmo: () => fixture.gizmo });
+        const service = new TerrainService();
+        service.select(fixture.target.nodeUuid);
+        const before = clone(fixture.state);
+        const error = new Error('asset database unavailable');
+
+        mockLoadAny.mockRejectedValueOnce(error);
+        await expect(service.setSculptBrushAsset(fixture.target, 'missing-brush')).resolves.toEqual({
+            target: fixture.target,
+            valid: true,
+            ...before,
+        });
+        expect(mockConsoleWarn).toHaveBeenCalledWith('[Terrain] load sculpt brush texture failed: missing-brush', error);
+        expect(fixture.gizmo.setSculptBrushTexture).not.toHaveBeenCalled();
+        expect(mockEmit).not.toHaveBeenCalled();
+
+        mockLoadAny.mockResolvedValueOnce({ _uuid: 'not-a-texture' });
+        await expect(service.setSculptBrushAsset(fixture.target, 'not-a-texture')).resolves.toEqual({
+            target: fixture.target,
+            valid: true,
+            ...before,
+        });
+        expect(fixture.gizmo.setSculptBrushTexture).not.toHaveBeenCalled();
+        expect(mockEmit).not.toHaveBeenCalled();
+    });
+
+    it('rejects a Sculpt brush request when its target becomes stale during asset loading', async () => {
+        const fixture = createFixture();
+        mockQueryRegisteredService.mockReturnValue({ getComponentGizmo: () => fixture.gizmo });
+        let finishLoad: ((texture: Texture2D) => void) | undefined;
+        mockLoadAny.mockImplementation(() => new Promise<Texture2D>((resolve) => {
+            finishLoad = resolve;
+        }));
+        const service = new TerrainService();
+        service.select(fixture.target.nodeUuid);
+        const before = clone(fixture.state);
+
+        const pending = service.setSculptBrushAsset(fixture.target, 'delayed-brush');
+        service.onSelectionClear();
+        finishLoad?.(new Texture2D('delayed-brush'));
+
+        await expect(pending).resolves.toEqual({ target: fixture.target, valid: false });
+        expect(fixture.state).toEqual(before);
+        expect(fixture.gizmo.setSculptBrushTexture).not.toHaveBeenCalled();
+        expect(mockEmit).not.toHaveBeenCalled();
     });
 
     it('reads the currently selected block without exposing the gizmo or mutating Terrain state', () => {

--- a/src/core/scene/test/terrain-service.test.ts
+++ b/src/core/scene/test/terrain-service.test.ts
@@ -72,7 +72,7 @@ jest.mock('../scene-process/scene-asset-binary-client', () => ({
     },
 }));
 
-import { Terrain, Texture2D } from 'cc';
+import { Terrain, TerrainAsset, Texture2D } from 'cc';
 import type {
     IPublicTerrainService,
     ITerrainBlockData,
@@ -138,7 +138,7 @@ function createFixture(nodeUuid = 'node-a', componentUuid = 'terrain-a') {
     };
 
     Object.assign(terrain as any, {
-        _asset: {},
+        _asset: { uuid: 'terrain-asset' },
         rebuild: jest.fn((info: any) => {
             state.manage = {
                 tileSize: info.tileSize,
@@ -277,6 +277,7 @@ describe('TerrainService target-safe public capability', () => {
         expect(service.read(fixture.target)).toEqual({
             target: fixture.target,
             valid: true,
+            assetUuid: 'terrain-asset',
             ...fixture.state,
         });
         expect(service.read(other.target)).toEqual({ target: other.target, valid: false });
@@ -285,6 +286,20 @@ describe('TerrainService target-safe public capability', () => {
             valid: false,
         });
         expect(gizmoService.getComponentGizmo).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports whether a valid target has a persisted Terrain asset in every read result', () => {
+        const fixture = createFixture();
+        mockQueryRegisteredService.mockReturnValue({ getComponentGizmo: () => fixture.gizmo });
+        const service = new TerrainService();
+        service.select(fixture.target.nodeUuid);
+
+        expect(service.read(fixture.target)).toMatchObject({ valid: true, assetUuid: 'terrain-asset' });
+        expect(service.setMode(fixture.target, 'sculpt')).toMatchObject({ valid: true, assetUuid: 'terrain-asset' });
+
+        (fixture.terrain as any)._asset = new TerrainAsset();
+        expect(service.read(fixture.target)).toMatchObject({ valid: true, assetUuid: null });
+        expect(service.setCurrentLayer(fixture.target, 0)).toMatchObject({ valid: true, assetUuid: null });
     });
 
     it('updates only the explicit target editor session, returns its canonical state, and emits invalidation', () => {
@@ -389,6 +404,7 @@ describe('TerrainService target-safe public capability', () => {
         await expect(service.setSculptBrushAsset(fixture.target, 'missing-brush')).resolves.toEqual({
             target: fixture.target,
             valid: true,
+            assetUuid: 'terrain-asset',
             ...before,
         });
         expect(mockConsoleWarn).toHaveBeenCalledWith('[Terrain] load sculpt brush texture failed: missing-brush', error);
@@ -399,6 +415,7 @@ describe('TerrainService target-safe public capability', () => {
         await expect(service.setSculptBrushAsset(fixture.target, 'not-a-texture')).resolves.toEqual({
             target: fixture.target,
             valid: true,
+            assetUuid: 'terrain-asset',
             ...before,
         });
         expect(fixture.gizmo.setSculptBrushTexture).not.toHaveBeenCalled();
@@ -519,11 +536,12 @@ describe('TerrainService target-safe public capability', () => {
         await expect(service.saveManage(fixture.target, { ...fixture.state.manage, tileSize: 3 })).resolves.toEqual({
             target: fixture.target,
             valid: true,
+            assetUuid: 'terrain-asset',
             ...before,
         });
-        await expect(service.addLayer(fixture.target, layer)).resolves.toEqual({ target: fixture.target, valid: true, ...before });
-        await expect(service.removeLayer(fixture.target, 0)).resolves.toEqual({ target: fixture.target, valid: true, ...before });
-        await expect(service.updateLayer(fixture.target, 0, { roughness: 0.5 })).resolves.toEqual({ target: fixture.target, valid: true, ...before });
+        await expect(service.addLayer(fixture.target, layer)).resolves.toEqual({ target: fixture.target, valid: true, assetUuid: 'terrain-asset', ...before });
+        await expect(service.removeLayer(fixture.target, 0)).resolves.toEqual({ target: fixture.target, valid: true, assetUuid: 'terrain-asset', ...before });
+        await expect(service.updateLayer(fixture.target, 0, { roughness: 0.5 })).resolves.toEqual({ target: fixture.target, valid: true, assetUuid: 'terrain-asset', ...before });
 
         expect(fixture.state).toEqual(before);
         expect(mockLoadAny).not.toHaveBeenCalled();
@@ -544,7 +562,7 @@ describe('TerrainService target-safe public capability', () => {
         const before = clone(fixture.state);
         await expect(service.addLayer(fixture.target, {
             detailMapUuid: 'detail-load-error', normalMapUuid: null, metallic: 0, roughness: 1, tileSize: 1,
-        })).resolves.toEqual({ target: fixture.target, valid: true, ...before });
+        })).resolves.toEqual({ target: fixture.target, valid: true, assetUuid: 'terrain-asset', ...before });
 
         expect(mockConsoleWarn).toHaveBeenCalledWith('[Terrain] load layer texture failed: detail-load-error', error);
         expect(fixture.state).toEqual(before);
@@ -676,7 +694,7 @@ describe('TerrainService target-safe public capability', () => {
         mockLoadAny.mockResolvedValueOnce({ _uuid: 'not-a-texture' });
         expect(await service.addLayer(fixture.target, {
             detailMapUuid: 'not-a-texture', normalMapUuid: null, metallic: 0, roughness: 1, tileSize: 1,
-        })).toEqual({ target: fixture.target, valid: true, ...beforeRejectedDrop });
+        })).toEqual({ target: fixture.target, valid: true, assetUuid: 'terrain-asset', ...beforeRejectedDrop });
         expect(mockUndo.push).toHaveBeenCalledTimes(4);
 
         expect(await service.updateLayer(other.target, 0, { roughness: 0.5 })).toEqual({ target: other.target, valid: false });

--- a/src/core/scene/test/terrain-service.test.ts
+++ b/src/core/scene/test/terrain-service.test.ts
@@ -184,6 +184,10 @@ function createFixture(nodeUuid = 'node-a', componentUuid = 'terrain-a') {
             state.sculpt.brush.imageUuid = texture?._uuid ?? null;
             state.sculpt.brush.kind = texture ? 'image' : 'circle';
         }),
+        setPaintBrushTexture: jest.fn((texture: Texture2D | null) => {
+            state.paint.brush.imageUuid = texture?._uuid ?? null;
+            state.paint.brush.kind = texture ? 'image' : 'circle';
+        }),
         updateTerrainPaintSession: jest.fn((patch: any) => {
             if (patch.brush) Object.assign(state.paint.brush, patch.brush);
         }),
@@ -222,6 +226,7 @@ describe('TerrainService target-safe public capability', () => {
             service.setCurrentLayer(target, 0);
             service.setSculptSession(target, { tool: 'set-height', brush: { radius: 8, setHeight: 12 } });
             const brush = service.setSculptBrushAsset(target, 'brush');
+            const paintBrush = service.setPaintBrushAsset(target, 'brush');
             service.setPaintSession(target, { brush: { strength: 7 } });
             const manage = service.saveManage(target, { tileSize: 1, weightMapSize: 128, lightMapSize: 128, blockCount: [1, 1] });
             const add = service.addLayer(target, {
@@ -229,7 +234,7 @@ describe('TerrainService target-safe public capability', () => {
             });
             const update = service.updateLayer(target, 0, { roughness: 0.5 });
             const remove = service.removeLayer(target, 0);
-            return { read, block, brush, manage, add, update, remove };
+            return { read, block, brush, paintBrush, manage, add, update, remove };
         };
 
         expect(assertPublicTerrainInterface).toBeDefined();
@@ -313,6 +318,36 @@ describe('TerrainService target-safe public capability', () => {
         expect(fixture.gizmo.setSculptBrushTexture).toHaveBeenNthCalledWith(1, expect.objectContaining({ _uuid: 'new-brush' }));
         expect(fixture.gizmo.setSculptBrushTexture).toHaveBeenNthCalledWith(2, null);
         expect(other.gizmo.setSculptBrushTexture).not.toHaveBeenCalled();
+        expect(mockEmit).toHaveBeenCalledWith('terrain:session-changed', fixture.target);
+        expect((fixture.terrain as any).isTerrainChange).not.toBe(true);
+    });
+
+    it('assigns or clears only the explicit target Paint image brush and emits invalidation', async () => {
+        const fixture = createFixture();
+        const other = createFixture('node-b', 'terrain-b');
+        mockQueryRegisteredService.mockReturnValue({
+            getComponentGizmo: (component: Terrain) => component === fixture.terrain ? fixture.gizmo : other.gizmo,
+        });
+        mockLoadAny.mockImplementation(async (uuid: string) => new Texture2D(uuid));
+        const service = new TerrainService();
+        service.select(fixture.target.nodeUuid);
+
+        await expect(service.setPaintBrushAsset(fixture.target, 'paint-brush')).resolves.toMatchObject({
+            valid: true,
+            paint: { brush: { kind: 'image', imageUuid: 'paint-brush' } },
+        });
+        await expect(service.setPaintBrushAsset(fixture.target, null)).resolves.toMatchObject({
+            valid: true,
+            paint: { brush: { kind: 'circle', imageUuid: null } },
+        });
+        await expect(service.setPaintBrushAsset(other.target, 'other-brush')).resolves.toEqual({
+            target: other.target,
+            valid: false,
+        });
+
+        expect(fixture.gizmo.setPaintBrushTexture).toHaveBeenNthCalledWith(1, expect.objectContaining({ _uuid: 'paint-brush' }));
+        expect(fixture.gizmo.setPaintBrushTexture).toHaveBeenNthCalledWith(2, null);
+        expect(other.gizmo.setPaintBrushTexture).not.toHaveBeenCalled();
         expect(mockEmit).toHaveBeenCalledWith('terrain:session-changed', fixture.target);
         expect((fixture.terrain as any).isTerrainChange).not.toBe(true);
     });

--- a/src/core/scene/test/terrain-service.test.ts
+++ b/src/core/scene/test/terrain-service.test.ts
@@ -75,6 +75,7 @@ jest.mock('../scene-process/scene-asset-binary-client', () => ({
 import { Terrain, Texture2D } from 'cc';
 import type {
     IPublicTerrainService,
+    ITerrainBlockData,
     ITerrainEditorState,
     ITerrainTarget,
     TerrainBlockReadResult,
@@ -84,6 +85,18 @@ import { TerrainService } from '../scene-process/service/terrain';
 
 function clone<T>(value: T): T {
     return JSON.parse(JSON.stringify(value));
+}
+
+function cloneBlock(block: ITerrainBlockData): ITerrainBlockData {
+    return {
+        ...block,
+        index: { ...block.index },
+        layers: block.layers.map((layer) => layer && { ...layer }),
+        weight: block.weight && {
+            ...block.weight,
+            data: new Uint8Array(block.weight.data),
+        },
+    };
 }
 
 function createFixture(nodeUuid = 'node-a', componentUuid = 'terrain-a') {
@@ -115,8 +128,13 @@ function createFixture(nodeUuid = 'node-a', componentUuid = 'terrain-a') {
 
     const block = {
         index: { x: 1, y: 2 },
-        layers: ['detail-a', null, 'detail-c', null],
-        weight: { width: 2, height: 1, data: [255, 0, 0, 0, 128, 127, 0, 0] },
+        layers: [
+            { layerIndex: 0, detailMapUuid: 'detail-a' },
+            null,
+            { layerIndex: 2, detailMapUuid: 'detail-c' },
+            null,
+        ],
+        weight: { width: 2, height: 1, data: new Uint8Array([255, 0, 0, 0, 128, 127, 0, 0]) },
     };
 
     Object.assign(terrain as any, {
@@ -196,7 +214,7 @@ function createFixture(nodeUuid = 'node-a', componentUuid = 'terrain-a') {
         updateTerrainPaintSession: jest.fn((patch: any) => {
             if (patch.brush) Object.assign(state.paint.brush, patch.brush);
         }),
-        readTerrainBlock: jest.fn(() => clone(block)),
+        readTerrainBlock: jest.fn(() => cloneBlock(block)),
     };
 
     return {
@@ -419,8 +437,13 @@ describe('TerrainService target-safe public capability', () => {
             valid: true,
             block: {
                 index: { x: 1, y: 2 },
-                layers: ['detail-a', null, 'detail-c', null],
-                weight: { width: 2, height: 1, data: [255, 0, 0, 0, 128, 127, 0, 0] },
+                layers: [
+                    { layerIndex: 0, detailMapUuid: 'detail-a' },
+                    null,
+                    { layerIndex: 2, detailMapUuid: 'detail-c' },
+                    null,
+                ],
+                weight: { width: 2, height: 1, data: new Uint8Array([255, 0, 0, 0, 128, 127, 0, 0]) },
             },
         });
         expect(fixture.gizmo.readTerrainBlock).toHaveBeenCalledTimes(1);

--- a/src/core/scene/test/terrain-service.test.ts
+++ b/src/core/scene/test/terrain-service.test.ts
@@ -3,6 +3,8 @@ const mockEmit = jest.fn();
 const mockQueryRegisteredService = jest.fn();
 const mockLoadAny = jest.fn();
 const mockServiceEventEmit = jest.fn();
+const mockAssetBinarySave = jest.fn();
+const mockAssetBinaryCreate = jest.fn();
 const mockUndo = {
     push: jest.fn(),
     isApplying: jest.fn(() => false),
@@ -63,8 +65,11 @@ jest.mock('../scene-process/service/core/global-events', () => ({
     },
 }));
 
-jest.mock('../scene-process/rpc', () => ({
-    Rpc: { getInstance: () => ({ request: jest.fn() }) },
+jest.mock('../scene-process/scene-asset-binary-client', () => ({
+    sceneAssetBinaryClient: {
+        save: (...args: unknown[]) => mockAssetBinarySave(...args),
+        create: (...args: unknown[]) => mockAssetBinaryCreate(...args),
+    },
 }));
 
 import { Terrain, Texture2D } from 'cc';
@@ -211,6 +216,8 @@ describe('TerrainService target-safe public capability', () => {
         mockQueryRegisteredService.mockReset();
         mockLoadAny.mockReset();
         mockServiceEventEmit.mockReset();
+        mockAssetBinarySave.mockReset();
+        mockAssetBinaryCreate.mockReset();
         mockUndo.push.mockReset();
         mockUndo.isApplying.mockReset();
         mockUndo.isApplying.mockReturnValue(false);
@@ -657,6 +664,61 @@ describe('TerrainService target-safe public capability', () => {
         expect(mockLoadAny).toHaveBeenCalledTimes(textureLoadsBeforeRejectedTarget);
         expect(mockUndo.push).toHaveBeenCalledTimes(4);
         expect(other.state).not.toEqual(fixture.state);
+    });
+
+    it('saves existing Terrain bytes through the binary client and clears dirty state only after the matching asset succeeds', async () => {
+        const fixture = createFixture();
+        (fixture.terrain as any)._asset = { _uuid: '10f83b52-8786-4de7-89e1-92e34e3176fc' };
+        (fixture.terrain as any).isTerrainChange = true;
+        const bytes = new Uint8Array([0, 1, 127, 255]);
+        mockAssetBinarySave.mockResolvedValue({ uuid: '10f83b52-8786-4de7-89e1-92e34e3176fc' });
+
+        const service = new TerrainService();
+        jest.spyOn(service, 'serialize').mockReturnValue(bytes);
+
+        await expect(service.saveAsset(false, fixture.terrain)).resolves.toBe(0);
+
+        expect(mockAssetBinarySave).toHaveBeenCalledWith('10f83b52-8786-4de7-89e1-92e34e3176fc', bytes);
+        expect((fixture.terrain as any).isTerrainChange).toBe(false);
+    });
+
+    it('keeps a Terrain dirty when the binary client rejects', async () => {
+        const fixture = createFixture();
+        (fixture.terrain as any)._asset = { _uuid: '10f83b52-8786-4de7-89e1-92e34e3176fc' };
+        (fixture.terrain as any).isTerrainChange = true;
+        mockAssetBinarySave.mockRejectedValue(new Error('Raw binary body exceeds 50 MiB'));
+        const service = new TerrainService();
+        jest.spyOn(service, 'serialize').mockReturnValue(new Uint8Array([1]));
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        await expect(service.saveAsset(false, fixture.terrain)).resolves.toBe(2);
+
+        expect((fixture.terrain as any).isTerrainChange).toBe(true);
+        consoleError.mockRestore();
+    });
+
+    it('creates a Terrain asset through the binary client using the requested db:// target', async () => {
+        const fixture = createFixture();
+        (fixture.terrain as any)._asset = null;
+        (fixture.terrain as any).isTerrainChange = true;
+        const bytes = new Uint8Array([9, 8, 7]);
+        const loadedAsset = { _uuid: 'created-terrain-uuid' };
+        mockAssetBinaryCreate.mockResolvedValue({ uuid: 'created-terrain-uuid' });
+        mockLoadAny.mockResolvedValue(loadedAsset);
+        const service = new TerrainService();
+        service.select(fixture.target.nodeUuid);
+        jest.spyOn(service, 'serialize').mockReturnValue(bytes);
+
+        await expect(service.saveAssetDialog('db://assets/terrain/New.terrain')).resolves.toBe(0);
+
+        expect(mockAssetBinaryCreate).toHaveBeenCalledWith({
+            target: 'db://assets/terrain/New.terrain',
+            overwrite: true,
+            content: bytes,
+        });
+        expect(mockLoadAny).toHaveBeenCalledWith('created-terrain-uuid');
+        expect((fixture.terrain as any)._asset).toBe(loadedAsset);
+        expect((fixture.terrain as any).isTerrainChange).toBe(false);
     });
 
 });


### PR DESCRIPTION
This pull request adds comprehensive support for the Terrain asset type in the asset handling and service layers, and improves type safety for asset handler types throughout the codebase. It also ensures binary content is properly handled when creating assets, and includes additional tests to verify these behaviors.

**Terrain asset support:**

* Added a full set of `ITerrain*` interfaces and types (such as `ITerrainService`, `ITerrainBlockData`, `TerrainReadResult`, etc.) to the type declarations, enabling proper typing and API support for terrain editing and management features. (`[[1]](diffhunk://#diff-a8348e31674835a05155d991b06289ab32594d5ea8f97984df20bd3ddb354d1dR6915-R7029)`, `[[2]](diffhunk://#diff-a8348e31674835a05155d991b06289ab32594d5ea8f97984df20bd3ddb354d1dR7423-R7427)`)
* Registered a new `Terrain` service in the `IServiceManager` interface, and imported the `Terrain` type for use in service APIs. (`[[1]](diffhunk://#diff-a8348e31674835a05155d991b06289ab32594d5ea8f97984df20bd3ddb354d1dR5419)`, `[[2]](diffhunk://#diff-a8348e31674835a05155d991b06289ab32594d5ea8f97984df20bd3ddb354d1dR6878)`)

**Asset handler type safety improvements:**

* Changed `ASSET_HANDLER_TYPES` to a `readonly` tuple type and updated its usage in all type declarations to improve literal type inference and ensure all asset handler types (including `"terrain"` and `"database"`) are correctly represented. (`[[1]](diffhunk://#diff-ee2f852140e8d3b6b50539ee6123466853fcbd1bf577400dc451100cf7660621L61-R61)`, `[[2]](diffhunk://#diff-a8348e31674835a05155d991b06289ab32594d5ea8f97984df20bd3ddb354d1dL63-R63)`, `[[3]](diffhunk://#diff-a8348e31674835a05155d991b06289ab32594d5ea8f97984df20bd3ddb354d1dL1061-R1063)`, `[[4]](diffhunk://#diff-a8348e31674835a05155d991b06289ab32594d5ea8f97984df20bd3ddb354d1dL5447-R5455)`, `[[5]](diffhunk://#diff-a8348e31674835a05155d991b06289ab32594d5ea8f97984df20bd3ddb354d1dL7749-R7878)`)
* Updated `AssetHandlerType` to be a union of the literal types from `ASSET_HANDLER_TYPES` and any string, increasing flexibility and future-proofing the type. (`[[1]](diffhunk://#diff-a8348e31674835a05155d991b06289ab32594d5ea8f97984df20bd3ddb354d1dL91-R93)`, `[[2]](diffhunk://#diff-a8348e31674835a05155d991b06289ab32594d5ea8f97984df20bd3ddb354d1dL1152-R1156)`, `[[3]](diffhunk://#diff-a8348e31674835a05155d991b06289ab32594d5ea8f97984df20bd3ddb354d1dL7791-R7922)`)

**Asset creation and binary content handling:**

* Fixed asset creation logic to avoid serializing `Buffer` content, preventing corruption of binary assets. (`[src/core/assets/manager/asset-handler.tsL428-R429](diffhunk://#diff-93b7be637fc879610bb5e2b8d3a728cb3cf80ea82f805463b7baf2647cfade02L428-R429)`)
* Added a test to verify that binary content is preserved when creating assets via the filesystem bridge. (`[src/core/assets/test/asset-handler-filesystem-bridge.test.tsR127-R136](diffhunk://#diff-8200d94463ba684ba5a8c3e14967da7422c2d095ed28dbb8fd9d298a07f48c52R127-R136)`)

**Testing and validation:**

* Added a test to ensure `ASSET_HANDLER_TYPES` and `AssetHandlerType` are correctly declared and preserve literal types in the generated `.d.ts` files. (`[packages/cocos-cli-types/__tests__/dts-snapshot.test.tsR41-R60](diffhunk://#diff-6f24011f84c590485167b2df90a246ebf6c355eba2fed80973300cfb48613b0cR41-R60)`)

**Minor API improvements:**

* Added a `getComponentGizmo` method to the `IGizmoService` interface. (`[packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snapR6377](diffhunk://#diff-a8348e31674835a05155d991b06289ab32594d5ea8f97984df20bd3ddb354d1dR6377)`)