### PR TITLE
fix(particle): 修复撤销时材质覆盖导致的渲染卡顿

### DIFF
--- a/src/core/scene/scene-process/service/dump/index.ts
+++ b/src/core/scene/scene-process/service/dump/index.ts
@@ -1,11 +1,12 @@
 'use strict';
-import { Node, Component, js, CCClass, Scene } from 'cc';
+import { Node, Component, js, CCClass, Scene, type ParticleSystem } from 'cc';
 import { parsingPath } from './utils';
 import get from 'lodash/get';
 import AssetUtil from './asset';
 import { decodePatch, decodeNode, decodeScene, resetProperty, updatePropertyFromNull } from './decode';
 import { encodeObject, encodeComponent, encodeScene, encodeNode } from './encode';
 import { IComponent, INode, IScene } from '../../../common';
+import { restoreParticleSystemSnapshot } from './particle-snapshot';
 import {
     NODE_SNAPSHOT_RESTORE_PROPERTY_PATHS,
     SCENE_SNAPSHOT_SPECIAL_PROPERTY_KEYS,
@@ -200,6 +201,10 @@ class DumpUtil {
      */
     async restoreComponentSnapshotProperties(component: Component, dump: any) {
         if (!dump?.value) {
+            return;
+        }
+        if (js.getClassName(component) === 'cc.ParticleSystem' && dump.value.renderer?.value) {
+            await restoreParticleSystemSnapshot(component as ParticleSystem, dump, (target, path, property) => decodePatch(path, property, target));
             return;
         }
         for (const key in dump.value) {

--- a/src/core/scene/scene-process/service/dump/particle-snapshot.ts
+++ b/src/core/scene/scene-process/service/dump/particle-snapshot.ts
@@ -1,0 +1,76 @@
+import type { Material, ParticleSystem } from 'cc';
+import type { IProperty } from '../../../@types/public';
+import { COMPONENT_SNAPSHOT_RESTORE_SKIP_KEYS } from './restore-policy';
+
+type RestoreProperty = (target: object, path: string, dump: IProperty) => Promise<unknown>;
+
+/** Cocos 3.8 stores both modes' materials, but both public setters change the active material. */
+interface ParticleRendererState {
+    _cpuMaterial: Material | null;
+    _gpuMaterial: Material | null;
+    useGPU: boolean;
+    particleMaterial: Material | null;
+}
+
+const rendererMaterialKeys = new Set([
+    'cpuMaterial', '_cpuMaterial', 'gpuMaterial', '_gpuMaterial',
+    'particleMaterial', 'useGPU', '_useGPU',
+]);
+
+/**
+ * Restore particle materials as one mode-aware operation. Replaying the hidden and public
+ * aliases independently can destroy the CPU material when the unused GPU material is null.
+ * Asset decoding finishes before mutating the live renderer; normal fields still use decodePatch.
+ */
+export async function restoreParticleSystemSnapshot(
+    component: ParticleSystem,
+    dump: IProperty,
+    restore: RestoreProperty,
+): Promise<void> {
+    const properties = dump.value as Record<string, IProperty>;
+    const rendererDump = properties.renderer;
+    const fields = rendererDump.value as Record<string, IProperty>;
+    const renderer = component.renderer as unknown as ParticleRendererState;
+    const targetGPU = Boolean((fields.useGPU ?? fields._useGPU)?.value ?? renderer.useGPU);
+
+    async function material(property: IProperty | undefined, fallback: Material | null): Promise<Material | null> {
+        if (!property) {
+            return fallback;
+        }
+        const holder = { value: null as Material | null };
+        await restore(holder, 'value', property);
+        if (holder.value && holder.value.passes.length === 0) {
+            throw new Error(`Cannot restore particle material without render passes: ${holder.value.uuid}`);
+        }
+        return holder.value;
+    }
+
+    const [cpuMaterial, gpuMaterial] = await Promise.all([
+        material(fields.cpuMaterial ?? fields._cpuMaterial, renderer._cpuMaterial),
+        material(fields.gpuMaterial ?? fields._gpuMaterial, renderer._gpuMaterial),
+    ]);
+    // particleMaterial is the effective material, including the engine's default fallback.
+    const activeMaterial = await material(fields.particleMaterial, targetGPU ? gpuMaterial : cpuMaterial);
+
+    // Cache both modes before switching processor. Never set _useGPU directly: its setter
+    // must rebuild the processor when Undo/Redo crosses CPU/GPU modes.
+    renderer._cpuMaterial = cpuMaterial;
+    renderer._gpuMaterial = gpuMaterial;
+    renderer.useGPU = targetGPU;
+    renderer.particleMaterial = renderer.useGPU === targetGPU
+        ? activeMaterial
+        : renderer.useGPU ? gpuMaterial : cpuMaterial;
+
+    for (const [key, property] of Object.entries(properties)) {
+        if (COMPONENT_SNAPSHOT_RESTORE_SKIP_KEYS.includes(key as typeof COMPONENT_SNAPSHOT_RESTORE_SKIP_KEYS[number])
+            || key === 'renderer' || key === 'sharedMaterials' || key === '_materials') {
+            continue;
+        }
+        await restore(component, key, property);
+    }
+    for (const [key, property] of Object.entries(fields)) {
+        if (!rendererMaterialKeys.has(key)) {
+            await restore(component, `renderer.${key}`, property);
+        }
+    }
+}

--- a/src/core/scene/test/particle-snapshot-restore.test.ts
+++ b/src/core/scene/test/particle-snapshot-restore.test.ts
@@ -1,0 +1,132 @@
+import type { ParticleSystem } from 'cc';
+import type { IProperty } from '../@types/public';
+import { restoreParticleSystemSnapshot } from '../scene-process/service/dump/particle-snapshot';
+
+function property(value: unknown, type = 'Number'): IProperty {
+    return { type, path: '', value } as IProperty;
+}
+
+function fixture(useGPU = false) {
+    const cpu = { uuid: 'cpu', passes: [{}] };
+    const gpu = { uuid: 'gpu', passes: [{}] };
+    const fallback = { uuid: 'default', passes: [{}] };
+    const assets = { cpu, gpu, default: fallback, broken: { uuid: 'broken', passes: [] } };
+    const writes: string[] = [];
+    let active: typeof cpu | null = useGPU ? gpu : cpu;
+    let processorGPU = useGPU;
+    const renderer = {
+        _cpuMaterial: cpu as typeof cpu | null,
+        _gpuMaterial: gpu as typeof gpu | null,
+        _useGPU: useGPU,
+        get useGPU() { return this._useGPU; },
+        set useGPU(value: boolean) {
+            if (this._useGPU === value) { return; }
+            this._useGPU = value;
+            processorGPU = value;
+            writes.push(`processor:${value}`);
+            this.particleMaterial = value ? this._gpuMaterial : this._cpuMaterial;
+        },
+        get cpuMaterial() { return this._cpuMaterial; },
+        set cpuMaterial(value: typeof cpu | null) {
+            this._cpuMaterial = value;
+            this.particleMaterial = value;
+        },
+        get gpuMaterial() { return this._gpuMaterial; },
+        set gpuMaterial(value: typeof gpu | null) {
+            this._gpuMaterial = value;
+            this.particleMaterial = value;
+        },
+        get particleMaterial() { return active; },
+        set particleMaterial(value: typeof cpu | null) {
+            writes.push(`active:${value?.uuid ?? 'null'}`);
+            active = value;
+        },
+        trailMaterial: null as typeof cpu | null,
+        velocityScale: 1,
+    };
+    const component = { renderer, radius: 1 };
+    const restore = async (target: object, path: string, dump: IProperty) => {
+        const keys = path.split('.');
+        let parent = target as Record<string, unknown>;
+        for (const key of keys.slice(0, -1)) { parent = parent[key] as Record<string, unknown>; }
+        const uuid = (dump.value as { uuid?: keyof typeof assets } | null)?.uuid;
+        parent[keys.at(-1)!] = dump.type === 'cc.Material' ? (uuid ? assets[uuid] : null) : dump.value;
+    };
+    const snapshot = (targetGPU: boolean, cpuUuid = 'cpu', gpuUuid = 'gpu', activeUuid = targetGPU ? gpuUuid : cpuUuid) => property({
+        uuid: property('component-id', 'String'),
+        radius: property(5),
+        // These aliases must not replay material setters outside the mode-aware restoration.
+        sharedMaterials: property([]),
+        _materials: property([]),
+        renderer: property({
+            cpuMaterial: property({ uuid: cpuUuid }, 'cc.Material'),
+            _cpuMaterial: property({ uuid: cpuUuid }, 'cc.Material'),
+            gpuMaterial: property({ uuid: gpuUuid }, 'cc.Material'),
+            _gpuMaterial: property({ uuid: gpuUuid }, 'cc.Material'),
+            particleMaterial: property({ uuid: activeUuid }, 'cc.Material'),
+            _useGPU: property(targetGPU, 'Boolean'),
+            useGPU: property(targetGPU, 'Boolean'),
+            velocityScale: property(3),
+            trailMaterial: property({ uuid: 'cpu' }, 'cc.Material'),
+        }, 'cc.ParticleSystemRenderer'),
+    }, 'cc.ParticleSystem');
+    return {
+        component, renderer, assets, writes, snapshot,
+        apply: (dump: IProperty) => restoreParticleSystemSnapshot(component as unknown as ParticleSystem, dump, restore),
+        state: () => ({ active: active?.uuid, cpu: renderer.cpuMaterial?.uuid, gpu: renderer.gpuMaterial?.uuid, processorGPU }),
+    };
+}
+
+describe('particle snapshot material restoration', () => {
+    it.each(['', 'gpu'])('preserves the CPU material when the inactive GPU material is %s', async gpu => {
+        const f = fixture();
+        await f.apply(f.snapshot(false, 'cpu', gpu));
+        expect({ ...f.state(), radius: f.component.radius, velocity: f.renderer.velocityScale }).toEqual({
+            active: 'cpu', cpu: 'cpu', gpu: gpu || undefined, processorGPU: false, radius: 5, velocity: 3,
+        });
+        expect(f.writes).toEqual(['active:cpu']);
+    });
+
+    it('preserves GPU mode when the inactive CPU material is empty', async () => {
+        const f = fixture(true);
+        await f.apply(f.snapshot(true, '', 'gpu'));
+        expect(f.state()).toEqual({ active: 'gpu', cpu: undefined, gpu: 'gpu', processorGPU: true });
+        expect(f.writes).toEqual(['active:gpu']);
+    });
+
+    it('restores the effective default material even when the mode cache is empty', async () => {
+        const f = fixture();
+        await f.apply(f.snapshot(false, '', '', 'default'));
+        expect(f.state()).toEqual({ active: 'default', cpu: undefined, gpu: undefined, processorGPU: false });
+    });
+
+    it('switches the processor on Undo and Redo without replaying the raw mode alias', async () => {
+        const f = fixture(true);
+        for (const mode of [false, true, false, true]) {
+            await f.apply(f.snapshot(mode));
+            expect(f.state()).toEqual({ active: mode ? 'gpu' : 'cpu', cpu: 'cpu', gpu: 'gpu', processorGPU: mode });
+        }
+        expect(f.writes.filter(value => value.startsWith('processor:'))).toEqual([
+            'processor:false', 'processor:true', 'processor:false', 'processor:true',
+        ]);
+    });
+
+    it('restores custom material changes and trail fields without mutating the snapshot', async () => {
+        const f = fixture();
+        const dump = f.snapshot(false, 'default', 'gpu');
+        const original = JSON.stringify(dump);
+        await f.apply(dump);
+        expect({ state: f.state(), trail: f.renderer.trailMaterial?.uuid }).toEqual({
+            state: { active: 'default', cpu: 'default', gpu: 'gpu', processorGPU: false }, trail: 'cpu',
+        });
+        expect(JSON.stringify(dump)).toBe(original);
+    });
+
+    it('rejects an invalid material before mutating the live component', async () => {
+        const f = fixture();
+        await expect(f.apply(f.snapshot(false, 'broken'))).rejects.toThrow('without render passes');
+        expect({ state: f.state(), radius: f.component.radius, writes: f.writes }).toEqual({
+            state: { active: 'cpu', cpu: 'cpu', gpu: 'gpu', processorGPU: false }, radius: 1, writes: [],
+        });
+    });
+});


### PR DESCRIPTION
- **解决的问题**：粒子编辑后执行 Undo／Redo 时，未启用的 GPU 材质可能覆盖当前 CPU 材质，导致渲染持续报错、场景停留在旧画面，反复撤销后编辑器变得卡顿。
- **解决方式**：为粒子组件增加专门的快照恢复逻辑，先加载并校验材质，再根据 CPU／GPU 模式恢复实际使用的材质，避免空材质和重复字段覆盖；切换模式时同步重建渲染处理器，并补充回归测试。

## 测试计划（测试）

- 打开包含 3D 粒子的场景，在 CPU 模式下分别将未启用的 GPU 材质设为空、设为有效材质，修改粒子属性后执行 Undo／Redo，预期属性正确恢复，当前 CPU 材质不被 GPU 材质覆盖，粒子持续正常渲染。
- 将 3D 粒子切换为 GPU 模式，在未启用的 CPU 材质为空时修改粒子属性并执行 Undo／Redo，预期仍使用正确的 GPU 材质，粒子正常渲染。
- 为 CPU／GPU 模式分别配置有效材质，切换模式后反复执行 Undo／Redo，预期模式、对应材质及粒子渲染结果同步恢复，不出现模式已切换但画面未更新的情况。
- 使用默认材质的 3D 粒子修改属性后执行 Undo／Redo，预期默认材质仍然生效，不因未配置自定义材质而出现粒子消失或渲染报错。
- 为 CPU 模式的 3D 粒子配置自定义材质并启用 Trail，分别修改粒子材质、Trail 材质和其他粒子属性，再依次执行 Undo／Redo，预期各项设置及对应渲染效果正确恢复。
- 连续修改粒子属性并多次执行 Undo／Redo，同时观察场景画面和控制台，预期画面持续刷新，无持续新增的材质或渲染错误，编辑器不因反复撤销重做而逐渐卡顿。
