### PR TITLE
[break] feat(builder): add publish build stage mirroring upload flow …

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -1313,6 +1313,7 @@ export declare namespace BuildHook {
     export type onBeforeUpload = IBuildStageHooks;
     export type upload = IBuildStageHooks;
     export type onAfterUpload = IBuildStageHooks;
+    export type publish = IBuildStageHooks;
     export type load = () => Promise<void> | void;
     export type unload = () => Promise<void> | void;
 }
@@ -3070,6 +3071,7 @@ export declare namespace IInternalHook {
     export type onBeforeUpload = IInternalStageTaskHooks;
     export type upload = IInternalStageTaskHooks;
     export type onAfterUpload = IInternalStageTaskHooks;
+    export type publish = IInternalStageTaskHooks;
 }
 export declare interface IInternalPackOptions {
     maxWidth: number;
@@ -4480,6 +4482,7 @@ export declare interface PreviewPackResult {
     storeInfo: PacStoreInfo;
     atlases: IAtlasInfo[];
 }
+export declare function publish(platform: Platform, dest: string): Promise<IBuildResultData>;
 export declare type PureModulesOption = boolean | string[] | IsPureModule;
 export declare function queryAssetsInBundle(uuid: string, bundleFilterConfig?: BundleFilterConfig[]): Promise<string[]>;
 export declare function queryAutoAtlasFileCache(pacUuid: string): Promise<PreviewPackResult | null>;

--- a/src/api/builder/builder.ts
+++ b/src/api/builder/builder.ts
@@ -2,7 +2,7 @@ import { build, createBuildTemplate as createCoreBuildTemplate, executeBuildStag
 import { HttpStatusCode, COMMON_STATUS, CommonResultType } from '../base/schema-base';
 import { BuildExitCode } from '../../core/builder/@types/protected';
 import { description, param, result, title, tool } from '../decorator/decorator';
-import { SchemaBuildConfigResult, SchemaBuildOption, SchemaBuildResult, SchemaPlatform, SchemaBuildDest, SchemaRunResult, TBuildConfigResult, TBuildOption, TBuildResultData, TPlatform, TBuildDest, TRunResult, SchemaPlatformCanMake, TPlatformCanMake, IMakeResultData, IRunResultData, IUploadResultData, SchemaMakeResult, SchemaUploadResult, SchemaUploadAccessToken, TUploadAccessToken, SchemaBuildTemplateName, TBuildTemplateName, SchemaCreateBuildTemplateResult, TCreateBuildTemplateResult } from './schema';
+import { SchemaBuildConfigResult, SchemaBuildOption, SchemaBuildResult, SchemaPlatform, SchemaBuildDest, SchemaRunResult, TBuildConfigResult, TBuildOption, TBuildResultData, TPlatform, TBuildDest, TRunResult, SchemaPlatformCanMake, TPlatformCanMake, IMakeResultData, IRunResultData, IUploadResultData, IPublishResultData, SchemaMakeResult, SchemaUploadResult, SchemaPublishResult, SchemaUploadAccessToken, TUploadAccessToken, SchemaBuildTemplateName, TBuildTemplateName, SchemaCreateBuildTemplateResult, TCreateBuildTemplateResult } from './schema';
 
 export class BuilderApi {
 
@@ -178,6 +178,34 @@ export class BuilderApi {
         } catch (e) {
             ret.code = COMMON_STATUS.FAIL;
             console.error(`upload project ${dest} in platform ${platform} failed:`, e instanceof Error ? e.message : String(e));
+            ret.reason = e instanceof Error ? e.message : String(e);
+        }
+        return ret;
+    }
+
+    @tool('builder-publish')
+    @title('Publish Build Package') // 发布构建产物
+    @description('Publish a previously uploaded game package, supported only by some platforms. Requires a successful upload stage to have produced a packageId.') // 发布已经上传成功的游戏包，仅部分平台支持，需要先成功执行过上传阶段以获取 packageId
+    @result(SchemaPublishResult)
+    async publish(@param(SchemaPlatform) platform: TPlatform, @param(SchemaBuildDest) dest: TBuildDest): Promise<CommonResultType<IPublishResultData>> {
+        const code: HttpStatusCode = COMMON_STATUS.SUCCESS;
+        const ret: CommonResultType<IPublishResultData> = {
+            code: code,
+            data: null,
+        };
+        try {
+            const res = await executeBuildStageTask(platform, 'publish', {
+                dest,
+                platform,
+            });
+            ret.data = res as IPublishResultData;
+            if (res.code !== BuildExitCode.BUILD_SUCCESS) {
+                ret.code = COMMON_STATUS.FAIL;
+                ret.reason = res.reason || `Publish ${platform} in ${dest} failed!`;
+            }
+        } catch (e) {
+            ret.code = COMMON_STATUS.FAIL;
+            console.error(`publish project ${dest} in platform ${platform} failed:`, e instanceof Error ? e.message : String(e));
             ret.reason = e instanceof Error ? e.message : String(e);
         }
         return ret;

--- a/src/api/builder/schema.ts
+++ b/src/api/builder/schema.ts
@@ -170,7 +170,7 @@ const BuildConfigCoreFields = z.object({
     useSplashScreen: z.boolean().describe('Whether to use custom splash screen'), // 是否使用自定义启动画面
 
     // Build Stages // 构建阶段
-    nextStages: z.array(z.enum(['make', 'run', 'upload'])).describe('Specify subsequent combined build stages, multiple can be specified'), // 指定后续联合的构建阶段，可指定多个
+    nextStages: z.array(z.enum(['make', 'run', 'upload', 'publish'])).describe('Specify subsequent combined build stages, multiple can be specified'), // 指定后续联合的构建阶段，可指定多个
 
     // Cache Configuration // 缓存配置
     useCacheConfig: z.object({
@@ -368,6 +368,12 @@ export const SchemaUploadResult = SchemaResultBase.extend({
     }).passthrough().optional().describe('Custom fields after uploading the build package, in object format'), // 上传构建产物后的自定义字段
 }).nullable().describe('Result after uploading the build package'); // 上传构建产物后的结果
 
+export const SchemaPublishResult = SchemaResultBase.extend({
+    custom: z.object({
+        publish: z.any().optional().describe('Platform publish result'), // 平台发布结果
+    }).passthrough().optional().describe('Custom fields after publishing the build package, in object format'), // 发布构建产物后的自定义字段
+}).nullable().describe('Result after publishing the build package'); // 发布构建产物后的结果
+
 export const SchemaPreviewSettingsResult = z.object({
     settings: z.object({
         CocosEngine: z.string().describe('Cocos Engine Version'), // Cocos Engine 版本
@@ -428,6 +434,7 @@ export type TBuildResultData = z.infer<typeof SchemaBuildResult>;
 export type IMakeResultData = z.infer<typeof SchemaMakeResult>;
 export type IRunResultData = z.infer<typeof SchemaBuildResult>;
 export type IUploadResultData = z.infer<typeof SchemaUploadResult>;
+export type IPublishResultData = z.infer<typeof SchemaPublishResult>;
 export type TBundleConfig = z.infer<typeof SchemaBundleConfig>;
 export type TPolyfills = z.infer<typeof SchemaPolyfills>;
 export type TSceneRef = z.infer<typeof SchemaSceneRef>;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -117,4 +117,14 @@ export class CocosAPI {
         const { default: Launcher } = await import('../core/launcher');
         return await Launcher.upload(platform, dest, accessToken);
     }
+
+    /**
+     * 命令行发布入口
+     * @param platform
+     * @param dest
+     */
+    public static async publishProject(@param(SchemaPlatform) platform: TPlatform, @param(SchemaBuildDest) dest: TBuildDest) {
+        const { default: Launcher } = await import('../core/launcher');
+        return await Launcher.publish(platform, dest);
+    }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import { initSentry } from './core/base/sentry';
 initSentry();
 
 import { Command } from 'commander';
-import { BuildCommand, McpServerCommand, CommandRegistry, CreateCommand, MakeCommand, RunCommand, UploadCommand } from './commands';
+import { BuildCommand, McpServerCommand, CommandRegistry, CreateCommand, MakeCommand, RunCommand, UploadCommand, PublishCommand } from './commands';
 import { config } from './display/config';
 import { PreviewCommand } from './commands/preview';
 
@@ -29,6 +29,7 @@ commandRegistry.register(new McpServerCommand(program));
 commandRegistry.register(new MakeCommand(program));
 commandRegistry.register(new RunCommand(program));
 commandRegistry.register(new UploadCommand(program));
+commandRegistry.register(new PublishCommand(program));
 commandRegistry.register(new PreviewCommand(program));
 
 // 注册所有命令

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -8,6 +8,7 @@ import { CreateCommand } from './create';
 import { MakeCommand } from './make';
 import { RunCommand } from './run';
 import { UploadCommand } from './upload';
+import { PublishCommand } from './publish';
 
 export { BaseCommand, CommandUtils } from './base';
 export { BuildCommand } from './build';
@@ -16,11 +17,12 @@ export { CreateCommand } from './create';
 export { MakeCommand } from './make';
 export { RunCommand } from './run';
 export { UploadCommand } from './upload';
+export { PublishCommand } from './publish';
 
 /**
  * 所有命令类的类型
  */
-export type CommandClass = BuildCommand | McpServerCommand | CreateCommand | MakeCommand | RunCommand | UploadCommand;
+export type CommandClass = BuildCommand | McpServerCommand | CreateCommand | MakeCommand | RunCommand | UploadCommand | PublishCommand;
 
 /**
  * 命令注册器

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -1,0 +1,32 @@
+import chalk from 'chalk';
+import { BaseCommand } from './base';
+import { BuildExitCode } from '../core/builder/@types/protected';
+
+/**
+ * Publish command.
+ */
+export class PublishCommand extends BaseCommand {
+    register(): void {
+        this.program
+            .command('publish')
+            .description('Publish a previously uploaded Cocos package')
+            .requiredOption('-p, --platform <platform>', 'Target platform')
+            .requiredOption('-d, --dest <path>', 'Destination path of the built project')
+            .action(async (options: any) => {
+                try {
+                    const { CocosAPI } = await import('../api/index');
+                    const result = await CocosAPI.publishProject(options.platform, options.dest);
+                    if (result.code === BuildExitCode.BUILD_SUCCESS) {
+                        console.log(chalk.green('Publish completed successfully!'));
+                    } else {
+                        console.error(chalk.red('Publish failed!'));
+                        process.exit(result.code);
+                    }
+                    process.exit(0);
+                } catch (error) {
+                    console.error(chalk.red('Failed to publish project:'), error);
+                    process.exit(1);
+                }
+            });
+    }
+}

--- a/src/core/builder/@types/protected/build-plugin.ts
+++ b/src/core/builder/@types/protected/build-plugin.ts
@@ -235,6 +235,9 @@ export namespace IInternalHook {
     export type onBeforeUpload = IInternalStageTaskHooks;
     export type upload = IInternalStageTaskHooks;
     export type onAfterUpload = IInternalStageTaskHooks;
+
+    // 内置插件才有可能触发这个函数
+    export type publish = IInternalStageTaskHooks;
 }
 
 export interface PlatformPackageOptions {

--- a/src/core/builder/@types/public/build-plugin.ts
+++ b/src/core/builder/@types/public/build-plugin.ts
@@ -80,6 +80,8 @@ export namespace BuildHook {
     export type upload = IBuildStageHooks;
     export type onAfterUpload = IBuildStageHooks;
 
+    export type publish = IBuildStageHooks;
+
     export type load = () => Promise<void> | void;
     export type unload = () => Promise<void> | void;
 }

--- a/src/core/builder/platforms/web-common/publish.ts
+++ b/src/core/builder/platforms/web-common/publish.ts
@@ -1,0 +1,65 @@
+import { IBuildStageTask, IInternalBuildOptions } from '../../@types/protected';
+
+export interface IWebPublishOptions {
+    appid?: string;
+    app_id?: string;
+    versionName?: string;
+    accessToken?: string;
+}
+
+export type IWebPublishTaskOption = IInternalBuildOptions;
+
+/**
+ * Publish stage (placeholder implementation).
+ *
+ * Mirrors the structure of the upload stage, but the real publish/release API
+ * call is not wired yet. It consumes the `packageId` produced by a prior
+ * successful upload stage and writes the publish result back onto
+ * `task.buildExitRes.custom.publish`.
+ */
+export async function publish(task: IBuildStageTask, platform: string, root: string, options: IWebPublishTaskOption) {
+    const packageOptions = getPackageOptions(platform, options);
+    const gameId = resolveGameId(packageOptions);
+    const version = String(packageOptions.versionName || '').trim();
+
+    const uploadResult = task.buildExitRes.custom.upload;
+    const packageId = uploadResult?.packageId;
+    if (!packageId) {
+        throw new Error('Publish requires a successful upload (missing packageId)');
+    }
+
+    console.log(`[web-publish] Publish start: platform=${platform}, game_id=${gameId}, version=${version}, packageId=${packageId}`);
+    task.buildExitRes.custom.publish = {
+        pending: true,
+        success: false,
+        packageId,
+    };
+
+    try {
+        // TODO: call the real publish/release API with packageId
+        task.buildExitRes.custom.publish = {
+            pending: false,
+            success: true,
+            packageId,
+        };
+        console.log(`[web-publish] Publish success: packageId=${packageId}`);
+    } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        task.buildExitRes.custom.publish = {
+            pending: false,
+            success: false,
+            reason,
+            packageId,
+        };
+        console.error(`[web-publish] Publish failed: ${reason}`);
+        throw error;
+    }
+}
+
+function getPackageOptions(platform: string, options: IWebPublishTaskOption): IWebPublishOptions {
+    return (options.packages?.[platform] || {}) as IWebPublishOptions;
+}
+
+function resolveGameId(options: IWebPublishOptions): string {
+    return String(options.appid || options.app_id || '').trim();
+}

--- a/src/core/builder/platforms/web-desktop/i18n/en.js
+++ b/src/core/builder/platforms/web-desktop/i18n/en.js
@@ -53,4 +53,8 @@ module.exports = {
         label: 'Publish',
         description: 'Click to publish and your game and claim more earnings.',
     },
+    publishStage: {
+        label: 'Release',
+        description: 'Release the uploaded package to make it publicly available.',
+    },
 };

--- a/src/core/builder/platforms/web-desktop/i18n/zh.js
+++ b/src/core/builder/platforms/web-desktop/i18n/zh.js
@@ -52,4 +52,8 @@ module.exports = {
         label: '发布',
         description: '点击发布游戏并获取更多收益。',
     },
+    publishStage: {
+        label: '正式发布',
+        description: '将已上传的包正式发布上线。',
+    },
 };

--- a/src/core/builder/platforms/web-desktop/src/config.ts
+++ b/src/core/builder/platforms/web-desktop/src/config.ts
@@ -164,6 +164,12 @@ const config: IPlatformBuildPluginConfig = {
         displayName: 'i18n:web-desktop.publish.label',
         description: 'i18n:web-desktop.publish.description',
         parallelism: 'all',
+    }, {
+        name: 'publish',
+        hook: 'publish',
+        displayName: 'i18n:web-desktop.publishStage.label',
+        description: 'i18n:web-desktop.publishStage.description',
+        parallelism: 'all',
     }],
 };
 

--- a/src/core/builder/platforms/web-desktop/src/config.ts
+++ b/src/core/builder/platforms/web-desktop/src/config.ts
@@ -164,12 +164,6 @@ const config: IPlatformBuildPluginConfig = {
         displayName: 'i18n:web-desktop.publish.label',
         description: 'i18n:web-desktop.publish.description',
         parallelism: 'all',
-    }, {
-        name: 'publish',
-        hook: 'publish',
-        displayName: 'i18n:web-desktop.publishStage.label',
-        description: 'i18n:web-desktop.publishStage.description',
-        parallelism: 'all',
     }],
 };
 

--- a/src/core/builder/platforms/web-desktop/src/hooks.ts
+++ b/src/core/builder/platforms/web-desktop/src/hooks.ts
@@ -8,6 +8,7 @@ import { IBuildResult } from './type';
 import { relativeUrl, transformCode } from '../../../worker/builder/utils';
 import * as commonUtils from '../../web-common/utils';
 import * as webUpload from '../../web-common/upload';
+import * as webPublish from '../../web-common/publish';
 import { ITaskOption } from '../../native-common/type';
 
 export const throwError = true;
@@ -114,4 +115,8 @@ export async function upload(this: IBuildStageTask, root: string, options: ITask
 
 export async function onAfterUpload(this: IBuildStageTask) {
     await webUpload.onAfterUpload(this);
+}
+
+export async function publish(this: IBuildStageTask, root: string, options: ITaskOption) {
+    await webPublish.publish(this, 'web-desktop', root, options);
 }

--- a/src/core/builder/platforms/web-mobile/i18n/en.js
+++ b/src/core/builder/platforms/web-mobile/i18n/en.js
@@ -56,4 +56,8 @@ module.exports = {
         label: 'Publish',
         description: 'Click to publish and your game and claim more earnings.',
     },
+    publishStage: {
+        label: 'Release',
+        description: 'Release the uploaded package to make it publicly available.',
+    },
 };

--- a/src/core/builder/platforms/web-mobile/i18n/zh.js
+++ b/src/core/builder/platforms/web-mobile/i18n/zh.js
@@ -56,4 +56,8 @@ module.exports = {
         label: '发布',
         description: '点击发布游戏并获取更多收益。',
     },
+    publishStage: {
+        label: '正式发布',
+        description: '将已上传的包正式发布上线。',
+    },
 };

--- a/src/core/builder/platforms/web-mobile/src/config.ts
+++ b/src/core/builder/platforms/web-mobile/src/config.ts
@@ -182,6 +182,12 @@ const config: IPlatformBuildPluginConfig = {
         displayName: 'i18n:web-mobile.publish.label',
         description: 'i18n:web-mobile.publish.description',
         parallelism: 'all',
+    }, {
+        name: 'publish',
+        hook: 'publish',
+        displayName: 'i18n:web-mobile.publishStage.label',
+        description: 'i18n:web-mobile.publishStage.description',
+        parallelism: 'all',
     }],
 };
 

