### PR TITLE
feat(animation): preserve embedded player track metadata

### DIFF
--- a/packages/asset-db/test/19.virtual-import-version.spec.js
+++ b/packages/asset-db/test/19.virtual-import-version.spec.js
@@ -1,0 +1,91 @@
+'use strict';
+
+/* global after, before */
+
+const { expect } = require('chai');
+const fse = require('fs-extra');
+const path = require('path');
+
+const { AssetDB } = require('../dist/libs/asset-db');
+const { Importer } = require('../dist/libs/importer');
+
+describe('虚拟资源导入版本', () => {
+    const PATH = {
+        ROOT: path.join(__dirname, './virtual-import-version'),
+        TARGET: path.join(__dirname, './virtual-import-version/target'),
+        LIBRARY: path.join(__dirname, './virtual-import-version/library'),
+        TEMP: path.join(__dirname, './virtual-import-version/temp'),
+        FILE: path.join(__dirname, './virtual-import-version/target/animation.cached'),
+    };
+
+    let childVersionCode = 3;
+    let parentImportCount = 0;
+    let childImportCount = 0;
+
+    class ParentImporter extends Importer {
+        get name() {
+            return 'versioned-parent';
+        }
+
+        async import(asset) {
+            parentImportCount++;
+            await asset.saveToLibrary('.parent', 'parent');
+            await asset.createSubAsset('animation', 'versioned-child');
+            return true;
+        }
+    }
+
+    class ChildImporter extends Importer {
+        get name() {
+            return 'versioned-child';
+        }
+
+        get versionCode() {
+            return childVersionCode;
+        }
+
+        async import(asset) {
+            childImportCount++;
+            await asset.saveToLibrary('.child', `version-${childVersionCode}`);
+            return true;
+        }
+    }
+
+    let database;
+
+    before(async () => {
+        fse.ensureDirSync(PATH.LIBRARY);
+        fse.outputFileSync(PATH.FILE, 'animation');
+
+        database = new AssetDB({
+            name: 'virtual-import-version',
+            target: PATH.TARGET,
+            library: PATH.LIBRARY,
+            temp: PATH.TEMP,
+            level: 0,
+        });
+        database.importerManager.add(ParentImporter, ['.cached']);
+        database.importerManager.add(ChildImporter, []);
+    });
+
+    after(async () => {
+        await database.stop();
+        fse.removeSync(PATH.ROOT);
+    });
+
+    it('仅虚拟子资源的 versionCode 变更时会重新导入子资源', async () => {
+        await database.start();
+        expect(parentImportCount).to.equal(1);
+        expect(childImportCount).to.equal(1);
+
+        await database.stop();
+        parentImportCount = 0;
+        childImportCount = 0;
+        childVersionCode = 4;
+
+        await database.start();
+
+        expect(parentImportCount).to.equal(0);
+        expect(childImportCount).to.equal(1);
+    });
+});

--- a/packages/cc-module/overwrite/embedded-player.js
+++ b/packages/cc-module/overwrite/embedded-player.js
@@ -1,0 +1,28 @@
+'use strict';
+
+module.exports = function patchEmbeddedPlayer(ccm, embeddedPlayerModule) {
+    if (!embeddedPlayerModule) {
+        try {
+            embeddedPlayerModule = require('cc/editor/embedded-player');
+        } catch {
+            return;
+        }
+    }
+
+    const EmbeddedPlayer = embeddedPlayerModule.EmbeddedPlayer;
+    const editorExtrasTag = ccm.editorExtrasTag || '__editorExtras__';
+    const classAttr = ccm.CCClass?.Attr;
+    if (!EmbeddedPlayer || !classAttr || !Array.isArray(EmbeddedPlayer.__props__) || !Array.isArray(EmbeddedPlayer.__values__)) {
+        return;
+    }
+
+    // CLI 以非 EDITOR 模式加载引擎，需要补回播放器的编辑器扩展数据。
+    if (!EmbeddedPlayer.__props__.includes(editorExtrasTag)) {
+        EmbeddedPlayer.__props__.push(editorExtrasTag);
+    }
+    if (!EmbeddedPlayer.__values__.includes(editorExtrasTag)) {
+        EmbeddedPlayer.__values__.push(editorExtrasTag);
+    }
+    classAttr.setClassAttr(EmbeddedPlayer, editorExtrasTag, 'serializable', true);
+    classAttr.setClassAttr(EmbeddedPlayer, editorExtrasTag, 'visible', false);
+};

