### PR TITLE
[fix] 修复 Gradient Fixed 模式无法保留

### DIFF
--- a/src/core/scene/scene-process/service/dump/types/gradient-dump.ts
+++ b/src/core/scene/scene-process/service/dump/types/gradient-dump.ts
@@ -26,6 +26,9 @@ class GradientDump implements DumpInterface {
         // 获取需要修改的数据
         const ccType = cc.js.getClassByName('cc.Gradient');
         const gradient = new ccType();
+        if (dump.value.mode !== undefined) {
+            gradient.mode = dump.value.mode;
+        }
         if (dump.value.alphaKeys.length > 0) {
             for (const item of dump.value.alphaKeys) {
                 const AlphaKeyCtor = cc.js.getClassByName('cc.AlphaKey');

--- a/src/core/scene/test/gradient-dump.test.ts
+++ b/src/core/scene/test/gradient-dump.test.ts
@@ -1,0 +1,87 @@
+import { gradientDump } from '../scene-process/service/dump/types/gradient-dump';
+
+class Gradient {
+    public mode = 0;
+    public alphaKeys: AlphaKey[] = [];
+    public colorKeys: ColorKey[] = [];
+}
+
+class AlphaKey {
+    public time = 0;
+    public alpha = 0;
+}
+
+class Color {
+    constructor(
+        public r: number,
+        public g: number,
+        public b: number,
+        public a = 255,
+    ) {}
+}
+
+class ColorKey {
+    public time = 0;
+    public color = new Color(0, 0, 0);
+}
+
+describe('gradient dump', () => {
+    const globalScope = globalThis as typeof globalThis & { cc?: unknown };
+    const originalCC = globalScope.cc;
+
+    beforeAll(() => {
+        const classes = {
+            'cc.Gradient': Gradient,
+            'cc.AlphaKey': AlphaKey,
+            'cc.ColorKey': ColorKey,
+            'cc.Color': Color,
+        };
+        globalScope.cc = {
+            js: {
+                getClassByName: (name: keyof typeof classes) => classes[name],
+            },
+        };
+    });
+
+    afterAll(() => {
+        if (originalCC === undefined) {
+            delete globalScope.cc;
+            return;
+        }
+        globalScope.cc = originalCC;
+    });
+
+    it.each([
+        ['Blend', 0],
+        ['Fixed', 1],
+    ])('restores the %s mode and gradient keys', (_name, mode) => {
+        const data: Record<string, Gradient> = {};
+
+        gradientDump.decode(data, { key: 'gradient' }, {
+            value: {
+                mode,
+                alphaKeys: [{ time: 0.25, alpha: 128 }],
+                colorKeys: [{ time: 0.75, color: [12, 34, 56, 78] }],
+            },
+        });
+
+        expect(data.gradient).toMatchObject({
+            mode,
+            alphaKeys: [{ time: 0.25, alpha: 128 }],
+            colorKeys: [{ time: 0.75, color: { r: 12, g: 34, b: 56, a: 78 } }],
+        });
+    });
+
+    it('keeps the engine default mode for legacy dumps without mode', () => {
+        const data: Record<string, Gradient> = {};
+
+        gradientDump.decode(data, { key: 'gradient' }, {
+            value: {
+                alphaKeys: [],
+                colorKeys: [],
+            },
+        });
+
+        expect(data.gradient.mode).toBe(0);
+    });
+});


### PR DESCRIPTION
## 背景

3D 粒子 Inspector 将 Gradient 切换为 Fixed 后，属性无法正确保留，保存或重新加载时会恢复为 Blend。

原因是 CLI 在解码 `cc.Gradient` 时只恢复了颜色键和透明度键，没有恢复 `mode`；新创建的 Gradient 默认使用 Blend，导致 Fixed 模式被覆盖。

## 解决方案

- 在 Gradient 解码时同步恢复 dump 中的 `mode`。
- 兼容不包含 `mode` 的旧数据，此时继续使用引擎默认值。
- 增加单元测试，覆盖 Fixed、Blend 和旧数据缺少 mode 的情况。

## 影响范围

仅影响 CLI 对 `cc.Gradient` 属性的解码和恢复，不改变 Gradient 数据格式，也不影响其他 Inspector 字段。

## 测试计划（测试）

- 打开 3D 粒子的 Color over Lifetime，切换 Gradient 为 Fixed，保存并重新加载，预期仍保持 Fixed。
- 切换为 Blend，保存并重新加载，预期仍保持 Blend。
- 对不包含 mode 的旧 Gradient 数据进行解码，预期继续使用默认 Blend 模式。