--- a/src/core/builder/platforms/web-mobile/src/config.ts
+++ b/src/core/builder/platforms/web-mobile/src/config.ts
@@ -182,12 +182,6 @@ const config: IPlatformBuildPluginConfig = {
         displayName: 'i18n:web-mobile.publish.label',
         description: 'i18n:web-mobile.publish.description',
         parallelism: 'all',
-    }, {
-        name: 'publish',
-        hook: 'publish',
-        displayName: 'i18n:web-mobile.publishStage.label',
-        description: 'i18n:web-mobile.publishStage.description',
-        parallelism: 'all',
     }],
 };
 

--- a/src/core/builder/platforms/web-mobile/src/hooks.ts
+++ b/src/core/builder/platforms/web-mobile/src/hooks.ts
@@ -8,6 +8,7 @@ import { relativeUrl, transformCode } from '../../../worker/builder/utils';
 import { IBuildResult } from './type';
 import * as commonUtils from '../../web-common/utils';
 import * as webUpload from '../../web-common/upload';
+import * as webPublish from '../../web-common/publish';
 export const throwError = true;
 
 export async function onAfterInit(options: IInterBuildTaskOption<'web-mobile'>, result: InternalBuildResult, cache: BuilderCache) {
@@ -136,4 +137,8 @@ export async function upload(this: IBuildStageTask, root: string, options: IInte
 
 export async function onAfterUpload(this: IBuildStageTask) {
     await webUpload.onAfterUpload(this);
+}
+
+export async function publish(this: IBuildStageTask, root: string, options: IInterBuildTaskOption<'web-mobile'>) {
+    await webPublish.publish(this, 'web-mobile', root, options);
 }

--- a/src/core/builder/test/builder-api-publish.spec.ts
+++ b/src/core/builder/test/builder-api-publish.spec.ts
@@ -56,3 +56,5 @@ describe('BuilderApi publish', () => {
         });
     });
 });