--- a/packages/cc-module/overwrite/embedded-player.js
+++ b/packages/cc-module/overwrite/embedded-player.js
@@ -25,4 +25,5 @@ module.exports = function patchEmbeddedPlayer(ccm, embeddedPlayerModule) {
     }
     classAttr.setClassAttr(EmbeddedPlayer, editorExtrasTag, 'serializable', true);
     classAttr.setClassAttr(EmbeddedPlayer, editorExtrasTag, 'visible', false);
+    classAttr.setClassAttr(EmbeddedPlayer, editorExtrasTag, 'editorOnly', true);
 };

--- a/packages/cc-module/overwrite/index.js
+++ b/packages/cc-module/overwrite/index.js
@@ -1,3 +1,4 @@
 module.exports = function(ccm) {
     require('./widget-manager')(ccm);
+    require('./embedded-player')(ccm);
 };

--- a/src/core/assets/asset-handler/assets/animation-clip.ts
+++ b/src/core/assets/asset-handler/assets/animation-clip.ts
@@ -32,7 +32,7 @@ const AnimationHandler: AssetHandler = {
     importer: {
         // 版本号如果变更，则会强制重新导入
         version: '2.0.4',
-        versionCode: 2,
+        versionCode: 3,
 
         /**
          * 如果改名就强制刷新

--- a/src/core/assets/asset-handler/assets/gltf/animation.ts
+++ b/src/core/assets/asset-handler/assets/gltf/animation.ts
@@ -33,7 +33,7 @@ export const GltfAnimationHandler: AssetHandler = {
     importer: {
         // 版本号如果变更，则会强制重新导入
         version: '1.0.18',
-        versionCode: 3,
+        versionCode: 4,
         /**
          * 实际导入流程
          * 需要自己控制是否生成、拷贝文件

--- a/tests/cc-module-embedded-player-overwrite.test.ts
+++ b/tests/cc-module-embedded-player-overwrite.test.ts
@@ -1,0 +1,31 @@
+const patchEmbeddedPlayer = require('../packages/cc-module/overwrite/embedded-player') as (
+    ccm: Record<string, any>,
+    embeddedPlayerModule: Record<string, any>,
+) => void;
+
+describe('EmbeddedPlayer cc-module overwrite', () => {
+    it('补全编辑器扩展属性的序列化语义', () => {
+        class EmbeddedPlayer {
+            static __props__: string[] = [];
+            static __values__: string[] = [];
+        }
+        const setClassAttr = jest.fn();
+        const ccm = {
+            editorExtrasTag: '__editorExtras__',
+            CCClass: {
+                Attr: {
+                    setClassAttr,
+                },
+            },
+        };
+
+        patchEmbeddedPlayer(ccm, { EmbeddedPlayer });
+        patchEmbeddedPlayer(ccm, { EmbeddedPlayer });
+
+        expect(EmbeddedPlayer.__props__).toEqual(['__editorExtras__']);
+        expect(EmbeddedPlayer.__values__).toEqual(['__editorExtras__']);
+        expect(setClassAttr).toHaveBeenCalledWith(EmbeddedPlayer, '__editorExtras__', 'serializable', true);
+        expect(setClassAttr).toHaveBeenCalledWith(EmbeddedPlayer, '__editorExtras__', 'visible', false);
+        expect(setClassAttr).toHaveBeenCalledWith(EmbeddedPlayer, '__editorExtras__', 'editorOnly', true);
+    });
+});


### PR DESCRIPTION
## Background

Creator stores each embedded player's track group and display name in `__editorExtras__`. cocos-cli initializes the engine with `CC_EDITOR=false`, so `EmbeddedPlayer` does not register this property at runtime.

As a result, animation clip import drops the metadata while deserializing source `.anim` files. The players remain present, but their group assignments are lost and consumers have to treat them as ungrouped players.

## Changes

- Register `__editorExtras__` in the `EmbeddedPlayer` runtime property and serialization metadata through the existing cc-module overwrite entry point.
- Keep the compatibility patch guarded against unavailable engine modules and unsupported class metadata.
- Bump the animation clip importer `versionCode` from `2` to `3` so existing library artifacts are reimported once with the corrected metadata.

## Impact

- Existing `.anim` assets are reimported once after upgrading.
- The public importer version remains `2.0.4` because the source asset format is unchanged.
- The compatibility change is limited to Embedded Player editor metadata; playback data and frame ranges are unaffected.

