### PR TITLE
feat(scene): add 2D rulers and faded the editing grid lines

### DIFF
--- a/src/core/scene/scene-process/service/camera/camera-controller-2d.ts
+++ b/src/core/scene/scene-process/service/camera/camera-controller-2d.ts
@@ -3,6 +3,7 @@ import CameraControllerBase, { EditorCameraInfo } from './camera-controller-base
 import { CameraMoveMode, CameraUtils } from './utils';
 import FiniteStateMachine from '../utils/state-machine/finite-state-machine';
 import Grid from './grid';
+import { Ruler2D, type IRulerView } from './ruler-2d';
 import { ModeBase2D } from './modes/mode-base-2d';
 import { IdleMode2D } from './modes/idle-mode-2d';
 import { PanMode2D } from './modes/pan-mode-2d';
@@ -21,6 +22,14 @@ function getCanvasSize(): ISizeLike {
 const _defaultMarginPercentage = 30;
 const _maxTicks = 100;
 
+// ruler 映射用临时向量
+const _rulerO = new Vec3();
+const _rulerX = new Vec3();
+const _rulerY = new Vec3();
+const _rulerP0 = new Vec3();
+const _rulerP1 = new Vec3();
+const _rulerP2 = new Vec3();
+
 function clamp(val: number, min: number, max: number): number {
     return Math.min(max, Math.max(min, val));
 }
@@ -37,6 +46,7 @@ export class CameraController2D extends CameraControllerBase {
     private _panMode!: PanMode2D;
     private _lineColor = cc.color().fromHEX('#555555');
     private _grid!: Grid;
+    private _ruler!: Ruler2D;
     private _contentRect!: Rect;
     private _scale2D = 1;
 
@@ -89,6 +99,8 @@ export class CameraController2D extends CameraControllerBase {
         this._gridMeshComp = CameraUtils.createGrid('internal/editor/grid-2d', this.node.parent!);
         this._gridMeshComp.node.active = false;
         this._initGrid();
+        this._ruler = new Ruler2D();
+        this._ruler.init();
         this._initMode();
         this.initOriginAxis();
     }
@@ -132,8 +144,10 @@ export class CameraController2D extends CameraControllerBase {
             this._camera.near = this._near;
             this._camera.far = this._far;
             this.onResize();
+            this._ruler?.show(true);
             this.showGrid(true);
         } else {
+            this._ruler?.show(false);
             this.showGrid(false);
         }
     }
@@ -260,10 +274,12 @@ export class CameraController2D extends CameraControllerBase {
             this._posAnim = tweenPosition(startPos, targetPos, 300);
             this._posAnim.step((pos: Vec3) => {
                 this.node.setWorldPosition(pos);
+                this._refreshRuler();
             });
         }
 
         this._updateOrthoHeight(scale);
+        this._refreshRuler();
 
         try {
             const { Service } = require('../core/decorator');
@@ -373,6 +389,67 @@ export class CameraController2D extends CameraControllerBase {
         CameraUtils.updateIB(this._gridMeshComp, indices);
 
         this.updateOriginAxis();
+        this._ruler?.updateTicks(this._grid, this._rulerView());
+    }
+
+    /**
+     * 相机更新后立即用最新矩阵刷新刻度。
+     * 各交互流程（缩放/拖拽/复位/resize）都以 adjustCamera 收尾，
+     * 在此处重画可保证刻度不再滞后一帧。
+     */
+    private _refreshRuler(): void {
+        if (!this._ruler || !this._grid) {
+            return;
+        }
+        this._ruler.updateTicks(this._grid, this._rulerView());
+    }
+
+    /**
+     * 刻度尺用的屏幕映射：用渲染相机的 worldToScreen 矩阵换算，
+     * 自动包含父节点变换 / zoom / 视口等所有因素，与最终画面逐像素一致；
+     * 正交投影下映射是仿射的，取 3 个世界点拟合出线性系数即可。
+     */
+    private _rulerView(): IRulerView {
+        const W = this._size.width;
+        const H = this._size.height;
+        const rc = (this._camera as any).camera as { worldToScreen?: (out: Vec3, p: Vec3) => Vec3; update?: (forceUpdate?: boolean) => void } | undefined;
+        let ox: number;
+        let oy: number;
+        let sx: number;
+        let sy: number;
+        if (rc && typeof rc.worldToScreen === 'function') {
+            // 矩阵在渲染帧才重算，这里同步 flush，保证缩放当帧刻度即用新相机
+            if (typeof rc.update === 'function') {
+                rc.update();
+            }
+            rc.worldToScreen(_rulerO, _rulerP0.set(0, 0, 0));
+            rc.worldToScreen(_rulerX, _rulerP1.set(1, 0, 0));
+            rc.worldToScreen(_rulerY, _rulerP2.set(0, 1, 0));
+            ox = _rulerO.x;
+            oy = _rulerO.y; // 引擎屏幕坐标 y 向上
+            sx = (_rulerX.x - ox) || 1;
+            sy = (_rulerY.y - oy) || 1;
+        } else {
+            const s = H / (2 * this._camera.orthoHeight);
+            const p = this._camera.node.worldPosition;
+            ox = W / 2 - p.x * s;
+            oy = H / 2 + p.y * s;
+            sx = s;
+            sy = s;
+        }
+        const x0 = (0 - ox) / sx;
+        const x1 = (W - ox) / sx;
+        const y0 = (0 - oy) / sy;
+        const y1 = (H - oy) / sy;
+        return {
+            pxPerUnit: Math.abs(sx),
+            xMin: Math.min(x0, x1),
+            xMax: Math.max(x0, x1),
+            yMin: Math.min(y0, y1),
+            yMax: Math.max(y0, y1),
+            toX: (v: number) => ox + v * sx,
+            toY: (v: number) => H - (oy + v * sy),
+        };
     }
 
     // ---------- 原点轴 ----------
@@ -647,6 +724,7 @@ export class CameraController2D extends CameraControllerBase {
         const width = this._size.width;
         const height = this._size.height;
         this._grid.resize(width, height);
+        this._ruler?.resize();
         this.updateGrid();
         this.adjustCamera();
     }

--- a/src/core/scene/scene-process/service/camera/camera-controller-2d.ts
+++ b/src/core/scene/scene-process/service/camera/camera-controller-2d.ts
@@ -100,6 +100,7 @@ export class CameraController2D extends CameraControllerBase {
         this._gridMeshComp.node.active = false;
         this._initGrid();
         this._ruler = new Ruler2D();
+        this._ruler.onNeedRedraw = () => this._refreshRuler();
         this._ruler.init();
         this._initMode();
         this.initOriginAxis();

--- a/src/core/scene/scene-process/service/camera/camera-controller-2d.ts
+++ b/src/core/scene/scene-process/service/camera/camera-controller-2d.ts
@@ -3,7 +3,7 @@ import CameraControllerBase, { EditorCameraInfo } from './camera-controller-base
 import { CameraMoveMode, CameraUtils } from './utils';
 import FiniteStateMachine from '../utils/state-machine/finite-state-machine';
 import Grid from './grid';
-import { Ruler2D, type IRulerView } from './ruler-2d';
+import { Ruler2D, buildRulerView, type IRulerRenderCamera, type IRulerView } from './ruler-2d';
 import { ModeBase2D } from './modes/mode-base-2d';
 import { IdleMode2D } from './modes/idle-mode-2d';
 import { PanMode2D } from './modes/pan-mode-2d';
@@ -21,14 +21,6 @@ function getCanvasSize(): ISizeLike {
 
 const _defaultMarginPercentage = 30;
 const _maxTicks = 100;
-
-// ruler 映射用临时向量
-const _rulerO = new Vec3();
-const _rulerX = new Vec3();
-const _rulerY = new Vec3();
-const _rulerP0 = new Vec3();
-const _rulerP1 = new Vec3();
-const _rulerP2 = new Vec3();
 
 function clamp(val: number, min: number, max: number): number {
     return Math.min(max, Math.max(min, val));
@@ -411,46 +403,9 @@ export class CameraController2D extends CameraControllerBase {
      * 正交投影下映射是仿射的，取 3 个世界点拟合出线性系数即可。
      */
     private _rulerView(): IRulerView {
-        const W = this._size.width;
-        const H = this._size.height;
-        const rc = (this._camera as any).camera as { worldToScreen?: (out: Vec3, p: Vec3) => Vec3; update?: (forceUpdate?: boolean) => void } | undefined;
-        let ox: number;
-        let oy: number;
-        let sx: number;
-        let sy: number;
-        if (rc && typeof rc.worldToScreen === 'function') {
-            // 矩阵在渲染帧才重算，这里同步 flush，保证缩放当帧刻度即用新相机
-            if (typeof rc.update === 'function') {
-                rc.update();
-            }
-            rc.worldToScreen(_rulerO, _rulerP0.set(0, 0, 0));
-            rc.worldToScreen(_rulerX, _rulerP1.set(1, 0, 0));
-            rc.worldToScreen(_rulerY, _rulerP2.set(0, 1, 0));
-            ox = _rulerO.x;
-            oy = _rulerO.y; // 引擎屏幕坐标 y 向上
-            sx = (_rulerX.x - ox) || 1;
-            sy = (_rulerY.y - oy) || 1;
-        } else {
-            const s = H / (2 * this._camera.orthoHeight);
-            const p = this._camera.node.worldPosition;
-            ox = W / 2 - p.x * s;
-            oy = H / 2 + p.y * s;
-            sx = s;
-            sy = s;
-        }
-        const x0 = (0 - ox) / sx;
-        const x1 = (W - ox) / sx;
-        const y0 = (0 - oy) / sy;
-        const y1 = (H - oy) / sy;
-        return {
-            pxPerUnit: Math.abs(sx),
-            xMin: Math.min(x0, x1),
-            xMax: Math.max(x0, x1),
-            yMin: Math.min(y0, y1),
-            yMax: Math.max(y0, y1),
-            toX: (v: number) => ox + v * sx,
-            toY: (v: number) => H - (oy + v * sy),
-        };
+        const rc = (this._camera as any).camera as IRulerRenderCamera | undefined;
+        const p = this._camera.node.worldPosition;
+        return buildRulerView(rc, this._size, { orthoHeight: this._camera.orthoHeight, x: p.x, y: p.y });
     }
 
     // ---------- 原点轴 ----------

--- a/src/core/scene/scene-process/service/camera/grid/index.ts
+++ b/src/core/scene/scene-process/service/camera/grid/index.ts
@@ -60,7 +60,7 @@ class Grid {
     }
 
     setScaleH(lods: number[], minScale: number, maxScale: number) {
-        this.hTicks = new LinearTicks().initTicks(lods, minScale, maxScale).spacing(10, 80);
+        this.hTicks = new LinearTicks().initTicks(lods, minScale, maxScale).spacing(10, 200);
         this.xAxisScale = clamp(this.xAxisScale, this.hTicks.minValueScale, this.hTicks.maxValueScale);
         this.pixelToValueH = (x: number) => (x - this.xAxisOffset) / this.xAxisScale;
         this.valueToPixelH = (x: number) => x * this.xAxisScale + this.xAxisOffset;
@@ -86,7 +86,7 @@ class Grid {
     }
 
     setScaleV(lods: number[], minScale: number, maxScale: number) {
-        this.vTicks = new LinearTicks().initTicks(lods, minScale, maxScale).spacing(10, 80);
+        this.vTicks = new LinearTicks().initTicks(lods, minScale, maxScale).spacing(10, 200);
         this.yAxisScale = clamp(this.yAxisScale, this.vTicks.minValueScale, this.vTicks.maxValueScale);
         this.pixelToValueV = (y: number) => (this._canvasHeight - y + this.yAxisOffset) / this.yAxisScale;
         this.valueToPixelV = (y: number) => -y * this.yAxisScale + this._canvasHeight + this.yAxisOffset;

--- a/src/core/scene/scene-process/service/camera/ruler-2d.ts
+++ b/src/core/scene/scene-process/service/camera/ruler-2d.ts
@@ -15,6 +15,82 @@ export interface IRulerView {
     yMax: number;
 }
 
+/** 渲染相机（renderer.scene.Camera）的最小结构类型，便于解耦与单测 */
+export interface IRulerRenderCamera {
+    width?: number;
+    height?: number;
+    worldToScreen?: (out: { x: number; y: number; z: number }, p: { x: number; y: number; z: number }) => { x: number; y: number; z: number };
+    update?: (forceUpdate?: boolean) => void;
+}
+
+// buildRulerView 复用临时点，避免高频路径分配
+const _bvO = { x: 0, y: 0, z: 0 };
+const _bvA = { x: 0, y: 0, z: 0 };
+const _bvB = { x: 0, y: 0, z: 0 };
+const _bvP = { x: 0, y: 0, z: 0 };
+
+/**
+ * 构建刻度尺屏幕映射（纯函数，便于单测）。
+ * 正交投影下映射是仿射的：投影世界点 (0,0)/(1,0)/(0,1) 拟合线性系数。
+ *
+ * 视口尺寸优先取渲染相机自身的 width/height（PR #914 第二轮 P2）：
+ * 跨不同 DPR/分辨率屏幕时宿主直接更新 canvas 与渲染相机、不走 onResize，
+ * 控制器缓存的 size 会陈旧；worldToScreen 的 y 位于渲染目标高度空间，
+ * Y 翻转必须用同一高度，否则纵向刻度整体错位。
+ */
+export function buildRulerView(
+    rc: IRulerRenderCamera | undefined,
+    size: { width: number; height: number },
+    ortho: { orthoHeight: number; x: number; y: number },
+): IRulerView {
+    const W = size.width;
+    const H = size.height;
+    let ox: number;
+    let oy: number;
+    let sx: number;
+    let sy: number;
+    let viewW = W;
+    let viewH = H;
+    if (rc && typeof rc.worldToScreen === 'function') {
+        // 矩阵在渲染帧才重算，这里同步 flush，保证缩放当帧刻度即用新相机
+        if (typeof rc.update === 'function') {
+            rc.update();
+        }
+        if (rc.width && rc.width > 0) {
+            viewW = rc.width;
+        }
+        if (rc.height && rc.height > 0) {
+            viewH = rc.height;
+        }
+        rc.worldToScreen(_bvO, { x: 0, y: 0, z: 0 });
+        rc.worldToScreen(_bvA, { x: 1, y: 0, z: 0 });
+        rc.worldToScreen(_bvB, { x: 0, y: 1, z: 0 });
+        ox = _bvO.x;
+        oy = _bvO.y; // 引擎屏幕坐标 y 向上
+        sx = (_bvA.x - ox) || 1;
+        sy = (_bvB.y - oy) || 1;
+    } else {
+        const s = H / (2 * ortho.orthoHeight);
+        ox = W / 2 - ortho.x * s;
+        oy = H / 2 + ortho.y * s;
+        sx = s;
+        sy = s;
+    }
+    const x0 = (0 - ox) / sx;
+    const x1 = (viewW - ox) / sx;
+    const y0 = (0 - oy) / sy;
+    const y1 = (viewH - oy) / sy;
+    return {
+        pxPerUnit: Math.abs(sx),
+        xMin: Math.min(x0, x1),
+        xMax: Math.max(x0, x1),
+        yMin: Math.min(y0, y1),
+        yMax: Math.max(y0, y1),
+        toX: (v: number) => ox + v * sx,
+        toY: (v: number) => viewH - (oy + v * sy),
+    };
+}
+
 /**
  * 2D 场景刻度尺：横向（底部）+ 纵向（左侧），参考 Creator 场景 web ruler 移植。
  * 两个透明 canvas 由本类自建并 fixed 覆盖在宿主页上（Pink 内嵌宿主 / scene-editor.ejs

--- a/src/core/scene/scene-process/service/camera/ruler-2d.ts
+++ b/src/core/scene/scene-process/service/camera/ruler-2d.ts
@@ -1,0 +1,160 @@
+import type Grid from './grid';
+
+/**
+ * 刻度尺的屏幕映射，由相机实时状态构建（见 CameraController2D._rulerView），
+ * 不依赖 Grid 的像素模型，保证刻度与渲染出的网格线/原点轴始终贴合。
+ */
+export interface IRulerView {
+    /** 世界单位 → 屏幕像素（画布后备像素） */
+    toX(value: number): number;
+    toY(value: number): number;
+    pxPerUnit: number;
+    xMin: number;
+    xMax: number;
+    yMin: number;
+    yMax: number;
+}
+
+/**
+ * 2D 场景刻度尺：横向（底部）+ 纵向（左侧），参考 Creator 场景 web ruler 移植。
+ * 两个透明 canvas 由本类自建并 fixed 覆盖在宿主页上（Pink 内嵌宿主 / scene-editor.ejs
+ * 等所有宿主通用，不依赖宿主页 DOM），仅绘制刻度文字。
+ *
+ * 刻度级别按「屏幕上 >= 50px 间隔」从 Grid 的 tick 序列里选取，缩放时自动换档；
+ * 位置由相机实时状态换算，拖动/缩放后随 updateGrid 重绘。
+ */
+export class Ruler2D {
+    private hCanvas: HTMLCanvasElement | null = null;
+    private vCanvas: HTMLCanvasElement | null = null;
+    private hCtx: CanvasRenderingContext2D | null = null;
+    private vCtx: CanvasRenderingContext2D | null = null;
+    private isShow = false;
+
+    public init(): void {
+        if (typeof document === 'undefined' || !document.body) {
+            return;
+        }
+        this.hCanvas = this.ensureCanvas('scene-h-ruler', { left: '0', bottom: '0', width: '100%', height: '22px' });
+        this.vCanvas = this.ensureCanvas('scene-v-ruler', { left: '0', top: '0', width: '35px', height: '100%' });
+        this.hCtx = this.hCanvas ? this.hCanvas.getContext('2d') : null;
+        this.vCtx = this.vCanvas ? this.vCanvas.getContext('2d') : null;
+        this.resize();
+    }
+
+    /** 复用或创建透明刻度 canvas（fixed 覆盖、不拦截鼠标） */
+    private ensureCanvas(id: string, css: Record<string, string>): HTMLCanvasElement | null {
+        let el = document.getElementById(id) as HTMLCanvasElement | null;
+        if (!el) {
+            el = document.createElement('canvas');
+            el.id = id;
+            el.style.position = 'fixed';
+            el.style.pointerEvents = 'none';
+            el.style.zIndex = '6';
+            for (const key of Object.keys(css)) {
+                (el.style as unknown as Record<string, string>)[key] = css[key];
+            }
+            document.body.appendChild(el);
+        }
+        return el;
+    }
+
+    public show(isShow: boolean): void {
+        this.isShow = isShow;
+        if (!isShow) {
+            // 切 3D 等场景下立即清屏，避免残留刻度
+            if (this.hCanvas && this.hCtx) {
+                this.hCtx.clearRect(0, 0, this.hCanvas.width, this.hCanvas.height);
+            }
+            if (this.vCanvas && this.vCtx) {
+                this.vCtx.clearRect(0, 0, this.vCanvas.width, this.vCanvas.height);
+            }
+        }
+    }
+
+    public resize(): void {
+        const dpr = typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1;
+        if (this.hCanvas) {
+            const rect = this.hCanvas.getBoundingClientRect();
+            const cssW = rect.width > 0 ? rect.width : (typeof window !== 'undefined' ? window.innerWidth : 0);
+            this.hCanvas.width = Math.max(1, Math.round(cssW * dpr));
+            this.hCanvas.height = Math.max(1, Math.round(22 * dpr));
+        }
+        if (this.vCanvas) {
+            const rect = this.vCanvas.getBoundingClientRect();
+            const cssH = rect.height > 0 ? rect.height : (typeof window !== 'undefined' ? window.innerHeight : 0);
+            this.vCanvas.width = Math.max(1, Math.round(35 * dpr));
+            this.vCanvas.height = Math.max(1, Math.round(cssH * dpr));
+        }
+    }
+
+    public updateTicks(grid: Grid, view: IRulerView): void {
+        if (!this.hCtx || !this.vCtx || !this.hCanvas || !this.vCanvas) {
+            return;
+        }
+        const dpr = typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1;
+
+        this.hCtx.clearRect(0, 0, this.hCanvas.width, this.hCanvas.height);
+        this.vCtx.clearRect(0, 0, this.vCanvas.width, this.vCanvas.height);
+
+        if (!this.isShow || !grid.hTicks || !grid.vTicks || !(view.pxPerUnit > 0)) {
+            return;
+        }
+
+        const font = `${Math.round(11 * dpr)}px Arial`;
+        const color = 'gray';
+        // 刻度文字最小像素间隔，避免标签挤在一起（与 Creator 一致取 50，按 dpr 缩放）
+        const minStep = 50 * dpr;
+
+        // 横向刻度
+        const hStep = pickTickStep(grid.hTicks.ticks, view.pxPerUnit, minStep);
+        if (hStep > 0) {
+            this.hCtx.font = font;
+            this.hCtx.fillStyle = color;
+            this.hCtx.textBaseline = 'bottom';
+            const first = Math.ceil(view.xMin / hStep);
+            const last = Math.floor(view.xMax / hStep);
+            for (let i = first; i <= last; i++) {
+                const value = i * hStep;
+                const x = Math.floor(view.toX(value)) + Math.round(4 * dpr);
+                this.hCtx.fillText(formatLabel(value), x, this.hCanvas.height - Math.round(3 * dpr));
+            }
+        }
+
+        // 纵向刻度
+        const vStep = pickTickStep(grid.vTicks.ticks, view.pxPerUnit, minStep);
+        if (vStep > 0) {
+            this.vCtx.font = font;
+            this.vCtx.fillStyle = color;
+            this.vCtx.textBaseline = 'middle';
+            const first = Math.ceil(view.yMin / vStep);
+            const last = Math.floor(view.yMax / vStep);
+            for (let i = first; i <= last; i++) {
+                const value = i * vStep;
+                const y = Math.floor(view.toY(value));
+                this.vCtx.fillText(formatLabel(value), Math.round(4 * dpr), y - Math.round(8 * dpr));
+            }
+        }
+    }
+}
+
+/** 从 tick 序列（升序）中选第一个屏幕间距 >= minStep 的级别；都不够则用最大级 */
+function pickTickStep(ticks: number[], pxPerUnit: number, minStep: number): number {
+    if (!ticks.length) {
+        return 0;
+    }
+    let step = ticks[ticks.length - 1];
+    for (const t of ticks) {
+        if (t * pxPerUnit >= minStep) {
+            step = t;
+            break;
+        }
+    }
+    return step;
+}
+
+function formatLabel(value: number): string {
+    const rounded = Math.round(value * 100) / 100;
+    return rounded.toString();
+}
+
+export default Ruler2D;

--- a/src/core/scene/scene-process/service/camera/ruler-2d.ts
+++ b/src/core/scene/scene-process/service/camera/ruler-2d.ts
@@ -5,7 +5,7 @@ import type Grid from './grid';
  * 不依赖 Grid 的像素模型，保证刻度与渲染出的网格线/原点轴始终贴合。
  */
 export interface IRulerView {
-    /** 世界单位 → 屏幕像素（画布后备像素） */
+    /** 世界单位 → 屏幕像素（引擎渲染后备像素） */
     toX(value: number): number;
     toY(value: number): number;
     pxPerUnit: number;
@@ -20,8 +20,15 @@ export interface IRulerView {
  * 两个透明 canvas 由本类自建并 fixed 覆盖在宿主页上（Pink 内嵌宿主 / scene-editor.ejs
  * 等所有宿主通用，不依赖宿主页 DOM），仅绘制刻度文字。
  *
- * 刻度级别按「屏幕上 >= 50px 间隔」从 Grid 的 tick 序列里选取，缩放时自动换档；
- * 位置由相机实时状态换算，拖动/缩放后随 updateGrid 重绘。
+ * 环境边界（review P1）：headless 场景进程提供 mock document，其元素没有 getContext，
+ * 本类在此整体 no-op，不影响场景服务启动与保存/关闭流程。
+ *
+ * 像素基准（review P2）：worldToScreen 坐标位于引擎渲染后备像素空间（引擎 DPR 封顶），
+ * 故刻度后备/字号统一使用「有效渲染 DPR」（引擎 canvas 后备/CSS 比），与引擎同基准。
+ *
+ * 视口变化（review P2）：Pink 宿主摘除引擎 window-resize 自适应、面板 resize 不走
+ * 引擎 canvas-resize 事件链，故本类自行观察 overlay 尺寸（ResizeObserver + window
+ * resize，rAF 去抖），变化后重设后备并经 onNeedRedraw 回调控制器重画。
  */
 export class Ruler2D {
     private hCanvas: HTMLCanvasElement | null = null;
@@ -29,6 +36,11 @@ export class Ruler2D {
     private hCtx: CanvasRenderingContext2D | null = null;
     private vCtx: CanvasRenderingContext2D | null = null;
     private isShow = false;
+    private ro: ResizeObserver | null = null;
+    private resizePending = false;
+
+    /** 控制器注入的重画入口；视口变化重设后备后触发 */
+    public onNeedRedraw: (() => void) | null = null;
 
     public init(): void {
         if (typeof document === 'undefined' || !document.body) {
@@ -38,24 +50,85 @@ export class Ruler2D {
         this.vCanvas = this.ensureCanvas('scene-v-ruler', { left: '0', top: '0', width: '35px', height: '100%' });
         this.hCtx = this.hCanvas ? this.hCanvas.getContext('2d') : null;
         this.vCtx = this.vCanvas ? this.vCanvas.getContext('2d') : null;
+        this.observeHost();
         this.resize();
     }
 
-    /** 复用或创建透明刻度 canvas（fixed 覆盖、不拦截鼠标） */
+    /** 复用或创建透明刻度 canvas；headless mock 元素无 getContext 时返回 null（整体 no-op） */
     private ensureCanvas(id: string, css: Record<string, string>): HTMLCanvasElement | null {
         let el = document.getElementById(id) as HTMLCanvasElement | null;
+        let created = false;
         if (!el) {
-            el = document.createElement('canvas');
+            created = true;
+            el = document.createElement('canvas') as HTMLCanvasElement;
             el.id = id;
-            el.style.position = 'fixed';
-            el.style.pointerEvents = 'none';
-            el.style.zIndex = '6';
-            for (const key of Object.keys(css)) {
-                (el.style as unknown as Record<string, string>)[key] = css[key];
+            const st = (el as unknown as { style?: Record<string, string> }).style;
+            if (st) {
+                st.position = 'fixed';
+                st.pointerEvents = 'none';
+                st.zIndex = '6';
+                for (const key of Object.keys(css)) {
+                    st[key] = css[key];
+                }
             }
+        }
+        if (typeof (el as unknown as { getContext?: unknown }).getContext !== 'function') {
+            return null;
+        }
+        if (created) {
             document.body.appendChild(el);
         }
         return el;
+    }
+
+    /** 独立观察宿主视口：overlay 尺寸或 window 变化时重设后备并重画 */
+    private observeHost(): void {
+        if (typeof window === 'undefined' || typeof window.addEventListener !== 'function') {
+            return;
+        }
+        window.addEventListener('resize', this.onHostResize);
+        if (typeof ResizeObserver === 'function') {
+            this.ro = new ResizeObserver(this.onHostResize);
+            if (this.hCanvas) {
+                this.ro.observe(this.hCanvas);
+            }
+            if (this.vCanvas) {
+                this.ro.observe(this.vCanvas);
+            }
+        }
+    }
+
+    private readonly onHostResize = (): void => {
+        if (this.resizePending) {
+            return;
+        }
+        this.resizePending = true;
+        const raf = (globalThis as unknown as { requestAnimationFrame?: (cb: () => void) => void }).requestAnimationFrame;
+        const run = (): void => {
+            this.resizePending = false;
+            this.resize();
+            if (this.onNeedRedraw) {
+                this.onNeedRedraw();
+            }
+        };
+        if (typeof raf === 'function') {
+            raf(run);
+        } else {
+            run();
+        }
+    };
+
+    /** 有效渲染 DPR：引擎 canvas 后备/CSS 比（与引擎同封顶），回退 window.devicePixelRatio */
+    private renderDpr(): number {
+        let dpr = typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1;
+        const engineCanvas = (globalThis as unknown as { cc?: { game?: { canvas?: HTMLCanvasElement } } }).cc?.game?.canvas;
+        if (engineCanvas && typeof engineCanvas.getBoundingClientRect === 'function') {
+            const rect = engineCanvas.getBoundingClientRect();
+            if (rect.width > 0 && engineCanvas.width > 0) {
+                dpr = engineCanvas.width / rect.width;
+            }
+        }
+        return dpr > 0 ? dpr : 1;
     }
 
     public show(isShow: boolean): void {
@@ -72,26 +145,44 @@ export class Ruler2D {
     }
 
     public resize(): void {
-        const dpr = typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1;
+        const dpr = this.renderDpr();
         if (this.hCanvas) {
-            const rect = this.hCanvas.getBoundingClientRect();
-            const cssW = rect.width > 0 ? rect.width : (typeof window !== 'undefined' ? window.innerWidth : 0);
+            const cssW = this.cssWidthOf(this.hCanvas);
             this.hCanvas.width = Math.max(1, Math.round(cssW * dpr));
             this.hCanvas.height = Math.max(1, Math.round(22 * dpr));
         }
         if (this.vCanvas) {
-            const rect = this.vCanvas.getBoundingClientRect();
-            const cssH = rect.height > 0 ? rect.height : (typeof window !== 'undefined' ? window.innerHeight : 0);
+            const cssH = this.cssHeightOf(this.vCanvas);
             this.vCanvas.width = Math.max(1, Math.round(35 * dpr));
             this.vCanvas.height = Math.max(1, Math.round(cssH * dpr));
         }
+    }
+
+    private cssWidthOf(el: HTMLCanvasElement): number {
+        if (typeof el.getBoundingClientRect === 'function') {
+            const rect = el.getBoundingClientRect();
+            if (rect.width > 0) {
+                return rect.width;
+            }
+        }
+        return typeof window !== 'undefined' ? window.innerWidth : 0;
+    }
+
+    private cssHeightOf(el: HTMLCanvasElement): number {
+        if (typeof el.getBoundingClientRect === 'function') {
+            const rect = el.getBoundingClientRect();
+            if (rect.height > 0) {
+                return rect.height;
+            }
+        }
+        return typeof window !== 'undefined' ? window.innerHeight : 0;
     }
 
     public updateTicks(grid: Grid, view: IRulerView): void {
         if (!this.hCtx || !this.vCtx || !this.hCanvas || !this.vCanvas) {
             return;
         }
-        const dpr = typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1;
+        const dpr = this.renderDpr();
 
         this.hCtx.clearRect(0, 0, this.hCanvas.width, this.hCanvas.height);
         this.vCtx.clearRect(0, 0, this.vCanvas.width, this.vCanvas.height);
@@ -102,7 +193,7 @@ export class Ruler2D {
 
         const font = `${Math.round(11 * dpr)}px Arial`;
         const color = 'gray';
-        // 刻度文字最小像素间隔，避免标签挤在一起（与 Creator 一致取 50，按 dpr 缩放）
+        // 刻度文字最小像素间隔，避免标签挤在一起（与 Creator 一致取 50，按有效 DPR 缩放）
         const minStep = 50 * dpr;
 
         // 横向刻度

--- a/src/core/scene/test/ruler-2d-headless.test.ts
+++ b/src/core/scene/test/ruler-2d-headless.test.ts
@@ -1,4 +1,4 @@
-import { Ruler2D } from '../scene-process/service/camera/ruler-2d';
+import { Ruler2D, buildRulerView } from '../scene-process/service/camera/ruler-2d';
 
 /**
  * 回归护栏（PR #914 review P1）：headless 场景进程提供 mock document，
@@ -44,6 +44,56 @@ describe('Ruler2D headless safety', () => {
         expect(() => ruler.resize()).not.toThrow();
     });
 
+describe('buildRulerView viewport freshness (PR #914 round-2 P2)', () => {
+    it('uses render-camera dimensions for the Y flip when controller size is stale', () => {
+        const rc = {
+            width: 1200,
+            height: 1080,
+            update: jest.fn(),
+            worldToScreen: (out: any, p: any) => {
+                out.x = 600 + p.x * 2;
+                out.y = 540 + p.y * 2;
+                return out;
+            },
+        };
+        // 控制器缓存 size 仍是旧的 600x700（跨屏前 DPR2），渲染目标已变为 1200x1080
+        const view = buildRulerView(rc as any, { width: 600, height: 700 }, { orthoHeight: 350, x: 0, y: 0 });
+        expect(rc.update).toHaveBeenCalled();
+        expect(view.pxPerUnit).toBe(2);
+        expect(view.toX(0)).toBe(600);
+        // Y 翻转必须用渲染高度 1080，而不是陈旧的 700
+        expect(view.toY(0)).toBe(1080 - 540);
+        expect(view.yMin).toBeCloseTo(-270);
+        expect(view.yMax).toBeCloseTo(270);
+        expect(view.xMin).toBeCloseTo(-300);
+        expect(view.xMax).toBeCloseTo(300);
+    });
+
+    it('falls back to cached size and ortho when no render camera', () => {
+        const view = buildRulerView(undefined, { width: 800, height: 600 }, { orthoHeight: 150, x: 100, y: 50 });
+        // s = 600 / (2*150) = 2
+        expect(view.pxPerUnit).toBe(2);
+        expect(view.toX(100)).toBe(400);
+        expect(view.toY(50)).toBe(100);
+    });
+
+    it('falls back to cached size when render camera lacks dimensions', () => {
+        const rc = {
+            width: 0,
+            height: 0,
+            worldToScreen: (out: any, p: any) => {
+                out.x = 10 + p.x;
+                out.y = 20 + p.y;
+                return out;
+            },
+        };
+        const view = buildRulerView(rc as any, { width: 640, height: 480 }, { orthoHeight: 240, x: 0, y: 0 });
+        expect(view.toY(0)).toBe(480 - 20);
+        expect(view.yMax).toBeCloseTo(460);
+    });
+});
+
+describe('Ruler2D DPR backing', () => {
     it('uses engine canvas backing ratio as effective DPR when available', () => {
         (globalThis as any).window = { devicePixelRatio: 3, innerWidth: 600, innerHeight: 400, addEventListener: jest.fn() };
         const rect = { width: 600, height: 400 };
@@ -79,4 +129,5 @@ describe('Ruler2D headless safety', () => {
         expect(vEl.width).toBe(70);
         expect(vEl.height).toBe(800);
     });
+});
 });

--- a/src/core/scene/test/ruler-2d-headless.test.ts
+++ b/src/core/scene/test/ruler-2d-headless.test.ts
@@ -1,0 +1,82 @@
+import { Ruler2D } from '../scene-process/service/camera/ruler-2d';
+
+/**
+ * 回归护栏（PR #914 review P1）：headless 场景进程提供 mock document，
+ * 其 canvas 元素没有 getContext；Ruler2D 必须整体 no-op，
+ * 不能让 CameraController2D.init / CameraService.onEditorOpened 抛异常。
+ */
+describe('Ruler2D headless safety', () => {
+    afterEach(() => {
+        delete (globalThis as any).document;
+        delete (globalThis as any).window;
+        delete (globalThis as any).cc;
+    });
+
+    it('no-ops when mock DOM elements lack getContext', () => {
+        (globalThis as any).document = {
+            body: { appendChild: jest.fn() },
+            getElementById: () => null,
+            createElement: () => ({ style: {} }),
+        };
+
+        const ruler = new Ruler2D();
+        expect(() => ruler.init()).not.toThrow();
+        expect(() => ruler.resize()).not.toThrow();
+        expect(() => ruler.show(true)).not.toThrow();
+
+        const grid: any = { hTicks: { ticks: [1, 10, 100] }, vTicks: { ticks: [1, 10, 100] } };
+        const view: any = {
+            toX: (v: number) => v * 2,
+            toY: (v: number) => v * 2,
+            pxPerUnit: 2,
+            xMin: 0,
+            xMax: 100,
+            yMin: 0,
+            yMax: 100,
+        };
+        expect(() => ruler.updateTicks(grid, view)).not.toThrow();
+        expect(() => ruler.show(false)).not.toThrow();
+    });
+
+    it('no-ops without any document', () => {
+        const ruler = new Ruler2D();
+        expect(() => ruler.init()).not.toThrow();
+        expect(() => ruler.resize()).not.toThrow();
+    });
+
+    it('uses engine canvas backing ratio as effective DPR when available', () => {
+        (globalThis as any).window = { devicePixelRatio: 3, innerWidth: 600, innerHeight: 400, addEventListener: jest.fn() };
+        const rect = { width: 600, height: 400 };
+        const engineCanvas = { width: 1200, height: 800, getBoundingClientRect: () => rect };
+        (globalThis as any).cc = { game: { canvas: engineCanvas } };
+
+        const hEl: any = {
+            style: {},
+            getContext: () => ({ clearRect: jest.fn(), fillText: jest.fn() }),
+            getBoundingClientRect: () => ({ width: 600, height: 22 }),
+            width: 0,
+            height: 0,
+        };
+        const vEl: any = {
+            style: {},
+            getContext: () => ({ clearRect: jest.fn(), fillText: jest.fn() }),
+            getBoundingClientRect: () => ({ width: 35, height: 400 }),
+            width: 0,
+            height: 0,
+        };
+        const queue = [hEl, vEl];
+        (globalThis as any).document = {
+            body: { appendChild: jest.fn() },
+            getElementById: () => null,
+            createElement: () => queue.shift() || hEl,
+        };
+
+        const ruler = new Ruler2D();
+        ruler.init();
+        // 引擎 canvas 1200/600 = 2（封顶基准），横向后备应为 600*2 而非 600*3
+        expect(hEl.width).toBe(1200);
+        expect(hEl.height).toBe(44);
+        expect(vEl.width).toBe(70);
+        expect(vEl.height).toBe(800);
+    });
+});


### PR DESCRIPTION
## Background
- 2D scene view lacked the horizontal/vertical rulers that Creator shows and that follow zoom/pan.
- The 2D grid fade window (10–80 px) saturated mid-level lines at common zoom levels, collapsing the major/minor hierarchy.

## Implementation
- Widened the 2D grid fade window to 10–200 px so mid-level lines keep fading and the hierarchy stays visible (3D/preview grids untouched).
- Added `Ruler2D`: draws left/bottom tick labels on self-created transparent overlay canvases, host-page agnostic (Pink embedded webview and scene-editor.ejs); label level follows the grid tick ladder with >=50 px on-screen spacing and re-levels on zoom, matching Creator.
- Labels map world→screen via the render camera's `worldToScreen` (matrix flushed with a synchronous `camera.update()`), staying pixel-aligned with grid lines and origin axes under any transform/zoom.
- Rulers refresh at the end of `adjustCamera()` (including tween steps) so zoom/pan never lag a frame, and are cleared when leaving 2D.

## Testing
- Open a 2D scene: rulers visible; 0 ticks coincide with the origin axes.
- Wheel zoom: labels re-level and stay aligned with grid lines immediately; drag: rulers track the grid; switch to 3D: rulers hidden.
- `tsc -b` clean; camera/gizmo unit suites 19/19 pass.