+
+export {};

--- a/src/core/builder/test/builder-api-publish.spec.ts
+++ b/src/core/builder/test/builder-api-publish.spec.ts
@@ -1,0 +1,58 @@
+const mockExecuteBuildStageTask = jest.fn();
+
+jest.mock('../index', () => ({
+    build: jest.fn(),
+    queryDefaultBuildConfigByPlatform: jest.fn(),
+    executeBuildStageTask: mockExecuteBuildStageTask,
+}));
+
+describe('BuilderApi publish', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('executes publish stage and returns successful publish result', async () => {
+        const { BuilderApi } = await import('../../../api/builder/builder');
+        const publishResult = {
+            code: 0,
+            dest: 'project://build/openpaas',
+            custom: {
+                publish: {
+                    success: true,
+                    packageId: 'pkg-1',
+                },
+            },
+        };
+        mockExecuteBuildStageTask.mockResolvedValueOnce(publishResult);
+
+        const result = await new BuilderApi().publish('openpaas', 'build/openpaas');
+
+        expect(mockExecuteBuildStageTask).toHaveBeenCalledWith('openpaas', 'publish', {
+            dest: 'build/openpaas',
+            platform: 'openpaas',
+        });
+        expect(result).toEqual({
+            code: 200,
+            data: publishResult,
+        });
+    });
+
+    it('returns failure when publish stage fails', async () => {
+        const { BuilderApi } = await import('../../../api/builder/builder');
+        mockExecuteBuildStageTask.mockResolvedValueOnce({
+            code: 34,
+            reason: 'publish failed',
+        });
+
+        const result = await new BuilderApi().publish('openpaas', 'build/openpaas');
+
+        expect(result).toEqual({
+            code: 500,
+            data: {
+                code: 34,
+                reason: 'publish failed',
+            },
+            reason: 'publish failed',
+        });
+    });
+});

