### PR TITLE
[break] refactor(builder): change clearCache to accept options object

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -1599,7 +1599,10 @@ export declare interface ChokidarOptions {
     	useFsEvents?: boolean;
     	usePolling?: boolean;
 }
-export declare function clearCache(scope: BuildCacheScope): Promise<ClearCacheResult>;
+export declare function clearCache(options: ClearCacheOptions): Promise<ClearCacheResult>;
+export declare interface ClearCacheOptions {
+    scope: BuildCacheScope;
+}
 export declare interface ClearCacheResult {
     scope: BuildCacheScope;
     cleared: string[];

--- a/src/core/builder/cache.ts
+++ b/src/core/builder/cache.ts
@@ -5,6 +5,10 @@ import { GlobalPaths } from '../../global';
 
 export type BuildCacheScope = 'project' | 'global' | 'all';
 
+export interface ClearCacheOptions {
+    scope: BuildCacheScope;
+}
+
 export interface ClearCacheResult {
     scope: BuildCacheScope;
     cleared: string[];
@@ -135,7 +139,8 @@ async function clearGlobalCache(): Promise<string[]> {
     return cleared;
 }
 
-export async function clearCache(scope: BuildCacheScope): Promise<ClearCacheResult> {
+export async function clearCache(options: ClearCacheOptions): Promise<ClearCacheResult> {
+    const scope = options?.scope;
     if (scope !== 'project' && scope !== 'global' && scope !== 'all') {
         throw new Error(`Invalid builder cache scope: ${scope}`);
     }

--- a/src/core/builder/index.ts
+++ b/src/core/builder/index.ts
@@ -14,7 +14,7 @@ import { middlewareService } from '../../server/middleware/core';
 import BuildMiddleware from './build.middleware';
 import { BuildGlobalInfo } from './share/global';
 export { clearCache } from './cache';
-export type { BuildCacheScope, ClearCacheResult } from './cache';
+export type { BuildCacheScope, ClearCacheOptions, ClearCacheResult } from './cache';
 
 export async function init(platform?: string[]) {
     await builderConfig.init();

--- a/src/core/builder/test/clear-cache.spec.ts
+++ b/src/core/builder/test/clear-cache.spec.ts
@@ -48,7 +48,7 @@ describe('builder clearCache', () => {
         await outputFile(builderCacheFile, '{}');
         await outputFile(logFile, 'log');
 
-        const result = await clearCache('project');
+        const result = await clearCache({ scope: 'project' });
 
         expect(result.scope).toBe('project');
         expect(await pathExists(assetBuildCacheFile)).toBe(false);
@@ -64,7 +64,7 @@ describe('builder clearCache', () => {
         await outputFile(legacyAssetBuildCacheFile, '{}');
         await outputFile(legacyAssetOtherFile, 'image');
 
-        const result = await clearCache('project');
+        const result = await clearCache({ scope: 'project' });
 
         expect(result.scope).toBe('project');
         expect(await pathExists(legacyAssetBuildCacheFile)).toBe(false);
@@ -82,7 +82,7 @@ describe('builder clearCache', () => {
         await outputFile(devCliCacheFile, 'cc');
         await outputFile(engineLogFile, 'log');
 
-        const result = await clearCache('global');
+        const result = await clearCache({ scope: 'global' });
 
         expect(result.scope).toBe('global');
         await expect(readdir(join(mockGlobalPaths.enginePath, 'bin', 'temp'))).resolves.toEqual([]);
@@ -98,7 +98,7 @@ describe('builder clearCache', () => {
         await outputFile(projectCacheFile, '{}');
         await outputFile(globalCacheFile, 'engine');
 
-        const result = await clearCache('all');
+        const result = await clearCache({ scope: 'all' });
 
         expect(result.scope).toBe('all');
         expect(await pathExists(projectCacheFile)).toBe(false);

--- a/src/core/builder/test/lib-clear-cache.spec.ts
+++ b/src/core/builder/test/lib-clear-cache.spec.ts
@@ -1,5 +1,5 @@
-const clearCacheMock = jest.fn(async (scope: 'project' | 'global' | 'all') => ({
-    scope,
+const clearCacheMock = jest.fn(async (options: { scope: 'project' | 'global' | 'all' }) => ({
+    scope: options.scope,
     cleared: [],
 }));
 
@@ -23,10 +23,10 @@ describe('lib/builder clearCache API', () => {
     it('delegates cache cleanup to core builder', async () => {
         const builderLib = await getBuilderLib();
 
-        const result = await builderLib.clearCache('project');
+        const result = await builderLib.clearCache({ scope: 'project' });
 
         expect(clearCacheMock).toHaveBeenCalledTimes(1);
-        expect(clearCacheMock).toHaveBeenCalledWith('project');
+        expect(clearCacheMock).toHaveBeenCalledWith({ scope: 'project' });
         expect(result).toEqual({
             scope: 'project',
             cleared: [],

--- a/src/lib/builder/builder.ts
+++ b/src/lib/builder/builder.ts
@@ -1,11 +1,11 @@
 import type { BuildStageProgressCallback, IBuildCommandOption, IBuildResultData, IBuildStageOptions, IBuildTaskOption, IBundleBuildOptions, IPackOptions, IPreviewSettingsResult, Platform, PreviewPackResult } from '../../core/builder/@types/private';
 import type { BuildConfiguration } from '../../core/builder/@types/config-export';
 import type { BuildCheckResult, PlatformBuildSchema, PlatformConfigItem } from '../../core/builder/@types/protected';
-import type { BuildCacheScope, ClearCacheResult } from '../../core/builder/cache';
+import type { BuildCacheScope, ClearCacheOptions, ClearCacheResult } from '../../core/builder/cache';
 
 export type * from '../../core/builder/@types/private';
 export type * from '../../core/builder/@types/config-export';
-export type { BuildCacheScope, ClearCacheResult };
+export type { BuildCacheScope, ClearCacheOptions, ClearCacheResult };
 export async function init(platform?: string[]): Promise<void> {
     const builder = await import('../../core/builder');
     return builder.init(platform);
@@ -108,9 +108,9 @@ export async function createBuildTemplate(nameOrPlatform: string): Promise<void>
     return builder.createBuildTemplate(nameOrPlatform);
 }
 
-export async function clearCache(scope: BuildCacheScope): Promise<ClearCacheResult> {
+export async function clearCache(options: ClearCacheOptions): Promise<ClearCacheResult> {
     const builder = await import('../../core/builder');
-    return builder.clearCache(scope);
+    return builder.clearCache(options);
 }
 
 export async function checkBuildOption(platform: string, key: string, value: unknown, options: IBuildTaskOption): Promise<BuildCheckResult> {


### PR DESCRIPTION
将 clearCache 参数从 scope 字符串改为 { scope: 'project' | 'global' | 'all' } 对象格式，并提取 ClearCacheOptions 类型；同步更新 lib 转发层、类型导出、
单测与 dts 快照。