### PR TITLE
fix(preview): pause game loop before first frame for IDE cold-start step

### DIFF
--- a/src/core/preview/test/game-boot-scene-load.test.ts
+++ b/src/core/preview/test/game-boot-scene-load.test.ts
@@ -67,6 +67,17 @@ describe('game-boot 场景加载失败路径（防 boot 挂死）', () => {
         expect(showErrors.length).toBeGreaterThanOrEqual(3);
     });
 
+    it('冷启动暂停意图必须在 cc.game.resume() 后立即生效（首帧前暂停，PR #914 review P2）', () => {
+        const resumeIndex = section.indexOf('cc.game.resume();');
+        expect(resumeIndex).toBeGreaterThan(-1);
+        const afterResume = section.slice(resumeIndex, section.indexOf('resolveSceneRun();', resumeIndex));
+        expect(afterResume).toContain('window.__pinkStartPaused');
+        // 意图生效必须同时暂停 director 与 game，且被 try/catch 收敛（引擎状态异常不阻断启动）
+        expect(afterResume).toContain('cc.director.pause();');
+        expect(afterResume).toContain('cc.game.pause();');
+        expect(afterResume).toContain('catch');
+    });
+
     it('sceneRunDone 的 reject 必须能传播到 gameBoot 外层 catch 并 rethrow（IDE 预览的失败感知契约）', () => {
         // await sceneRunDone 必须位于外层 try 内（其后存在统一 catch + rethrow）
         const awaitDone = source.indexOf('await sceneRunDone');

--- a/static/web/game-boot.js
+++ b/static/web/game-boot.js
@@ -277,6 +277,11 @@ export default async function gameBoot() {
                             scene._name = sceneAsset._name;
                             cc.director.runSceneImmediate(scene, () => {
                                 cc.game.resume();
+                                // PinK 预览冷启动暂停意图：resume 后立即 pause，在游戏循环首帧前生效，
+                                // 配合 IDE 侧随后的一次显式 step（避免 ready 后才暂停导致已推进多帧）。
+                                if (window.__pinkStartPaused) {
+                                    try { cc.director.pause(); cc.game.pause(); } catch (e) { /* 忽略引擎状态异常 */ }
+                                }
                                 resolveSceneRun();
                             });
                         } catch (e) {


### PR DESCRIPTION
Companion to SUD-GLOBAL/PinK#1419 (Preview In Editor cold-start Step).

## Problem
PinK's Preview In Editor cold-start Step passes `{ paused: true, stepOnce: true }`, but the pause was only applied after `view:ready`, which fires after inspect assembly and the loading-overlay hide animation. `game-boot.js` calls `cc.game.resume()` in the scene-run callback, so the game advances many frames before the IDE pauses it (source-level repro: ~36 frames on the 600ms fallback path).

## Change
- `game-boot.js`: when `window.__pinkStartPaused` is set (injected by the IDE host before the boot chain), pause director + game immediately after `cc.game.resume()`, i.e. before the first game-loop frame; wrapped in try/catch so engine state anomalies cannot break startup.
- Regression test: structural invariant pinning pause-after-resume (director + game pause, try/catch converged) in `game-boot-scene-load.test.ts`.

## Validation
- `npx jest src/core/preview/test/game-boot-scene-load.test.ts`: 6/6 passing.
- `npx tsc -b`: clean.