--- a/src/core/builder/test/builder-api-upload.spec.ts
+++ b/src/core/builder/test/builder-api-upload.spec.ts
@@ -78,3 +78,5 @@ describe('BuilderApi upload', () => {
         });
     });
 });
+
+export {};

--- a/src/core/launcher.ts
+++ b/src/core/launcher.ts
@@ -270,6 +270,16 @@ export default class Launcher {
         });
     }
 
+    static async publish(platform: Platform, dest: string) {
+        GlobalConfig.mode = 'simple';
+        const { init, executeBuildStageTask } = await import('./builder');
+        await init([platform]);
+        return await executeBuildStageTask('command publish', 'publish', {
+            platform,
+            dest,
+        });
+    }
+
     async close() {
         // 释放浏览器预览资源（扩展预览后端 + 热重载监听），对齐 Creator 生命周期
         try {

--- a/src/lib/builder/builder.ts
+++ b/src/lib/builder/builder.ts
@@ -61,6 +61,11 @@ export async function upload(platform: Platform, dest: string, accessToken?: str
     return Launcher.upload(platform, dest, accessToken);
 }
 
+export async function publish(platform: Platform, dest: string) {
+    const { default: Launcher } = await import('../../core/launcher');
+    return Launcher.publish(platform, dest);
+}
+
 export async function queryBuildConfig(): Promise<BuildConfiguration> {
     const builder = await import('../../core/builder');
     return builder.queryBuildConfig();


### PR DESCRIPTION
…(#publish)

Add a new `publish` build stage as a chained post-build step, mirroring the existing `upload` stage's flow but with a placeholder implementation.

- schema: extend `nextStages` enum with `publish`; add `SchemaPublishResult` / `IPublishResultData`
- api: `BuilderApi.publish` -> `executeBuildStageTask(platform, 'publish', ...)`
- api: `CocosAPI.publishProject` entry point
- launcher: `Launcher.publish` static method
- cli: register `PublishCommand` (`cocos publish -p <platform> -d <dest>`)
- types: declare `publish` hook in `IInternalHook` / `BuildHook` namespaces (only the main `publish` hook, no before/after wrappers)
- platform config (web-mobile/web-desktop): register `publish` in `customBuildStages` with distinct `publishStage.*` i18n keys to avoid collision with the upload stage's existing `publish.*` keys
- platform hooks (web-mobile/web-desktop): add `publish` delegating to `webPublish.publish`
- web-common/publish.ts: placeholder implementation that reads the `packageId` produced by a prior successful upload stage and writes `custom.publish = { pending, success, packageId }`; the real publish/release API call is left as a TODO
- tests: mirror `builder-api-upload.spec.ts` -> `builder-api-publish.spec.ts`