### PR TITLE
feat(scene): preview in editor

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -6308,6 +6308,7 @@ export declare interface IEditorService extends IServiceEvents {
     create(params: ICreateOptions): Promise<IBaseIdentifier>;
     hasOpen(): Promise<boolean>;
     queryCurrent(): Promise<TEditorEntity | null>;
+    querySceneSerializedData(): Promise<string>;
     getRootNode(): TEditorInstance | null;
     lock(): Promise<void>;
     unlock(): void;

--- a/src/core/preview/game-preview.middleware.ts
+++ b/src/core/preview/game-preview.middleware.ts
@@ -173,6 +173,62 @@ export const gamePreviewResourceRoutes = [
             }
         },
     },
+    {
+        /**
+         * 预览态类型化创建节点所需的「节点类型 → 内置 Prefab uuid」映射（只读）。
+         *
+         * 预览 iframe 里的 inspect agent（static/web/preview-inspect.js）在 Hierarchy 右键
+         * Create ▸ Cube / Button … 时需要这张表。这里**直接输出编辑态的 NODE_CONFIGS**，
+         * 而不是在前端 JS 里重抄一份，保证两侧的 uuid / canvasRequired / project-type 永不漂移。
+         *
+         * node-type-config 是无依赖的纯数据模块（不 import cc），可安全在 CLI 主进程加载。
+         * 注意必须注册在 `/scene/(.+).json` 之前也无妨——两者路径模式不重叠（本路由无 .json 后缀）。
+         */
+        url: '/scene/asset-meta',
+        async handler(req: Request, res: Response, next: NextFunction) {
+            try {
+                const dbURL = typeof req.query.dbURL === 'string' ? req.query.dbURL : '';
+                if (!dbURL) {
+                    return next();
+                }
+                const { assetManager } = await import('../assets');
+                const info = assetManager.queryAssetInfo(dbURL);
+                res.set('Cache-Control', 'no-store');
+                if (!info || info.isDirectory || !info.uuid) {
+                    res.status(404).json({ error: `asset not found: ${dbURL}` });
+                    return;
+                }
+                // subAssets 一并输出(一层):预览端创建 Sprite 节点时优先挂真子资产 SpriteFrame,
+                // 让 Inspector 的 spriteFrame 属性带资产 uuid、可索引回 Assets。
+                const subAssets = info.subAssets
+                    ? Object.values(info.subAssets).map(sub => ({ uuid: sub.uuid, type: sub.type, name: sub.name }))
+                    : [];
+                res.status(200).json({ uuid: info.uuid, type: info.type, name: info.name, subAssets });
+            } catch (err) {
+                next(err);
+            }
+        },
+    },
+    {
+        /**
+         * 预览态「按资产拖拽创建节点」所需的「db:// URL → { uuid, type, name }」只读路由。
+         *
+         * Hierarchy 接受资产拖拽时（node.create-by-asset）只把 db:// URL 传进预览 iframe 的
+         * inspect agent（static/web/preview-inspect.js），而活场景加载/实例化需要 uuid 与类型：
+         * 这里在 CLI 主进程直接查 asset-db 返回最小字段，与 node-type-config 同属预览只读数据路由。
+         */
+        url: '/scene/node-type-config',
+        async handler(_req: Request, res: Response, next: NextFunction) {
+            try {
+                const { NODE_CONFIGS } = await import('../scene/scene-process/service/node/node-type-config');
+                // 表随 CLI 版本固定，但预览生命周期短，不缓存以免升级后拿到旧表。
+                res.set('Cache-Control', 'no-store');
+                res.status(200).json(NODE_CONFIGS);
+            } catch (err) {
+                next(err);
+            }
+        },
+    },
 ];
 
 export default {

--- a/src/core/preview/test/game-boot-scene-load.test.ts
+++ b/src/core/preview/test/game-boot-scene-load.test.ts
@@ -1,0 +1,80 @@
+/**
+ * `static/web/game-boot.js`「场景加载失败必须 reject boot promise」的回归护栏。
+ *
+ * 背景（PR #906 review P1）：场景加载写在 `cc.game.run(async () => {...})` 的回调里，而引擎的
+ * `game.run` 返回 void、fire-and-forget 该回调——回调内抛出的异常**不会**传播到 gameBoot 外层
+ * try/catch。若 fetch 失败 / 响应非 JSON / 快照缺失（/scene/current.json 404），`rejectSceneRun`
+ * 永不触发，`await sceneRunDone` 永远 pending：
+ *  - IDE 预览（PinK previewMain 等 `await gameBoot()` 的消费方）卡在 loading，view:error 永不
+ *    fire，错误浮层与重试都不可达；
+ *  - 浏览器首屏表现为游戏停在 `cc.game.pause()` 之后、无任何报错。
+ *
+ * 该文件是有 import 的浏览器 ESM，无法像 preview-inspect 测试那样 new Function 求值执行，
+ * 故这里对源码做结构断言：钉住「回调整体被 try/catch 收敛到 rejectSceneRun」「fetch 响应
+ * 先查 ok 再 .json()」「外层 catch 仍 rethrow（IDE 感知失败的契约）」三条不变量。
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const GAME_BOOT_SOURCE_PATH = path.resolve(__dirname, '../../../../static/web/game-boot.js');
+
+function loadSource(): string {
+    return fs.readFileSync(GAME_BOOT_SOURCE_PATH, 'utf8');
+}
+
+/** 截取「场景加载入口 → await sceneRunDone;」之间的区段（带分号匹配真实代码行，避开注释里的同名词）。 */
+function extractSceneRunSection(source: string): string {
+    const start = source.indexOf('await cc.game.run(');
+    const end = source.indexOf('await sceneRunDone;');
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    return source.slice(start, end);
+}
+
+describe('game-boot 场景加载失败路径（防 boot 挂死）', () => {
+    const source = loadSource();
+    const section = extractSceneRunSection(source);
+
+    it('cc.game.run 回调的场景加载路径必须整体包在 try/catch 内，且 catch 收敛到 rejectSceneRun', () => {
+        const tryIndex = section.indexOf('try {');
+        const fetchIndex = section.indexOf('fetch(');
+        const catchIndex = section.lastIndexOf('catch');
+        expect(tryIndex).toBeGreaterThan(-1);
+        expect(fetchIndex).toBeGreaterThan(tryIndex); // fetch 必须落在 try 之内
+        expect(catchIndex).toBeGreaterThan(fetchIndex);
+        // 最后一个 catch 块里必须调用 rejectSceneRun（而非只打日志）
+        expect(section.slice(catchIndex)).toContain('rejectSceneRun(');
+    });
+
+    it('场景加载路径不允许「未检查 ok 的 fetch(...).json() 一行式」这一历史挂死写法', () => {
+        // 仅约束 cc.game.run 回调内的场景加载段（fire-and-forget 上下文）；
+        // 主流程里其他 await (await fetch(...)).json()（如 engine modules 查询）本身在
+        // gameBoot 的 try/catch 内，失败会正常冒泡，不在此限。
+        expect(section).not.toMatch(/await\s*\(\s*await\s+fetch\([^)]*\)\s*\)\.json\(\)/);
+    });
+
+    it('fetch 响应必须先做 ok/状态检查，非 2xx 时抛出可读错误', () => {
+        expect(section).toMatch(/if\s*\(\s*!\s*\w+\.ok\s*\)/);
+        expect(section).toContain('throw new Error(');
+    });
+
+    it('所有失败出口（loadWithJson 错误 / runSceneImmediate 抛出 / 回调外层捕获）都收敛到 rejectSceneRun', () => {
+        const rejects = section.match(/rejectSceneRun\(/g) || [];
+        expect(rejects.length).toBeGreaterThanOrEqual(3);
+        // 失败时都要在预览面上可见：每个 reject 附近都有 showError
+        const showErrors = section.match(/showError\(/g) || [];
+        expect(showErrors.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('sceneRunDone 的 reject 必须能传播到 gameBoot 外层 catch 并 rethrow（IDE 预览的失败感知契约）', () => {
+        // await sceneRunDone 必须位于外层 try 内（其后存在统一 catch + rethrow）
+        const awaitDone = source.indexOf('await sceneRunDone');
+        const outerCatch = source.indexOf('Failed to start game preview');
+        expect(awaitDone).toBeGreaterThan(-1);
+        expect(outerCatch).toBeGreaterThan(awaitDone);
+        const tail = source.slice(outerCatch);
+        expect(tail).toContain('showError(err)');
+        expect(tail).toMatch(/throw\s+err\s*;/);
+    });
+});

--- a/src/core/preview/test/node-type-config-route.test.ts
+++ b/src/core/preview/test/node-type-config-route.test.ts
@@ -1,0 +1,88 @@
+import GamePreviewMiddleware from '../game-preview.middleware';
+import { NODE_CONFIGS } from '../../scene/scene-process/service/node/node-type-config';
+
+/**
+ * `GET /scene/node-type-config`：预览态「类型化创建节点」的数据源。
+ *
+ * 背景：Preview In Editor 期间 Hierarchy 右键 Create ▸ Cube / Button… 由预览 iframe 内的
+ * inspect agent（static/web/preview-inspect.js）直接对活场景 `cc.instantiate` 内置 Prefab 完成，
+ * 而「节点类型 → 内置 Prefab uuid / canvasRequired / project-type」这张表只存在于编辑态的
+ * NODE_CONFIGS。本路由把它原样输出，避免在前端 JS 里重抄一份导致两侧漂移。
+ *
+ * 本测试锁定三条不变量：
+ *  1. 路由存在且返回 200 + 与 NODE_CONFIGS **完全一致**的 JSON（漂移即失败）；
+ *  2. 响应 no-store —— 表随 CLI 版本变化，缓存会让升级后的预览拿到旧 uuid；
+ *  3. 路由不依赖 asset-db / builder / scene 进程（node-type-config 是无依赖纯数据模块），
+ *     因此在 CLI 初始化早期即可服务，不会因为预览页抢跑而 404。
+ */
+
+interface MockRes {
+    statusCode: number;
+    json_: unknown;
+    headers: Record<string, string>;
+    status(code: number): MockRes;
+    set(k: string, v: string): MockRes;
+    json(payload: unknown): MockRes;
+}
+
+function makeRes(): MockRes {
+    const res: MockRes = {
+        statusCode: 0,
+        json_: undefined,
+        headers: {},
+        status(code: number) { this.statusCode = code; return this; },
+        set(k: string, v: string) { this.headers[k] = v; return this; },
+        json(payload: unknown) { this.json_ = payload; return this; },
+    };
+    return res;
+}
+
+function findNodeTypeConfigHandler() {
+    const entry = (GamePreviewMiddleware.get || []).find((m: any) => m.url === '/scene/node-type-config');
+    if (!entry) {
+        throw new Error('GamePreview middleware has no `/scene/node-type-config` route');
+    }
+    return entry.handler as (req: any, res: any, next: any) => Promise<void> | void;
+}
+
+describe('GET /scene/node-type-config (preview typed node creation)', () => {
+    it('returns NODE_CONFIGS verbatim with 200 + no-store', async () => {
+        const handler = findNodeTypeConfigHandler();
+        const res = makeRes();
+        const next = jest.fn();
+
+        await handler({}, res, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(res.statusCode).toBe(200);
+        expect(res.headers['Cache-Control']).toBe('no-store');
+        // 原样输出：任何一处改写都会让预览端创建出错误的节点类型。
+        expect(res.json_).toEqual(NODE_CONFIGS);
+    });
+
+    it('carries the entries the preview agent depends on (Empty / Cube / Button / Canvas)', async () => {
+        const handler = findNodeTypeConfigHandler();
+        const res = makeRes();
+
+        await handler({}, res, jest.fn());
+        const table = res.json_ as Record<string, Array<Record<string, unknown>>>;
+
+        // Empty 必须没有 assetUuid —— 预览端据此走 `new cc.Node()` 而不是加载 Prefab。
+        expect(table.Empty?.[0]).toBeDefined();
+        expect(table.Empty[0].assetUuid).toBeFalsy();
+        // 有 Prefab 的类型必须带 uuid，否则预览端会静默降级成空节点。
+        expect(typeof table.Cube?.[0]?.assetUuid).toBe('string');
+        // UI 类型必须带 canvasRequired，预览端据此自动补 Canvas 父节点。
+        expect(table.Button?.[0]?.canvasRequired).toBe(true);
+        // Canvas 本身有 2d / 3d 两个变体，预览端按 workMode 在第 1/2 项间选择。
+        expect(table.Canvas?.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('does not require asset-db / builder / scene process to be initialized', () => {
+        // node-type-config 是零 import 的纯数据模块；若未来有人给它加依赖，这条断言会失败，
+        // 提醒该路由将不再能在 CLI 初始化早期服务（预览页抢跑会拿到 404 或 500）。
+        const mod = require('../../scene/scene-process/service/node/node-type-config');
+        expect(Object.keys(mod).length).toBeGreaterThan(0);
+        expect(mod.NODE_CONFIGS).toBe(NODE_CONFIGS);
+    });
+});

--- a/src/core/preview/test/preview-inspect-script-uuid.test.ts
+++ b/src/core/preview/test/preview-inspect-script-uuid.test.ts
@@ -1,0 +1,325 @@
+/**
+ * `static/web/preview-inspect.js` 的「组件 Script 一栏 uuid 归一」用例。
+ *
+ * 背景（真实缺陷）：Preview In Editor 后，挂了自定义脚本的节点在 Inspector 里 Script 一栏红字
+ * "Missing"，而同组件的其它引用字段（Button / Label / Node）都正常。
+ *
+ * 机制：面板的资源选择器（`@pink-ui-kit` ref-picker）用 `items.find(i => i.uuid === dump.value.uuid)`
+ * 做**严格相等**匹配，items 来自 asset-db 的 `queryAssets`（两态一致，都是**带短横** uuid）。
+ * 编辑态由 `encode.ts` 直接写入 `component.__scriptUuid`；预览运行时没有编辑器注入的这个字段，
+ * 只能从 classId 反查 —— 用户脚本的 classId 就是**压缩后**的脚本 uuid。压缩形式（22/23 位 base64）
+ * 解压出来又是 **32 位无短横**形式，跟 asset-db 的带短横形式仍然不相等。少任一步 → "Missing"。
+ *
+ * 本测试钉住三条不变量：
+ *  1. 压缩 / 32 位无短横 / 带短横 三种输入都归一到**带短横** 36 位形式（引擎自带的黄金向量）；
+ *  2. `EditorExtends.UuidUtils.decompressUUID` 存在时以它为准，缺席时本地移植版给出**相同**结果
+ *     （预览页确实会加载 editor-extends.bundle.js，但不能依赖它一定在）；
+ *  3. 认不出来的 classId（`ccclass('Foo')` 手写类名）→ 隐藏 Script 行而不是丢一个查不到的 uuid
+ *     给面板渲染成红字，并且按类名去重告警一次（静默隐藏会让人以为面板漏字段）。
+ *
+ * 加载方式与 preview-inspect-structure.test.ts 一致：该文件是零 import 的浏览器 ESM，
+ * ts-jest/CommonJS 下 `import()` 会被降级成 `require` 而在 `export function` 处语法失败，
+ * 故读源码、去掉唯一的 `export ` 前缀后用 `new Function` 求值。
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const AGENT_SOURCE_PATH = path.resolve(__dirname, '../../../../static/web/preview-inspect.js');
+
+/**
+ * 引擎 `utils/uuid` 文档注释里的黄金向量：23 位（普通压缩）与 22 位（min 压缩）两种形态
+ * 解压到同一个 uuid。这两串直接抄自引擎实现的 doc comment，是本地移植版的验收基准。
+ */
+const COMPRESSED_23 = 'fc9913XADNLgJ1ByKhqcC5Z';
+const COMPRESSED_22 = 'fcmR3XADNLgJ1ByKhqcC5Z';
+const NORMALIZED = 'fc991dd700334b809d41c8a86a702e59';
+const DASHED = 'fc991dd7-0033-4b80-9d41-c8a86a702e59';
+
+// ---- 桩引擎 --------------------------------------------------------------
+
+let uuidSequence = 0;
+
+class StubNode {
+    public uuid = `node-${++uuidSequence}`;
+    public parent: StubNode | null = null;
+    public children: StubNode[] = [];
+    public active = true;
+    public _objFlags = 0;
+    public _components: unknown[] = [];
+    constructor(public name = 'New Node') { }
+    getSiblingIndex(): number {
+        return this.parent ? this.parent.children.indexOf(this) : -1;
+    }
+}
+class StubScene extends StubNode { }
+class StubComponent {
+    public node: StubNode | null = null;
+    public enabled = true;
+    public uuid = `comp-${++uuidSequence}`;
+}
+
+/**
+ * 一个「用户脚本组件」：`__props__` 里带 `__scriptAsset`（DEV/预览构建下该 getter 确实进 __props__，
+ * 这正是 Script 行会被渲染出来的前提），attrs 给出 `ctor` 以模拟 `@type(Script)`。
+ */
+function makeScriptComponentClass(className: string, classId: string): any {
+    const ctor = class extends StubComponent { };
+    Object.defineProperty(ctor, 'name', { value: className.replace(/\W/g, '_') });
+    (ctor as any).__props__ = ['__scriptAsset'];
+    (ctor as any).__cid__ = classId;
+    (ctor as any).__className__ = className;
+    return ctor;
+}
+
+/**
+ * `@type(Script)` 的 ctor：`_encodeProp` 的空引用分支据它产出 type + extends 继承链，
+ * 面板 getElementType 靠链里含 'cc.Asset' 才把该行提升成资源选择器（光有 type 不够）。
+ */
+class StubAsset { }
+class StubScriptAsset extends StubAsset { }
+const ASSET_CLASS_NAMES = new Map<unknown, string>([
+    [StubAsset, 'cc.Asset'],
+    [StubScriptAsset, 'cc.Script'],
+]);
+
+interface IWorld {
+    agent: any;
+    events: Array<{ type: string; payload: any }>;
+    logs: string[];
+}
+
+const liveAgents: any[] = [];
+
+function loadAgentFactory(): (env: any) => any {
+    const source = fs.readFileSync(AGENT_SOURCE_PATH, 'utf8');
+    const exportsFound = source.match(/^export /gm) || [];
+    // 只允许唯一导出：一旦有人加了第二个 export，下面的裸 new Function 求值就不再成立，必须显式失败。
+    if (exportsFound.length !== 1) {
+        throw new Error(`preview-inspect.js is expected to have exactly 1 top-level export, found ${exportsFound.length}`);
+    }
+    const body = `${source.replace(/^export function /m, 'function ')}\nreturn { createPreviewInspect };`;
+    const evaluate = new Function('fetch', body) as (f: unknown) => { createPreviewInspect: (env: any) => any };
+    return evaluate(async () => ({ ok: false, status: 404, json: async () => ({}) })).createPreviewInspect;
+}
+
+/**
+ * @param editorExtends 传入以模拟预览页已加载 editor-extends.bundle.js；不传则强制走本地移植版。
+ */
+function createWorld(editorExtends?: unknown): IWorld {
+    const scene = new StubScene('Scene');
+    const events: Array<{ type: string; payload: any }> = [];
+
+    const cc: any = {
+        Node: StubNode,
+        Scene: StubScene,
+        Component: StubComponent,
+        Asset: StubAsset,
+        Object: { Flags: { HideInHierarchy: 1 << 9, LockedInEditor: 1 << 8 } },
+        director: { getScene: () => scene },
+        isValid: (obj: any) => Boolean(obj) && !obj._destroyed,
+        js: {
+            getClassName: (ctor: any) => ASSET_CLASS_NAMES.get(ctor) || (ctor && ctor.__className__) || (ctor && ctor.name) || '',
+            getClassId: (ctor: any) => (ctor && ctor.__cid__) || '',
+        },
+        // 组件属性 attrs：`__scriptAsset` 是 `@type(Script)` 的空引用，ctor 保证它被编码成资源行。
+        Class: {
+            attr: (_owner: unknown, key: string) => (key === '__scriptAsset' ? { ctor: StubScriptAsset } : {}),
+        },
+    };
+
+    const agent = loadAgentFactory()({ cc, EditorExtends: editorExtends, serverURL: 'http://localhost:7456' });
+    liveAgents.push(agent);
+    agent.start((type: string, payload: unknown) => events.push({ type, payload }));
+
+    return {
+        agent,
+        events,
+        get logs(): string[] {
+            return events
+                .filter(event => event.type === 'view:log')
+                .map(event => String(event.payload && event.payload.message));
+        },
+    };
+}
+
+afterEach(() => {
+    // start() 挂了 150ms 轮询定时器；不 stop 会把句柄留到进程退出。
+    while (liveAgents.length > 0) {
+        try {
+            liveAgents.pop().stop();
+        } catch {
+            /* 已 stop 过，忽略 */
+        }
+    }
+});
+
+// ---- uuid 归一 -----------------------------------------------------------
+
+describe('preview-inspect uuid 归一（Script 一栏不再 Missing）', () => {
+    it('本地移植版解压两种压缩形态到同一 32 位无短横 uuid（引擎黄金向量）', () => {
+        const world = createWorld(/* 无 EditorExtends：强制走本地实现 */);
+
+        expect(world.agent._decompressUuid(COMPRESSED_23)).toBe(NORMALIZED);
+        expect(world.agent._decompressUuid(COMPRESSED_22)).toBe(NORMALIZED);
+    });
+
+    it('EditorExtends 在场时以它为准；抛异常则静默回落到本地实现', () => {
+        const authoritative = createWorld({ UuidUtils: { decompressUUID: () => 'deadbeef00000000000000000000cafe' } });
+        expect(authoritative.agent._decompressUuid(COMPRESSED_23)).toBe('deadbeef00000000000000000000cafe');
+
+        // 权威实现抛错/返回空不能让整栏失效——预览的 EditorExtends 版本不受本仓库控制。
+        const broken = createWorld({ UuidUtils: { decompressUUID: () => { throw new Error('boom'); } } });
+        expect(broken.agent._decompressUuid(COMPRESSED_23)).toBe(NORMALIZED);
+        const empty = createWorld({ UuidUtils: { decompressUUID: () => '' } });
+        expect(empty.agent._decompressUuid(COMPRESSED_23)).toBe(NORMALIZED);
+    });
+
+    it('EditorExtends.decompressUUID 返回带短横 36 位（真实 editor-extends.bundle.js 形态）也能归一', () => {
+        // 真实 editor-extends.bundle.js 的 decompressUUID 末尾 join('-'),产出 **36 位带短横**形式,
+        // 而非 32 位无短横(见 cocos-cli/static/web/editor-extends.bundle.js 的 decompressNormalUuid)。
+        // 预览页必然加载该 bundle,故这条路径是生产真实命中的路径。旧 _normalizeAssetUuid 解压后
+        // 只判 32 位无短横,带短横形态漏判成 '' → _scriptUuid 返回空 → Script 行被隐藏
+        // (正是「Preview in Editor 后挂自定义脚本的节点 Script 一栏消失」的回归点)。这里用与真实
+        // bundle 完全一致的返回值钉死回归:解压后必须复判 dashed。
+        const world = createWorld({ UuidUtils: { decompressUUID: () => DASHED } });
+
+        // _decompressUuid 透传权威返回的带短横串。
+        expect(world.agent._decompressUuid(COMPRESSED_23)).toBe(DASHED);
+        // _normalizeAssetUuid 必须在解压后复判 dashed,否则这里就会得到 ''(回归前的行为)。
+        expect(world.agent._normalizeAssetUuid(COMPRESSED_23)).toBe(DASHED);
+        expect(world.agent._normalizeAssetUuid(COMPRESSED_22)).toBe(DASHED);
+    });
+
+    it('三种输入形态都归一成带短横 36 位（asset-db 形式）', () => {
+        const { agent } = createWorld();
+
+        expect(agent._normalizeAssetUuid(COMPRESSED_23)).toBe(DASHED);
+        expect(agent._normalizeAssetUuid(COMPRESSED_22)).toBe(DASHED);
+        expect(agent._normalizeAssetUuid(NORMALIZED)).toBe(DASHED);
+        // 已是带短横的原样返回（编辑器注入的 __scriptUuid 通常就是这个形态）。
+        expect(agent._normalizeAssetUuid(DASHED)).toBe(DASHED);
+    });
+
+    it('子资源后缀原样保留在归一结果尾部', () => {
+        const { agent } = createWorld();
+
+        expect(agent._normalizeAssetUuid(`${COMPRESSED_23}@6c48a`)).toBe(`${DASHED}@6c48a`);
+    });
+
+    it('不是 uuid 形状的输入一律返回空串（调用方据此隐藏 Script 行）', () => {
+        const { agent } = createWorld();
+
+        // `ccclass('Test1')` 这种手写类名：长度像压缩 uuid 也不能瞎解压。
+        expect(agent._normalizeAssetUuid('Test1')).toBe('');
+        expect(agent._normalizeAssetUuid('cc.Sprite')).toBe('');
+        expect(agent._normalizeAssetUuid('')).toBe('');
+        expect(agent._normalizeAssetUuid(undefined)).toBe('');
+        expect(agent._normalizeAssetUuid(123)).toBe('');
+        // 32 位但含非 hex 字符。
+        expect(agent._normalizeAssetUuid('zz991dd700334b809d41c8a86a702e59')).toBe('');
+    });
+});
+
+// ---- _scriptUuid 取值来源 ------------------------------------------------
+
+describe('preview-inspect _scriptUuid 取值来源', () => {
+    it('优先用编辑器注入的 __scriptUuid，且同样过一遍归一', () => {
+        const { agent } = createWorld();
+        const Ctor = makeScriptComponentClass('Test1', 'some-non-uuid-cid');
+        const comp = new Ctor();
+        comp.__scriptUuid = COMPRESSED_23;
+
+        expect(agent._scriptUuid(comp)).toBe(DASHED);
+    });
+
+    it('没有 __scriptUuid 时从 classId 反查（用户脚本的 classId 即压缩后的脚本 uuid）', () => {
+        const { agent } = createWorld();
+        const comp = new (makeScriptComponentClass('Test1', COMPRESSED_23))();
+
+        expect(agent._scriptUuid(comp)).toBe(DASHED);
+    });
+
+    it('内置组件（cc.*）直接返回空串，不去碰 classId', () => {
+        const { agent } = createWorld();
+        // 内置组件的 classId 也可能是短字符串（如 'cc.Sprite' 的注册 id），但类名前缀已足以判定。
+        const comp = new (makeScriptComponentClass('cc.Sprite', COMPRESSED_23))();
+
+        expect(agent._scriptUuid(comp)).toBe('');
+    });
+
+    it('空组件 / 取不到 classId 时返回空串而不抛', () => {
+        const { agent } = createWorld();
+
+        expect(agent._scriptUuid(null)).toBe('');
+        expect(agent._scriptUuid(undefined)).toBe('');
+        const noCid = new (makeScriptComponentClass('Test1', ''))();
+        expect(agent._scriptUuid(noCid)).toBe('');
+    });
+});
+
+// ---- 端到端：_dumpComponent 的 __scriptAsset 行 ---------------------------
+
+describe('preview-inspect __scriptAsset dump（对齐编辑态 encode.ts）', () => {
+    it('认出脚本 uuid：Script 行可见、带短横 uuid、type=cc.Script、displayOrder=-999', () => {
+        const { agent } = createWorld();
+        const comp = new (makeScriptComponentClass('Test1', COMPRESSED_23))();
+
+        const dump = agent._dumpComponent(comp, 'Node/Test1');
+        const sa = dump.value.__scriptAsset;
+
+        expect(dump.type).toBe('Test1');
+        expect(sa.visible).toBe(true);
+        // 面板拿这个 uuid 去 asset-db 的 items 里做严格相等匹配，形态错一位就是红字 Missing。
+        expect(sa.value).toEqual({ uuid: DASHED });
+        expect(sa.type).toBe('cc.Script');
+        expect(sa.extends).toEqual(['cc.Script', 'cc.Asset']);
+        // -999 让 Script 行排在组件所有字段最前面（与编辑态一致）。
+        expect(sa.displayOrder).toBe(-999);
+    });
+
+    it('EditorExtends 返回带短横 uuid 时 Script 行仍可见（生产回归点：Preview in Editor 后 Script 一栏消失）', () => {
+        // 预览页加载的 editor-extends.bundle.js 的 decompressUUID 返回 36 位带短横（见上组同名测试说明）。
+        // 走真实 bundle 形态的端到端 _dumpComponent,确保 Script 行可见且 uuid 是带短横。
+        const world = createWorld({ UuidUtils: { decompressUUID: () => DASHED } });
+        const comp = new (makeScriptComponentClass('MyPlayer', COMPRESSED_23))();
+
+        const sa = world.agent._dumpComponent(comp, 'Node/MyPlayer').value.__scriptAsset;
+
+        // 回归前:_normalizeAssetUuid 解压后漏判 dashed → '' → 走 else 分支 sa.visible=false。
+        expect(sa.visible).toBe(true);
+        expect(sa.value).toEqual({ uuid: DASHED });
+        expect(world.logs.filter(m => m.includes('cannot resolve script asset uuid'))).toHaveLength(0);
+    });
+
+    it('内置组件：Script 行隐藏且不告警（本就无脚本，不是异常）', () => {
+        const world = createWorld();
+        const comp = new (makeScriptComponentClass('cc.Sprite', 'cc.Sprite'))();
+
+        const dump = world.agent._dumpComponent(comp, 'Node/cc.Sprite');
+
+        expect(dump.value.__scriptAsset.visible).toBe(false);
+        expect(dump.value.__scriptAsset.value).toEqual({ uuid: '' });
+        expect(world.logs).toEqual([]);
+    });
+
+    it('用户脚本但 uuid 认不出来：隐藏 Script 行 + 按类名去重告警恰好一次', () => {
+        const world = createWorld();
+        const Ctor = makeScriptComponentClass('Test1', 'Test1');
+
+        const first = world.agent._dumpComponent(new Ctor(), 'Node/Test1');
+        expect(first.value.__scriptAsset.visible).toBe(false);
+
+        // 同类的第二个实例（以及后续每次轮询 dump）不能再刷日志。
+        world.agent._dumpComponent(new Ctor(), 'Other/Test1');
+        world.agent._dumpComponent(new Ctor(), 'Third/Test1');
+
+        const warnings = world.logs.filter(message => message.includes('cannot resolve script asset uuid'));
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]).toContain("'Test1'");
+
+        // 换一个类名要再告警一次（否则第二个坏脚本会被第一个的去重吞掉）。
+        world.agent._dumpComponent(new (makeScriptComponentClass('Test2', 'Test2'))(), 'Node/Test2');
+        expect(world.logs.filter(m => m.includes('cannot resolve script asset uuid'))).toHaveLength(2);
+    });
+});

--- a/src/core/preview/test/preview-inspect-structure.test.ts
+++ b/src/core/preview/test/preview-inspect-structure.test.ts
@@ -1,0 +1,1113 @@
+/**
+ * `static/web/preview-inspect.js` 的 M4 结构编辑用例(桩 `cc`)。
+ *
+ * 这份 agent 跑在预览 iframe 里,是「Preview In Editor 期间 Hierarchy 右键编辑节点」的真正执行者:
+ * PinK 侧 `PreviewSceneApi` 只做 dispatch(已由 previewSceneApi.test.ts 钉住),
+ * 路径索引、undo 栈、剪贴板、类型化创建这些容易出错的逻辑全在这里。
+ *
+ * 用桩 `cc`(下面的 StubNode/StubScene + 极简 assetManager)驱动,覆盖:
+ *  - 路径编码:非法字符替换、同级重名后缀、HideInHierarchy 过滤;
+ *  - create-by-type:Empty / 内置 Prefab / 加载失败降级 / workMode 变体 / canvasRequired 自动补 Canvas;
+ *  - delete(摘除不 destroy)、rename、set-parent(含环检测)、reorder、change-node-lock;
+ *  - 剪贴板:copy 离线副本、cut 变移动、paste 同级重名唯一化、duplicate;
+ *  - 预览内独立 undo 栈:逐操作可撤销、group 合成单步、cancel 回滚、空栈不抛;
+ *  - 「停止即丢弃」:stop()/clearHistory() 销毁游离节点与剪贴板副本。
+ *
+ * 加载方式:该文件是浏览器 ESM(唯一导出 `createPreviewInspect`,且零 import),而本仓库 jest 走
+ * ts-jest/CommonJS —— `import()` 会被降级成 `require` 从而在 `export function` 处语法失败。
+ * 因此这里读源码、去掉唯一的 `export ` 前缀后用 `new Function` 求值,并把它依赖的唯一外部全局
+ * (`fetch`)作为形参注入,不污染全局。
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const AGENT_SOURCE_PATH = path.resolve(__dirname, '../../../../static/web/preview-inspect.js');
+
+const CANVAS_PREFAB_UUID_2D = '4c33600e-9ca9-483b-b734-946008261697';
+const CANVAS_PREFAB_UUID_3D = 'f773db21-62b8-4540-956a-29bacf5ddbf5';
+const CUBE_UUID = 'cube-uuid-0000';
+const BUTTON_UUID = 'button-uuid-00';
+
+/** 与 CLI `/scene/node-type-config` 同形的最小表(真实表的契约由 node-type-config-route.test.ts 钉住)。 */
+const NODE_TYPE_TABLE: Record<string, Array<Record<string, unknown>>> = {
+    Empty: [{ name: 'Empty' }],
+    Cube: [{ name: 'Cube', assetUuid: CUBE_UUID, 'project-type': '3d' }],
+    Button: [{ name: 'Button', assetUuid: BUTTON_UUID, canvasRequired: true, 'project-type': '2d' }],
+    Canvas: [
+        { name: 'Canvas', assetUuid: CANVAS_PREFAB_UUID_2D, 'project-type': '2d' },
+        { name: 'Canvas', assetUuid: CANVAS_PREFAB_UUID_3D, 'project-type': '3d' },
+    ],
+};
+
+// ---- 桩引擎 --------------------------------------------------------------
+
+let uuidSequence = 0;
+
+class StubComponent {
+    public node: StubNode | null = null;
+    public enabled = true;
+    public uuid = `comp-${++uuidSequence}`;
+}
+class StubCanvas extends StubComponent { }
+class StubUITransform extends StubComponent { }
+
+class StubNode {
+    public uuid = `node-${++uuidSequence}`;
+    public parent: StubNode | null = null;
+    public children: StubNode[] = [];
+    public active = true;
+    public layer = 1073741824;
+    public _objFlags = 0;
+    public _components: StubComponent[] = [];
+    public _destroyed = false;
+    public _prefab: unknown = { fake: true };
+    public position = { x: 0, y: 0, z: 0 };
+    public eulerAngles = { x: 0, y: 0, z: 0 };
+    public scale = { x: 1, y: 1, z: 1 };
+
+    constructor(public name = 'New Node') { }
+
+    get components(): StubComponent[] {
+        return this._components;
+    }
+
+    setParent(parent: StubNode | null): void {
+        if (this.parent) {
+            const index = this.parent.children.indexOf(this);
+            if (index >= 0) {
+                this.parent.children.splice(index, 1);
+            }
+        }
+        this.parent = parent;
+        if (parent) {
+            parent.children.push(this);
+        }
+    }
+
+    getSiblingIndex(): number {
+        return this.parent ? this.parent.children.indexOf(this) : -1;
+    }
+
+    /** 对齐 cc.Node:先摘出再插入,越界(含 -1)落到末尾。 */
+    setSiblingIndex(index: number): void {
+        if (!this.parent) {
+            return;
+        }
+        const siblings = this.parent.children;
+        const from = siblings.indexOf(this);
+        if (from < 0) {
+            return;
+        }
+        siblings.splice(from, 1);
+        if (index < 0 || index >= siblings.length) {
+            siblings.push(this);
+        } else {
+            siblings.splice(index, 0, this);
+        }
+    }
+
+    getComponent(type: any): StubComponent | null {
+        return this._components.find(comp => comp instanceof type) || null;
+    }
+
+    addComponent(type: any): StubComponent {
+        const comp = new type();
+        comp.node = this;
+        this._components.push(comp);
+        return comp;
+    }
+
+    setPosition(value: any): void {
+        this.position = { x: value.x, y: value.y, z: value.z };
+    }
+
+    destroy(): boolean {
+        this._destroyed = true;
+        return true;
+    }
+}
+
+class StubScene extends StubNode { }
+
+function cloneNode(source: StubNode): StubNode {
+    const copy = new StubNode(source.name);
+    copy.layer = source.layer;
+    copy._objFlags = source._objFlags;
+    copy.position = { ...source.position };
+    for (const comp of source._components) {
+        copy.addComponent(comp.constructor as any);
+    }
+    for (const child of source.children.slice()) {
+        cloneNode(child).setParent(copy);
+    }
+    return copy;
+}
+
+/** 桩「内置 Prefab」:只需带一个模板节点,`cc.instantiate` 据此产出实例。 */
+function makePrefab(template: StubNode): any {
+    return { __prefabNode__: template, _destroyed: false };
+}
+
+interface IWorldOptions {
+    /** uuid → 桩 Prefab;未登记的 uuid 会走 loadAny 失败 → import JSON 404 → 降级路径。 */
+    assets?: Record<string, any>;
+    /** `/scene/node-type-config` 的响应;null 表示该路由 404。 */
+    table?: unknown;
+    /** `/scene/asset-meta` 的响应表:dbURL → { uuid, type, name, subAssets? };未登记的 dbURL 404。 */
+    assetMeta?: Record<string, { uuid: string; type: string; name: string; subAssets?: Array<{ uuid: string; type: string; name: string }> }>;
+}
+
+interface IWorld {
+    agent: any;
+    scene: StubScene;
+    cc: any;
+    events: Array<{ type: string; payload: any }>;
+    loadedUuids: string[];
+    /** 建好初始树之后再 start,避免基线快照缺节点导致首次 flush 误报 node:added。 */
+    start(): void;
+    node(name: string, parent: StubNode): StubNode;
+    childNames(parent: StubNode): string[];
+    eventsOf(type: string): any[];
+}
+
+const liveAgents: any[] = [];
+
+function loadAgentFactory(fetchImpl: unknown): (env: any) => any {
+    const source = fs.readFileSync(AGENT_SOURCE_PATH, 'utf8');
+    const exportsFound = source.match(/^export /gm) || [];
+    // 只允许唯一导出:一旦有人加了第二个 export,下面的裸 new Function 求值就不再成立,必须显式失败。
+    if (exportsFound.length !== 1) {
+        throw new Error(`preview-inspect.js is expected to have exactly 1 top-level export, found ${exportsFound.length}`);
+    }
+    const body = `${source.replace(/^export function /m, 'function ')}\nreturn { createPreviewInspect };`;
+    const evaluate = new Function('fetch', body) as (f: unknown) => { createPreviewInspect: (env: any) => any };
+    return evaluate(fetchImpl).createPreviewInspect;
+}
+
+function createWorld(options: IWorldOptions = {}): IWorld {
+    const assets = options.assets || {};
+    const table = 'table' in options ? options.table : NODE_TYPE_TABLE;
+    const loadedUuids: string[] = [];
+    const events: Array<{ type: string; payload: any }> = [];
+    const scene = new StubScene('Scene');
+
+    const fetchImpl = async (url: string): Promise<any> => {
+        if (url.endsWith('/scene/node-type-config')) {
+            return table === null
+                ? { ok: false, status: 404, json: async () => ({}) }
+                : { ok: true, status: 200, json: async () => table };
+        }
+        if (url.includes('/scene/asset-meta')) {
+            const metaTable = options.assetMeta || {};
+            const dbURL = decodeURIComponent(url.split('dbURL=')[1] || '');
+            const info = metaTable[dbURL];
+            return info
+                ? { ok: true, status: 200, json: async () => info }
+                : { ok: false, status: 404, json: async () => ({ error: `asset not found: ${dbURL}` }) };
+        }
+        // 内置资源的 import JSON 兜底路径:桩里一律 404,让「loadAny 失败」直接走到降级分支。
+        return { ok: false, status: 404, json: async () => ({}) };
+    };
+
+    const cc: any = {
+        Node: StubNode,
+        Scene: StubScene,
+        Canvas: StubCanvas,
+        UITransform: StubUITransform,
+        Vec3: class Vec3 {
+            constructor(public x = 0, public y = 0, public z = 0) { }
+        },
+        Object: { Flags: { HideInHierarchy: 1 << 9, LockedInEditor: 1 << 8 } },
+        director: { getScene: () => scene },
+        isValid: (obj: any) => Boolean(obj) && !obj._destroyed,
+        js: {
+            getClassName: (ctor: any) => {
+                if (typeof ctor !== 'function' || !ctor.name) {
+                    return '';
+                }
+                if (ctor === StubScene) {
+                    return 'cc.Scene';
+                }
+                if (ctor === StubNode) {
+                    return 'cc.Node';
+                }
+                return `cc.${String(ctor.name).replace(/^Stub/, '')}`;
+            },
+        },
+        instantiate: (target: any) => {
+            if (target && target.__prefabNode__) {
+                return cloneNode(target.__prefabNode__);
+            }
+            return target instanceof StubNode ? cloneNode(target) : null;
+        },
+        assetManager: {
+            loadAny: ({ uuid }: { uuid: string }, callback: (err: unknown, asset?: unknown) => void) => {
+                loadedUuids.push(uuid);
+                const asset = assets[uuid];
+                callback(asset ? null : new Error(`asset '${uuid}' is not registered`), asset);
+            },
+            loadWithJson: (
+                _json: unknown,
+                _options: unknown,
+                _progress: unknown,
+                complete: (err: unknown, asset?: unknown) => void,
+            ) => complete(new Error('loadWithJson is not supported in the stub')),
+        },
+    };
+
+    const createPreviewInspect = loadAgentFactory(fetchImpl);
+    const agent = createPreviewInspect({ cc, serverURL: 'http://localhost:7456' });
+    liveAgents.push(agent);
+
+    return {
+        agent,
+        scene,
+        cc,
+        events,
+        loadedUuids,
+        start: () => agent.start((type: string, payload: unknown) => events.push({ type, payload })),
+        node: (name: string, parent: StubNode) => {
+            const created = new StubNode(name);
+            created.setParent(parent);
+            return created;
+        },
+        childNames: (parent: StubNode) => parent.children.map(child => child.name),
+        eventsOf: (type: string) => events.filter(event => event.type === type).map(event => event.payload),
+    };
+}
+
+afterEach(() => {
+    // 每个 agent 的 start() 都挂了 150ms 轮询定时器;不 stop 会把句柄留到进程退出。
+    while (liveAgents.length > 0) {
+        try {
+            liveAgents.pop().stop();
+        } catch {
+            /* 已 stop 过,忽略 */
+        }
+    }
+});
+
+// ---- 路径索引 ------------------------------------------------------------
+
+describe('preview-inspect 路径索引', () => {
+    it('非法字符替换为 _、同级重名加 _00N 后缀(与编辑态编码规则一致)', () => {
+        const world = createWorld();
+        const first = world.node('Foo', world.scene);
+        const second = world.node('Foo', world.scene);
+        const weird = world.node('a/b:c*d', world.scene);
+        world.start();
+
+        expect(world.agent.getPathByUuid(first.uuid)).toBe('Foo');
+        expect(world.agent.getPathByUuid(second.uuid)).toBe('Foo_001');
+        expect(world.agent.getPathByUuid(weird.uuid)).toBe('a_b_c_d');
+    });
+
+    it('HideInHierarchy 节点不进索引;场景根是 "/";未知 uuid 返回空串', () => {
+        const world = createWorld();
+        const hidden = world.node('Hidden', world.scene);
+        hidden._objFlags = world.cc.Object.Flags.HideInHierarchy;
+        world.start();
+
+        expect(world.agent.getPathByUuid(hidden.uuid)).toBe('');
+        expect(world.agent.getPathByUuid(world.scene.uuid)).toBe('/');
+        expect(world.agent.getPathByUuid('no-such-uuid')).toBe('');
+    });
+});
+
+// ---- 类型化创建 ----------------------------------------------------------
+
+describe('preview-inspect create-by-type', () => {
+    it('Empty 走 new cc.Node:挂到目标父级、继承 layer、即时发出 node:added、可撤销', async () => {
+        const world = createWorld();
+        const parent = world.node('Parent', world.scene);
+        parent.layer = 42;
+        world.start();
+
+        const dump = await world.agent.createNodeByType({ path: 'Parent', nodeType: 'Empty', name: 'Hero' });
+
+        expect(dump.path).toBe('Parent/Hero');
+        expect(world.childNames(parent)).toEqual(['Hero']);
+        expect(parent.children[0].layer).toBe(42);
+        // 不等 150ms 轮询:写操作末尾同步 flush 一次。
+        expect(world.eventsOf('node:added')).toEqual([{ path: 'Parent/Hero' }]);
+        expect(world.agent.canUndo()).toBe(true);
+
+        const undo = world.agent.undo();
+        expect(undo).toEqual({ success: true, label: 'Create Empty' });
+        expect(parent.children).toHaveLength(0);
+        expect(world.agent.redo()).toEqual({ success: true, label: 'Create Empty' });
+        expect(world.childNames(parent)).toEqual(['Hero']);
+    });
+
+    it('Canvas 下的空节点自动补 UITransform', async () => {
+        const world = createWorld();
+        const canvas = world.node('Canvas', world.scene);
+        canvas.addComponent(StubCanvas);
+        world.start();
+
+        await world.agent.createNodeByType({ path: 'Canvas', nodeType: 'Empty' });
+
+        expect(canvas.children[0].getComponent(StubUITransform)).toBeTruthy();
+    });
+
+    it('内置 Prefab 类型走 instantiate,不产生降级 warn', async () => {
+        const template = new StubNode('Cube');
+        const world = createWorld({ assets: { [CUBE_UUID]: makePrefab(template) } });
+        world.start();
+
+        const dump = await world.agent.createNodeByType({ path: '/', nodeType: 'Cube' });
+
+        expect(dump.path).toBe('Cube');
+        expect(world.childNames(world.scene)).toEqual(['Cube']);
+        // prefab 元数据必须摘掉:预览永不回盘,残留会让 Inspector 显示错误的关联状态。
+        expect(world.scene.children[0]._prefab).toBeNull();
+        expect(world.eventsOf('view:log')).toEqual([]);
+    });
+
+    it('Prefab 加载失败降级为空节点 + view:log warn,创建本身仍然成功', async () => {
+        const world = createWorld(); // 未登记任何资源 → loadAny 失败 → import JSON 404
+        world.start();
+
+        const dump = await world.agent.createNodeByType({ path: '/', nodeType: 'Cube' });
+
+        expect(dump.path).toBe('Cube');
+        expect(world.childNames(world.scene)).toEqual(['Cube']);
+        const logs = world.eventsOf('view:log');
+        expect(logs).toHaveLength(1);
+        expect(logs[0].level).toBe('warn');
+        expect(logs[0].message).toContain("create 'Cube' fell back to an empty node");
+        // 降级也必须留下 undo 记录,否则用户撤销不掉这个节点。
+        expect(world.agent.canUndo()).toBe(true);
+    });
+
+    it('workMode 与 project-type 不符且存在备选时取第 2 项(Canvas 的 2d/3d 变体)', async () => {
+        const world = createWorld({
+            assets: {
+                [CANVAS_PREFAB_UUID_2D]: makePrefab(new StubNode('Canvas2D')),
+                [CANVAS_PREFAB_UUID_3D]: makePrefab(new StubNode('Canvas3D')),
+            },
+        });
+        world.start();
+
+        await world.agent.createNodeByType({ path: '/', nodeType: 'Canvas', workMode: '3d' });
+
+        expect(world.loadedUuids).toEqual([CANVAS_PREFAB_UUID_3D]);
+        expect(world.childNames(world.scene)).toEqual(['Canvas3D']);
+    });
+
+    it('canvasRequired 在无 Canvas 场景下自动补 Canvas,且整体只算一步 undo', async () => {
+        const canvasTemplate = new StubNode('Canvas');
+        canvasTemplate.addComponent(StubCanvas);
+        const world = createWorld({
+            assets: {
+                [CANVAS_PREFAB_UUID_2D]: makePrefab(canvasTemplate),
+                [BUTTON_UUID]: makePrefab(new StubNode('Button')),
+            },
+        });
+        world.start();
+
+        const dump = await world.agent.createNodeByType({ path: '/', nodeType: 'Button', workMode: '2d' });
+
+        expect(dump.path).toBe('Canvas/Button');
+        expect(world.childNames(world.scene)).toEqual(['Canvas']);
+        expect(world.childNames(world.scene.children[0])).toEqual(['Button']);
+
+        // 自动补的 Canvas 与 Button 由 _asOneCommand 合成单步:一次 Ctrl+Z 应把两者一起撤掉。
+        expect(world.agent.undo().success).toBe(true);
+        expect(world.scene.children).toHaveLength(0);
+        expect(world.agent.canUndo()).toBe(false);
+    });
+
+    it('未实现的类型 / 缺 nodeType 直接抛,且不留下空 undo 步骤', async () => {
+        const world = createWorld();
+        world.start();
+
+        await expect(world.agent.createNodeByType({ path: '/', nodeType: 'NoSuchType' }))
+            .rejects.toThrow(/is not implemented/);
+        await expect(world.agent.createNodeByType({ path: '/' })).rejects.toThrow(/nodeType is required/);
+        expect(world.agent.canUndo()).toBe(false);
+    });
+
+    it('node-type-config 路由不可用时抛出可定位的错误,并允许下次重试', async () => {
+        const world = createWorld({ table: null });
+        world.start();
+
+        await expect(world.agent.createNodeByType({ path: '/', nodeType: 'Empty' }))
+            .rejects.toThrow(/failed to load the node type config/);
+        // pending promise 已被清掉 → 再试一次仍然是「重新请求后失败」,而不是拿到脏缓存。
+        await expect(world.agent.createNodeByType({ path: '/', nodeType: 'Empty' }))
+            .rejects.toThrow(/failed to load the node type config/);
+    });
+});
+
+// ---- 删除 / 改名 --------------------------------------------------------
+
+describe('preview-inspect delete / rename', () => {
+    it('delete 只摘除不 destroy,发出 node:removed,undo 原位复活', () => {
+        const world = createWorld();
+        const parent = world.node('Parent', world.scene);
+        world.node('A', parent);
+        const target = world.node('B', parent);
+        world.node('C', parent);
+        world.start();
+
+        world.agent.deleteNode({ path: 'Parent/B' });
+
+        expect(world.childNames(parent)).toEqual(['A', 'C']);
+        // 关键:节点没被 destroy,引用交给 undo 栈持有(对齐编辑态 baseRemoveNode)。
+        expect(target._destroyed).toBe(false);
+        expect(world.eventsOf('node:removed')).toEqual([{ path: 'Parent/B' }]);
+
+        expect(world.agent.undo()).toEqual({ success: true, label: 'Delete Node' });
+        expect(world.childNames(parent)).toEqual(['A', 'B', 'C']);
+    });
+
+    it('删除场景根 / 不存在的路径都抛错', () => {
+        const world = createWorld();
+        world.start();
+
+        expect(() => world.agent.deleteNode({ path: '/' })).toThrow(/scene root cannot be modified/);
+        expect(() => world.agent.deleteNode({ path: 'Ghost' })).toThrow(/node not found/);
+    });
+
+    it('rename(set-property name)重建索引并单独记 undo', () => {
+        const world = createWorld();
+        const parent = world.node('Parent', world.scene);
+        const target = world.node('A', parent);
+        world.start();
+
+        world.agent.setProperty({ nodePath: 'Parent/A', path: 'name', dump: { type: 'String', value: 'Renamed' } });
+
+        expect(target.name).toBe('Renamed');
+        // 名字是路径的一部分:不重建索引,后续所有按 path 的定位都会指向旧名。
+        expect(world.agent.getPathByUuid(target.uuid)).toBe('Parent/Renamed');
+        expect(world.agent.undo()).toEqual({ success: true, label: 'Rename Node' });
+        expect(target.name).toBe('A');
+        expect(world.agent.getPathByUuid(target.uuid)).toBe('Parent/A');
+    });
+});
+
+// ---- 移动 / 排序 / 锁定 -------------------------------------------------
+
+describe('preview-inspect set-parent / reorder / lock', () => {
+    it('set-parent 返回移动后的路径,undo 回到原父级与原兄弟位置', () => {
+        const world = createWorld();
+        const from = world.node('From', world.scene);
+        const to = world.node('To', world.scene);
+        world.node('X', from);
+        const moved = world.node('A', from);
+        world.start();
+
+        const paths = world.agent.setParent({ paths: ['From/A'], parentPath: 'To' });
+
+        expect(paths).toEqual(['To/A']);
+        expect(world.childNames(to)).toEqual(['A']);
+        expect(world.agent.undo()).toEqual({ success: true, label: 'Move Nodes' });
+        expect(world.childNames(from)).toEqual(['X', 'A']);
+        expect(moved.getSiblingIndex()).toBe(1);
+    });
+
+    it('set-parent 环检测在任何写入之前完成(自身/后代做父级都抛且不留脏状态)', () => {
+        const world = createWorld();
+        const root = world.node('Root', world.scene);
+        world.node('Child', root);
+        world.start();
+
+        expect(() => world.agent.setParent({ paths: ['Root'], parentPath: 'Root/Child' }))
+            .toThrow(/cannot set parent to the node itself or its descendant/);
+        expect(() => world.agent.setParent({ paths: ['Root'], parentPath: 'Root' }))
+            .toThrow(/cannot set parent to the node itself or its descendant/);
+
+        expect(world.childNames(world.scene)).toEqual(['Root']);
+        expect(world.childNames(root)).toEqual(['Child']);
+        expect(world.agent.canUndo()).toBe(false);
+    });
+
+    it('reorder 的 path 是父节点路径,target/offset 语义对齐编辑态,可撤销', () => {
+        const world = createWorld();
+        const parent = world.node('Parent', world.scene);
+        world.node('A', parent);
+        world.node('B', parent);
+        world.node('C', parent);
+        world.start();
+
+        expect(world.agent.reorder({ path: 'Parent', target: 0, offset: 2 })).toBe(true);
+
+        expect(world.childNames(parent)).toEqual(['B', 'C', 'A']);
+        expect(world.agent.undo()).toEqual({ success: true, label: 'Reorder Node' });
+        expect(world.childNames(parent)).toEqual(['A', 'B', 'C']);
+    });
+
+    it('reorder 参数非法时返回 false 而不抛', () => {
+        const world = createWorld();
+        const parent = world.node('Parent', world.scene);
+        world.node('A', parent);
+        world.start();
+
+        expect(world.agent.reorder({ path: 'Parent', target: 'x', offset: 0 })).toBe(false);
+        expect(world.agent.reorder({ path: 'Parent', target: 99, offset: 0 })).toBe(false);
+        expect(world.agent.canUndo()).toBe(false);
+    });
+
+    it('change-node-lock 写节点自身 objFlags 的 LockedInEditor 位,回推 node:change(propPath:locked)', () => {
+        const world = createWorld();
+        const target = world.node('A', world.scene);
+        const child = world.node('Inner', target);
+        world.start();
+        const flag = world.cc.Object.Flags.LockedInEditor;
+
+        world.agent.changeNodeLock({ paths: ['A'], locked: true, loop: true });
+
+        expect(target._objFlags & flag).toBe(flag);
+        expect(child._objFlags & flag).toBe(flag);
+        const changes = world.eventsOf('node:change');
+        expect(changes).toHaveLength(2);
+        expect(changes[0].change).toEqual({ propPath: 'locked', source: 'engine' });
+        expect(changes[0].node.locked.value).toBe(true);
+
+        expect(world.agent.undo()).toEqual({ success: true, label: 'Lock Node' });
+        expect(target._objFlags & flag).toBe(0);
+        expect(child._objFlags & flag).toBe(0);
+    });
+});
+
+// ---- 剪贴板 ------------------------------------------------------------
+
+describe('preview-inspect 剪贴板', () => {
+    it('copy 存离线副本:源节点被删除后仍可粘贴,clipboard-state 的 paths 按当前索引过滤', () => {
+        const world = createWorld();
+        const parent = world.node('Parent', world.scene);
+        world.node('A', parent);
+        world.start();
+
+        expect(world.agent.copyNodes({ paths: ['Parent/A'] })).toEqual(['Parent/A']);
+        expect(world.agent.queryClipboardState()).toEqual({ type: 'copy', paths: ['Parent/A'] });
+
+        world.agent.deleteNode({ path: 'Parent/A' });
+        // 源节点已不在树上:Paste 依旧可用,但 paths 被过滤(与编辑态一致,避免显示幽灵路径)。
+        expect(world.agent.queryClipboardState()).toEqual({ type: 'copy', paths: [] });
+
+        expect(world.agent.pasteNodes({ parentPath: 'Parent' })).toEqual(['Parent/A']);
+        expect(world.childNames(parent)).toEqual(['A']);
+    });
+
+    it('paste 到仍有同名兄弟的父级时唯一化名字,并可整体撤销', () => {
+        const world = createWorld();
+        const parent = world.node('Parent', world.scene);
+        world.node('A', parent);
+        world.start();
+
+        world.agent.copyNodes({ paths: ['Parent/A'] });
+        const pasted = world.agent.pasteNodes({ parentPath: 'Parent' });
+
+        expect(pasted).toEqual(['Parent/A-001']);
+        expect(world.childNames(parent)).toEqual(['A', 'A-001']);
+        expect(world.agent.undo()).toEqual({ success: true, label: 'Paste Nodes' });
+        expect(world.childNames(parent)).toEqual(['A']);
+    });
+
+    it('cut + paste 是移动(不产生新节点),且剪贴板被消费', () => {
+        const world = createWorld();
+        const from = world.node('From', world.scene);
+        const to = world.node('To', world.scene);
+        const moved = world.node('A', from);
+        world.start();
+
+        expect(world.agent.cutNodes({ paths: ['From/A'] })).toEqual(['From/A']);
+        expect(world.agent.queryClipboardState()).toEqual({ type: 'cut', paths: ['From/A'] });
+
+        expect(world.agent.pasteNodes({ parentPath: 'To' })).toEqual(['To/A']);
+        expect(to.children).toHaveLength(1);
+        expect(to.children[0]).toBe(moved);
+        expect(from.children).toHaveLength(0);
+        // 剪切是一次性的:粘贴后剪贴板必须清空,否则第二次粘贴会粘出幽灵。
+        expect(world.agent.queryClipboardState()).toEqual({ type: 'none', paths: [] });
+    });
+
+    it('空剪贴板 paste 抛错;copy/cut 场景根抛错', () => {
+        const world = createWorld();
+        world.node('A', world.scene);
+        world.start();
+
+        expect(() => world.agent.pasteNodes({ parentPath: '/' })).toThrow(/no nodes have been copied/);
+        expect(() => world.agent.copyNodes({ paths: ['/'] })).toThrow(/scene root cannot be modified/);
+        expect(() => world.agent.cutNodes({ paths: ['/'] })).toThrow(/scene root cannot be modified/);
+    });
+
+    it('duplicate 把副本挂在源节点同一父级下并顺次唯一化名字', () => {
+        const world = createWorld();
+        const parent = world.node('Parent', world.scene);
+        world.node('A', parent);
+        world.start();
+
+        expect(world.agent.duplicateNodes({ paths: ['Parent/A'] })).toEqual(['Parent/A-001']);
+        expect(world.agent.duplicateNodes({ paths: ['Parent/A'] })).toEqual(['Parent/A-002']);
+        expect(world.childNames(parent)).toEqual(['A', 'A-001', 'A-002']);
+
+        expect(world.agent.undo()).toEqual({ success: true, label: 'Duplicate Nodes' });
+        expect(world.childNames(parent)).toEqual(['A', 'A-001']);
+    });
+});
+
+// ---- 预览内独立 undo 栈 -------------------------------------------------
+
+describe('preview-inspect 预览内独立 undo 栈', () => {
+    it('group 把多个写操作合成单步(嵌套 begin 只在最外层开栈)', () => {
+        const world = createWorld();
+        const parent = world.node('Parent', world.scene);
+        world.node('A', parent);
+        world.node('B', parent);
+        world.start();
+
+        const token = world.agent.beginGroup({ label: 'Batch Delete' });
+        expect(world.agent.isGroupActive()).toBe(true);
+        // host 侧 sceneOps 也会开 group,嵌套时必须复用同一个 id。
+        expect(world.agent.beginGroup({ label: 'Inner' })).toBe(token);
+        world.agent.deleteNode({ path: 'Parent/A' });
+        world.agent.deleteNode({ path: 'Parent/B' });
+        expect(world.agent.endGroup(token)).toEqual({ success: true, commandId: token, label: 'Batch Delete' });
+        expect(world.agent.isGroupActive()).toBe(true);
+        expect(world.agent.endGroup(token)).toEqual({ success: true, commandId: token, label: 'Batch Delete' });
+
+        expect(parent.children).toHaveLength(0);
+        expect(world.agent.undo()).toEqual({ success: true, label: 'Batch Delete' });
+        expect(world.childNames(parent)).toEqual(['A', 'B']);
+        expect(world.agent.canUndo()).toBe(false);
+    });
+
+    it('cancel-group 逐条逆序回滚且不入栈', () => {
+        const world = createWorld();
+        const parent = world.node('Parent', world.scene);
+        world.node('A', parent);
+        world.start();
+
+        const token = world.agent.beginGroup({ label: 'Attempt' });
+        world.agent.deleteNode({ path: 'Parent/A' });
+        expect(world.agent.cancelGroup(token)).toEqual({ success: true, commandId: token, label: 'Attempt' });
+
+        expect(world.childNames(parent)).toEqual(['A']);
+        expect(world.agent.canUndo()).toBe(false);
+    });
+
+    it('group 未结束时 undo/redo 返回 success:false;非法 token 与无 group 也只返回结构化结果', () => {
+        const world = createWorld();
+        world.start();
+
+        expect(world.agent.endGroup('nope')).toEqual({ success: false, reason: 'preview end-group: no active undo group' });
+        expect(world.agent.cancelGroup()).toEqual({ success: false, reason: 'preview cancel-group: no active undo group' });
+
+        const token = world.agent.beginGroup({ label: 'Open' });
+        expect(world.agent.undo().success).toBe(false);
+        expect(world.agent.redo().success).toBe(false);
+        expect(world.agent.endGroup('wrong-token').success).toBe(false);
+        world.agent.endGroup(token);
+    });
+
+    it('空栈 undo/redo 不抛,返回 history is empty;新命令清空 redo 栈', () => {
+        const world = createWorld();
+        const parent = world.node('Parent', world.scene);
+        world.node('A', parent);
+        world.start();
+
+        expect(world.agent.undo()).toEqual({ success: false, reason: 'preview undo: history is empty' });
+        expect(world.agent.redo()).toEqual({ success: false, reason: 'preview redo: history is empty' });
+
+        world.agent.deleteNode({ path: 'Parent/A' });
+        world.agent.undo();
+        expect(world.agent.canRedo()).toBe(true);
+        // 撤销后又做了新操作 → redo 分支必须丢弃。
+        world.agent.setProperty({ nodePath: 'Parent/A', path: 'name', dump: { type: 'String', value: 'A2' } });
+        expect(world.agent.canRedo()).toBe(false);
+    });
+
+    it('isDirty 恒 false:预览改动绝不让编辑器 tab 变 dirty(停止即丢弃)', () => {
+        const world = createWorld();
+        const parent = world.node('Parent', world.scene);
+        world.node('A', parent);
+        world.start();
+
+        world.agent.deleteNode({ path: 'Parent/A' });
+
+        expect(world.agent.isDirty()).toBe(false);
+    });
+});
+
+// ---- 停止即丢弃 --------------------------------------------------------
+
+describe('preview-inspect 停止即丢弃', () => {
+    it('stop() 销毁被 undo 栈持有的游离节点与剪贴板离线副本,并清空历史', () => {
+        const world = createWorld();
+        const parent = world.node('Parent', world.scene);
+        const deleted = world.node('A', parent);
+        world.node('B', parent);
+        world.start();
+
+        world.agent.copyNodes({ paths: ['Parent/B'] });
+        const stashed = (world.agent as any)._clipboard.entries[0].instant;
+        world.agent.deleteNode({ path: 'Parent/A' });
+
+        world.agent.stop();
+
+        expect(deleted._destroyed).toBe(true);
+        expect(stashed._destroyed).toBe(true);
+        expect(world.agent.canUndo()).toBe(false);
+        expect(world.agent.canRedo()).toBe(false);
+    });
+
+    it('clearHistory() 同样销毁游离节点(它们已不可能被复活)', () => {
+        const world = createWorld();
+        const parent = world.node('Parent', world.scene);
+        const deleted = world.node('A', parent);
+        world.start();
+
+        world.agent.deleteNode({ path: 'Parent/A' });
+        world.agent.clearHistory();
+
+        expect(deleted._destroyed).toBe(true);
+        expect(world.agent.canUndo()).toBe(false);
+    });
+
+    it('stop() 之后不再发事件(sink 已解绑,轮询定时器已清)', () => {
+        const world = createWorld();
+        const parent = world.node('Parent', world.scene);
+        world.node('A', parent);
+        world.start();
+
+        world.agent.stop();
+        const before = world.events.length;
+        world.node('Late', parent);
+        (world.agent as any)._flushStructure();
+
+        expect(world.events.length).toBe(before);
+    });
+});
+
+// ---- M5 组件操作 --------------------------------------------------------
+
+class StubLabel extends StubComponent {
+    public content = 'hello';
+    public fontSize = 20;
+    public offset = { x: 1, y: 2 };
+    public _destroyed = false;
+    destroy(): boolean {
+        this._destroyed = true;
+        return true;
+    }
+}
+(StubLabel as any).__props__ = ['content', 'fontSize', 'offset'];
+
+class StubBadge extends StubComponent { }
+
+describe('preview-inspect M5 组件操作', () => {
+    it('removeComponent 摘除不 destroy、发 node:change(__comps__)、undo 原位复活', () => {
+        const world = createWorld();
+        const ui = world.node('UI', world.scene);
+        const label = ui.addComponent(StubLabel) as StubLabel;
+        ui.addComponent(StubBadge);
+        world.start();
+
+        world.agent.removeComponent({ path: 'UI/cc.Label' });
+
+        expect(ui._components).toHaveLength(1);
+        expect(ui._components[0]).toBeInstanceOf(StubBadge);
+        expect(label._destroyed).toBe(false); // 摘除不 destroy,等待 undo 复活
+        const changes = world.eventsOf('node:change');
+        expect(changes[changes.length - 1].change).toEqual({ propPath: '__comps__', source: 'engine' });
+        expect(world.agent.canUndo()).toBe(true);
+
+        expect(world.agent.undo()).toEqual({ success: true, label: 'Remove Component' });
+        expect(ui._components).toHaveLength(2);
+        expect(ui._components[0]).toBe(label); // 原位复活
+        expect(world.agent.redo()).toEqual({ success: true, label: 'Remove Component' });
+        expect(ui._components).toHaveLength(1);
+        expect(ui._components[0]).toBeInstanceOf(StubBadge);
+    });
+
+    it('removeComponent 对不存在的组件抛可定位错误,且不留 undo 步骤', () => {
+        const world = createWorld();
+        world.node('UI', world.scene);
+        world.start();
+
+        expect(() => world.agent.removeComponent({ path: 'UI/cc.Label' })).toThrow(/component not found/);
+        expect(world.agent.canUndo()).toBe(false);
+    });
+
+    it('stop() 销毁被摘除的游离组件(停止即丢弃)', () => {
+        const world = createWorld();
+        const ui = world.node('UI', world.scene);
+        const label = ui.addComponent(StubLabel) as StubLabel;
+        world.start();
+
+        world.agent.removeComponent({ path: 'UI/cc.Label' });
+        world.agent.stop();
+
+        expect(label._destroyed).toBe(true);
+    });
+
+    it('resetComponent 恢复临时默认值并合成单步 undo;undo 还原改值', () => {
+        const world = createWorld();
+        const ui = world.node('UI', world.scene);
+        const label = ui.addComponent(StubLabel) as StubLabel;
+        world.start();
+
+        label.content = 'changed';
+        label.fontSize = 99;
+        world.agent.resetComponent({ path: 'UI/cc.Label' });
+
+        expect(label.content).toBe('hello');
+        expect(label.fontSize).toBe(20);
+        expect(world.agent.undo()).toEqual({ success: true, label: 'Reset Component' });
+        expect(label.content).toBe('changed');
+        expect(label.fontSize).toBe(99);
+        expect(world.agent.canUndo()).toBe(false);
+    });
+
+    it('moveArrayElement 交换组件顺序、undo 反交换;越界与非 __comps__ 路径直接抛', () => {
+        const world = createWorld();
+        const ui = world.node('UI', world.scene);
+        const label = ui.addComponent(StubLabel);
+        const badge = ui.addComponent(StubBadge);
+        world.start();
+
+        world.agent.moveArrayElement({ nodePath: 'UI', path: '__comps__', target: 0, offset: 1 });
+        expect(ui._components[0]).toBe(badge);
+        expect(ui._components[1]).toBe(label);
+
+        expect(world.agent.undo().success).toBe(true);
+        expect(ui._components[0]).toBe(label);
+        expect(ui._components[1]).toBe(badge);
+
+        expect(() => world.agent.moveArrayElement({ nodePath: 'UI', path: '__comps__', target: 1, offset: 1 })).toThrow(/out of range/);
+        expect(() => world.agent.moveArrayElement({ nodePath: 'UI', path: 'children', target: 0, offset: 1 })).toThrow(/__comps__/);
+    });
+
+    it('节点 dump 的组件带 component_path(同级去重),kebab 菜单可据此直接定位 remove/reset', () => {
+        const world = createWorld();
+        const ui = world.node('UI', world.scene);
+        ui.addComponent(StubLabel);
+        ui.addComponent(StubLabel);
+        ui.addComponent(StubBadge);
+        world.start();
+
+        const dump = world.agent.query({ path: 'UI' });
+        expect(dump.__comps__.map((c: any) => c.component_path)).toEqual([
+            'UI/cc.Label',
+            'UI/cc.Label_001',
+            'UI/cc.Badge',
+        ]);
+
+        // 回归:面板用 dump 里的 component_path 调菜单操作,必须命中同名去重后的正确实例。
+        world.agent.resetComponent({ path: dump.__comps__[1].component_path });
+        const label2 = ui._components[1] as StubLabel;
+        expect(label2.content).toBe('hello');
+        world.agent.removeComponent({ path: dump.__comps__[1].component_path });
+        expect(ui._components).toHaveLength(2);
+        expect(ui._components[1]).toBeInstanceOf(StubBadge);
+    });
+
+    it('setProperty 整包形态逐键应用 visible 键、跳过 visible:false 与骨架键,undo 还原', () => {
+        const world = createWorld();
+        const ui = world.node('UI', world.scene);
+        const label = ui.addComponent(StubLabel) as StubLabel;
+        const originalUuid = label.uuid;
+        world.start();
+
+        world.agent.setProperty({
+            nodePath: 'UI',
+            path: '__comps__.0',
+            dump: {
+                value: {
+                    content: { type: 'String', value: 'pasted' },
+                    fontSize: { type: 'Number', value: 32 },
+                    offset: { type: 'cc.Vec2', value: { x: 7, y: 8 }, visible: false },
+                    uuid: { type: 'String', value: 'comp-evil' },
+                },
+            },
+        });
+
+        expect(label.content).toBe('pasted');
+        expect(label.fontSize).toBe(32);
+        expect(label.offset).toEqual({ x: 1, y: 2 }); // visible:false 跳过
+        expect(label.uuid).toBe(originalUuid); // 骨架键跳过
+
+        expect(world.agent.undo().success).toBe(true);
+        expect(label.content).toBe('hello');
+        expect(label.fontSize).toBe(20);
+    });
+});
+
+// ---- M6 按资产创建 ------------------------------------------------------
+
+class StubPrefab {
+    public _destroyed = false;
+    constructor(public __prefabNode__: StubNode) { }
+}
+class StubSprite extends StubComponent {
+    public spriteFrame: unknown = null;
+}
+class StubSpriteFrame {
+    public _destroyed = false;
+    public texture: unknown = null;
+}
+class StubAudioClip {
+    public _destroyed = false;
+}
+class StubImageAsset {
+    public _destroyed = false;
+}
+class StubTexture2D {
+    public _destroyed = false;
+    public image: unknown = null;
+}
+class StubAudioSource extends StubComponent {
+    public clip: unknown = null;
+}
+class StubMaterial {
+    public _destroyed = false;
+}
+
+describe('preview-inspect M6 按资产创建', () => {
+    it('Prefab 拖拽:instantiate + 摘 prefab 元数据 + 即时 node:added + 可撤销', async () => {
+        const uuid = 'hero-prefab-uuid';
+        const world = createWorld({
+            assets: { [uuid]: new StubPrefab(new StubNode('Hero')) },
+            assetMeta: { 'db://assets/hero.prefab': { uuid, type: 'cc.Prefab', name: 'hero' } },
+        });
+        const canvas = world.node('Canvas', world.scene);
+        world.start();
+
+        const dump = await world.agent.createByAsset({ dbURL: 'db://assets/hero.prefab', path: 'Canvas' });
+
+        expect(dump.path).toBe('Canvas/Hero');
+        expect(canvas.children).toHaveLength(1);
+        expect(canvas.children[0]._prefab).toBeNull(); // 预览永不回盘,prefab 元数据必须摘掉
+        expect(world.eventsOf('node:added')).toEqual([{ path: 'Canvas/Hero' }]);
+        expect(world.agent.undo().success).toBe(true);
+        expect(canvas.children).toHaveLength(0);
+    });
+
+    it('SpriteFrame 拖拽:新节点 + UITransform + Sprite,2d 自动补 Canvas 父级', async () => {
+        const world = createWorld({
+            assets: {
+                [CANVAS_PREFAB_UUID_2D]: makePrefab(new StubNode('Canvas2D')),
+                'sf-uuid': new StubSpriteFrame(),
+            },
+            assetMeta: { 'db://assets/logo.spriteFrame': { uuid: 'sf-uuid', type: 'cc.SpriteFrame', name: 'logo' } },
+        });
+        world.cc.Sprite = StubSprite;
+        world.cc.SpriteFrame = StubSpriteFrame;
+        world.start();
+
+        const dump = await world.agent.createByAsset({ dbURL: 'db://assets/logo.spriteFrame', path: '/', workMode: '2d' });
+
+        expect(world.childNames(world.scene)).toEqual(['Canvas2D']);
+        const canvas = world.scene.children[0];
+        expect(world.childNames(canvas)).toEqual(['logo']);
+        const spriteNode = canvas.children[0];
+        expect(spriteNode.getComponent(StubUITransform)).toBeTruthy();
+        const sprite = spriteNode.getComponent(StubSprite) as StubSprite;
+        expect(sprite).toBeTruthy();
+        expect(sprite.spriteFrame).toBeInstanceOf(StubSpriteFrame);
+        expect(dump.path).toBe('Canvas2D/logo');
+    });
+
+    it('AudioClip 拖拽:新节点 + AudioSource 挂 clip', async () => {
+        const clip = new StubAudioClip();
+        const world = createWorld({
+            assets: { 'clip-uuid': clip },
+            assetMeta: { 'db://assets/bgm.mp3': { uuid: 'clip-uuid', type: 'cc.AudioClip', name: 'bgm' } },
+        });
+        world.cc.AudioSource = StubAudioSource;
+        world.start();
+
+        await world.agent.createByAsset({ dbURL: 'db://assets/bgm.mp3', path: '/' });
+
+        const node = world.scene.children[0];
+        expect(node.name).toBe('bgm');
+        const source = node.getComponent(StubAudioSource) as StubAudioSource;
+        expect(source).toBeTruthy();
+        expect(source.clip).toBe(clip);
+    });
+
+    it('ImageAsset 拖拽:节点名去扩展后缀,spriteFrame 优先挂 asset-db 真子资产(可索引回 Assets)', async () => {
+        const image = new StubImageAsset();
+        const realSf = new StubSpriteFrame();
+        const world = createWorld({
+            assets: {
+                [CANVAS_PREFAB_UUID_2D]: makePrefab(new StubNode('Canvas2D')),
+                'img-uuid': image,
+                'img-uuid@f9941': realSf,
+            },
+            assetMeta: {
+                'db://assets/tex/GreenBtn.png': {
+                    uuid: 'img-uuid',
+                    type: 'cc.ImageAsset',
+                    name: 'GreenBtn.png',
+                    subAssets: [{ uuid: 'img-uuid@f9941', type: 'cc.SpriteFrame', name: 'spriteFrame' }],
+                },
+            },
+        });
+        world.cc.Sprite = StubSprite;
+        world.cc.SpriteFrame = StubSpriteFrame;
+        world.cc.Texture2D = StubTexture2D;
+        world.start();
+
+        await world.agent.createByAsset({ dbURL: 'db://assets/tex/GreenBtn.png', path: '/', workMode: '2d' });
+
+        const canvas = world.scene.children[0];
+        const spriteNode = canvas.children[0];
+        expect(spriteNode.name).toBe('GreenBtn'); // 扩展后缀去掉
+        const sprite = spriteNode.getComponent(StubSprite) as StubSprite;
+        expect(sprite).toBeTruthy();
+        expect(sprite.spriteFrame).toBe(realSf); // 真子资产,非临时包装
+    });
+
+    it('ImageAsset 缺 spriteFrame 子资产时:回退 Texture2D → SpriteFrame 两层临时包装', async () => {
+        const image = new StubImageAsset();
+        const world = createWorld({
+            assets: {
+                [CANVAS_PREFAB_UUID_2D]: makePrefab(new StubNode('Canvas2D')),
+                'img-uuid': image,
+            },
+            assetMeta: { 'db://assets/tex/logo.png': { uuid: 'img-uuid', type: 'cc.ImageAsset', name: 'logo' } },
+        });
+        world.cc.Sprite = StubSprite;
+        world.cc.SpriteFrame = StubSpriteFrame;
+        world.cc.Texture2D = StubTexture2D;
+        world.start();
+
+        await world.agent.createByAsset({ dbURL: 'db://assets/tex/logo.png', path: '/', workMode: '2d' });
+
+        const canvas = world.scene.children[0];
+        const spriteNode = canvas.children[0];
+        expect(spriteNode.name).toBe('logo');
+        const sprite = spriteNode.getComponent(StubSprite) as StubSprite;
+        expect(sprite).toBeTruthy();
+        const sf = sprite.spriteFrame as StubSpriteFrame;
+        expect(sf).toBeInstanceOf(StubSpriteFrame);
+        expect(sf.texture).toBeInstanceOf(StubTexture2D);
+        expect((sf.texture as StubTexture2D).image).toBe(image);
+    });
+
+    it('不支持的类型抛可定位错误,且不留 undo 步骤', async () => {
+        const world = createWorld({
+            assets: { 'mat-uuid': new StubMaterial() },
+            assetMeta: { 'db://assets/m.material': { uuid: 'mat-uuid', type: 'cc.Material', name: 'm' } },
+        });
+        world.start();
+
+        await expect(world.agent.createByAsset({ dbURL: 'db://assets/m.material' }))
+            .rejects.toThrow(/not supported in preview/);
+        expect(world.agent.canUndo()).toBe(false);
+    });
+
+    it('asset-meta 路由缺失时抛可定位错误,允许下次重试', async () => {
+        const world = createWorld(); // 未登记任何 assetMeta → 404
+        world.start();
+
+        await expect(world.agent.createByAsset({ dbURL: 'db://assets/nope.prefab' }))
+            .rejects.toThrow(/failed to load the asset meta/);
+        expect(world.agent.canUndo()).toBe(false);
+    });
+});

--- a/src/core/scene/common/editor/index.ts
+++ b/src/core/scene/common/editor/index.ts
@@ -89,6 +89,12 @@ export interface IEditorService extends IServiceEvents {
     queryCurrent(): Promise<TEditorEntity | null>;
 
     /**
+     * 序列化当前正在编辑的场景（含未保存改动），返回可被 loadWithJson 加载的 JSON 字符串。
+     * 用于「Preview in Editor」把编辑器实时场景交给游戏运行时预览。
+     */
+    querySceneSerializedData(): Promise<string>;
+
+    /**
      *
      */
     getRootNode(): TEditorInstance | null;

--- a/src/core/scene/main-process/proxy/editor-proxy.ts
+++ b/src/core/scene/main-process/proxy/editor-proxy.ts
@@ -45,6 +45,9 @@ export const EditorProxy: IEditorProxy = {
         if (!result) return null;
         return convertEditorResult(result);
     },
+    querySceneSerializedData() {
+        return Rpc.getInstance().request('Editor', 'querySceneSerializedData');
+    },
     hasOpen() {
         return Rpc.getInstance().request('Editor', 'hasOpen');
     }

--- a/src/core/scene/scene-process/service/editor.ts
+++ b/src/core/scene/scene-process/service/editor.ts
@@ -128,6 +128,19 @@ export class EditorService extends BaseService<IEditorEvents> implements IEditor
         return editor ? await editor.encode() : null;
     }
 
+    /**
+     * 序列化当前正在编辑的场景（含未保存改动），返回可被 loadWithJson 加载的 JSON 字符串。
+     * 用于「Preview in Editor」：把编辑器里的实时场景交给游戏运行时预览。
+     * 该方法经 Service proxy 自动暴露到浏览器侧 window.cli.Scene.Editor.querySceneSerializedData。
+     */
+    async querySceneSerializedData(): Promise<string> {
+        const editor = this.currentEditorUuid && this.editorMap.get(this.currentEditorUuid);
+        if (editor instanceof SceneEditor) {
+            return editor.serializeCurrent();
+        }
+        throw new Error('[querySceneSerializedData] 当前没有打开场景');
+    }
+
     getRootNode(): cc.Scene | cc.Node | null {
         const editor = this.currentEditorUuid && this.editorMap.get(this.currentEditorUuid);
         return editor ? editor.getRootNode() : null;

--- a/src/core/scene/scene-process/service/editors/scene-editor.ts
+++ b/src/core/scene/scene-process/service/editors/scene-editor.ts
@@ -61,6 +61,19 @@ export class SceneEditor extends BaseEditor {
         return this.saveSerializedDataToAsset(this.entity.identifier.assetUuid);
     }
 
+    /**
+     * 序列化「当前正在编辑」的实时场景（含未保存改动），返回 JSON 字符串。
+     * 复用 save/reload 完全一致的 sceneUtils.serialize 路径，因此其输出可被
+     * cc.assetManager.loadWithJson 加载（等价于 querySceneSerializedData）。
+     * 默认 stringify:true，返回的是 JSON 字符串（非对象）。
+     */
+    serializeCurrent(): string {
+        if (!this.entity) {
+            throw new Error('[serializeCurrent] 没有打开场景');
+        }
+        return sceneUtils.serialize(this.entity.instance as Scene) as string;
+    }
+
     async saveAs(asset: IAssetInfo): Promise<IAssetInfo> {
         return this.saveSerializedDataToAsset(asset.uuid);
     }

--- a/src/core/scene/scene.middleware.ts
+++ b/src/core/scene/scene.middleware.ts
@@ -9,6 +9,15 @@ import fse from 'fs-extra';
  * library 目录中唯一定位文件（与预览 game-preview.middleware.getLibraryDirs 对齐）。
  */
 let libraryDirsCache: string[] | null = null;
+
+/**
+ * 「Preview in Editor」当前场景快照缓存（内存中继）。
+ * 浏览器场景编辑器点 Play 时把编辑器里的实时场景（含未保存改动）序列化后 POST 到
+ * /scene/current；游戏预览 iframe 以 /?scene=__current__ 启动，其 game-boot 通过
+ * GET /scene/current.json 读回该快照并 loadWithJson 运行。缓存的是 serialize 输出的
+ * JSON 字符串（非对象）。MVP 只保留单个活动预览。
+ */
+let currentSceneCache: string | null = null;
 async function getLibraryDirs(): Promise<string[]> {
     if (libraryDirsCache) {
         return libraryDirsCache;
@@ -165,6 +174,22 @@ export default {
             },
         },
         {
+            // Preview in Editor：读回「当前编辑场景」快照。
+            // 必须注册在下面的通用资源路由 `/:dir/:uuid.:ext` 之前，否则会被其捕获
+            // （dir=scene, uuid=current, ext=json），走 asset-db 查询而 404。
+            url: '/scene/current.json',
+            async handler(req: Request, res: Response) {
+                if (currentSceneCache == null) {
+                    return res.status(404).json({ error: 'no current scene cached' });
+                }
+                // iframe reload 时必须实时读回最新快照，禁止缓存。
+                res.setHeader('Cache-Control', 'no-store');
+                // 缓存的是 serialize 输出的 JSON 字符串，直接以 application/json 原样发出，
+                // game-boot 侧 fetch 后 .json() 解析（与 /scene/{uuid}.json 一致）。
+                res.type('application/json').send(currentSceneCache);
+            },
+        },
+        {
             // Serve library assets by UUID - try asset database first,
             // then fall back to library directories on disk
             url: '/:dir/:uuid/:nativeName.:ext',
@@ -256,6 +281,21 @@ export default {
         }
     ],
     post: [
+        {
+            // Preview in Editor：写入「当前编辑场景」快照。
+            // 约定 body 为 { data: <serialize 输出的 JSON 字符串> }：serialize 交付的是字符串，
+            // 若客户端直接把顶层字符串作为 JSON 发送，会被 express.json 的 strict 模式（默认）
+            // 以 400 拒绝，故用对象包裹。
+            url: '/scene/current',
+            async handler(req: Request, res: Response) {
+                const data = req.body?.data;
+                if (typeof data !== 'string') {
+                    return res.status(400).json({ error: 'body.data (serialized scene string) is required' });
+                }
+                currentSceneCache = data;
+                res.status(200).json({ ok: true });
+            },
+        },
         {
             url: '/rpc/:module/:method',
             async handler(req: Request, res: Response) {

--- a/static/web/game-boot.js
+++ b/static/web/game-boot.js
@@ -222,50 +222,73 @@ export default async function gameBoot() {
         });
 
         await cc.game.run(async () => {
-            cc.game.pause();
+            // 引擎的 game.run 返回 void：该 async 回调是 fire-and-forget，回调内的异常不会传播到
+            // 外层 try/catch。因此整条场景加载路径必须在这里全部捕获并收敛到 rejectSceneRun——
+            // 否则 fetch/解析失败时 `await sceneRunDone` 永远 pending，boot 挂死：
+            // IDE 预览（PinK previewMain 等 await gameBoot() 的消费方）卡在 loading 且无法触发
+            // view:error 重试，浏览器首屏则表现为游戏停在 pause 无任何报错。
+            try {
+                cc.game.pause();
 
-            // Preview in Editor：当启动场景为 __current__ 时，读回编辑器 POST 上来的
-            // 「当前编辑场景」实时快照（/scene/current.json），而非从磁盘按 uuid 取已保存场景。
-            // 该快照是 sceneUtils.serialize 的输出（与编辑器 save/reload 同一路径），
-            // 故与常规路径一样 fetch → .json() → loadWithJson。
-            const isCurrent = launchScene === '__current__';
-            const sceneJsonUrl = isCurrent
-                ? `${env.serverURL}/scene/current.json`
-                : `${env.serverURL}/scene/${encodeURIComponent(launchScene)}.json`;
-            const json = await (await fetch(sceneJsonUrl)).json();
-            let loadOptions = null;
-            if (!isCurrent) {
-                try {
-                    launchScene = json[1]._id;
-                } catch (e) {
-                    // ignore
-                }
-                loadOptions = { assetId: launchScene };
-            }
-            cc.assetManager.loadWithJson(
-                json,
-                loadOptions,
-                () => { /* progress */ },
-                (err, sceneAsset) => {
-                    if (err) {
-                        showError(err);
-                        cc.error(err);
-                        rejectSceneRun(err instanceof Error ? err : new Error(String(err)));
-                        return;
-                    }
+                // Preview in Editor：当启动场景为 __current__ 时，读回编辑器 POST 上来的
+                // 「当前编辑场景」实时快照（/scene/current.json），而非从磁盘按 uuid 取已保存场景。
+                // 该快照是 sceneUtils.serialize 的输出（与编辑器 save/reload 同一路径），
+                // 故与常规路径一样 fetch → .json() → loadWithJson。
+                const isCurrent = launchScene === '__current__';
+                const sceneJsonUrl = isCurrent
+                    ? `${env.serverURL}/scene/current.json`
+                    : `${env.serverURL}/scene/${encodeURIComponent(launchScene)}.json`;
+                const resp = await fetch(sceneJsonUrl);
+                if (!resp.ok) {
+                    // 快照未写入（未点 Play / 已停止）时 /scene/current.json 返回 404 且带
+                    // { error } JSON body；磁盘场景缺失走 next() 兜底也可能是非 200。把状态码与
+                    // 服务端 error 一并带进消息，便于错误浮层定位。
+                    let detail = '';
                     try {
-                        const scene = sceneAsset.scene;
-                        scene._name = sceneAsset._name;
-                        cc.director.runSceneImmediate(scene, () => {
-                            cc.game.resume();
-                            resolveSceneRun();
-                        });
+                        detail = (await resp.json()).error || '';
                     } catch (e) {
-                        showError(e);
-                        rejectSceneRun(e instanceof Error ? e : new Error(String(e)));
+                        // 非 JSON body（如网关 502 HTML），忽略
                     }
+                    throw new Error(`fetch scene failed: ${resp.status}${detail ? ` (${detail})` : ''} ${sceneJsonUrl}`);
                 }
-            );
+                const json = await resp.json();
+                let loadOptions = null;
+                if (!isCurrent) {
+                    try {
+                        launchScene = json[1]._id;
+                    } catch (e) {
+                        // ignore
+                    }
+                    loadOptions = { assetId: launchScene };
+                }
+                cc.assetManager.loadWithJson(
+                    json,
+                    loadOptions,
+                    () => { /* progress */ },
+                    (err, sceneAsset) => {
+                        if (err) {
+                            showError(err);
+                            cc.error(err);
+                            rejectSceneRun(err instanceof Error ? err : new Error(String(err)));
+                            return;
+                        }
+                        try {
+                            const scene = sceneAsset.scene;
+                            scene._name = sceneAsset._name;
+                            cc.director.runSceneImmediate(scene, () => {
+                                cc.game.resume();
+                                resolveSceneRun();
+                            });
+                        } catch (e) {
+                            showError(e);
+                            rejectSceneRun(e instanceof Error ? e : new Error(String(e)));
+                        }
+                    }
+                );
+            } catch (e) {
+                showError(e);
+                rejectSceneRun(e instanceof Error ? e : new Error(String(e)));
+            }
         });
 
         // 等待场景真正 run 起来后再视为 boot 成功。

--- a/static/web/game-boot.js
+++ b/static/web/game-boot.js
@@ -187,37 +187,72 @@ export default async function gameBoot() {
             console.warn('[Game Preview] set design resolution failed:', e);
         }
 
+        // 场景 run 完成信号：resolve 于 runSceneImmediate 回调、reject 于加载错误。
+        // gameBoot 只有在场景真正跑起来后才视为成功——IDE 预览 boot 据此 fire view:ready，
+        // 避免在场景仍在加载/失败时过早上报就绪。
+        let resolveSceneRun;
+        let rejectSceneRun;
+        const sceneRunDone = new Promise((resolve, reject) => {
+            resolveSceneRun = resolve;
+            rejectSceneRun = reject;
+        });
+
         await cc.game.run(async () => {
             cc.game.pause();
 
-            const json = await (await fetch(`${env.serverURL}/scene/${encodeURIComponent(launchScene)}.json`)).json();
-            try {
-                launchScene = json[1]._id;
-            } catch (e) {
-                // ignore
+            // Preview in Editor：当启动场景为 __current__ 时，读回编辑器 POST 上来的
+            // 「当前编辑场景」实时快照（/scene/current.json），而非从磁盘按 uuid 取已保存场景。
+            // 该快照是 sceneUtils.serialize 的输出（与编辑器 save/reload 同一路径），
+            // 故与常规路径一样 fetch → .json() → loadWithJson。
+            const isCurrent = launchScene === '__current__';
+            const sceneJsonUrl = isCurrent
+                ? `${env.serverURL}/scene/current.json`
+                : `${env.serverURL}/scene/${encodeURIComponent(launchScene)}.json`;
+            const json = await (await fetch(sceneJsonUrl)).json();
+            let loadOptions = null;
+            if (!isCurrent) {
+                try {
+                    launchScene = json[1]._id;
+                } catch (e) {
+                    // ignore
+                }
+                loadOptions = { assetId: launchScene };
             }
             cc.assetManager.loadWithJson(
                 json,
-                { assetId: launchScene },
+                loadOptions,
                 () => { /* progress */ },
                 (err, sceneAsset) => {
                     if (err) {
                         showError(err);
                         cc.error(err);
+                        rejectSceneRun(err instanceof Error ? err : new Error(String(err)));
                         return;
                     }
-                    const scene = sceneAsset.scene;
-                    scene._name = sceneAsset._name;
-                    cc.director.runSceneImmediate(scene, () => {
-                        cc.game.resume();
-                    });
+                    try {
+                        const scene = sceneAsset.scene;
+                        scene._name = sceneAsset._name;
+                        cc.director.runSceneImmediate(scene, () => {
+                            cc.game.resume();
+                            resolveSceneRun();
+                        });
+                    } catch (e) {
+                        showError(e);
+                        rejectSceneRun(e instanceof Error ? e : new Error(String(e)));
+                    }
                 }
             );
         });
+
+        // 等待场景真正 run 起来后再视为 boot 成功。
+        await sceneRunDone;
 
         console.log('Cocos game preview started');
     } catch (err) {
         console.error('Failed to start game preview:', err.stack || err);
         showError(err);
+        // 重新抛出，让 await gameBoot() 的调用方（IDE 预览 boot、game.ejs）能感知失败。
+        // 浏览器 game.ejs 已用 try/catch 包裹，不会产生未处理拒绝。
+        throw err;
     }
 }

--- a/static/web/game.ejs
+++ b/static/web/game.ejs
@@ -114,8 +114,14 @@
         if (window.__previewSettingsFailed) {
             console.info('[Game Preview Warning] backend not ready (settings.js failed); skip boot, awaiting server-driven reload.');
         } else {
-            const { default: gameBoot } = await import('/static/web/game-boot.js');
-            await gameBoot();
+            try {
+                const { default: gameBoot } = await import('/static/web/game-boot.js');
+                await gameBoot();
+            } catch (e) {
+                // gameBoot 现在会在 boot 失败时 rethrow（供 IDE 预览感知）；浏览器首屏这里吞掉，
+                // 错误已由 game-boot 内部 showError + console.error 呈现，且由 live-reload 自愈。
+                console.error('[Game Preview] boot failed:', e && (e.stack || e.message) || e);
+            }
         }
     </script>
 </body>

--- a/static/web/preview-inspect.js
+++ b/static/web/preview-inspect.js
@@ -1,7 +1,7 @@
-/* global window, globalThis, requestAnimationFrame, cancelAnimationFrame, performance */
+/* global window, globalThis, requestAnimationFrame, cancelAnimationFrame, performance, fetch */
 
 /**
- * 预览运行时 Inspect Agent(M1:只读 Hierarchy + selection + 结构 liveness)。
+ * 预览运行时 Inspect Agent(M1:只读 Hierarchy + selection + 结构 liveness;M5:组件增删/reset/排序/整包粘贴;M6:资产拖拽创建节点)。
  *
  * 由 previewMain 在 game-boot 跑起启动场景后装配,直接读活 `cc.director` 的场景图,
  * 产出与编辑器 `node.query-tree` 契约一致的 INodeTreeItem,并以轻量结构快照 diff
@@ -21,6 +21,44 @@ const ILLEGAL_NAME_CHARS = /[/\\:*?"<>|]/g;
 
 /** 结构快照扫描间隔(ms),对齐 plan「变更监听策略」的 ~100–150ms 上限。 */
 const STRUCTURE_SCAN_INTERVAL_MS = 150;
+
+/** 预览内 undo 栈上限,防长时间预览下命令无限堆积。 */
+const PREVIEW_UNDO_STACK_LIMIT = 100;
+
+/**
+ * 类型化创建所需的「类型 → 内置 Prefab」映射的只读路由。
+ * 由 CLI 直接输出编辑态的 NODE_CONFIGS(见 game-preview.middleware.ts),避免在此重抄一份而漂移。
+ */
+const NODE_TYPE_CONFIG_ROUTE = '/scene/node-type-config';
+
+/**
+ * 脚本 uuid 形状识别(逐字对齐 editor-extends 的 utils/uuid:Reg_Uuid / Reg_NormalizedUuid /
+ * Reg_CompressedUuid / Reg_CompressedSubAssetUuid)。
+ *
+ * 面板的资源选择器按 **asset-db 里的带短横 uuid** 在候选列表里查名字(`items.find(i => i.uuid === uuid)`),
+ * 查不到就渲染红色 "Missing"。而运行时能直接拿到的只有 classId —— 用户脚本组件的 classId 是
+ * **压缩后的 uuid**(23 或 22 字符 base64,如 `fc9913XADNLgJ1ByKhqcC5Z`),解压后还是 32 位无短横形式。
+ * 因此必须「解压 + 补短横」两步归一,否则 Script 一栏必然显示 Missing。
+ */
+const REG_UUID_DASHED = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+const REG_UUID_NORMALIZED = /^[0-9a-fA-F]{32}$/;
+const REG_UUID_COMPRESSED = /^[0-9a-zA-Z+/]{22,23}$/;
+/** 压缩 uuid + 子资源后缀(`@xxxxx`),子资源段原样保留。 */
+const REG_UUID_COMPRESSED_SUB = /^([0-9a-zA-Z+/]{22,23})((@[0-9a-fA-F]{5,})+)$/;
+
+/** base64 字符 → 6bit 值(compressUUID 用的字母表,与标准 base64 同序)。 */
+const UUID_BASE64_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+const UUID_ASCII_TO_64 = (() => {
+	const table = new Array(128).fill(0);
+	for (let i = 0; i < 64; i++) {
+		table[UUID_BASE64_CHARS.charCodeAt(i)] = i;
+	}
+	return table;
+})();
+
+/** 内置 Canvas Prefab(与编辑态 checkCanvasRequired 的硬编码 uuid 一致)。 */
+const CANVAS_PREFAB_UUID_2D = '4c33600e-9ca9-483b-b734-946008261697';
+const CANVAS_PREFAB_UUID_3D = 'f773db21-62b8-4540-956a-29bacf5ddbf5';
 
 /** prefab 状态兜底:预览态未加载 prefab 工具,统一按「非 prefab」上报(M2 再补真值)。 */
 const DEFAULT_PREFAB_INFO = Object.freeze({	state: 0, // PrefabState.NotAPrefab
@@ -111,6 +149,9 @@ class PreviewInspect {
 		/** uuid → cc.Node */
 		this._uuidToNode = new Map();
 
+		/** 已告警过「脚本 uuid 认不出来」的类名,避免每次 dump 都刷日志 */
+		this._scriptUuidWarned = new Set();
+
 		/** 选中集合(mgr path;scene 用 '') */
 		this._selection = new Set();
 		/** mgr path → transform 签名字符串,用于选中节点属性 liveness diff */
@@ -132,6 +173,27 @@ class PreviewInspect {
 		// 运行时若取不到(空数组)则回退成普通 Number 字段(见 _dumpNode),避免出现空下拉。
 		this._layersEnumList = this._buildLayersEnumList();
 		this._mobilityEnumList = this._buildMobilityEnumList();
+
+		// ---- M4 结构编辑状态(全部随 stop() 一起丢弃,绝不回写编辑场景)----
+
+		/** 预览独立剪贴板。entries:copy 存 `{uuid, instant}` 离线副本,cut 只存 `{uuid}`。 */
+		this._clipboard = { type: 'none', entries: [] };
+		/** @type {Array<{ label: string, undo: () => void, redo: () => void }>} */
+		this._undoStack = [];
+		/** @type {Array<{ label: string, undo: () => void, redo: () => void }>} */
+		this._redoStack = [];
+		/** @type {{ id: string, label: string, depth: number, commands: any[] } | null} */
+		this._undoGroup = null;
+		this._groupSequence = 0;
+		/** 被删除/被撤销掉的游离节点(未 destroy,等待 undo 复活);stop()/clearHistory() 时销毁。 */
+		this._detachedNodes = new Set();
+		/** M5:被摘除的组件实例(未 destroy,等待 undo 复活);stop()/clearHistory() 时销毁。 */
+		this._detachedComponents = new Set();
+		/** `/scene/node-type-config` 的响应缓存 */
+		this._nodeTypeConfig = null;
+		this._nodeTypeConfigPromise = null;
+		/** uuid → 已加载的内置 Prefab 资源 */
+		this._prefabCache = new Map();
 	}
 
 	// ---- 生命周期 ----------------------------------------------------------
@@ -155,6 +217,17 @@ class PreviewInspect {
 		this._uuidToNode.clear();
 		this._selection.clear();
 		this._snapshot.clear();
+		// 「停止即丢弃」:undo 历史、剪贴板离线副本、被历史持有的游离节点全部销毁,
+		// 既保证预览改动不残留、也避免这些脱离场景图的节点泄漏。
+		this._undoStack.length = 0;
+		this._redoStack.length = 0;
+		this._undoGroup = null;
+		this._destroyDetachedNodes();
+		this._destroyDetachedComponents();
+		this._clearClipboard();
+		this._prefabCache.clear();
+		this._nodeTypeConfig = null;
+		this._nodeTypeConfigPromise = null;
 	}
 
 	// ---- 查询 --------------------------------------------------------------
@@ -226,21 +299,14 @@ class PreviewInspect {
 		// 去掉可能的 _NNN 后缀还原类名。
 		const className = compSeg.replace(/_\d{3}$/, '');
 		const comps = (node.components) || node._components || [];
-		const taken = new Map();
+		const names = this._componentTargetNames(comps);
+		let named = 0;
 		for (const comp of comps) {
 			if (!comp) {
 				continue;
 			}
+			const name = names[named++];
 			const base = this._className(comp.constructor) || 'cc.Component';
-			let name;
-			if (taken.has(base)) {
-				const count = taken.get(base) + 1;
-				taken.set(base, count);
-				name = `${base}_${pad3(count)}`;
-			} else {
-				taken.set(base, 0);
-				name = base;
-			}
 			if (name === compSeg || base === className) {
 				return comp;
 			}
@@ -271,6 +337,56 @@ class PreviewInspect {
 		if (!node || !this._isValid(node)) {
 			throw new Error(`preview set-property: node not found at '${(params && params.nodePath) || ''}'`);
 		}
+		// M5:整包组件 dump 写回(Inspector Paste Component Values / Paste Component 第二步)。
+		// path 形态 `__comps__.{i}`(无子键)且 dump.value 为对象 → 逐键 best-effort 写入,
+		// 跳过不可见属性与序列化骨架键;快照旧值合成单步 undo。
+		const compWholeMatch = /^__comps__\.(\d+)$/.exec(rawPath);
+		if (compWholeMatch && dump && typeof dump.value === 'object' && dump.value !== null) {
+			const wholeComps = (node.components) || node._components || [];
+			const wholeComp = wholeComps[Number(compWholeMatch[1])];
+			if (!wholeComp || !this._isValid(wholeComp)) {
+				throw new Error(`preview set-property: component[${compWholeMatch[1]}] not found on '${nodePath}'`);
+			}
+			this._asOneCommand('Paste Component Values', () => {
+				const snapshot = [];
+				for (const key of Object.keys(dump.value)) {
+					const propDump = dump.value[key];
+					if (!propDump || propDump.visible === false) {
+						continue;
+					}
+					if (key === 'uuid' || key === 'name' || key === '__scriptAsset') {
+						continue;
+					}
+					snapshot.push([key, this._clonePropValue(wholeComp[key])]);
+					try {
+						this._applyValue(wholeComp, key, propDump);
+					} catch {
+						// 单个属性写回失败(getter-only 等)不应拖垮其余键。
+					}
+				}
+				this._pushCommand({
+					label: 'Paste Component Values',
+					undo: () => {
+						if (!this._isValid(wholeComp)) { return; }
+						for (const [key, old] of snapshot) {
+							try { wholeComp[key] = old; } catch { /* 忽略 */ }
+						}
+					},
+					redo: () => {
+						if (!this._isValid(wholeComp)) { return; }
+						for (const key of Object.keys(dump.value)) {
+							const propDump = dump.value[key];
+							if (!propDump || propDump.visible === false || key === 'uuid' || key === 'name' || key === '__scriptAsset') {
+								continue;
+							}
+							try { this._applyValue(wholeComp, key, propDump); } catch { /* 忽略 */ }
+						}
+					},
+				});
+			});
+			this._afterWrite(node, nodePath, rawPath);
+			return true;
+		}
 		const compMatch = /^__comps__\.(\d+)\.(.+)$/.exec(rawPath);
 		if (compMatch) {
 			const comps = (node.components) || node._components || [];
@@ -281,8 +397,26 @@ class PreviewInspect {
 			if (!this._applyValueByPath(comp, compMatch[2], dump)) {
 				throw new Error(`preview set-property: failed to apply '${rawPath}' on '${nodePath}'`);
 			}
-		} else if (!this._applyValueByPath(node, rawPath, dump)) {
-			throw new Error(`preview set-property: failed to apply '${rawPath}' on '${nodePath}'`);
+		} else {
+			// 改名(Hierarchy 的 Rename 就走这条路径)需要额外记 undo 并重建索引:名字是路径的组成部分,
+			// 不重建索引的话后续所有按 path 的定位都会指向旧名。
+			const isRename = rawPath === 'name' && !this._isScene(node);
+			const oldName = isRename ? node.name : undefined;
+			if (!this._applyValueByPath(node, rawPath, dump)) {
+				throw new Error(`preview set-property: failed to apply '${rawPath}' on '${nodePath}'`);
+			}
+			if (isRename && node.name !== oldName) {
+				const newName = node.name;
+				this._pushCommand({
+					label: 'Rename Node',
+					undo: () => { if (this._isValid(node)) { node.name = oldName; } },
+					redo: () => { if (this._isValid(node)) { node.name = newName; } },
+				});
+				this._afterWrite(node, nodePath, rawPath);
+				this._rebuildIndex();
+				this._flushStructure();
+				return true;
+			}
 		}
 		this._afterWrite(node, nodePath, rawPath);
 		return true;
@@ -353,6 +487,39 @@ class PreviewInspect {
 			}
 		}
 		return value;
+	}
+
+	/**
+	 * 深拷一个属性值,供 undo 快照 / reset 默认值搬运:类实例(ValueType 等)新建实例拷自身可枚举标量,
+	 * 纯对象/数组 JSON clone,标量原样。JSON clone 失败(循环引用)时退回原值(best-effort)。
+	 */
+	_clonePropValue(value) {
+		if (value === null || typeof value !== 'object') {
+			return value;
+		}
+		const ctor = value.constructor;
+		if (ctor && ctor !== Object && ctor !== Array) {
+			let inst = null;
+			try {
+				inst = new ctor();
+			} catch {
+				inst = null;
+			}
+			if (inst) {
+				for (const k of Object.keys(value)) {
+					const v = value[k];
+					if (typeof v === 'number' || typeof v === 'string' || typeof v === 'boolean') {
+						inst[k] = v;
+					}
+				}
+				return inst;
+			}
+		}
+		try {
+			return JSON.parse(JSON.stringify(value));
+		} catch {
+			return value;
+		}
 	}
 
 	/** dump.type(如 'cc.Vec3'/'cc.Color')→ 引擎 ValueType 构造器。 */
@@ -496,6 +663,179 @@ class PreviewInspect {
 		return this._dumpComponent(added, `${nodePath}/${this._className(added.constructor)}`);
 	}
 
+	/**
+	 * M5 组件删除(component.remove):摘除但**不 destroy**(对齐节点删除哲学),undo 原位插回复活,
+	 * 真正 destroy 推迟到 stop()/clearHistory()。params = `{ path }`,path 为组件 target 路径
+	 * (`节点路径/类名_NNN`);成功后回推 node:change(propPath '__comps__'),Inspector 刷新组件列表。
+	 * 已知取舍:直接 splice 跳过引擎 removeComponent 的 destroy 调度,best-effort 补 onDisable/onEnable。
+	 * @param {{ path?: string } | undefined} params
+	 */
+	removeComponent(params) {
+		this._rebuildIndex();
+		const rawPath = (params && params.path) || '';
+		const comp = this._resolveComponentByPath(stripLeadingSlashes(rawPath));
+		if (!comp || !this._isValid(comp)) {
+			throw new Error(`preview remove-component: component not found at '${rawPath}'`);
+		}
+		const node = comp.node;
+		if (!node || !this._isValid(node)) {
+			throw new Error(`preview remove-component: owner node not found for '${rawPath}'`);
+		}
+		this._assertNotScene(node, 'remove-component');
+		const nodePath = this._pathOfNode(node);
+		const comps = (node.components) || node._components || [];
+		const index = comps.indexOf(comp);
+		if (index < 0) {
+			throw new Error(`preview remove-component: component not attached to '${nodePath}'`);
+		}
+		const detach = () => {
+			const list = (node.components) || node._components || [];
+			const at = list.indexOf(comp);
+			if (at >= 0) {
+				list.splice(at, 1);
+			}
+			this._detachedComponents.add(comp);
+			try {
+				if (typeof comp.onDisable === 'function') { comp.onDisable(); }
+			} catch { /* 生命周期补偿失败无副作用 */ }
+		};
+		const attach = () => {
+			const list = (node.components) || node._components || [];
+			list.splice(Math.min(index, list.length), 0, comp);
+			this._detachedComponents.delete(comp);
+			try {
+				if (comp.enabled && typeof comp.onEnable === 'function') { comp.onEnable(); }
+			} catch { /* 生命周期补偿失败无副作用 */ }
+		};
+		detach();
+		this._pushCommand({
+			label: 'Remove Component',
+			undo: () => { attach(); this._rebuildIndex(); this._emitCompsChange(node, nodePath); },
+			redo: () => { detach(); this._rebuildIndex(); this._emitCompsChange(node, nodePath); },
+		});
+		this._rebuildIndex();
+		this._emitCompsChange(node, nodePath);
+		return null;
+	}
+
+	/**
+	 * M5 组件 reset(component.reset):new 临时实例取默认值写回(对齐编辑态 reset 语义),
+	 * 跳过 enabled/uuid/name/__scriptAsset 与 readonly 属性;整段合成单步 undo;
+	 * 结束 `_afterWrite` 回推 node:change。params = `{ path }`,path 为组件 target 路径。
+	 * @param {{ path?: string } | undefined} params
+	 */
+	resetComponent(params) {
+		this._rebuildIndex();
+		const rawPath = (params && params.path) || '';
+		const comp = this._resolveComponentByPath(stripLeadingSlashes(rawPath));
+		if (!comp || !this._isValid(comp)) {
+			throw new Error(`preview reset-component: component not found at '${rawPath}'`);
+		}
+		const ctor = comp.constructor;
+		let fresh;
+		try {
+			fresh = new ctor();
+		} catch (e) {
+			throw new Error(`preview reset-component: cannot instantiate '${this._className(ctor) || 'cc.Component'}' for defaults: ${(e && e.message) || e}`);
+		}
+		const node = comp.node;
+		const keys = (ctor && ctor.__props__) || [];
+		const snapshot = [];
+		this._asOneCommand('Reset Component', () => {
+			for (const key of keys) {
+				if (key === 'enabled' || key === 'uuid' || key === 'name' || key === '__scriptAsset') {
+					continue;
+				}
+				let attrs = {};
+				try {
+					attrs = this._cc.Class && typeof this._cc.Class.attr === 'function' ? (this._cc.Class.attr(comp, key) || {}) : {};
+				} catch {
+					attrs = {};
+				}
+				if (attrs.readonly) {
+					continue;
+				}
+				snapshot.push([key, this._clonePropValue(comp[key])]);
+				try {
+					comp[key] = this._clonePropValue(fresh[key]);
+				} catch {
+					// 单个属性写回失败(getter-only 等)不应拖垮其余属性。
+				}
+			}
+			this._pushCommand({
+				label: 'Reset Component',
+				undo: () => {
+					if (!this._isValid(comp)) { return; }
+					for (const [key, old] of snapshot) {
+						try { comp[key] = old; } catch { /* 忽略 */ }
+					}
+				},
+				redo: () => {
+					if (!this._isValid(comp)) { return; }
+					for (const [key] of snapshot) {
+						try { comp[key] = this._clonePropValue(fresh[key]); } catch { /* 忽略 */ }
+					}
+				},
+			});
+		});
+		if (node && this._isValid(node) && !this._isScene(node)) {
+			const comps = (node.components) || node._components || [];
+			const index = comps.indexOf(comp);
+			this._afterWrite(node, this._pathOfNode(node), index >= 0 ? `__comps__.${index}` : '__comps__');
+		}
+		return undefined;
+	}
+
+	/**
+	 * M5 组件排序(node.move-array-element,path 固定 '__comps__')。
+	 * params = `{ nodePath, path, target, offset }`:把 target 位组件移动 offset 位(Inspector Move Up/Down)。
+	 * 越界抛错(UI 侧有 enabled 规则,agent 仍防御);undo 为反向交换;组件路径去重后缀依赖顺序,
+	 * 交换后重建索引并回推 node:change(propPath '__comps__')。
+	 * @param {{ nodePath?: string, path?: string, target?: number, offset?: number } | undefined} params
+	 */
+	moveArrayElement(params) {
+		this._rebuildIndex();
+		const p = params || {};
+		if (p.path !== '__comps__') {
+			throw new Error(`preview move-array-element: only '__comps__' is supported, got '${p.path}'`);
+		}
+		const node = this._requireNode(p.nodePath, 'move-array-element');
+		this._assertNotScene(node, 'move-array-element');
+		const nodePath = stripLeadingSlashes((p.nodePath) || '');
+		const comps = (node.components) || node._components || [];
+		const target = Number(p.target);
+		const offset = Number(p.offset);
+		const to = target + offset;
+		if (!Number.isInteger(target) || !Number.isInteger(offset) || target < 0 || to < 0 || target >= comps.length || to >= comps.length) {
+			throw new Error(`preview move-array-element: index out of range (target=${p.target}, offset=${p.offset}, length=${comps.length})`);
+		}
+		if (target === to) {
+			return true;
+		}
+		const swap = (from, dest) => {
+			const list = (node.components) || node._components || [];
+			const moved = list.splice(from, 1)[0];
+			list.splice(dest, 0, moved);
+		};
+		swap(target, to);
+		this._pushCommand({
+			label: offset < 0 ? 'Move Up Component' : 'Move Down Component',
+			undo: () => { swap(to, target); this._rebuildIndex(); this._emitCompsChange(node, nodePath); },
+			redo: () => { swap(target, to); this._rebuildIndex(); this._emitCompsChange(node, nodePath); },
+		});
+		this._rebuildIndex();
+		this._emitCompsChange(node, nodePath);
+		return true;
+	}
+
+	/** 组件结构变更后统一回推 node:change(propPath '__comps__'),与 addComponent 的回显模式对齐。 */
+	_emitCompsChange(node, nodePath) {
+		this._emit('node:change', {
+			node: this._dumpNode(node, nodePath, true),
+			change: { propPath: '__comps__', source: 'engine' },
+		});
+	}
+
 	/** 把组件类名或 cid 解析成运行时构造器(getClassByName 优先,回退 getClassById);已是构造器则直接返回。 */
 	_resolveComponentClass(component) {
 		if (!component) {
@@ -560,6 +900,1124 @@ class PreviewInspect {
 
 	getSelection() {
 		return [...this._selection].map(norm => this._displayPath(norm));
+	}
+
+	// ---- 结构编辑(M4:节点增删改 + 剪贴板 + 预览内独立 undo 栈)---------------
+	//
+	// 设计要点(与编辑态 service/node 严格对齐,见 plan「关键复用清单」):
+	//  - **路径**:每个写操作开头与结尾都 `_rebuildIndex()`,返回路径一律按重建后的索引计算,
+	//    避免「同名兄弟后缀按当前顺序重算」造成的路径漂移;
+	//  - **事件即时性**:结束时 `_flushStructure()` 同步跑一次现成的 `_diffAndEmit()`,Hierarchy 立刻刷新,
+	//    不等 150ms 轮询,也不必为每个操作手写事件载荷;
+	//  - **删除不 destroy**:对齐编辑态 `baseRemoveNode`——只 `setParent(null)`,节点引用交给 undo 栈,
+	//    以便撤销时原位复活;真正的 destroy 推迟到 `clearHistory()` / `stop()`;
+	//  - **停止即丢弃**:undo 栈、剪贴板离线副本、游离节点全部随 `stop()` 一起清理,绝不回写编辑场景。
+
+	/**
+	 * 结构写操作后立即产出结构事件(node:added / node:removed / node:change),不等 150ms 轮询。
+	 * 直接复用扫描期的 `_diffAndEmit()`,故事件载荷与轮询路径完全一致,Hierarchy 无需区分来源。
+	 */
+	_flushStructure() {
+		try {
+			this._diffAndEmit();
+		} catch {
+			// 事件产出失败不应回滚已经生效的结构改动;下一轮扫描会补发。
+		}
+	}
+
+	/** '' / '/' → 场景根;其余按 mgr path 查活节点。找不到即抛(与编辑态「节点不存在即抛」一致)。 */
+	_requireNode(rawPath, op) {
+		const norm = stripLeadingSlashes(typeof rawPath === 'string' ? rawPath : '');
+		const node = norm === '' ? this._getScene() : this._pathToNode.get(norm);
+		if (!node || !this._isValid(node)) {
+			throw new Error(`preview ${op}: node not found at '${typeof rawPath === 'string' ? rawPath : '/'}'`);
+		}
+		return node;
+	}
+
+	/** 场景根不参与结构编辑(删除/移动/复制/改父),与编辑态一致。 */
+	_assertNotScene(node, op) {
+		if (this._isScene(node)) {
+			throw new Error(`preview ${op}: the scene root cannot be modified`);
+		}
+	}
+
+	/** uuid → 展示路径('/' 表示场景根);当前索引里没有(已删除/游离)时返回 ''。 */
+	_pathOfUuid(uuid) {
+		const mgrPath = this._uuidToPath.get(uuid);
+		return mgrPath === undefined ? '' : this._displayPath(mgrPath);
+	}
+
+	_pathOfNode(node) {
+		return node ? this._pathOfUuid(node.uuid) : '';
+	}
+
+	/** node 是否为 ancestor 的后代(setParent 环检测,对齐 nodeMgr.setParent 的父子关系校验)。 */
+	_isDescendantOf(node, ancestor) {
+		let cursor = node && node.parent;
+		while (cursor) {
+			if (cursor === ancestor) {
+				return true;
+			}
+			cursor = cursor.parent;
+		}
+		return false;
+	}
+
+	/** 同级唯一名(镜像编辑态 node-utils.getNodeName:`Node` → `Node-001` → `Node-002`)。 */
+	_availableName(name, parent) {
+		let candidate = name || 'Node';
+		const taken = ((parent && parent.children) || []).map(child => (child && child.name) || '');
+		while (taken.includes(candidate)) {
+			if (/(\d+)$/.test(candidate)) {
+				candidate = candidate.replace(/(\d+)$/, (_all, digits) =>
+					String(parseInt(digits, 10) + 1).padStart(digits.length, '0'));
+			} else {
+				candidate += '-001';
+			}
+		}
+		return candidate;
+	}
+
+	// ---- undo 基元 ---------------------------------------------------------
+
+	/** 把节点挂回 parent 的指定兄弟位置;siblingIndex 越界时落到末尾。 */
+	_attachNode(node, parent, siblingIndex) {
+		if (!this._isValid(node) || !parent || !this._isValid(parent)) {
+			return false;
+		}
+		node.setParent(parent);
+		this._detachedNodes.delete(node);
+		if (typeof siblingIndex === 'number' && siblingIndex >= 0 && typeof node.setSiblingIndex === 'function') {
+			const last = ((parent.children && parent.children.length) || 1) - 1;
+			node.setSiblingIndex(Math.min(siblingIndex, last));
+		}
+		return true;
+	}
+
+	/** 摘除但**不 destroy**:引用交给 undo 栈持有,`clearHistory()`/`stop()` 时才真正销毁。 */
+	_detachNode(node) {
+		if (!this._isValid(node)) {
+			return false;
+		}
+		node.setParent(null);
+		this._detachedNodes.add(node);
+		return true;
+	}
+
+	/** 新建类操作的通用 undo 记录:undo 摘除、redo 原位挂回。必须在 setParent 之后调用。 */
+	_recordCreate(node, parent, label) {
+		const siblingIndex = this._siblingIndex(node);
+		this._pushCommand({
+			label,
+			undo: () => { this._detachNode(node); },
+			redo: () => { this._attachNode(node, parent, siblingIndex); },
+		});
+	}
+
+	/** 入栈一条命令:group 活跃时收集进 group,否则直接入 undo 栈;任何新命令都清空 redo 栈。 */
+	_pushCommand(command) {
+		this._redoStack.length = 0;
+		if (this._undoGroup) {
+			this._undoGroup.commands.push(command);
+			return;
+		}
+		this._undoStack.push(command);
+		while (this._undoStack.length > PREVIEW_UNDO_STACK_LIMIT) {
+			this._undoStack.shift();
+		}
+	}
+
+	/**
+	 * 把一段写操作合成**单个** undo 步骤。与 host 传入的 group 天然嵌套(begin 只在最外层真正开栈),
+	 * 因此 `undo:begin-group` → `node:paste` → `undo:end-group` 的既有调用序列仍然只产出一步。
+	 * 同时兼容同步/异步 run:异步失败时同样 cancelGroup 回滚已产生的部分改动。
+	 */
+	_asOneCommand(label, run) {
+		const token = this.beginGroup({ label });
+		let result;
+		try {
+			result = run();
+		} catch (error) {
+			this.cancelGroup(token);
+			throw error;
+		}
+		if (result && typeof result.then === 'function') {
+			return result.then(
+				value => { this.endGroup(token); return value; },
+				error => { this.cancelGroup(token); throw error; },
+			);
+		}
+		this.endGroup(token);
+		return result;
+	}
+
+	// ---- undo / redo(预览内独立栈,与编辑器 undo 栈完全隔离)-----------------
+
+	undo() {
+		return this._applyHistory(this._undoStack, this._redoStack, 'undo');
+	}
+
+	redo() {
+		return this._applyHistory(this._redoStack, this._undoStack, 'redo');
+	}
+
+	canUndo() {
+		return this._undoStack.length > 0;
+	}
+
+	canRedo() {
+		return this._redoStack.length > 0;
+	}
+
+	isGroupActive() {
+		return this._undoGroup !== null;
+	}
+
+	/** 预览是内存快照,永远「不脏」——编辑器 tab 不得因预览改动变 dirty(停止即丢弃)。 */
+	isDirty() {
+		return false;
+	}
+
+	/** 清空历史:栈里持有的游离节点此时才真正 destroy(它们已不可能再被复活)。 */
+	clearHistory() {
+		this._undoStack.length = 0;
+		this._redoStack.length = 0;
+		this._undoGroup = null;
+		this._destroyDetachedNodes();
+		this._destroyDetachedComponents();
+	}
+
+	/**
+	 * 取一条命令执行并转移到对侧栈。**任何情况下都不抛**:`IUndoRedoResult` 是结构化结果,
+	 * 上层(sceneOps._withUndoGroup / 全局 Ctrl+Z contribution)并不总检查 success,抛异常只会变成噪声。
+	 */
+	_applyHistory(from, to, kind) {
+		if (this._undoGroup) {
+			return { success: false, reason: `preview ${kind}: an undo group is still active` };
+		}
+		const command = from.pop();
+		if (!command) {
+			return { success: false, reason: `preview ${kind}: history is empty` };
+		}
+		try {
+			if (kind === 'undo') {
+				command.undo();
+			} else {
+				command.redo();
+			}
+		} catch (error) {
+			// 该命令的状态已不可信,丢弃而不是放回栈——避免后续 undo 在坏状态上继续放大问题。
+			this._rebuildIndex();
+			this._flushStructure();
+			return { success: false, reason: `preview ${kind} failed: ${(error && error.message) || error}` };
+		}
+		to.push(command);
+		this._rebuildIndex();
+		this._flushStructure();
+		return { success: true, label: command.label };
+	}
+
+	/** 开一个 undo group;已有活跃 group 时只增加嵌套深度并复用其 id。 */
+	beginGroup(options) {
+		if (this._undoGroup) {
+			this._undoGroup.depth++;
+			return this._undoGroup.id;
+		}
+		this._groupSequence++;
+		const id = `preview-undo-group-${this._groupSequence}`;
+		this._undoGroup = {
+			id,
+			label: (options && options.label) || 'Preview Operation',
+			depth: 1,
+			commands: [],
+		};
+		return id;
+	}
+
+	/** 结束 group:最外层结束时把收集到的命令合成一条复合命令入栈;空 group 不入栈。 */
+	endGroup(token) {
+		const group = this._undoGroup;
+		if (!group) {
+			return { success: false, reason: 'preview end-group: no active undo group' };
+		}
+		if (token && token !== group.id) {
+			return { success: false, reason: `preview end-group: unknown group token '${token}'` };
+		}
+		group.depth--;
+		if (group.depth > 0) {
+			return { success: true, commandId: group.id, label: group.label };
+		}
+		this._undoGroup = null;
+		const commands = group.commands;
+		if (commands.length === 0) {
+			return { success: true, commandId: group.id, label: group.label };
+		}
+		this._pushCommand({
+			label: group.label,
+			undo: () => {
+				for (let i = commands.length - 1; i >= 0; i--) {
+					commands[i].undo();
+				}
+			},
+			redo: () => {
+				for (const command of commands) {
+					command.redo();
+				}
+			},
+		});
+		return { success: true, commandId: group.id, label: group.label };
+	}
+
+	/** 取消 group:逐条逆序回滚后丢弃。同样不抛,失败信息随结果返回。 */
+	cancelGroup(token) {
+		const group = this._undoGroup;
+		if (!group) {
+			return { success: false, reason: 'preview cancel-group: no active undo group' };
+		}
+		if (token && token !== group.id) {
+			return { success: false, reason: `preview cancel-group: unknown group token '${token}'` };
+		}
+		this._undoGroup = null;
+		let reason;
+		for (let i = group.commands.length - 1; i >= 0; i--) {
+			try {
+				group.commands[i].undo();
+			} catch (error) {
+				reason = `preview cancel-group: rollback failed: ${(error && error.message) || error}`;
+			}
+		}
+		this._rebuildIndex();
+		this._flushStructure();
+		return reason
+			? { success: false, commandId: group.id, reason }
+			: { success: true, commandId: group.id, label: group.label };
+	}
+
+	// ---- 节点写操作 --------------------------------------------------------
+
+	/**
+	 * 类型化创建(node.create-by-type)。`params.path` 是**父节点**路径('' / '/' = 场景根)。
+	 * 类型 → 内置 Prefab uuid 的映射来自 CLI 的 `/scene/node-type-config`(直接输出编辑态的 NODE_CONFIGS,
+	 * 不在此处重抄一份),`Empty` 走 `new cc.Node()`。Prefab 或其依赖加载失败时降级为空节点 + view:log warn,
+	 * 绝不让一次创建失败把菜单/树打挂。
+	 * @returns {Promise<object>} INode dump
+	 */
+	async createNodeByType(params) {
+		const p = params || {};
+		const nodeType = typeof p.nodeType === 'string' ? p.nodeType : '';
+		if (!nodeType) {
+			throw new Error('preview create-by-type: nodeType is required');
+		}
+		const workMode = String(p.workMode || '2d').toLowerCase();
+		const config = await this._resolveNodeTypeConfig(nodeType, workMode);
+		const canvasRequired = Boolean(p.canvasRequired || config.canvasRequired);
+		const label = `Create ${config.name || nodeType}`;
+		return this._asOneCommand(label, async () => {
+			this._rebuildIndex();
+			let parent = this._requireNode(p.path, 'create-by-type');
+			const node = await this._instantiateForNodeType(config, nodeType);
+			if (canvasRequired) {
+				parent = await this._resolveCanvasParent(parent, workMode);
+			}
+			if (typeof p.name === 'string' && p.name.length > 0) {
+				node.name = p.name;
+			}
+			// 新节点 layer 跟随父级,场景根除外;parent.layer 为 0(None)时不跟随——对齐编辑态 _createNode。
+			if (parent.layer && !this._isScene(parent)) {
+				this._setLayerDeep(node, parent.layer);
+			}
+			if (p.position) {
+				node.setPosition(this._toVec3(p.position));
+			}
+			node.setParent(parent, Boolean(p.keepWorldTransform));
+			if (!config.assetUuid) {
+				// 编辑态在 setParent **之前**调用(此时 parent 还是 null,实际形同空转);
+				// 预览这里放到挂载之后,让 Canvas 下的空节点真正拿到 UITransform。
+				this._ensureUITransformComponent(node);
+			}
+			this._recordCreate(node, parent, label);
+			this._rebuildIndex();
+			this._flushStructure();
+			const mgrPath = this._uuidToPath.get(node.uuid);
+			return this._dumpNode(node, mgrPath === undefined ? '' : mgrPath, true);
+		});
+	}
+
+	/**
+	 * M6 按资产创建(node.create-by-asset):Hierarchy 接受 Assets 拖拽时预览在活场景实时建节点。
+	 * db:// URL 经 CLI `/scene/asset-meta` 换 uuid/type,`_loadAssetByUuid` 加载后按类型装配:
+	 *  - `cc.Prefab` → instantiate(摘除 prefab 元数据,预览永不回盘);
+	 *  - `cc.SpriteFrame` / `cc.Texture2D` / `cc.ImageAsset` → 新节点 + UITransform + Sprite,并自动补 Canvas 父级
+	 *    (Texture 挂临时 SpriteFrame;ImageAsset 先包 Texture2D 再包 SpriteFrame);
+	 *  - `cc.AudioClip` → 新节点 + AudioSource;
+	 * 其余类型抛「预览暂不支持」清晰错误。父级/name/position/keepWorldTransform 语义对齐 create-by-type。
+	 * @param {{ dbURL?: string, path?: string, name?: string, workMode?: string, position?: unknown, keepWorldTransform?: boolean } | undefined} params
+	 * @returns {Promise<object>} INode dump
+	 */
+	async createByAsset(params) {
+		const p = params || {};
+		const dbURL = typeof p.dbURL === 'string' ? p.dbURL : '';
+		if (!dbURL) {
+			throw new Error('preview create-by-asset: dbURL is required');
+		}
+		const meta = await this._loadAssetMeta(dbURL);
+		const workMode = String(p.workMode || '2d').toLowerCase();
+		const baseName = this._assetNodeName(meta.name) || meta.name || dbURL;
+		const label = `Create ${baseName}`;
+		return this._asOneCommand(label, async () => {
+			this._rebuildIndex();
+			let parent = this._requireNode(p.path, 'create-by-asset');
+			const asset = await this._loadAssetByUuid(meta.uuid);
+			if (!asset) {
+				throw new Error(`preview create-by-asset: asset '${dbURL}' resolved to null`);
+			}
+			const kind = this._className(asset.constructor) || meta.type || '';
+			let node;
+			if (kind === 'cc.Prefab') {
+				node = this._cc.instantiate(asset);
+				if (!node) {
+					throw new Error(`preview create-by-asset: cc.instantiate('${dbURL}') returned null`);
+				}
+				this._stripPrefabInfo(node);
+			} else if (kind === 'cc.SpriteFrame' || kind === 'cc.Texture2D' || kind === 'cc.ImageAsset') {
+				node = await this._buildSpriteNodeForAsset(asset, kind, baseName, meta);
+				parent = await this._resolveCanvasParent(parent, workMode);
+			} else if (kind === 'cc.AudioClip') {
+				node = new this._cc.Node(baseName || 'AudioClip');
+				const source = node.addComponent(this._cc.AudioSource);
+				if (source) {
+					source.clip = asset;
+				}
+			} else {
+				throw new Error(`preview create-by-asset: asset type '${meta.type || kind}' is not supported in preview`);
+			}
+			if (typeof p.name === 'string' && p.name.length > 0) {
+				node.name = p.name;
+			}
+			// 新节点 layer 跟随父级,场景根除外——对齐 create-by-type / 编辑态 _createNode。
+			if (parent.layer && !this._isScene(parent)) {
+				this._setLayerDeep(node, parent.layer);
+			}
+			if (p.position) {
+				node.setPosition(this._toVec3(p.position));
+			}
+			node.setParent(parent, Boolean(p.keepWorldTransform));
+			this._recordCreate(node, parent, label);
+			this._rebuildIndex();
+			this._flushStructure();
+			const mgrPath = this._uuidToPath.get(node.uuid);
+			return this._dumpNode(node, mgrPath === undefined ? '' : mgrPath, true);
+		});
+	}
+
+	/**
+	 * Sprite/Texture/Image 资产 → 新节点 + UITransform + Sprite(运行期临时对象,停止即丢弃)。
+	 *  - `cc.SpriteFrame` 直接挂;
+	 *  - `cc.Texture2D` 包临时 SpriteFrame;
+	 *  - `cc.ImageAsset`(图片主资产)先包 Texture2D(`texture.image = asset`)再包 SpriteFrame。
+	 * 2D 组件类在个别运行时构建里可能被裁剪:Sprite 缺失抛清晰错误,UITransform 缺失则跳过(不撞引擎 nil 断言)。
+	 */
+	async _buildSpriteNodeForAsset(asset, kind, fallbackName, meta) {
+		const cc = this._cc;
+		if (!cc.Sprite) {
+			throw new Error('preview create-by-asset: cc.Sprite is unavailable in this engine build');
+		}
+		const node = new cc.Node(fallbackName || 'Sprite');
+		if (cc.UITransform) {
+			node.addComponent(cc.UITransform);
+		}
+		const sprite = node.addComponent(cc.Sprite);
+		if (sprite) {
+			// 优先挂 asset-db 真子资产 SpriteFrame(带资产 uuid):Inspector 的 spriteFrame 属性才能
+			// 索引/定位回 Assets;加载不到才退到运行期临时包装(停止即丢弃)。
+			let spriteFrame = kind === 'cc.SpriteFrame' ? asset : null;
+			if (!spriteFrame) {
+				const sub = Array.isArray(meta && meta.subAssets)
+					? meta.subAssets.find(s => s && s.type === 'cc.SpriteFrame' && typeof s.uuid === 'string' && s.uuid)
+					: null;
+				if (sub) {
+					try {
+						const loaded = await this._loadAssetByUuid(sub.uuid);
+						if (loaded && this._className(loaded.constructor) === 'cc.SpriteFrame') {
+							spriteFrame = loaded;
+						}
+					} catch {
+						// 子资产加载失败 → 下面的临时包装兜底。
+					}
+				}
+			}
+			if (!spriteFrame && cc.SpriteFrame) {
+				if (kind === 'cc.Texture2D') {
+					spriteFrame = new cc.SpriteFrame();
+					spriteFrame.texture = asset;
+				} else if (kind === 'cc.ImageAsset' && cc.Texture2D) {
+					const texture = new cc.Texture2D();
+					texture.image = asset;
+					spriteFrame = new cc.SpriteFrame();
+					spriteFrame.texture = texture;
+				}
+			}
+			if (spriteFrame) {
+				sprite.spriteFrame = spriteFrame;
+			}
+		}
+		return node;
+	}
+
+	/** 资产名 → 节点名:去掉尾部扩展后缀(对齐编辑态 create-by-asset 节点命名,GreenBtn.png → GreenBtn)。 */
+	_assetNodeName(name) {
+		if (typeof name !== 'string' || !name) {
+			return '';
+		}
+		return name.replace(/\.[^.]+$/, '');
+	}
+
+	/** `/scene/asset-meta` 只读路由:db:// URL → { uuid, type, name };失败抛可定位错误并允许下次重试。 */
+	_loadAssetMeta(dbURL) {
+		const url = `${this._serverURL || ''}/scene/asset-meta?dbURL=${encodeURIComponent(dbURL)}`;
+		return fetch(url)
+			.then(response => {
+				if (!response.ok) {
+					throw new Error(`HTTP ${response.status}`);
+				}
+				return response.json();
+			})
+			.then(json => {
+				if (!json || typeof json.uuid !== 'string' || !json.uuid) {
+					throw new Error(`asset meta for '${dbURL}' has no uuid`);
+				}
+				return json;
+			})
+			.catch(error => {
+				throw new Error(`preview create-by-asset: failed to load the asset meta for '${dbURL}': ${(error && error.message) || error}`);
+			});
+	}
+
+	/** 删除(node.delete):摘除但不 destroy,undo 可原位复活。返回 void。 */
+	deleteNode(params) {
+		this._rebuildIndex();
+		const node = this._requireNode(params && params.path, 'delete');
+		this._assertNotScene(node, 'delete');
+		const parent = node.parent;
+		const siblingIndex = this._siblingIndex(node);
+		const command = {
+			label: 'Delete Node',
+			undo: () => { this._attachNode(node, parent, siblingIndex); },
+			redo: () => { this._detachNode(node); },
+		};
+		command.redo();
+		this._pushCommand(command);
+		this._rebuildIndex();
+		this._flushStructure();
+	}
+
+	/**
+	 * 改父(node.set-parent,拖拽移动)。环检测在**任何写入之前**全部跑完,避免半途失败留下脏状态。
+	 * @returns {string[]} 移动后的展示路径
+	 */
+	setParent(params) {
+		this._rebuildIndex();
+		const p = params || {};
+		const parent = this._requireNode(p.parentPath, 'set-parent');
+		const keepWorldTransform = Boolean(p.keepWorldTransform);
+		const nodes = toPathArray(p.paths).map(path => this._requireNode(path, 'set-parent'));
+		for (const node of nodes) {
+			this._assertNotScene(node, 'set-parent');
+			if (parent === node || this._isDescendantOf(parent, node)) {
+				throw new Error('preview set-parent: cannot set parent to the node itself or its descendant');
+			}
+		}
+		const records = [];
+		for (const node of nodes) {
+			const oldParent = node.parent;
+			if (!oldParent) {
+				continue;
+			}
+			records.push({ node, oldParent, oldIndex: this._siblingIndex(node) });
+			node.setParent(parent, keepWorldTransform);
+		}
+		if (records.length > 0) {
+			this._pushCommand({
+				label: 'Move Nodes',
+				undo: () => {
+					for (let i = records.length - 1; i >= 0; i--) {
+						this._attachNode(records[i].node, records[i].oldParent, records[i].oldIndex);
+					}
+				},
+				redo: () => {
+					for (const record of records) {
+						if (this._isValid(record.node) && this._isValid(parent)) {
+							record.node.setParent(parent, keepWorldTransform);
+						}
+					}
+				},
+			});
+		}
+		this._rebuildIndex();
+		this._flushStructure();
+		return records.map(record => this._pathOfNode(record.node)).filter(Boolean);
+	}
+
+	/**
+	 * 同级排序(node.reorder)。`params.path` 是**父节点**路径,`target` 是「可见子节点」列表里的下标,
+	 * `offset` 是位移量——语义逐行对齐编辑态 nodeMgr.moveArrayElement 的 children 分支:
+	 * 目标位置取 `visible[target + offset]` 在**未过滤** children 里的原始下标,越界得 -1(移到末尾)。
+	 */
+	reorder(params) {
+		this._rebuildIndex();
+		const p = params || {};
+		const parent = this._requireNode(p.path, 'reorder');
+		const target = Number(p.target);
+		const offset = Number(p.offset);
+		if (!Number.isFinite(target) || !Number.isFinite(offset)) {
+			return false;
+		}
+		const raw = (parent.children && parent.children.slice()) || [];
+		const visible = this._visibleChildrenWithNames(parent).map(entry => entry[0]);
+		const child = visible[target];
+		if (!child || typeof child.setSiblingIndex !== 'function') {
+			return false;
+		}
+		const destination = raw.indexOf(visible[target + offset]);
+		const before = this._siblingIndex(child);
+		child.setSiblingIndex(destination);
+		const after = this._siblingIndex(child);
+		if (after !== before) {
+			this._pushCommand({
+				label: 'Reorder Node',
+				undo: () => { if (this._isValid(child)) { child.setSiblingIndex(before); } },
+				redo: () => { if (this._isValid(child)) { child.setSiblingIndex(destination); } },
+			});
+		}
+		this._rebuildIndex();
+		this._flushStructure();
+		return true;
+	}
+
+	/**
+	 * 锁定/解锁(node.change-node-lock):写节点自身 objFlags 的 LockedInEditor 位(与编辑态一致,
+	 * 不外挂 map),`_dumpNode` 已读该位。锁定不改变结构快照,故这里逐节点回推带完整 dump 的
+	 * node:change(propPath:'locked'),由 Hierarchy 侧刷新锁图标。
+	 */
+	changeNodeLock(params) {
+		this._rebuildIndex();
+		const p = params || {};
+		const flag = this._flagLockedInEditor;
+		if (!flag) {
+			throw new Error('preview change-node-lock: the LockedInEditor flag is unavailable in this engine build');
+		}
+		const locked = Boolean(p.locked);
+		const roots = toPathArray(p.paths).map(path => this._requireNode(path, 'change-node-lock'));
+		const records = [];
+		const visit = node => {
+			if (!this._isValid(node)) {
+				return;
+			}
+			const objFlags = this._objFlagsOf(node);
+			records.push({ node, objFlags });
+			this._setObjFlags(node, locked ? (objFlags | flag) : (objFlags & ~flag));
+			if (p.loop) {
+				for (const child of (node.children || [])) {
+					visit(child);
+				}
+			}
+		};
+		for (const root of roots) {
+			visit(root);
+		}
+		if (records.length > 0) {
+			this._pushCommand({
+				label: locked ? 'Lock Node' : 'Unlock Node',
+				undo: () => {
+					for (const record of records) {
+						this._setObjFlags(record.node, record.objFlags);
+					}
+					this._emitLockChanges(records);
+				},
+				redo: () => {
+					for (const record of records) {
+						this._setObjFlags(record.node, locked ? (record.objFlags | flag) : (record.objFlags & ~flag));
+					}
+					this._emitLockChanges(records);
+				},
+			});
+		}
+		this._rebuildIndex();
+		this._emitLockChanges(records);
+	}
+
+	_emitLockChanges(records) {
+		for (const record of records) {
+			if (!this._isValid(record.node)) {
+				continue;
+			}
+			const mgrPath = this._uuidToPath.get(record.node.uuid);
+			if (mgrPath !== undefined) {
+				this._afterWrite(record.node, mgrPath, 'locked');
+			}
+		}
+	}
+
+	_objFlagsOf(node) {
+		const value = node && (node._objFlags != null ? node._objFlags : node.objFlags);
+		return value || 0;
+	}
+
+	_setObjFlags(node, value) {
+		try {
+			node.objFlags = value;
+			if (this._objFlagsOf(node) === value) {
+				return;
+			}
+		} catch {
+			// 部分引擎版本 objFlags 只有 getter,退回写内部字段。
+		}
+		node._objFlags = value;
+	}
+
+	// ---- 剪贴板(预览独立,停止即丢弃)---------------------------------------
+
+	/**
+	 * 复制(node.copy):`cc.instantiate` 出**离线副本**存入 stash(思路对齐编辑态 stashInstants),
+	 * 之后即便源节点被改动/删除,粘贴出的内容仍是复制那一刻的样子。
+	 * @returns {string[]} 被复制节点的当前展示路径
+	 */
+	copyNodes(params) {
+		this._rebuildIndex();
+		const nodes = toPathArray(params && params.paths).map(path => this._requireNode(path, 'copy'));
+		for (const node of nodes) {
+			this._assertNotScene(node, 'copy');
+		}
+		this._clearClipboard();
+		const entries = [];
+		for (const node of nodes) {
+			const instant = this._cc.instantiate(node);
+			if (!instant) {
+				continue;
+			}
+			this._stripPrefabInfo(instant);
+			entries.push({ uuid: node.uuid, instant });
+		}
+		this._clipboard = { type: entries.length > 0 ? 'copy' : 'none', entries };
+		return entries.map(entry => this._pathOfUuid(entry.uuid)).filter(Boolean);
+	}
+
+	/** 剪切(node.cut):只登记 uuid,不立即摘除;paste 时改为移动(对齐编辑态 _cutUuids)。 */
+	cutNodes(params) {
+		this._rebuildIndex();
+		const paths = toPathArray(params && params.paths);
+		const nodes = paths.map(path => this._requireNode(path, 'cut'));
+		for (const node of nodes) {
+			this._assertNotScene(node, 'cut');
+		}
+		this._clearClipboard();
+		this._clipboard = {
+			type: nodes.length > 0 ? 'cut' : 'none',
+			entries: nodes.map(node => ({ uuid: node.uuid })),
+		};
+		return paths;
+	}
+
+	/**
+	 * 粘贴(node.paste):剪切态走「移动」、复制态走「从 stash 再 instantiate 一份」。
+	 * `parentPath` 缺省为场景根。返回新节点(或被移动节点)的展示路径。
+	 */
+	pasteNodes(params) {
+		this._rebuildIndex();
+		const p = params || {};
+		const parent = this._requireNode(p.parentPath, 'paste');
+		if (this._clipboard.type === 'cut') {
+			const paths = this._clipboard.entries.map(entry => this._pathOfUuid(entry.uuid)).filter(Boolean);
+			this._clipboard = { type: 'none', entries: [] };
+			if (paths.length === 0) {
+				return [];
+			}
+			return this.setParent({
+				paths,
+				parentPath: this._pathOfNode(parent),
+				keepWorldTransform: p.keepWorldTransform,
+			});
+		}
+		if (this._clipboard.entries.length === 0) {
+			throw new Error('preview paste: no nodes have been copied');
+		}
+		return this._asOneCommand('Paste Nodes', () => {
+			const created = [];
+			for (const entry of this._clipboard.entries) {
+				const node = this._cc.instantiate(entry.instant);
+				if (!node) {
+					continue;
+				}
+				this._stripPrefabInfo(node);
+				node.name = this._availableName(node.name, parent);
+				// 编辑态 createNodeFromStash 以 keepLayer=true 粘贴,故这里**不**用父级 layer 覆盖副本。
+				node.setParent(parent, Boolean(p.keepWorldTransform));
+				this._recordCreate(node, parent, 'Paste Nodes');
+				created.push(node);
+			}
+			this._rebuildIndex();
+			this._flushStructure();
+			return created.map(node => this._pathOfNode(node)).filter(Boolean);
+		});
+	}
+
+	/** 原地复制(node.duplicate):副本挂在源节点的同一个父级下,名字同级唯一化。 */
+	duplicateNodes(params) {
+		this._rebuildIndex();
+		const nodes = toPathArray(params && params.paths).map(path => this._requireNode(path, 'duplicate'));
+		for (const node of nodes) {
+			this._assertNotScene(node, 'duplicate');
+		}
+		return this._asOneCommand('Duplicate Nodes', () => {
+			const created = [];
+			for (const source of nodes) {
+				const parent = source.parent;
+				if (!parent) {
+					continue;
+				}
+				const copy = this._cc.instantiate(source);
+				if (!copy) {
+					continue;
+				}
+				this._stripPrefabInfo(copy);
+				copy.name = this._availableName(source.name, parent);
+				copy.setParent(parent);
+				this._recordCreate(copy, parent, 'Duplicate Nodes');
+				created.push(copy);
+			}
+			this._rebuildIndex();
+			this._flushStructure();
+			return created.map(node => this._pathOfNode(node)).filter(Boolean);
+		});
+	}
+
+	/**
+	 * 剪贴板状态(node.query-clipboard-state)。paths 按**当前**索引重算,源节点已删除则被过滤——
+	 * 与编辑态 queryClipboardState 完全一致(Paste 因此会置灰,而不是粘出一个孤儿副本)。
+	 */
+	queryClipboardState() {
+		this._rebuildIndex();
+		if (this._clipboard.type === 'none' || this._clipboard.entries.length === 0) {
+			return { type: 'none', paths: [] };
+		}
+		return {
+			type: this._clipboard.type,
+			paths: this._clipboard.entries.map(entry => this._pathOfUuid(entry.uuid)).filter(Boolean),
+		};
+	}
+
+	/** node.get-path-by-uuid:未知 uuid 返回 ''(与编辑态过滤空串的用法一致)。 */
+	getPathByUuid(params) {
+		this._rebuildIndex();
+		const uuid = typeof params === 'string' ? params : (params && params.uuid);
+		return typeof uuid === 'string' ? this._pathOfUuid(uuid) : '';
+	}
+
+	_clearClipboard() {
+		for (const entry of this._clipboard.entries) {
+			const instant = entry.instant;
+			if (instant && this._isValid(instant) && typeof instant.destroy === 'function') {
+				try {
+					instant.destroy();
+				} catch {
+					// 离线副本销毁失败无副作用,忽略。
+				}
+			}
+		}
+		this._clipboard = { type: 'none', entries: [] };
+	}
+
+	_destroyDetachedNodes() {
+		for (const node of this._detachedNodes) {
+			if (node && this._isValid(node) && typeof node.destroy === 'function') {
+				try {
+					node.destroy();
+				} catch {
+					// 游离节点销毁失败无副作用,忽略。
+				}
+			}
+		}
+		this._detachedNodes.clear();
+	}
+
+	/** M5:销毁被摘除的组件实例(best-effort),与 _destroyDetachedNodes 同一清理时机。 */
+	_destroyDetachedComponents() {
+		for (const comp of this._detachedComponents) {
+			if (comp && this._isValid(comp) && typeof comp.destroy === 'function') {
+				try {
+					comp.destroy();
+				} catch {
+					// 游离组件销毁失败无副作用,忽略。
+				}
+			}
+		}
+		this._detachedComponents.clear();
+	}
+
+	// ---- 类型化创建的资源装配 ----------------------------------------------
+
+	/** 类型 → 配置项。`project-type` 与 workMode 不符且存在备选时取第 2 项(对齐 _resolveTypeCreateOptions)。 */
+	async _resolveNodeTypeConfig(nodeType, workMode) {
+		const table = await this._loadNodeTypeConfig();
+		const list = table && table[nodeType];
+		if (!Array.isArray(list) || list.length === 0) {
+			throw new Error(`preview create-by-type: node type '${nodeType}' is not implemented`);
+		}
+		let config = list[0];
+		const projectType = config['project-type'];
+		if (projectType && workMode && projectType !== workMode && list.length > 1) {
+			config = list[1];
+		}
+		return config;
+	}
+
+	/** 拉取并缓存 CLI 输出的 NODE_CONFIGS(只读路由);失败时清掉 pending 以便下次重试。 */
+	_loadNodeTypeConfig() {
+		if (this._nodeTypeConfig) {
+			return Promise.resolve(this._nodeTypeConfig);
+		}
+		if (!this._nodeTypeConfigPromise) {
+			const url = `${this._serverURL || ''}${NODE_TYPE_CONFIG_ROUTE}`;
+			this._nodeTypeConfigPromise = fetch(url)
+				.then(response => {
+					if (!response.ok) {
+						throw new Error(`HTTP ${response.status}`);
+					}
+					return response.json();
+				})
+				.then(json => {
+					this._nodeTypeConfig = json;
+					return json;
+				})
+				.catch(error => {
+					this._nodeTypeConfigPromise = null;
+					throw new Error(`preview create-by-type: failed to load the node type config from ${url}: ${(error && error.message) || error}`);
+				});
+		}
+		return this._nodeTypeConfigPromise;
+	}
+
+	/** 无 assetUuid(Empty)→ `new cc.Node`;否则内置 Prefab instantiate,失败降级为空节点 + warn。 */
+	async _instantiateForNodeType(config, nodeType) {
+		const fallbackName = config.name || nodeType || 'Node';
+		if (!config.assetUuid) {
+			return new this._cc.Node(fallbackName);
+		}
+		try {
+			const prefab = await this._loadBuiltinPrefab(config.assetUuid);
+			const node = this._cc.instantiate(prefab);
+			if (!node) {
+				throw new Error('cc.instantiate returned null');
+			}
+			this._stripPrefabInfo(node);
+			return node;
+		} catch (error) {
+			this._emit('view:log', {
+				level: 'warn',
+				message: `[preview-inspect] create '${nodeType}' fell back to an empty node: ${(error && error.message) || error}`,
+			});
+			return new this._cc.Node(fallbackName);
+		}
+	}
+
+	_loadBuiltinPrefab(uuid) {
+		const cached = this._prefabCache.get(uuid);
+		if (cached && this._isValid(cached)) {
+			return Promise.resolve(cached);
+		}
+		return this._loadAssetByUuid(uuid).then(asset => {
+			if (!asset) {
+				throw new Error(`asset '${uuid}' resolved to null`);
+			}
+			this._prefabCache.set(uuid, asset);
+			return asset;
+		});
+	}
+
+	/**
+	 * 按 uuid 取内置资源。先试 `assetManager.loadAny`(uuid 命中已注册 bundle 配置时最省事),
+	 * 不行再退到「fetch import JSON + loadWithJson」——预览资源路由 `/assets/<bundle>/import/**`
+	 * 忽略 bundle 段、遍历全部 library 目录(含 db://internal),故内置 Prefab 的 JSON 可直接按 uuid 取到;
+	 * 其依赖即 settings.engine.builtinAssets,预览启动时已被硬性校验非空。
+	 */
+	_loadAssetByUuid(uuid) {
+		const assetManager = this._cc.assetManager;
+		if (!assetManager) {
+			return Promise.reject(new Error('cc.assetManager is unavailable'));
+		}
+		return new Promise((resolve, reject) => {
+			let settled = false;
+			const loadViaJson = () => {
+				const url = `${this._serverURL || ''}/assets/general/import/${uuid.slice(0, 2)}/${uuid}.json`;
+				fetch(url)
+					.then(response => {
+						if (!response.ok) {
+							throw new Error(`HTTP ${response.status} for ${url}`);
+						}
+						return response.json();
+					})
+					.then(json => {
+						assetManager.loadWithJson(json, { assetId: uuid }, () => { /* progress */ }, (err, asset) => {
+							if (err) {
+								reject(err instanceof Error ? err : new Error(String(err)));
+							} else {
+								resolve(asset);
+							}
+						});
+					})
+					.catch(reject);
+			};
+			try {
+				assetManager.loadAny({ uuid }, (err, asset) => {
+					if (settled) {
+						return;
+					}
+					settled = true;
+					if (!err && asset) {
+						resolve(asset);
+					} else {
+						loadViaJson();
+					}
+				});
+			} catch {
+				if (!settled) {
+					settled = true;
+					loadViaJson();
+				}
+			}
+		});
+	}
+
+	/**
+	 * canvasRequired 的父级解析(对齐编辑态 checkCanvasRequired + getUICanvasNode 的非 prefab 分支):
+	 * 自身/祖先已在 Canvas 下 → 保持原父级;否则取直接子节点里最后一个 Canvas;都没有则创建内置 Canvas。
+	 */
+	async _resolveCanvasParent(parent, workMode) {
+		const canvas = this._findUICanvasNode(parent);
+		if (canvas) {
+			return canvas;
+		}
+		const uuid = workMode === '2d' ? CANVAS_PREFAB_UUID_2D : CANVAS_PREFAB_UUID_3D;
+		try {
+			const prefab = await this._loadBuiltinPrefab(uuid);
+			const node = this._cc.instantiate(prefab);
+			if (!node) {
+				throw new Error('cc.instantiate returned null');
+			}
+			this._stripPrefabInfo(node);
+			node.setParent(parent);
+			this._recordCreate(node, parent, 'Create Canvas');
+			return node;
+		} catch (error) {
+			this._emit('view:log', {
+				level: 'warn',
+				message: `[preview-inspect] auto Canvas creation failed; the new node stays under its original parent: ${(error && error.message) || error}`,
+			});
+			return parent;
+		}
+	}
+
+	/** 自身或任一祖先带 cc.Canvas → 返回自身;否则返回最后一个带 cc.Canvas 的直接子节点;都没有 → null。 */
+	_findUICanvasNode(node) {
+		if (!node) {
+			return null;
+		}
+		if (this._hasCanvasComponent(node)) {
+			return node;
+		}
+		const scene = this._getScene();
+		if (node !== scene) {
+			let cursor = node.parent;
+			while (cursor) {
+				if (this._hasCanvasComponent(cursor)) {
+					return node;
+				}
+				if (cursor === scene) {
+					break;
+				}
+				cursor = cursor.parent;
+			}
+		}
+		const children = (node.children && node.children.slice()) || [];
+		for (let i = children.length - 1; i >= 0; i--) {
+			if (this._hasCanvasComponent(children[i])) {
+				return children[i];
+			}
+		}
+		return null;
+	}
+
+	_hasCanvasComponent(node) {
+		const Canvas = this._cc.Canvas;
+		if (!node || !Canvas || typeof node.getComponent !== 'function') {
+			return false;
+		}
+		try {
+			return Boolean(node.getComponent(Canvas));
+		} catch {
+			return false;
+		}
+	}
+
+	/** 空节点挂在 Canvas 下时补 cc.UITransform(对齐编辑态 nodeMgr.ensureUITransformComponent)。 */
+	_ensureUITransformComponent(node) {
+		const UITransform = this._cc.UITransform;
+		if (!UITransform || !node || (node.children && node.children.length > 0)) {
+			return;
+		}
+		let inside = false;
+		let cursor = node.parent;
+		while (cursor) {
+			if (this._hasCanvasComponent(cursor)) {
+				inside = true;
+				break;
+			}
+			cursor = cursor.parent;
+		}
+		if (!inside) {
+			return;
+		}
+		try {
+			if (!node.getComponent(UITransform)) {
+				node.addComponent(UITransform);
+			}
+		} catch {
+			// 补组件失败不影响节点已经创建成功的事实。
+		}
+	}
+
+	_setLayerDeep(node, layer) {
+		if (!node) {
+			return;
+		}
+		node.layer = layer;
+		for (const child of (node.children || [])) {
+			this._setLayerDeep(child, layer);
+		}
+	}
+
+	/**
+	 * 摘掉 prefab 元数据:预览态的创建/复制都当作普通节点(对齐编辑态 create-by-type 的 removePrefabInfo),
+	 * 且预览永不序列化回盘,残留的 prefab info 只会让 Inspector 显示错误的关联状态。
+	 */
+	_stripPrefabInfo(node) {
+		if (!node) {
+			return;
+		}
+		try {
+			node._prefab = null;
+			for (const comp of (node.components || node._components || [])) {
+				if (comp) {
+					comp.__prefab = null;
+				}
+			}
+		} catch {
+			// 只是清理元数据,失败可忽略。
+		}
+		for (const child of (node.children || [])) {
+			this._stripPrefabInfo(child);
+		}
 	}
 
 	// ---- 结构快照 diff -----------------------------------------------------
@@ -903,8 +2361,8 @@ class PreviewInspect {
 		const data = {
 			path: mgrPath,
 			__type__: this._typeName(node),
-			// 预览态只读标志(顶层普通布尔,非 IProperty):Inspector 据此禁用 Add Component / 组件·节点 kebab 菜单
-			// (组件增删、reset、粘贴等未实现的写操作),避免用户触发后撞到「预览暂不支持」并弹错误 toast(M4 capability)。
+			// 预览态只读标志(顶层普通布尔,非 IProperty):M5 起组件级写操作(增删/reset/排序/整包粘贴)已支持,
+			// Inspector 据此在预览态显示组件 kebab 菜单;该标志此后仅门控节点级菜单(node.reset-property 等仍不支持)。
 			readonly: true,
 			name: this._withMeta(this._prop(node.name, 'String'), { displayName: 'Name', animatable: false }),
 			// active/locked 用作 section 头部复选框(visible:false 不作为字段单独渲染),对齐 encode.ts:88-89。
@@ -918,7 +2376,7 @@ class PreviewInspect {
 			uuid: this._withMeta(this._prop(node.uuid, 'String'), { displayName: 'UUID', animatable: false }),
 			parent: this._propRef(node.parent, 'cc.Node'),
 			children: this._visibleChildrenWithNames(node).map(([child]) => this._propRef(child, 'cc.Node')),
-			__comps__: includeComponents ? comps.filter(c => c).map(c => this._dumpComponent(c, undefined)) : [],
+			__comps__: includeComponents ? this._dumpComponentsWithPaths(comps, mgrPath) : [],
 		};
 		// 关键:逐属性填 path(含组件属性),否则面板 web 侧无 path 会早退、setProperty 不发出。
 		return this._fillDumpPaths(data, includeComponents);
@@ -938,6 +2396,46 @@ class PreviewInspect {
 			_globals: {},
 		};
 		return this._fillDumpPaths(data, false);
+	}
+
+	/**
+	 * 同级去重的组件 target 名(`ClassName` / `ClassName_001`),与 comps 数组的非空组件顺序一一对应。
+	 * `_dumpNode`(节点 dump 挂 component_path)与 `_resolveComponentByPath`(按 target 路径反查组件)共用,
+	 * 保证面板挂的路径与菜单定位用的路径永不漂移。
+	 */
+	_componentTargetNames(comps) {
+		const taken = new Map();
+		const names = [];
+		for (const comp of comps) {
+			if (!comp) {
+				continue;
+			}
+			const base = this._className(comp.constructor) || 'cc.Component';
+			if (taken.has(base)) {
+				const count = taken.get(base) + 1;
+				taken.set(base, count);
+				names.push(`${base}_${pad3(count)}`);
+			} else {
+				taken.set(base, 0);
+				names.push(base);
+			}
+		}
+		return names;
+	}
+
+	/** M5:逐个带 target 路径(`节点路径/ClassName_NNN`)dump 组件,供 Inspector kebab 菜单直接用 component_path 驱动 remove/reset 等。 */
+	_dumpComponentsWithPaths(comps, mgrPath) {
+		const names = this._componentTargetNames(comps);
+		const prefix = mgrPath ? `${mgrPath}/` : '';
+		const out = [];
+		let named = 0;
+		for (const comp of comps) {
+			if (!comp) {
+				continue;
+			}
+			out.push(this._dumpComponent(comp, `${prefix}${names[named++]}`));
+		}
+		return out;
 	}
 
 	_dumpComponent(comp, path) {
@@ -998,7 +2496,17 @@ class PreviewInspect {
 				sa.visible = true;
 				sa.displayOrder = -999;
 			} else {
-				sa.visible = false; // 内置组件(cc.UITransform/cc.Sprite…):隐藏空 Script 行。
+				// 内置组件(cc.UITransform/cc.Sprite…)本就无脚本:隐藏空 Script 行。
+				// 但用户脚本组件走到这里说明 uuid 没认出来(classId 不是 uuid 形状),
+				// 静默隐藏会让人以为面板漏了字段,故按类名去重告警一次。
+				sa.visible = false;
+				if (className && className.indexOf('cc.') !== 0 && !this._scriptUuidWarned.has(className)) {
+					this._scriptUuidWarned.add(className);
+					this._emit('view:log', {
+						level: 'warn',
+						message: `[preview-inspect] cannot resolve script asset uuid for '${className}'; the Script row is hidden`,
+					});
+				}
 			}
 			value.__scriptAsset = sa;
 		}
@@ -1019,16 +2527,22 @@ class PreviewInspect {
 	}
 
 	/**
-	 * best-effort 取组件绑定的脚本 uuid(对齐编辑态所读的 __scriptUuid)。
-	 * 内置组件(cc.Xxx)无脚本 → ''。用户脚本组件:优先 comp.__scriptUuid(DEV 构建常存在);
-	 * 否则用「类 id 形如 uuid 且类名非 cc.* 前缀」的启发式,必要时 decompressUuid 还原完整 uuid。
+	 * best-effort 取组件绑定的脚本 uuid,并归一成 **asset-db 的带短横形式**。
+	 *
+	 * 内置组件(cc.Xxx)无脚本 → ''。用户脚本组件:优先 `comp.__scriptUuid`(编辑器构建才注入),
+	 * 否则取 classId —— 用户脚本的 classId 就是压缩后的脚本 uuid(editor-extends 的 MissingReporter
+	 * 也是这么反查的:`isUUID(classId)` → `decompressUUID(classId)`)。
+	 *
+	 * 两侧都要过 `_normalizeAssetUuid`:压缩形式解压出来是 32 位无短横 uuid,而面板的资源选择器是拿
+	 * asset-db 的**带短横** uuid 做严格相等匹配的,少这一步 Script 一栏就会红字 "Missing"。
 	 */
 	_scriptUuid(comp) {
 		if (!comp) {
 			return '';
 		}
 		if (typeof comp.__scriptUuid === 'string' && comp.__scriptUuid) {
-			return comp.__scriptUuid;
+			// 编辑器构建注入的值通常已是带短横 uuid;仍过一遍归一,避免个别构建给的是压缩形式。
+			return this._normalizeAssetUuid(comp.__scriptUuid);
 		}
 		try {
 			const ctor = comp.constructor;
@@ -1041,18 +2555,85 @@ class PreviewInspect {
 			if (typeof cid !== 'string' || !cid) {
 				return '';
 			}
-			// 用户脚本组件的 classId 即压缩后的脚本 uuid;还原为标准 uuid 供面板解析。
-			if (js && typeof js.decompressUuid === 'function') {
-				try {
-					return js.decompressUuid(cid) || cid;
-				} catch {
-					return cid;
-				}
-			}
-			return cid;
+			return this._normalizeAssetUuid(cid);
 		} catch {
 			return '';
 		}
+	}
+
+	/**
+	 * 任意 uuid 形态 → asset-db 的带短横 uuid;认不出来则返回 ''(调用方据此隐藏 Script 行,
+	 * 而不是丢一个查不到的 uuid 给面板渲染成红字 "Missing")。
+	 *
+	 * 认得的输入:带短横 36 位(原样)、32 位无短横(补短横)、22/23 位压缩 base64(解压 + 补短横),
+	 * 以及上述压缩形式带 `@子资源` 后缀。解压这一步的输出形态随实现来源而变:本地移植版给出 32 位
+	 * 无短横,而预览页加载的 `EditorExtends.UuidUtils.decompressUUID` 给出 36 位带短横——两种都要认。
+	 * `ccclass('Foo')` 这种手写类名的 classId 不是 uuid 形状 → ''。
+	 */
+	_normalizeAssetUuid(raw) {
+		if (typeof raw !== 'string' || !raw) {
+			return '';
+		}
+		// 子资源后缀原样保留(脚本资源不会有,但同一归一函数也被别处复用时才不会踩坑)。
+		let suffix = '';
+		let body = raw;
+		const sub = raw.match(REG_UUID_COMPRESSED_SUB);
+		if (sub) {
+			body = sub[1];
+			suffix = sub[2];
+		}
+		if (REG_UUID_DASHED.test(body)) {
+			return body + suffix;
+		}
+		if (REG_UUID_COMPRESSED.test(body)) {
+			body = this._decompressUuid(body);
+		}
+		// `_decompressUuid` 的返回形态随实现来源而变:本地移植版产出 32 位无短横(走下面的
+		// normalized 分支补短横);但预览页会加载 editor-extends.bundle.js,其 `UuidUtils.decompressUUID`
+		// 直接返回 **36 位带短横**形式(逐字对齐引擎 decompressNormalUuid 末尾的 join('-'))。
+		// 旧实现解压后只判 32 位无短横,带短横形态匹配不上 → 漏判成 '' → `_scriptUuid` 返回空 →
+		// Script 行被隐藏。这正是「Preview in Editor 后挂自定义脚本的节点 Script 一栏消失、编辑态正常」
+		// 的根因(编辑态 encode.ts 直接读引擎注入的 __scriptUuid,不经此函数)。故解压后再判一次 dashed。
+		if (REG_UUID_DASHED.test(body)) {
+			return body + suffix;
+		}
+		if (REG_UUID_NORMALIZED.test(body)) {
+			return `${body.slice(0, 8)}-${body.slice(8, 12)}-${body.slice(12, 16)}-${body.slice(16, 20)}-${body.slice(20, 32)}${suffix}`;
+		}
+		return '';
+	}
+
+	/**
+	 * 压缩 uuid(22/23 位 base64)→ uuid(32 位无短横 或 36 位带短横,取决于实现来源)。
+	 *
+	 * 优先用 EditorExtends 的权威实现(预览页会加载 editor-extends.bundle.js,`UuidUtils.decompressUUID`
+	 * 可用,返回 **36 位带短横**形式),缺失时用本地移植版(逐字对齐 decompressNormalUuid 的 hex 部分,
+	 * 返回 **32 位无短横**)。两种返回形态都由调用方 `_normalizeAssetUuid` 兜住(解压后复判 dashed / normalized),
+	 * 故不因 EditorExtends 缺席或其返回形态差异而失效。
+	 */
+	_decompressUuid(compressed) {
+		const authoritative = this._editorExtends && this._editorExtends.UuidUtils;
+		if (authoritative && typeof authoritative.decompressUUID === 'function') {
+			try {
+				const out = authoritative.decompressUUID(compressed);
+				if (typeof out === 'string' && out) {
+					return out;
+				}
+			} catch {
+				/* 落到本地实现 */
+			}
+		}
+		// 23 位:前 5 位保留 + 后 18 位 base64 解成 27 个 hex;22 位(min):前 2 位保留 + 后 20 位解成 30 个 hex。
+		const keep = compressed.length === 23 ? 5 : 2;
+		const hexChars = [];
+		for (let i = keep; i < compressed.length; i += 2) {
+			const lhs = UUID_ASCII_TO_64[compressed.charCodeAt(i)];
+			const rhs = UUID_ASCII_TO_64[compressed.charCodeAt(i + 1)];
+			hexChars.push((lhs >> 2).toString(16));
+			hexChars.push((((lhs & 3) << 2) | (rhs >> 4)).toString(16));
+			hexChars.push((rhs & 0xF).toString(16));
+		}
+		return compressed.slice(0, keep) + hexChars.join('');
 	}
 
 	// ---- IProperty 编码 -----------------------------------------------------

--- a/static/web/preview-inspect.js
+++ b/static/web/preview-inspect.js
@@ -1,0 +1,1345 @@
+/* global window, globalThis, requestAnimationFrame, cancelAnimationFrame, performance */
+
+/**
+ * 预览运行时 Inspect Agent(M1:只读 Hierarchy + selection + 结构 liveness)。
+ *
+ * 由 previewMain 在 game-boot 跑起启动场景后装配,直接读活 `cc.director` 的场景图,
+ * 产出与编辑器 `node.query-tree` 契约一致的 INodeTreeItem,并以轻量结构快照 diff
+ * 广播 node:added/node:removed/node:change,以及 selection 回显事件。
+ *
+ * 关键约束(对齐 node-path-manager,见 plan「关键约束 4」):
+ *  - 主键是 canonical node path(不是 uuid);根 scene 的 path = '/',顶层子节点无前导斜杠;
+ *  - 同名兄弟按出现顺序去重:首个不加后缀,其后 `_001`/`_002`(3 位零填充);
+ *  - 组件 target 路径 = `节点路径/类名`(M1 不派发 component,故此处只做节点树)。
+ *
+ * 本文件是手写 ESM(风格对齐 game-boot.js),不依赖 scene-bundle / EditorExtends.serialize
+ * ——那些是 M2 dump 的事。M1 完全靠遍历活场景图产出结构。
+ */
+
+/** node-path-manager 的非法字符替换规则:`/\:*?"<>|` → `_`。 */
+const ILLEGAL_NAME_CHARS = /[/\\:*?"<>|]/g;
+
+/** 结构快照扫描间隔(ms),对齐 plan「变更监听策略」的 ~100–150ms 上限。 */
+const STRUCTURE_SCAN_INTERVAL_MS = 150;
+
+/** prefab 状态兜底:预览态未加载 prefab 工具,统一按「非 prefab」上报(M2 再补真值)。 */
+const DEFAULT_PREFAB_INFO = Object.freeze({	state: 0, // PrefabState.NotAPrefab
+	isUnwrappable: false,
+	isRevertable: false,
+	isApplicable: false,
+	isAddedChild: false,
+	isNested: false,
+	assetUuid: '',
+});
+
+/**
+ * cc.Class.attr 中可透传到 IProperty 的属性描述字段(对齐 encode.ts 的 attributeProps)。
+ * 决定面板控件形态:枚举下拉、单选、位掩码、显示名、分组、多行、步长、滑块、提示、
+ * 可动画、单位、弧度、显示顺序。
+ */
+const PREVIEW_ATTRIBUTE_PROPS = [
+	'enumList',
+	'radioGroup',
+	'bitmaskList',
+	'displayName',
+	'group',
+	'multiline',
+	'step',
+	'slide',
+	'tooltip',
+	'animatable',
+	'unit',
+	'radian',
+	'displayOrder',
+];
+
+/**
+ * @param {{ cc: any, EditorExtends?: any, serverURL?: string }} env
+ * @returns {PreviewInspect}
+ */
+export function createPreviewInspect(env) {
+	const cc = env && env.cc;
+	if (!cc) {
+		throw new Error('preview-inspect: cc namespace is required');
+	}
+	return new PreviewInspect(cc, env.EditorExtends, env.serverURL);
+}
+
+/** 去掉前导斜杠:'/' → '',  '/Canvas' → 'Canvas',  'Canvas/Foo' → 'Canvas/Foo'。 */
+function stripLeadingSlashes(path) {
+	if (typeof path !== 'string') {
+		return '';
+	}
+	let i = 0;
+	while (i < path.length && path[i] === '/') {
+		i++;
+	}
+	return path.slice(i);
+}
+
+function sanitizeName(name) {
+	const base = typeof name === 'string' && name.length > 0 ? name : 'New Node';
+	return base.replace(ILLEGAL_NAME_CHARS, '_');
+}
+
+function pad3(n) {
+	return String(n).padStart(3, '0');
+}
+
+function toPathArray(param) {
+	if (!param) {
+		return [];
+	}
+	const value = typeof param === 'object' && 'path' in param ? param.path : param;
+	if (Array.isArray(value)) {
+		return value.filter(p => typeof p === 'string');
+	}
+	return typeof value === 'string' ? [value] : [];
+}
+
+class PreviewInspect {
+	constructor(cc, editorExtends, serverURL) {
+		/** @type {any} */
+		this._cc = cc;
+		this._editorExtends = editorExtends;
+		this._serverURL = serverURL;
+
+		/** path(mgr,无前导斜杠;scene 存 '') → cc.Node */
+		this._pathToNode = new Map();
+		/** uuid → path(mgr) */
+		this._uuidToPath = new Map();
+		/** uuid → cc.Node */
+		this._uuidToNode = new Map();
+
+		/** 选中集合(mgr path;scene 用 '') */
+		this._selection = new Set();
+		/** mgr path → transform 签名字符串,用于选中节点属性 liveness diff */
+		this._selectionPropSig = new Map();
+
+		/** @type {((type: string, payload?: unknown) => void) | null} */
+		this._sink = null;
+		/** uuid → { parentUuid, siblingIndex, name, active, path } */
+		this._snapshot = new Map();
+		this._scanTimer = 0;
+		this._disposed = false;
+
+		// CCObject 标志位(HideInHierarchy / LockedInEditor)。不同引擎版本挂载位置略有差异,做兜底。
+		const flags = (cc.CCObject && cc.CCObject.Flags) || (cc.Object && cc.Object.Flags) || {};
+		this._flagHideInHierarchy = flags.HideInHierarchy || 0;
+		this._flagLockedInEditor = flags.LockedInEditor || 0;
+
+		// 枚举清单缓存(对齐编辑器 encode.ts):layer 用 cc.Layers.Enum,mobility 用 cc.MobilityMode。
+		// 运行时若取不到(空数组)则回退成普通 Number 字段(见 _dumpNode),避免出现空下拉。
+		this._layersEnumList = this._buildLayersEnumList();
+		this._mobilityEnumList = this._buildMobilityEnumList();
+	}
+
+	// ---- 生命周期 ----------------------------------------------------------
+
+	/** @param {(type: string, payload?: unknown) => void} sink */
+	start(sink) {
+		this._sink = typeof sink === 'function' ? sink : null;
+		this._snapshot = this._takeSnapshot();
+		this._scheduleScan();
+	}
+
+	stop() {
+		this._disposed = true;
+		this._sink = null;
+		if (this._scanTimer) {
+			clearTimeout(this._scanTimer);
+			this._scanTimer = 0;
+		}
+		this._pathToNode.clear();
+		this._uuidToPath.clear();
+		this._uuidToNode.clear();
+		this._selection.clear();
+		this._snapshot.clear();
+	}
+
+	// ---- 查询 --------------------------------------------------------------
+
+	/**
+	 * 产出与编辑器 node.query-tree 契约一致的 INodeTreeItem。
+	 * @param {{ path?: string } | undefined} params
+	 * @returns {object | null}
+	 */
+	queryNodeTree(params) {
+		const scene = this._getScene();
+		if (!scene) {
+			return null;
+		}
+		const requested = params && typeof params.path === 'string' ? stripLeadingSlashes(params.path) : '';
+		if (requested === '') {
+			return this._buildTreeItem(scene, '');
+		}
+		this._rebuildIndex();
+		const node = this._pathToNode.get(requested);
+		if (!node || !this._isValid(node)) {
+			return null;
+		}
+		return this._buildTreeItem(node, requested);
+	}
+
+	/**
+	 * 完整属性 dump(M2:Inspector 读属性)。产出与编辑器 node.query 契约一致的 INode/IScene/IComponent
+	 * ——每属性包成 IProperty `{ value, type, ... }`。支持 path 为数组批量、kind=auto(先节点后组件)。
+	 * @param {{ path?: string | string[], kind?: string, includeComponents?: boolean } | undefined} params
+	 */
+	query(params) {
+		this._rebuildIndex();
+		const path = params && params.path;
+		const kind = (params && params.kind) || 'auto';
+		const includeComponents = !(params && params.includeComponents === false);
+		if (Array.isArray(path)) {
+			return path.map(p => this._queryOne(p, kind, includeComponents));
+		}
+		return this._queryOne(path, kind, includeComponents);
+	}
+
+	_queryOne(rawPath, kind, includeComponents) {
+		const norm = stripLeadingSlashes(typeof rawPath === 'string' ? rawPath : '');
+		if (kind !== 'component') {
+			const node = norm === '' ? this._getScene() : this._pathToNode.get(norm);
+			if (node && this._isValid(node)) {
+				return this._isScene(node) ? this._dumpScene(node) : this._dumpNode(node, norm, includeComponents);
+			}
+		}
+		if (kind === 'auto' || kind === 'component') {
+			const comp = this._resolveComponentByPath(norm);
+			if (comp) {
+				return this._dumpComponent(comp, norm);
+			}
+		}
+		return null;
+	}
+
+	/** 组件路径形态 = `节点路径/类名`(含 _NNN 去重)。best-effort:按最后一段类名在父节点上匹配。 */
+	_resolveComponentByPath(norm) {
+		const slash = norm.lastIndexOf('/');
+		const nodePath = slash < 0 ? '' : norm.slice(0, slash);
+		const compSeg = slash < 0 ? norm : norm.slice(slash + 1);
+		const node = nodePath === '' ? this._getScene() : this._pathToNode.get(nodePath);
+		if (!node || !this._isValid(node)) {
+			return null;
+		}
+		// 去掉可能的 _NNN 后缀还原类名。
+		const className = compSeg.replace(/_\d{3}$/, '');
+		const comps = (node.components) || node._components || [];
+		const taken = new Map();
+		for (const comp of comps) {
+			if (!comp) {
+				continue;
+			}
+			const base = this._className(comp.constructor) || 'cc.Component';
+			let name;
+			if (taken.has(base)) {
+				const count = taken.get(base) + 1;
+				taken.set(base, count);
+				name = `${base}_${pad3(count)}`;
+			} else {
+				taken.set(base, 0);
+				name = base;
+			}
+			if (name === compSeg || base === className) {
+				return comp;
+			}
+		}
+		return null;
+	}
+
+	// ---- 写属性(M3:Inspector 改属性 → 写回活 cc 对象)------------------------
+
+	/**
+	 * 写单值属性。params = `{ nodePath, path, dump: { type?, value, isArray? } }`;
+	 * value 为**裸值**(host 侧已 stripGhostFields):标量/enum 直接给数字/布尔/字符串,
+	 * ValueType 给平铺对象(Vec3→`{x,y,z}`、Color→`{r,g,b,a}` 0–255)。
+	 *  - `path` 以 `__comps__.{i}.` 前缀 → 定位组件实例 + 组件内子路径;否则为节点属性子路径;
+	 *  - 节点 transform(position/scale/rotation)走 cc.Node 的 setter(rotation dump 为欧拉角);
+	 *  - ValueType 一律**新建实例**赋回(避免 getter 返回临时对象导致写入丢失);
+	 *  - 成功后主动回推一次带完整 dump 的 node:change(source:'engine'),让 Inspector/多选面板
+	 *    立即反映写入后的规范值,并同步 transform 签名以免扫描循环把本次写入当作 engine 变更重发。
+	 * 定位失败抛 Error(与编辑态 setProperty 返回 false→抛错的语义一致)。
+	 * @param {{ nodePath?: string, path?: string, dump?: { type?: string, value?: unknown } }} params
+	 */
+	setProperty(params) {
+		this._rebuildIndex();
+		const nodePath = stripLeadingSlashes((params && params.nodePath) || '');
+		const rawPath = (params && params.path) || '';
+		const dump = (params && params.dump) || {};
+		const node = nodePath === '' ? this._getScene() : this._pathToNode.get(nodePath);
+		if (!node || !this._isValid(node)) {
+			throw new Error(`preview set-property: node not found at '${(params && params.nodePath) || ''}'`);
+		}
+		const compMatch = /^__comps__\.(\d+)\.(.+)$/.exec(rawPath);
+		if (compMatch) {
+			const comps = (node.components) || node._components || [];
+			const comp = comps[Number(compMatch[1])];
+			if (!comp || !this._isValid(comp)) {
+				throw new Error(`preview set-property: component[${compMatch[1]}] not found on '${nodePath}'`);
+			}
+			if (!this._applyValueByPath(comp, compMatch[2], dump)) {
+				throw new Error(`preview set-property: failed to apply '${rawPath}' on '${nodePath}'`);
+			}
+		} else if (!this._applyValueByPath(node, rawPath, dump)) {
+			throw new Error(`preview set-property: failed to apply '${rawPath}' on '${nodePath}'`);
+		}
+		this._afterWrite(node, nodePath, rawPath);
+		return true;
+	}
+
+	/** 按 `.` 分段下钻到父容器 + 末段 key,再 _applyValue 写值。 */
+	_applyValueByPath(root, path, dump) {
+		const segs = String(path).split('.').filter(s => s.length > 0);
+		if (segs.length === 0) {
+			return false;
+		}
+		let holder = root;
+		for (let i = 0; i < segs.length - 1; i++) {
+			if (holder == null) {
+				return false;
+			}
+			holder = holder[segs[i]];
+		}
+		if (holder == null) {
+			return false;
+		}
+		return this._applyValue(holder, segs[segs.length - 1], dump);
+	}
+
+	/** 把裸值写回 holder[key]:节点 transform 走 setter,ValueType 新建实例,其余标量/enum 直接赋。 */
+	_applyValue(holder, key, dump) {
+		const type = dump && dump.type;
+		const value = dump ? dump.value : undefined;
+		// 节点内建 transform:position/scale 走 setter;rotation dump 为欧拉角(cc.Vec3)。
+		if (this._cc.Node && holder instanceof this._cc.Node) {
+			if (key === 'position') {
+				holder.position = this._toVec3(value);
+				return true;
+			}
+			if (key === 'scale') {
+				holder.scale = this._toVec3(value);
+				return true;
+			}
+			if (key === 'rotation') {
+				holder.eulerAngles = this._toVec3(value);
+				return true;
+			}
+		}
+		holder[key] = this._coerceValue(holder[key], value, type);
+		return true;
+	}
+
+	/** 标量/enum(number/boolean/string/null)原样返回;ValueType 平铺对象按 type/现值构造器新建实例。 */
+	_coerceValue(current, value, type) {
+		if (value === null || value === undefined || typeof value !== 'object') {
+			return value;
+		}
+		const ctor = this._valueTypeCtor(type) || (current && current.constructor) || null;
+		if (ctor) {
+			let inst;
+			try {
+				inst = new ctor();
+			} catch {
+				inst = null;
+			}
+			if (inst) {
+				for (const k of Object.keys(value)) {
+					if (typeof value[k] === 'number') {
+						inst[k] = value[k];
+					}
+				}
+				return inst;
+			}
+		}
+		return value;
+	}
+
+	/** dump.type(如 'cc.Vec3'/'cc.Color')→ 引擎 ValueType 构造器。 */
+	_valueTypeCtor(type) {
+		if (!type) {
+			return null;
+		}
+		const map = {
+			'cc.Vec2': this._cc.Vec2,
+			'cc.Vec3': this._cc.Vec3,
+			'cc.Vec4': this._cc.Vec4,
+			'cc.Quat': this._cc.Quat,
+			'cc.Color': this._cc.Color,
+			'cc.Size': this._cc.Size,
+			'cc.Rect': this._cc.Rect,
+		};
+		return map[type] || null;
+	}
+
+	/** `{x,y,z}` 裸值 → cc.Vec3(缺失分量按 0)。 */
+	_toVec3(value) {
+		const v = value || {};
+		const x = typeof v.x === 'number' ? v.x : 0;
+		const y = typeof v.y === 'number' ? v.y : 0;
+		const z = typeof v.z === 'number' ? v.z : 0;
+		const V = this._cc.Vec3;
+		return V ? new V(x, y, z) : { x, y, z };
+	}
+
+	/** 写入后回推:同步 selection transform 签名(防扫描循环重发)+ fire 带完整 dump 的 node:change。 */
+	_afterWrite(node, nodePath, rawPath) {
+		if (!this._sink || this._isScene(node)) {
+			return;
+		}
+		if (this._selection.has(nodePath)) {
+			this._selectionPropSig.set(nodePath, this._transformSignature(node));
+		}
+		this._emit('node:change', {
+			node: this._dumpNode(node, nodePath, true),
+			change: { propPath: rawPath, source: 'engine' },
+		});
+	}
+
+	// ---- 结构编辑(M3:Add Component 实时加组件)---------------------------
+
+	/**
+	 * 枚举运行时已注册的 cc.Component 子类,供 Add Component 面板列表使用。
+	 * 返回 `Array<{ name, cid, path }>`,与编辑态 `component.query-all` 契约对齐。
+	 * 已知限制:菜单分组路径(如 `UI/Sprite`)是编辑器元数据,运行时构建取不到,
+	 * 故 path 退化为类名(扁平列表)——不影响「选中并添加」,仅影响分组层级显示。
+	 */
+	queryComponents() {
+		const cc = this._cc;
+		const js = cc && cc.js;
+		const Component = cc && cc.Component;
+		if (!js || !Component) {
+			return [];
+		}
+		const seen = new Set();
+		const out = [];
+		const consider = ctor => {
+			if (typeof ctor !== 'function' || ctor === Component || seen.has(ctor)) {
+				return;
+			}
+			seen.add(ctor);
+			let isComp = false;
+			try {
+				isComp = typeof js.isChildClassOf === 'function'
+					? js.isChildClassOf(ctor, Component)
+					: ctor.prototype instanceof Component;
+			} catch {
+				isComp = false;
+			}
+			if (!isComp) {
+				return;
+			}
+			const name = this._className(ctor);
+			if (!name) {
+				return;
+			}
+			let cid = '';
+			try {
+				cid = (typeof js.getClassId === 'function' && js.getClassId(ctor)) || '';
+			} catch {
+				cid = '';
+			}
+			out.push({ name, cid: cid || name, path: name });
+		};
+		// 运行时类注册表:cid 表 + 名字表(不同引擎版本挂载点略有差异,两张表都扫一遍并去重)。
+		const collect = table => {
+			if (!table || typeof table !== 'object') {
+				return;
+			}
+			for (const key in table) {
+				consider(table[key]);
+			}
+		};
+		collect(js._registeredClassIds);
+		collect(js._registeredClassNames);
+		out.sort((a, b) => a.name.localeCompare(b.name));
+		return out;
+	}
+
+	/**
+	 * 实时向活场景节点添加组件(临时、不回写磁盘,符合预览「停止即丢弃」约定)。
+	 * params = `{ nodePath, component }`;`component` 为类名或 cid,解析成运行时构造器后 `node.addComponent`。
+	 * 成功后回推一次带完整 dump 的 node:change(source:'engine'),使 Inspector 重取该节点、刷新组件列表。
+	 * 定位/解析/添加失败均抛 Error(与编辑态 add 返回 null→抛错的语义一致)。
+	 * @param {{ nodePath?: string, component?: string } | undefined} params
+	 */
+	addComponent(params) {
+		this._rebuildIndex();
+		const rawNodePath = (params && params.nodePath) || '';
+		const nodePath = stripLeadingSlashes(rawNodePath);
+		const component = params && params.component;
+		const node = nodePath === '' ? this._getScene() : this._pathToNode.get(nodePath);
+		if (!node || !this._isValid(node)) {
+			throw new Error(`preview add-component: node not found at '${rawNodePath}'`);
+		}
+		if (this._isScene(node)) {
+			throw new Error('preview add-component: cannot add component to scene root');
+		}
+		const ctor = this._resolveComponentClass(component);
+		if (!ctor) {
+			throw new Error(`preview add-component: unknown component '${component}'`);
+		}
+		let added;
+		try {
+			added = node.addComponent(ctor);
+		} catch (e) {
+			throw new Error(`preview add-component: addComponent('${component}') failed: ${(e && e.message) || e}`);
+		}
+		if (!added) {
+			throw new Error(`preview add-component: addComponent('${component}') returned null`);
+		}
+		// 结构变更:回推带完整 dump 的 node:change,让 Inspector 重取该节点、刷新出新组件。
+		this._emit('node:change', {
+			node: this._dumpNode(node, nodePath, true),
+			change: { propPath: '__comps__', source: 'engine' },
+		});
+		return this._dumpComponent(added, `${nodePath}/${this._className(added.constructor)}`);
+	}
+
+	/** 把组件类名或 cid 解析成运行时构造器(getClassByName 优先,回退 getClassById);已是构造器则直接返回。 */
+	_resolveComponentClass(component) {
+		if (!component) {
+			return null;
+		}
+		if (typeof component === 'function') {
+			return component;
+		}
+		if (typeof component !== 'string') {
+			return null;
+		}
+		const js = this._cc.js;
+		let ctor = null;
+		if (js && typeof js.getClassByName === 'function') {
+			try {
+				ctor = js.getClassByName(component);
+			} catch {
+				ctor = null;
+			}
+		}
+		if (!ctor && js && typeof js.getClassById === 'function') {
+			try {
+				ctor = js.getClassById(component);
+			} catch {
+				ctor = null;
+			}
+		}
+		return ctor || null;
+	}
+
+	// ---- selection ---------------------------------------------------------
+
+	select(params) {
+		this._rebuildIndex();
+		const paths = toPathArray(params);
+		for (const raw of paths) {
+			const norm = stripLeadingSlashes(raw);
+			if (!this._selection.has(norm)) {
+				this._selection.add(norm);
+				this._emit('scene:node-selected', { path: this._displayPath(norm) });
+			}
+		}
+	}
+
+	deselect(params) {
+		const paths = toPathArray(params);
+		for (const raw of paths) {
+			const norm = stripLeadingSlashes(raw);
+			if (this._selection.delete(norm)) {
+				this._emit('scene:node-deselected', { path: this._displayPath(norm) });
+			}
+		}
+	}
+
+	clearSelection() {
+		if (this._selection.size === 0) {
+			return;
+		}
+		this._selection.clear();
+		this._emit('scene:selection-cleared');
+	}
+
+	getSelection() {
+		return [...this._selection].map(norm => this._displayPath(norm));
+	}
+
+	// ---- 结构快照 diff -----------------------------------------------------
+
+	_scheduleScan() {
+		if (this._disposed) {
+			return;
+		}
+		this._scanTimer = setTimeout(() => {
+			this._scanTimer = 0;
+			this._scan();
+		}, STRUCTURE_SCAN_INTERVAL_MS);
+	}
+
+	_scan() {
+		if (this._disposed || !this._sink) {
+			return;
+		}
+		try {
+			this._diffAndEmit();
+			this._emitSelectionPropChanges();
+		} catch {
+			// 扫描是尽力而为的附加能力,单帧异常不应终止后续扫描。
+		}
+		this._scheduleScan();
+	}
+
+	_diffAndEmit() {
+		const next = this._takeSnapshot();
+		const prev = this._snapshot;
+
+		// 新增
+		for (const [uuid, info] of next) {
+			if (!prev.has(uuid)) {
+				this._emit('node:added', { path: this._displayPath(info.path) });
+			}
+		}
+		// 删除
+		for (const [uuid, info] of prev) {
+			if (!next.has(uuid)) {
+				this._emit('node:removed', { path: this._displayPath(info.path) });
+			}
+		}
+		// 移动 / 改父 / 重命名 / 兄弟重排 → 结构性 node:change(触发 Hierarchy re-query)
+		for (const [uuid, info] of next) {
+			const old = prev.get(uuid);
+			if (!old) {
+				continue;
+			}
+			if (old.parentUuid !== info.parentUuid) {
+				this._emitStructureChange(info, uuid, 'parent-changed');
+			} else if (old.name !== info.name || old.siblingIndex !== info.siblingIndex || old.path !== info.path) {
+				this._emitStructureChange(info, uuid, 'child-changed');
+			}
+		}
+
+		this._snapshot = next;
+	}
+
+	_emitStructureChange(info, uuid, type) {
+		this._emit('node:change', {
+			node: { path: this._displayPath(info.path), uuid },
+			change: { type },
+		});
+	}
+
+	/**
+	 * 选中节点属性 liveness(M2):对 selection 内节点做 transform 签名 diff,变化时 dump 全量属性并
+	 * fire node:change(带完整 dump + change.propPath),满足 host router 的 property-changed 分流。
+	 * 首次见到某选中节点只记签名不广播(避免选中瞬间产生伪变更)。索引由 _diffAndEmit 已重建。
+	 */
+	_emitSelectionPropChanges() {
+		for (const norm of this._selection) {
+			const node = norm === '' ? this._getScene() : this._pathToNode.get(norm);
+			if (!node || !this._isValid(node) || this._isScene(node)) {
+				continue;
+			}
+			const sig = this._transformSignature(node);
+			const prev = this._selectionPropSig.get(norm);
+			if (prev !== sig) {
+				this._selectionPropSig.set(norm, sig);
+				if (prev !== undefined) {
+					this._emit('node:change', {
+						node: this._dumpNode(node, norm, true),
+						change: { propPath: 'position', source: 'engine' },
+					});
+				}
+			}
+		}
+		for (const key of [...this._selectionPropSig.keys()]) {
+			if (!this._selection.has(key)) {
+				this._selectionPropSig.delete(key);
+			}
+		}
+	}
+
+	_transformSignature(node) {
+		const p = node.position || {};
+		const r = node.eulerAngles || {};
+		const s = node.scale || {};
+		return [
+			node.name, node.active, node.layer,
+			p.x, p.y, p.z, r.x, r.y, r.z, s.x, s.y, s.z,
+		].join(',');
+	}
+
+	_takeSnapshot() {
+		this._rebuildIndex();
+		const snap = new Map();
+		for (const [uuid, node] of this._uuidToNode) {
+			snap.set(uuid, {
+				parentUuid: (node.parent && node.parent.uuid) || '',
+				siblingIndex: this._siblingIndex(node),
+				name: node.name,
+				active: !!node.active,
+				path: this._uuidToPath.get(uuid) || '',
+			});
+		}
+		return snap;
+	}
+
+	// ---- 索引 --------------------------------------------------------------
+
+	_rebuildIndex() {
+		this._pathToNode.clear();
+		this._uuidToPath.clear();
+		this._uuidToNode.clear();
+		const scene = this._getScene();
+		if (!scene) {
+			return;
+		}
+		this._pathToNode.set('', scene);
+		this._uuidToPath.set(scene.uuid, '');
+		this._uuidToNode.set(scene.uuid, scene);
+		const walk = (node, mgrPath) => {
+			for (const [child, name] of this._visibleChildrenWithNames(node)) {
+				const childPath = mgrPath === '' ? name : `${mgrPath}/${name}`;
+				this._pathToNode.set(childPath, child);
+				this._uuidToPath.set(child.uuid, childPath);
+				this._uuidToNode.set(child.uuid, child);
+				walk(child, childPath);
+			}
+		};
+		walk(scene, '');
+	}
+
+	/**
+	 * 返回可见子节点(丢弃 HideInHierarchy)及其去重后名字,顺序与 children 一致。
+	 * @returns {Array<[any, string]>}
+	 */
+	_visibleChildrenWithNames(node) {
+		const children = (node && node.children) || [];
+		const taken = new Map();
+		const out = [];
+		for (const child of children) {
+			if (!child || !this._isValid(child) || this._hasFlag(child, this._flagHideInHierarchy)) {
+				continue;
+			}
+			const base = sanitizeName(child.name);
+			let name;
+			if (taken.has(base)) {
+				const count = taken.get(base) + 1;
+				taken.set(base, count);
+				name = `${base}_${pad3(count)}`;
+			} else {
+				taken.set(base, 0);
+				name = base;
+			}
+			out.push([child, name]);
+		}
+		return out;
+	}
+
+	// ---- INodeTreeItem 构造 ------------------------------------------------
+
+	_buildTreeItem(node, mgrPath) {
+		const isScene = this._isScene(node);
+		let name = node.name;
+		if ((!name || name.length === 0) && isScene) {
+			name = 'Scene';
+		}
+		const children = this._visibleChildrenWithNames(node).map(([child, childName]) => {
+			const childPath = mgrPath === '' ? childName : `${mgrPath}/${childName}`;
+			return this._buildTreeItem(child, childPath);
+		});
+		return {
+			name,
+			active: !!node.active,
+			locked: this._hasFlag(node, this._flagLockedInEditor),
+			type: this._typeName(node),
+			uuid: node.uuid,
+			children,
+			prefab: DEFAULT_PREFAB_INFO,
+			parent: (node.parent && node.parent.uuid) || '',
+			path: isScene ? '/' : mgrPath,
+			isScene,
+			readonly: false,
+			components: this._buildComponents(node),
+		};
+	}
+
+	_buildComponents(node) {
+		const comps = (node && node.components) || node._components || [];
+		const out = [];
+		for (const comp of comps) {
+			if (!comp) {
+				continue;
+			}
+			const ctor = comp.constructor;
+			const className = this._className(ctor) || 'cc.Component';
+			out.push({
+				isCustom: !className.startsWith('cc.'),
+				type: className,
+				value: comp.uuid,
+				extends: this._inheritanceChain(ctor),
+			});
+		}
+		return out;
+	}
+
+	_inheritanceChain(ctor) {
+		const chain = [];
+		let cur = ctor;
+		let guard = 0;
+		while (cur && guard++ < 50) {
+			const name = this._className(cur);
+			if (!name || name === 'Object') {
+				break;
+			}
+			chain.push(name);
+			if (name === 'cc.Component' || name === 'cc.Object') {
+				break;
+			}
+			cur = cur.$super || Object.getPrototypeOf(cur);
+		}
+		return chain;
+	}
+
+	// ---- dump 元信息辅助(对齐编辑器 encode.ts)------------------------------
+
+	/** 从 cc.Layers.Enum 生成 layer 枚举清单(对齐 encode.ts:70-75)。运行时取不到则返回空数组。 */
+	_buildLayersEnumList() {
+		const Layers = this._cc.Layers;
+		const list = [];
+		if (Layers && Layers.Enum) {
+			for (const key of Object.keys(Layers.Enum)) {
+				const value = Layers.Enum[key];
+				if (typeof value === 'number') {
+					list.push({ name: key, value });
+				}
+			}
+			list.sort((a, b) => a.value - b.value);
+		}
+		return list;
+	}
+
+	/** 从 cc.MobilityMode 生成 mobility 枚举清单(对齐 encode.ts:77-79)。运行时取不到则返回空数组。 */
+	_buildMobilityEnumList() {
+		const MobilityMode = this._cc.MobilityMode;
+		const list = [];
+		if (MobilityMode) {
+			for (const key of Object.keys(MobilityMode)) {
+				const value = MobilityMode[key];
+				if (typeof value === 'number') {
+					list.push({ name: key, value });
+				}
+			}
+		}
+		return list;
+	}
+
+	/** 把 meta 中已定义的字段合并进 IProperty(用于给内置属性补 enumList/default/displayName 等)。 */
+	_withMeta(prop, meta) {
+		if (meta) {
+			for (const key of Object.keys(meta)) {
+				if (meta[key] !== undefined) {
+					prop[key] = meta[key];
+				}
+			}
+		}
+		return prop;
+	}
+
+	/**
+	 * 逐属性填充 `.path`(语义对齐 encode.ts:197-214)。
+	 * 这是「预览态改属性生效」的关键:面板 web 侧无 path 会直接早退,setProperty 不会发出。
+	 * - 顶层 IProperty(形如 {type,value}):path = key
+	 * - 组件(includeComponents):comp.path = '__comps__.{i}';comp.value[key].path = '__comps__.{i}.{key}'
+	 */
+	_fillDumpPaths(data, includeComponents) {
+		for (const [key, val] of Object.entries(data)) {
+			if (val && typeof val === 'object' && !Array.isArray(val) && 'type' in val && 'value' in val) {
+				val.path = key;
+			}
+		}
+		if (includeComponents && Array.isArray(data.__comps__)) {
+			data.__comps__.forEach((comp, index) => {
+				if (!comp) {
+					return;
+				}
+				comp.path = '__comps__.' + index;
+				if (comp.value && typeof comp.value === 'object' && !Array.isArray(comp.value)) {
+					for (const [key, prop] of Object.entries(comp.value)) {
+						if (prop && typeof prop === 'object' && !Array.isArray(prop) && 'type' in prop && 'value' in prop) {
+							prop.path = '__comps__.' + index + '.' + key;
+						}
+					}
+				}
+			});
+		}
+		return data;
+	}
+
+	/** 组件 editor 附加数据(尽力而为:运行时能拿到 icon/help 就给,拿不到给空串;对齐 encode.ts:352-363)。 */
+	_componentEditor(ctor, comp) {
+		return {
+			inspector: (ctor && ctor._inspector) || '',
+			icon: (ctor && ctor._icon) || '',
+			help: (ctor && ctor._help) || '',
+			_showTick:
+				typeof comp.start === 'function' ||
+				typeof comp.update === 'function' ||
+				typeof comp.lateUpdate === 'function' ||
+				typeof comp.onEnable === 'function' ||
+				typeof comp.onDisable === 'function',
+		};
+	}
+
+	// ---- INode / IComponent 完整 dump(IProperty 形态)------------------------
+
+	_dumpNode(node, mgrPath, includeComponents) {
+		const comps = (node.components) || node._components || [];
+		// layer/mobility 尽量对齐编辑态的枚举下拉;运行时取不到枚举清单时回退成普通 Number 字段,避免空下拉。
+		const layerProp = this._layersEnumList.length
+			? this._withMeta(this._prop(node.layer, 'Enum'), { enumList: this._layersEnumList, default: 1073741824, displayName: 'Layer', animatable: false })
+			: this._withMeta(this._prop(node.layer, 'Number'), { displayName: 'Layer', animatable: false });
+		const mobilityVal = node.mobility != null ? node.mobility : 0;
+		const mobilityProp = this._mobilityEnumList.length
+			? this._withMeta(this._prop(mobilityVal, 'Enum'), { enumList: this._mobilityEnumList, default: 0, displayName: 'Mobility' })
+			: this._withMeta(this._prop(mobilityVal, 'Number'), { displayName: 'Mobility' });
+		const data = {
+			path: mgrPath,
+			__type__: this._typeName(node),
+			// 预览态只读标志(顶层普通布尔,非 IProperty):Inspector 据此禁用 Add Component / 组件·节点 kebab 菜单
+			// (组件增删、reset、粘贴等未实现的写操作),避免用户触发后撞到「预览暂不支持」并弹错误 toast(M4 capability)。
+			readonly: true,
+			name: this._withMeta(this._prop(node.name, 'String'), { displayName: 'Name', animatable: false }),
+			// active/locked 用作 section 头部复选框(visible:false 不作为字段单独渲染),对齐 encode.ts:88-89。
+			active: this._withMeta(this._prop(!!node.active, 'Boolean'), { displayName: 'Active', visible: false }),
+			locked: this._withMeta(this._prop(this._hasFlag(node, this._flagLockedInEditor), 'Boolean'), { displayName: 'Locked', animatable: false, visible: false }),
+			position: this._withMeta(this._propValueType(node.position, 'cc.Vec3'), { displayName: 'Position', default: { x: 0, y: 0, z: 0 } }),
+			rotation: this._withMeta(this._propValueType(node.eulerAngles, 'cc.Vec3'), { displayName: 'Rotation', default: { x: 0, y: 0, z: 0 } }),
+			scale: this._withMeta(this._propValueType(node.scale, 'cc.Vec3'), { displayName: 'Scale', default: { x: 1, y: 1, z: 1 } }),
+			mobility: mobilityProp,
+			layer: layerProp,
+			uuid: this._withMeta(this._prop(node.uuid, 'String'), { displayName: 'UUID', animatable: false }),
+			parent: this._propRef(node.parent, 'cc.Node'),
+			children: this._visibleChildrenWithNames(node).map(([child]) => this._propRef(child, 'cc.Node')),
+			__comps__: includeComponents ? comps.filter(c => c).map(c => this._dumpComponent(c, undefined)) : [],
+		};
+		// 关键:逐属性填 path(含组件属性),否则面板 web 侧无 path 会早退、setProperty 不发出。
+		return this._fillDumpPaths(data, includeComponents);
+	}
+
+	_dumpScene(scene) {
+		const data = {
+			name: this._withMeta(this._prop(scene.name || 'Scene', 'String'), { displayName: 'Name' }),
+			active: this._withMeta(this._prop(!!scene.active, 'Boolean'), { displayName: 'Active', visible: false }),
+			locked: this._withMeta(this._prop(false, 'Boolean'), { displayName: 'Locked', visible: false }),
+			uuid: this._withMeta(this._prop(scene.uuid, 'String'), { displayName: 'UUID', visible: false }),
+			autoReleaseAssets: this._withMeta(this._prop(!!scene.autoReleaseAssets, 'Boolean'), { displayName: 'Auto Release Assets' }),
+			children: this._visibleChildrenWithNames(scene).map(([child]) => this._propRef(child, 'cc.Node')),
+			parent: '',
+			isScene: true,
+			__type__: 'cc.Scene',
+			_globals: {},
+		};
+		return this._fillDumpPaths(data, false);
+	}
+
+	_dumpComponent(comp, path) {
+		const ctor = comp.constructor;
+		const className = this._className(ctor) || 'cc.Component';
+		// enabled/uuid/name 是组件序列化骨架(对齐编辑态 encodeComponent 的 visible:false):
+		// enabled 供 section 头部复选框读取,uuid/name 不作为字段单独渲染,否则会像预览降级那样外露成原始行。
+		const value = {
+			enabled: this._withMeta(this._prop(!!comp.enabled, 'Boolean'), { visible: false }),
+			uuid: this._withMeta(this._prop(comp.uuid, 'String'), { visible: false }),
+			name: this._withMeta(this._prop(className, 'String'), { visible: false }),
+		};
+		// 遍历序列化 props(与编辑器 encodeComponent 一致:含 _xxx,按 attrs.visible 过滤)。
+		const props = (ctor && ctor.__props__) || [];
+		for (const key of props) {
+			if (key === 'enabled' || key === 'uuid' || key === 'name') {
+				continue;
+			}
+			let attrs = {};
+			try {
+				attrs = this._cc.Class && typeof this._cc.Class.attr === 'function' ? (this._cc.Class.attr(comp, key) || {}) : {};
+			} catch {
+				attrs = {};
+			}
+			// 函数式 visible(如 cc.Label 的 outline/shadow/font 子字段 visible:()=>this._enableOutline)
+			// 必须以组件实例求值(对齐 encode.ts _checkFuncAttribute),否则这些编辑态本应隐藏的条件字段会全部外露。
+			const vis = this._evalVisible(attrs, comp);
+			if (vis === false) {
+				continue;
+			}
+			try {
+				const encoded = this._encodeProp(comp[key], attrs);
+				// 面板标签取自 dump.displayName ?? dump.name ?? propertyKey;但组件专属面板(如 cc.Label.tsx)
+				// 调 DumpField 时不传 propertyKey,只能靠 dump.name。编辑态 encode.ts 给每个 prop 都写了 name,
+				// 预览这里必须对齐,否则专属面板里的属性标签会整列空白。
+				encoded.name = key;
+				// _decorate 只透传布尔 visible;函数式已在上面求值,这里把结果覆盖回去(undefined 则删除,面板默认可见)。
+				if (vis === undefined) {
+					delete encoded.visible;
+				} else {
+					encoded.visible = vis;
+				}
+				value[key] = encoded;
+			} catch {
+				// 单个属性(可能是抛异常的 getter/循环引用)编码失败不应拖垮整个组件 dump。
+			}
+		}
+		// __scriptAsset:cc.Component 基类的只读 getter(@displayName('Script') @type(Script)),
+		// DEV/预览构建下进入 __props__,被上面当普通 null 引用编码 → 内置组件也外露成 "Script" Null/Create 行。
+		// 对齐编辑态 encodeComponent(encode.ts:365-379):无脚本则隐藏,有脚本则填脚本 uuid + displayOrder:-999。
+		if (Object.prototype.hasOwnProperty.call(value, '__scriptAsset')) {
+			const scriptUuid = this._scriptUuid(comp);
+			const sa = value.__scriptAsset || {};
+			if (scriptUuid) {
+				sa.value = { uuid: scriptUuid };
+				sa.type = (sa.type && sa.type !== 'Unknown') ? sa.type : 'cc.Script';
+				sa.extends = (sa.extends && sa.extends.length) ? sa.extends : ['cc.Script', 'cc.Asset'];
+				sa.visible = true;
+				sa.displayOrder = -999;
+			} else {
+				sa.visible = false; // 内置组件(cc.UITransform/cc.Sprite…):隐藏空 Script 行。
+			}
+			value.__scriptAsset = sa;
+		}
+		const dump = {
+			type: className,
+			value,
+			extends: this._inheritanceChain(ctor),
+			// cid 用于面板选择组件专属渲染器 / kebab 菜单;缺失会退回通用面板。
+			cid: (comp.__cid__) || (ctor && ctor.__cid__) || '',
+			readonly: false,
+			visible: true,
+			editor: this._componentEditor(ctor, comp),
+		};
+		if (path) {
+			dump.component_path = path;
+		}
+		return dump;
+	}
+
+	/**
+	 * best-effort 取组件绑定的脚本 uuid(对齐编辑态所读的 __scriptUuid)。
+	 * 内置组件(cc.Xxx)无脚本 → ''。用户脚本组件:优先 comp.__scriptUuid(DEV 构建常存在);
+	 * 否则用「类 id 形如 uuid 且类名非 cc.* 前缀」的启发式,必要时 decompressUuid 还原完整 uuid。
+	 */
+	_scriptUuid(comp) {
+		if (!comp) {
+			return '';
+		}
+		if (typeof comp.__scriptUuid === 'string' && comp.__scriptUuid) {
+			return comp.__scriptUuid;
+		}
+		try {
+			const ctor = comp.constructor;
+			const className = this._className(ctor) || '';
+			if (!className || className.indexOf('cc.') === 0) {
+				return ''; // 内置类,无脚本。
+			}
+			const js = this._cc.js;
+			const cid = (js && typeof js.getClassId === 'function') ? js.getClassId(ctor) : (ctor && ctor.__cid__);
+			if (typeof cid !== 'string' || !cid) {
+				return '';
+			}
+			// 用户脚本组件的 classId 即压缩后的脚本 uuid;还原为标准 uuid 供面板解析。
+			if (js && typeof js.decompressUuid === 'function') {
+				try {
+					return js.decompressUuid(cid) || cid;
+				} catch {
+					return cid;
+				}
+			}
+			return cid;
+		} catch {
+			return '';
+		}
+	}
+
+	// ---- IProperty 编码 -----------------------------------------------------
+
+	_prop(value, type) {
+		return { value, type };
+	}
+
+	_propValueType(vt, type) {
+		return { value: this._valueTypeToPlain(vt), type };
+	}
+
+	_propRef(node, type) {
+		return { value: { uuid: (node && node.uuid) || '' }, type };
+	}
+
+	_encodeProp(value, attrs) {
+		let prop;
+		if (attrs && (attrs.type === 'Enum' || attrs.enumList)) {
+			prop = { value: typeof value === 'number' ? value : 0, type: 'Enum' };
+			if (attrs.enumList) {
+				prop.enumList = attrs.enumList;
+			}
+			return this._decorate(prop, attrs);
+		}
+		// 位掩码(改动六):对齐 encode.ts:439-440(!ctor && attrs.type 用字符串覆写),BitMask 值是 number,
+		// 缺此分支会退化成普通数字框而非位掩码多选(如 Camera.visibility、Light 阴影 flags)。
+		if (attrs && (attrs.type === 'BitMask' || attrs.bitmaskList)) {
+			prop = { value: typeof value === 'number' ? value : 0, type: 'BitMask' };
+			if (attrs.bitmaskList) {
+				prop.bitmaskList = attrs.bitmaskList;
+			}
+			return this._decorate(prop, attrs);
+		}
+		// 数组(改动六):对齐 encode.ts,设 isArray + 逐元素编码。面板 getElementType 靠 isArray
+		// 路由到 Array 控件;缺 isArray 的数组值会落到 'Unknown'(cc.MeshRenderer 的 Materials
+		// = sharedMaterials 返回数组,即因此退化成 "Unknown Type")。
+		if (Array.isArray(value)) {
+			const elemCtor = attrs && attrs.ctor;
+			const arr = [];
+			for (let i = 0; i < value.length; i++) {
+				const item = value[i];
+				// 元素类型:非空取自身构造器,空引用沿用父级 @type 的元素 ctor(如 [Material])。
+				const itemAttrs = { ctor: (item && item.constructor) || elemCtor };
+				arr.push(this._encodeProp(item, itemAttrs));
+			}
+			prop = { value: arr, type: this._className(elemCtor) || 'Unknown', isArray: true };
+			const decorated = this._decorate(prop, attrs);
+			// 面板 getElementType 对数组:若 default 存在且非数组会强制判成 'Unknown'(dump-field L158)。
+			// _decorate 只透传标量/null 型 default,对数组属性无意义且会踩此陷阱,故一律去掉。
+			if (decorated.default !== undefined && !Array.isArray(decorated.default)) {
+				delete decorated.default;
+			}
+			return decorated;
+		}
+		const t = typeof value;
+		if (t === 'number') {
+			prop = { value, type: 'Number' };
+		} else if (t === 'string') {
+			prop = { value, type: 'String' };
+		} else if (t === 'boolean') {
+			prop = { value, type: 'Boolean' };
+		} else if (value == null) {
+			// 空引用:运行时构建裁剪了编辑器元数据,但 attrs.ctor(反序列化所需,如 cc.Material/cc.SpriteFrame/cc.Node)
+			// 不受门控。关键在于面板 getElementType 判具体资源子类靠 extends 继承链(含 'cc.Asset' 才提升为资源
+			// 选择器),光有 type 不够;且资源选择器读 value.uuid,故 value 归一为 {uuid:''}(对齐编辑态 asset-dump)。
+			const refCtor = attrs && attrs.ctor;
+			if (refCtor) {
+				prop = { value: { uuid: '' }, type: this._className(refCtor) || 'cc.Object', extends: this._inheritanceChain(refCtor) };
+			} else {
+				prop = { value: null, type: 'Unknown' };
+			}
+		} else if (this._isValueType(value)) {
+			prop = { value: this._valueTypeToPlain(value), type: this._className(value.constructor) || 'cc.ValueType' };
+		} else if (this._cc.Node && value instanceof this._cc.Node) {
+			prop = { value: { uuid: value.uuid }, type: 'cc.Node', extends: this._inheritanceChain(value.constructor) };
+		} else if (this._cc.Component && value instanceof this._cc.Component) {
+			prop = { value: { uuid: value.uuid }, type: this._className(value.constructor) || 'cc.Component', extends: this._inheritanceChain(value.constructor) };
+		} else if (this._cc.Asset && value instanceof this._cc.Asset) {
+			// 非空资源:补 extends(否则 getElementType 落到 'cc.Object' 通用可展开对象,而非资源选择器)。
+			prop = { value: { uuid: value._uuid || value.uuid || '' }, type: this._className(value.constructor) || 'cc.Asset', extends: this._inheritanceChain(value.constructor) };
+		} else {
+			// 嵌套可序列化 @ccclass 对象(改动六):如 cc.ModelBakeSettings(Bake Settings)。
+			// 递归子属性成 {key: IProperty},面板据 value 非空 + 未知类型渲染为可展开 cc.Object;
+			// 缺递归时裸实例过桥序列化会丢方法/退化,呈现成 "Null" + Create。
+			const objCtor = value && value.constructor;
+			if (objCtor && Array.isArray(objCtor.__props__)) {
+				prop = {
+					value: this._encodeNested(value, objCtor),
+					type: this._className(objCtor) || 'cc.Object',
+					extends: this._inheritanceChain(objCtor),
+				};
+			} else {
+				prop = { value, type: (attrs && attrs.type) || 'Object' };
+			}
+		}
+		return this._decorate(prop, attrs);
+	}
+
+	/**
+	 * 递归编码嵌套 @ccclass 对象的子属性(键→IProperty),复用组件属性的可见性/标签规则
+	 * (对齐 encode.ts 的 __props__ 递归):跳过 visible:false、函数式 visible 以对象为 this 求值、
+	 * 每个子属性补 name=key(修标签)。子属性读取/编码失败则跳过,避免中断整体 dump。
+	 */
+	_encodeNested(obj, ctor) {
+		const out = {};
+		const props = (ctor && ctor.__props__) || [];
+		for (const key of props) {
+			let attrs = {};
+			try {
+				attrs = (this._cc.Class && typeof this._cc.Class.attr === 'function') ? (this._cc.Class.attr(obj, key) || {}) : {};
+			} catch {
+				attrs = {};
+			}
+			const vis = this._evalVisible(attrs, obj);
+			if (vis === false) {
+				continue;
+			}
+			try {
+				const encoded = this._encodeProp(obj[key], attrs);
+				encoded.name = key;
+				if (vis === undefined) {
+					delete encoded.visible;
+				} else {
+					encoded.visible = vis;
+				}
+				out[key] = encoded;
+			} catch {
+				/* 子属性读取/编码失败则跳过 */
+			}
+		}
+		return out;
+	}
+
+	_evalVisible(attrs, owner) {
+		if (!attrs || attrs.visible === undefined) {
+			return undefined;
+		}
+		if (typeof attrs.visible === 'function') {
+			// 条件可见函数以组件实例为 this 求值(对齐 encode.ts 的 _checkFuncAttribute)。
+			try {
+				return !!attrs.visible.call(owner);
+			} catch {
+				return undefined;
+			}
+		}
+		return attrs.visible;
+	}
+
+	_decorate(prop, attrs) {
+		if (!attrs) {
+			return prop;
+		}
+		// 透传 cc.Class.attr 里存在的属性描述(对齐 encode.ts 的 attributeProps),
+		// 恢复数值滑块/单位/角度、分组 Tab、字段排序、枚举下拉、多行文本等控件形态。
+		for (const name of PREVIEW_ATTRIBUTE_PROPS) {
+			if (Object.prototype.hasOwnProperty.call(attrs, name) && attrs[name] !== undefined) {
+				prop[name] = attrs[name];
+			}
+		}
+		if (attrs.readonly) {
+			prop.readonly = true;
+		}
+		// 仅有 getter 没有 setter 视为只读(对齐 encode.ts 的 _checkAttributes)。
+		if (attrs.hasGetter && !attrs.hasSetter) {
+			prop.readonly = true;
+		}
+		// visible 可能是布尔或函数(条件可见)。函数交由 _dumpComponent 以组件实例求值后覆盖;
+		// 这里只透传布尔,避免把函数原样塞进 prop.visible(会被面板当真值)。
+		if (typeof attrs.visible === 'boolean') {
+			prop.visible = attrs.visible;
+		}
+		// default 仅透传标量/null(用于 revert/重置判断);对象/函数型 default 可能与 value 类型不匹配,
+		// 会被面板判成 Unknown 类型(见 dump-field checkValueMatchType),故谨慎跳过。
+		if (attrs.default !== undefined) {
+			const dt = typeof attrs.default;
+			if (attrs.default === null || dt === 'number' || dt === 'string' || dt === 'boolean') {
+				prop.default = attrs.default;
+			}
+		}
+		return prop;
+	}
+
+	_isValueType(value) {
+		return Boolean(this._cc.ValueType && value instanceof this._cc.ValueType);
+	}
+
+	/** ValueType → 纯数值对象(不依赖 EditorExtends.serialize;对齐 value-type-dump.decode 的逐 prop 拷贝)。 */
+	_valueTypeToPlain(vt) {
+		const out = {};
+		if (!vt) {
+			return out;
+		}
+		const ctor = vt.constructor;
+		const props = (ctor && ctor.__props__) || [];
+		if (props.length) {
+			for (const k of props) {
+				if (typeof vt[k] === 'number') {
+					out[k] = vt[k];
+				}
+			}
+			if (Object.keys(out).length > 0) {
+				return out;
+			}
+		}
+		for (const k of ['x', 'y', 'z', 'w', 'r', 'g', 'b', 'a', 'width', 'height']) {
+			if (typeof vt[k] === 'number') {
+				out[k] = vt[k];
+			}
+		}
+		return out;
+	}
+
+	// ---- 引擎适配小工具 ----------------------------------------------------
+
+	_getScene() {
+		const director = this._cc.director;
+		const scene = director && director.getScene && director.getScene();
+		return scene && this._isValid(scene) ? scene : null;
+	}
+
+	_isValid(obj) {
+		return typeof this._cc.isValid === 'function' ? this._cc.isValid(obj) : !!obj;
+	}
+
+	_isScene(node) {
+		if (this._cc.Scene && node instanceof this._cc.Scene) {
+			return true;
+		}
+		return this._typeName(node) === 'cc.Scene';
+	}
+
+	/** 优先用 cc.js.getClassName(抗压缩混淆),回退 constructor.name。 */
+	_typeName(node) {
+		const viaClass = this._className(node && node.constructor);
+		if (viaClass) {
+			return viaClass;
+		}
+		const ctorName = node && node.constructor && node.constructor.name;
+		return ctorName ? `cc.${ctorName}` : 'cc.Node';
+	}
+
+	_className(ctor) {
+		if (!ctor) {
+			return '';
+		}
+		const js = this._cc.js;
+		if (js && typeof js.getClassName === 'function') {
+			try {
+				return js.getClassName(ctor) || '';
+			} catch {
+				return '';
+			}
+		}
+		return ctor.name || '';
+	}
+
+	_hasFlag(node, flag) {
+		if (!flag) {
+			return false;
+		}
+		const objFlags = node && (node._objFlags != null ? node._objFlags : node.objFlags);
+		return Boolean((objFlags || 0) & flag);
+	}
+
+	_siblingIndex(node) {
+		if (node && typeof node.getSiblingIndex === 'function') {
+			try {
+				return node.getSiblingIndex();
+			} catch {
+				/* fallthrough */
+			}
+		}
+		const parent = node && node.parent;
+		if (parent && parent.children) {
+			return parent.children.indexOf(node);
+		}
+		return -1;
+	}
+
+	_displayPath(mgrPath) {
+		return mgrPath === '' ? '/' : mgrPath;
+	}
+
+	_emit(type, payload) {
+		if (this._sink && !this._disposed) {
+			this._sink(type, payload);
+		}
+	}
+}

--- a/static/web/preview-inspect.js
+++ b/static/web/preview-inspect.js
@@ -3,7 +3,14 @@
 /**
  * 预览运行时 Inspect Agent(M1:只读 Hierarchy + selection + 结构 liveness;M5:组件增删/reset/排序/整包粘贴;M6:资产拖拽创建节点)。
  *
- * 由 previewMain 在 game-boot 跑起启动场景后装配,直接读活 `cc.director` 的场景图,
+ * 装配契约:本文件是运行时库,game.ejs / game-boot.js 都**不**会自动装配它——
+ * 生产装配方是 IDE 侧预览 webview(PinK 仓库 PreviewInEditor 分支 previewMain.pink.ts):
+ * 先复用 game-boot.js 跑起启动场景,再动态 import 本文件调 createPreviewInspect,
+ * 把 agent 经 PreviewSceneApi 挂到宿主 SceneViewBridge(scene:invoke 等)后才 fire view:ready。
+ * 普通浏览器预览没有 Hierarchy/Inspector 宿主 UI 消费这些能力,故刻意不装配;
+ * IDE 预览时页面内只有这一个实例,也避免了双重装配(两个 agent 同时轮询/抢占 undo)。
+ *
+ * 装配后直接读活 `cc.director` 的场景图,
  * 产出与编辑器 `node.query-tree` 契约一致的 INodeTreeItem,并以轻量结构快照 diff
  * 广播 node:added/node:removed/node:change,以及 selection 回显事件。
  *

--- a/static/web/scene-editor.ejs
+++ b/static/web/scene-editor.ejs
@@ -489,6 +489,9 @@
          * Play：序列化编辑器里的实时场景（含未保存改动）→ POST /scene/current →
          *   在覆盖画布的 iframe 里以 /?scene=__current__ 运行游戏运行时。
          * Stop：卸掉 iframe，恢复编辑器视图。
+         * 注意：本页的预览 iframe 只叠加游戏画面，不装配 static/web/preview-inspect.js
+         * （运行态 Hierarchy 编辑 agent）——该 agent 需要宿主侧 Hierarchy/Inspector UI 消费，
+         * 由 IDE 侧预览 webview（PinK previewMain.pink.ts）装配；本页没有这套 UI。
          */
         let _previewPlaying = false;
 

--- a/static/web/scene-editor.ejs
+++ b/static/web/scene-editor.ejs
@@ -35,6 +35,20 @@
             height: 100%;
         }
 
+        /* ── Preview in Editor：Play 时以全屏 iframe 加载游戏运行时，覆盖编辑器画布 ── */
+        #previewFrame {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            border: 0;
+            z-index: 9998; /* 低于 testPanel(9999)，高于游戏画布 */
+            background: #000;
+            display: none;
+        }
+        #previewFrame.active { display: block; }
+
         /* ── Test Panel ── */
         #testPanel {
             position: fixed;
@@ -164,6 +178,9 @@
         </div>
     </div>
 
+    <!-- Preview in Editor：Play 时把编辑器实时场景交给游戏运行时，在此 iframe 内运行 -->
+    <iframe id="previewFrame" title="Game Preview"></iframe>
+
     <button id="panelToggle" onclick="togglePanel()">Panel</button>
 
     <div id="testPanel">
@@ -182,6 +199,10 @@
                 <div class="row">
                     <button class="btn btn-primary" id="btnPreview" onclick="openBrowserPreview()">▶ Preview (Browser)</button>
                     <span class="info-text">opens /</span>
+                </div>
+                <div class="row">
+                    <button class="btn btn-primary" id="btnPlayInEditor" onclick="togglePlayInEditor()">▶ Play (In Editor)</button>
+                    <span id="playStatus" class="info-text">stopped</span>
                 </div>
                 <div class="row">
                     <label>Script</label>
@@ -463,6 +484,79 @@
             const url = scene ? '/?scene=' + encodeURIComponent(scene) : '/';
             window.open(url, '_blank');
         }
+
+        /* ── Preview in Editor ──
+         * Play：序列化编辑器里的实时场景（含未保存改动）→ POST /scene/current →
+         *   在覆盖画布的 iframe 里以 /?scene=__current__ 运行游戏运行时。
+         * Stop：卸掉 iframe，恢复编辑器视图。
+         */
+        let _previewPlaying = false;
+
+        async function playInEditor() {
+            const status = document.getElementById('playStatus');
+            const btn = document.getElementById('btnPlayInEditor');
+            try {
+                const ed = window.cli && window.cli.Scene && window.cli.Scene.Editor;
+                if (!ed || !ed.querySceneSerializedData) {
+                    log('Editor.querySceneSerializedData not available', 'status-err');
+                    status.textContent = 'no editor'; status.className = 'info-text status-err';
+                    return;
+                }
+                status.textContent = 'serializing...'; status.className = 'info-text status-warn';
+                // querySceneSerializedData 已返回 JSON 字符串，禁止再 JSON.stringify(json)——
+                // 那会得到顶层字符串被 express.json strict 以 400 拒绝。
+                const json = await ed.querySceneSerializedData();
+                const res = await fetch(WebEnv.serverURL + '/scene/current', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ data: json }),
+                });
+                if (!res.ok) {
+                    throw new Error('POST /scene/current failed: ' + res.status);
+                }
+                // iframe reload 会自动经 game-boot fetch /scene/current.json，无需再 post。
+                const frame = document.getElementById('previewFrame');
+                frame.src = '/?scene=__current__';
+                frame.classList.add('active');
+                // 让编辑器引擎停在下方不再渲染，避免与预览抢 GPU（可选，失败无害）。
+                try { window.cli.Scene.Engine.pause && window.cli.Scene.Engine.pause(); } catch (e) {}
+                _previewPlaying = true;
+                btn.textContent = '■ Stop (In Editor)';
+                btn.classList.add('active');
+                status.textContent = 'running'; status.className = 'info-text status-ok';
+                log('Play in editor: running current scene', 'status-ok');
+            } catch (e) {
+                status.textContent = 'failed'; status.className = 'info-text status-err';
+                log('Play in editor error: ' + e.message, 'status-err');
+            }
+        }
+
+        function stopPreview() {
+            const frame = document.getElementById('previewFrame');
+            frame.classList.remove('active');
+            frame.src = 'about:blank';
+            // 恢复编辑器引擎渲染。
+            try { window.cli.Scene.Engine.resume && window.cli.Scene.Engine.resume(); } catch (e) {}
+            try { window.cli.Scene.Engine.repaintInEditMode && window.cli.Scene.Engine.repaintInEditMode(); } catch (e) {}
+            _previewPlaying = false;
+            const btn = document.getElementById('btnPlayInEditor');
+            btn.textContent = '▶ Play (In Editor)';
+            btn.classList.remove('active');
+            const status = document.getElementById('playStatus');
+            status.textContent = 'stopped'; status.className = 'info-text';
+            log('Stopped preview, editor view restored', 'status-ok');
+        }
+
+        function togglePlayInEditor() {
+            if (_previewPlaying) {
+                stopPreview();
+            } else {
+                playInEditor();
+            }
+        }
+        window.playInEditor = playInEditor;
+        window.stopPreview = stopPreview;
+        window.togglePlayInEditor = togglePlayInEditor;
 
         /* ── Scene ── */
         async function doLoadScene() {


### PR DESCRIPTION
## Background

Preview currently runs in an external browser, forcing a stop-edit-restart loop for any scene tweak. This PR adds **Preview In Editor**: the game runs in a full-screen iframe inside the scene editor, with the preview itself supporting Hierarchy-menu scene editing.

## Implementation

**Commit 1 (f118008) — make in-editor preview work end to end.**
When the user hits Play, the editor serializes the current scene, hands it to the CLI through a new snapshot route, and the preview iframe boots straight from that snapshot instead of reloading from disk. Stop simply tears the iframe down and resumes the editor. A new agent script (`preview-inspect.js`) inside the preview page could already read the live scene and edit properties.

**Commit 2 (2d00b57) — let the preview edit the scene structure.**
That agent can now do everything the Hierarchy context menu needs: create nodes (by type or by dragging in an asset), delete, rename, re-parent, reorder, lock, copy/cut/paste, and undo/redo — with the same semantics as the editor itself. Two small read-only routes feed it the editor's own node-type table and asset info, so the preview never keeps a second copy that could drift out of sync. Also fixes a bug where script components vanished from the property panel because of a uuid format mismatch.

**Safety rule: preview changes are disposable.** Undo history, clipboard contents and deleted nodes are all thrown away when the preview stops, and the editor never marks the scene dirty — nothing done in preview can leak back into your saved work.

## Testing

3 new test files (1526 lines): route contract (88), 45 agent cases covering all node/component/clipboard/undo ops and the disposable-changes rule (1113), script-uuid normalization (325). dts snapshots updated; `npm test` passes.