### PR TITLE
[fix] 补齐粒子 Inspector 条件展示 metadata

### DIFF
--- a/src/core/scene/scene-process/service/dump/encode.ts
+++ b/src/core/scene/scene-process/service/dump/encode.ts
@@ -5,6 +5,7 @@ declare const EditorExtends: any;
 
 import dumpUtil from './utils';
 import { getDumpComponentAccess } from './service-access';
+import { applyParticleInspectorMetadata } from './particle-inspector-metadata';
 
 import { DumpDefines } from './dump-defines';
 import { IProperty } from '../../../@types/public';
@@ -388,6 +389,7 @@ export function encodeComponent(component: any): IComponent {
     // component的__prefab只有一个属性，所以这里可以直接复制
     (data as any).__compPrefab__ = (component as any).__prefab || null;
 
+    applyParticleInspectorMetadata(data);
     return data;
 }
 

--- a/src/core/scene/scene-process/service/dump/particle-inspector-metadata.ts
+++ b/src/core/scene/scene-process/service/dump/particle-inspector-metadata.ts
@@ -1,0 +1,106 @@
+import type { IProperty } from '../../../@types/public';
+import type { IComponent } from '../../../common/component';
+
+type PropertyMap = Record<string, IProperty | undefined>;
+
+// Creator 3.8.8, editor/inspector/components/particle-system.js:
+// getShapeTypeEmitFrom(). Keep the Inspector order, not the engine enum order.
+const emitFromNames: Record<string, readonly string[]> = {
+    Box: ['Volume', 'Shell', 'Edge'],
+    Cone: ['Base', 'Shell', 'Volume'],
+    Sphere: ['Volume', 'Shell'],
+    Hemisphere: ['Volume', 'Shell'],
+    Circle: [],
+};
+
+// Creator 3.8.8, editor/inspector/components/particle-system-2d.js:
+// custom.update() and emitterMode.update(). Var fields are inline children in
+// Creator; flat dump consumers need the same visibility on those fields too.
+const customIndependentFields = new Set([
+    'customMaterial', 'color', 'preview', 'playOnLoad', 'autoRemoveOnFinish', 'file', 'custom',
+]);
+const gravityFields = [
+    'gravity', 'speed', 'speedVar', 'tangentialAccel', 'tangentialAccelVar',
+    'radialAccel', 'radialAccelVar', 'rotationIsDir',
+];
+const radiusFields = [
+    'startRadius', 'startRadiusVar', 'endRadius', 'endRadiusVar', 'rotatePerS', 'rotatePerSVar',
+];
+
+function fieldsOf(property: IProperty | undefined): PropertyMap | undefined {
+    const value = property?.value;
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return undefined;
+    }
+    return value as PropertyMap;
+}
+
+function hide(property: IProperty | undefined): void {
+    if (property) {
+        property.visible = false;
+    }
+}
+
+function apply3DMetadata(component: IComponent): void {
+    const fields = component.value as PropertyMap;
+    const renderer = fieldsOf(fields.renderer);
+    const useGPU = renderer?.useGPU?.value;
+    if (typeof useGPU === 'boolean') {
+        // particle-system.js: Trail / Limit Velocity showflag and useGPU.changeState().
+        if (useGPU) {
+            hide(fields.trailModule);
+            hide(fields.limitVelocityOvertimeModule);
+        }
+        for (const name of ['cpuMaterial', 'gpuMaterial', 'trailMaterial']) {
+            const material = renderer?.[name];
+            if (material) {
+                material.readonly = Boolean(material.readonly || fields.renderer?.readonly
+                    || component.readonly || (name === 'gpuMaterial' ? !useGPU : useGPU));
+            }
+        }
+    }
+
+    const shape = fieldsOf(fields.shapeModule);
+    const shapeType = shape?.shapeType;
+    const emitFrom = shape?.emitFrom;
+    const shapeName = shapeType?.enumList?.find(entry => entry.value === shapeType.value)?.name;
+    if (typeof shapeName !== 'string' || !Object.hasOwn(emitFromNames, shapeName) || !emitFrom?.enumList) {
+        return;
+    }
+    const names = emitFromNames[shapeName];
+    const options = names.map(name => emitFrom.enumList!.find(entry => entry.name === name));
+    // An unfamiliar/incomplete engine enum must not silently lose options.
+    if (options.every(option => option !== undefined)) {
+        emitFrom.enumList = options.map(option => ({ ...option }));
+    }
+}
+
+function apply2DMetadata(component: IComponent): void {
+    const fields = component.value as PropertyMap;
+    const custom = fields.custom?.value;
+    if (custom === false) {
+        for (const [name, field] of Object.entries(fields)) {
+            if (!customIndependentFields.has(name)) {
+                hide(field);
+            }
+        }
+    } else if (custom === true) {
+        // cc.ParticleSystem2D.EmitterMode: GRAVITY = 0, RADIUS = 1.
+        const mode = fields.emitterMode?.value;
+        const hiddenFields = mode === 0 ? radiusFields : mode === 1 ? gravityFields : [];
+        hiddenFields.forEach(name => hide(fields[name]));
+    }
+}
+
+/**
+ * Add Creator Inspector presentation rules to a freshly encoded component dump.
+ * Never change values, shared engine attributes or restore/write permissions:
+ * hidden and UI-readonly fields must remain available to Undo snapshots.
+ */
+export function applyParticleInspectorMetadata(component: IComponent): void {
+    if (component.type === 'cc.ParticleSystem' || component.extends?.includes('cc.ParticleSystem')) {
+        apply3DMetadata(component);
+    } else if (component.type === 'cc.ParticleSystem2D' || component.extends?.includes('cc.ParticleSystem2D')) {
+        apply2DMetadata(component);
+    }
+}

--- a/src/core/scene/test/particle-inspector-metadata.e2e.test.ts
+++ b/src/core/scene/test/particle-inspector-metadata.e2e.test.ts
@@ -1,0 +1,214 @@
+/** Real scene-worker RPC coverage: the public MCP node summary omits component metadata. */
+import { mkdtemp, remove } from 'fs-extra';
+import { basename, join } from 'path';
+import type { IComponent, INode, ISetPropertyOptions } from '../common';
+import type { IProperty } from '../@types/public';
+import { NodeType } from '../common';
+import { Rpc } from '../main-process/rpc';
+import { EditorProxy } from '../main-process/proxy/editor-proxy';
+import { ComponentProxy } from '../main-process/proxy/component-proxy';
+import { TestGlobalEnv } from '../../../tests/global-env';
+
+type Particle = { nodePath: string; componentPath: string; uuid: string };
+
+describe('particle Inspector metadata real scene RPC', () => {
+    let directory: string;
+    let sceneUrl: string;
+
+    beforeAll(async () => {
+        const { globalSetup } = await import('../../test/global-setup');
+        const server = await import('../../../server');
+        const { getAvailablePort } = await import('../../../server/utils');
+        const port = await getAvailablePort(19527);
+        const startServer = server.startServer;
+        // The shared setup otherwise uses localhost:9527. An IPv6 PinK listener
+        // can own that URL while the test binds IPv4; pin both address and port.
+        const start = jest.spyOn(server, 'startServer').mockImplementationOnce(() => startServer(port, '127.0.0.1'));
+        try {
+            await globalSetup();
+        } finally {
+            start.mockRestore();
+        }
+        directory = await mkdtemp(join(TestGlobalEnv.projectRoot, 'assets/particle-metadata-'));
+        const { assetManager } = await import('../../assets');
+        await assetManager.refreshAsset(directory);
+        const { loadSceneI18n } = await import('../index');
+        await loadSceneI18n();
+        const asset = await EditorProxy.create({
+            type: 'scene', baseName: 'metadata', targetDirectory: `db://assets/${basename(directory)}`,
+        });
+        if (!asset) { throw new Error('Failed to create particle metadata scene'); }
+        sceneUrl = asset.assetUrl;
+        await EditorProxy.open({ urlOrUUID: sceneUrl });
+    }, 180000);
+
+    afterAll(async () => {
+        try {
+            if (sceneUrl) { await EditorProxy.close({ save: false }); }
+        } finally {
+            const { projectManager } = await import('../../project-manager');
+            await projectManager.close();
+            if (directory) {
+                await remove(directory);
+                await remove(`${directory}.meta`);
+            }
+        }
+    });
+
+    async function create(name: string, type = 'cc.ParticleSystem'): Promise<Particle> {
+        const node = await Rpc.getInstance().request('Node', 'createByType', [{ path: '', name, nodeType: NodeType.EMPTY }]);
+        if (!node) { throw new Error(`Failed to create ${name}`); }
+        const dump = await Rpc.getInstance().request('Component', 'add', [{ nodePath: name, component: type }]);
+        if (!dump) { throw new Error(`Failed to add ${type}`); }
+        if (type === 'cc.ParticleSystem') {
+            const nodeDump = await Rpc.getInstance().request('Node', 'query', [{ path: name, includeComponents: true }]) as INode;
+            const index = nodeDump.__comps__.findIndex(item => item.value.uuid.value === dump.value.uuid.value);
+            const initializer = Rpc.getInstance() as unknown as {
+                request(service: 'Node', method: 'updatePropertyFromNull', args: [ISetPropertyOptions]): Promise<boolean>;
+            };
+            // Headless engine modules may be lazy/null; use the Inspector's
+            // standard initialization operation rather than patching live objects.
+            for (const key of ['shapeModule', 'trailModule', 'limitVelocityOvertimeModule']) {
+                if (dump.value[key].value === null) {
+                    expect(await initializer.request('Node', 'updatePropertyFromNull', [{
+                        nodePath: name, path: `__comps__.${index}.${key}`, dump: dump.value[key], record: false,
+                    }])).toBe(true);
+                }
+            }
+        }
+        return { nodePath: name, componentPath: `${name}/${type}`, uuid: dump.value.uuid.value };
+    }
+
+    async function query(particle: Particle): Promise<IComponent> {
+        const rpc = Rpc.getInstance();
+        const dump = await rpc.request('Component', 'query', [{ path: particle.componentPath }]);
+        if (!dump) { throw new Error(`Missing ${particle.componentPath}`); }
+        const node = await rpc.request('Node', 'query', [{ path: particle.nodePath, includeComponents: true }]) as INode;
+        const nested = node.__comps__.find(item => item.value.uuid.value === dump.value.uuid.value);
+        // Node encoding adds paths; compare metadata and values independently of those paths.
+        const withoutPaths = (value: IComponent | undefined) => JSON.parse(JSON.stringify(value,
+            (key, item) => key === 'path' ? undefined : item));
+        expect(withoutPaths(nested)).toEqual(withoutPaths(dump));
+        const publicDump = await ComponentProxy.query({ path: particle.componentPath });
+        expect(publicDump?.properties.renderer ?? publicDump?.properties.custom)
+            .toEqual(dump.value.renderer ?? dump.value.custom);
+        return dump;
+    }
+
+    async function set(particle: Particle, path: string, value: IProperty['value']): Promise<void> {
+        const dump = await query(particle);
+        let field: IProperty = dump;
+        for (const key of path.split('.')) {
+            field = field.value[key];
+        }
+        const node = await Rpc.getInstance().request('Node', 'query', [{ path: particle.nodePath, includeComponents: true }]) as INode;
+        const index = node.__comps__.findIndex(item => item.value.uuid.value === particle.uuid);
+        expect(index).toBeGreaterThanOrEqual(0);
+        // Inspector property writes are an internal Scene RPC, omitted from the
+        // public API type. Exercise component recording and the Inspector leaf path.
+        const componentRpc = Rpc.getInstance() as unknown as {
+            request(service: 'Component', method: 'setProperty', args: [ISetPropertyOptions]): Promise<boolean>;
+        };
+        expect(await componentRpc.request('Component', 'setProperty', [{
+            nodePath: particle.nodePath, path: `__comps__.${index}.${path}`, dump: { ...field, value },
+        }])).toBe(true);
+    }
+
+    async function undo(): Promise<void> {
+        expect((await Rpc.getInstance().request('Undo', 'undo', [{}])).success).toBe(true);
+    }
+
+    it('round-trips 3D metadata for the actual device mode, including CPU fallback', async () => {
+        const particle = await create('Metadata3D');
+        const other = await create('MetadataOther3D');
+        await set(particle, 'trailModule.widthRatio.constant', 0.37);
+        const cpu = await query(particle);
+        expect(cpu.value.renderer.value.useGPU.value).toBe(false);
+        expect(cpu.value.renderer.value.gpuMaterial.readonly).toBe(true);
+        await set(particle, 'renderer.useGPU', true);
+        const gpu = await query(particle);
+        const useGPU: boolean = gpu.value.renderer.value.useGPU.value;
+        // Node's headless gfx device may reject GPU mode. Keep that fallback
+        // covered, and allow GPU-capable test runners to require the GPU branch.
+        if (process.env.COCOS_REQUIRE_GPU_PARTICLES === '1') {
+            expect(useGPU).toBe(true);
+        }
+        if (!useGPU) {
+            console.warn('GPU particle mode unavailable on the scene worker: GPU round-trip requires browser verification.');
+        }
+        expect([
+            gpu.value.trailModule.visible, gpu.value.limitVelocityOvertimeModule.visible,
+            gpu.value.renderer.value.cpuMaterial.readonly, gpu.value.renderer.value.gpuMaterial.readonly,
+            gpu.value.renderer.value.trailMaterial.readonly,
+        ]).toEqual([!useGPU, !useGPU, useGPU, !useGPU, useGPU]);
+        expect((await query(other)).value.trailModule.visible).toBe(true);
+        if (!useGPU) { await set(particle, 'trailModule.widthRatio.constant', 0.5); }
+        await undo();
+        expect((await query(particle)).value.trailModule.visible).toBe(true);
+        expect((await query(particle)).value.trailModule.value.widthRatio.value.constant.value).toBeCloseTo(0.37);
+        expect((await Rpc.getInstance().request('Redo', 'redo', [{}])).success).toBe(true);
+        expect((await query(particle)).value.trailModule.visible).toBe(!useGPU);
+        if (!useGPU) { await set(particle, 'trailModule.widthRatio.constant', 0.37); }
+        await EditorProxy.save({ urlOrUUID: sceneUrl });
+        await EditorProxy.close({ save: false });
+        await EditorProxy.open({ urlOrUUID: sceneUrl });
+        const reloaded = await query(particle);
+        expect(reloaded.value.renderer.value.useGPU.value).toBe(useGPU);
+        expect(reloaded.value.trailModule.value.widthRatio.value.constant.value).toBeCloseTo(0.37);
+        await set(particle, 'renderer.useGPU', false);
+        expect((await query(particle)).value.trailModule.visible).toBe(true);
+    });
+
+    it('recomputes all five Shape choice lists without cross-instance pollution', async () => {
+        const particle = await create('MetadataShape');
+        const other = await create('MetadataShapeOther');
+        for (const [shapeType, names] of [
+            [0, ['Volume', 'Shell', 'Edge']], [1, []], [2, ['Base', 'Shell', 'Volume']],
+            [3, ['Volume', 'Shell']], [4, ['Volume', 'Shell']], [0, ['Volume', 'Shell', 'Edge']],
+        ] as const) {
+            await set(particle, 'shapeModule.shapeType', shapeType);
+            const shape = (await query(particle)).value.shapeModule.value;
+            expect(shape.shapeType.value).toBe(shapeType);
+            expect(shape.emitFrom.enumList.map((entry: { name: string }) => entry.name)).toEqual(names);
+            expect(shape.emitFrom.visible).toBe(shapeType !== 1);
+            expect((await query(other)).value.shapeModule.value.emitFrom.enumList.map((entry: { name: string }) => entry.name))
+                .toEqual(['Base', 'Shell', 'Volume']);
+        }
+        await undo();
+        expect((await query(particle)).value.shapeModule.value.shapeType.value).toBe(4);
+        expect((await Rpc.getInstance().request('Redo', 'redo', [{}])).success).toBe(true);
+        expect((await query(particle)).value.shapeModule.value.emitFrom.enumList.map((entry: { name: string }) => entry.name))
+            .toEqual(['Volume', 'Shell', 'Edge']);
+    });
+
+    it('preserves 2D hidden values across Custom / emitter mode changes and reload', async () => {
+        const particle = await create('Metadata2D', 'cc.ParticleSystem2D');
+        await set(particle, 'custom', true);
+        await set(particle, 'speedVar', 23);
+        await set(particle, 'startRadiusVar', 31);
+        for (const mode of [1, 0, 1]) {
+            await set(particle, 'emitterMode', mode);
+            const dump = await query(particle);
+            expect([dump.value.speed.visible, dump.value.speedVar.visible, dump.value.startRadius.visible, dump.value.startRadiusVar.visible])
+                .toEqual([mode === 0, mode === 0, mode === 1, mode === 1]);
+        }
+        await set(particle, 'custom', false);
+        const hidden = await query(particle);
+        expect([hidden.value.custom.value, hidden.value.speedVar.visible, hidden.value.startRadiusVar.visible])
+            .toEqual([false, false, false]);
+        await undo();
+        expect((await query(particle)).value.startRadiusVar.visible).toBe(true);
+        expect((await Rpc.getInstance().request('Redo', 'redo', [{}])).success).toBe(true);
+        expect((await query(particle)).value.startRadiusVar.visible).toBe(false);
+        await EditorProxy.save({ urlOrUUID: sceneUrl });
+        await EditorProxy.close({ save: false });
+        await EditorProxy.open({ urlOrUUID: sceneUrl });
+        const reloaded = await query(particle);
+        expect([reloaded.value.custom.value, reloaded.value.speedVar.visible, reloaded.value.startRadiusVar.visible])
+            .toEqual([false, false, false]);
+        await set(particle, 'custom', true);
+        const restored = await query(particle);
+        expect([restored.value.speedVar.value, restored.value.startRadiusVar.value, restored.value.startRadiusVar.visible])
+            .toEqual([23, 31, true]);
+    });
+});

--- a/src/core/scene/test/particle-inspector-metadata.test.ts
+++ b/src/core/scene/test/particle-inspector-metadata.test.ts
@@ -1,0 +1,173 @@
+import type { IProperty } from '../@types/public';
+import type { IComponent } from '../common/component';
+import { applyParticleInspectorMetadata } from '../scene-process/service/dump/particle-inspector-metadata';
+
+function property(value: IProperty['value'], metadata: Partial<IProperty> = {}): IProperty {
+    return { value, type: 'Number', path: 'unchanged', visible: true, readonly: false, ...metadata };
+}
+
+function component(type: string, fields: Record<string, IProperty>): IComponent {
+    return { type, path: '', value: { uuid: property('id'), name: property('name'), enabled: property(true), ...fields } };
+}
+
+const shapeTypes = ['Box', 'Circle', 'Cone', 'Sphere', 'Hemisphere'].map((name, value) => ({ name, value }));
+const emitLocations = ['Base', 'Edge', 'Shell', 'Volume'].map((name, value) => ({ name, value, displayName: `Label ${name}` }));
+
+function particle3D(useGPU = false, shapeType = 2) {
+    const renderer = {
+        useGPU: property(useGPU),
+        cpuMaterial: property({ uuid: 'cpu' }),
+        gpuMaterial: property({ uuid: 'gpu' }),
+        trailMaterial: property({ uuid: 'trail' }),
+    };
+    const shape = {
+        shapeType: property(shapeType, { enumList: shapeTypes }),
+        emitFrom: property(3, { enumList: emitLocations, visible: shapeType !== 1 }),
+    };
+    const dump = component('cc.ParticleSystem', {
+        renderer: property(renderer), shapeModule: property(shape),
+        trailModule: property({ enable: property(true), width: property(12) }),
+        limitVelocityOvertimeModule: property({ limit: property(17) }),
+    });
+    return { dump, renderer, shape };
+}
+
+const gravity = ['gravity', 'speed', 'speedVar', 'tangentialAccel', 'tangentialAccelVar', 'radialAccel', 'radialAccelVar', 'rotationIsDir'];
+const radius = ['startRadius', 'startRadiusVar', 'endRadius', 'endRadiusVar', 'rotatePerS', 'rotatePerSVar'];
+const independent = ['customMaterial', 'color', 'preview', 'playOnLoad', 'autoRemoveOnFinish', 'file', 'custom'];
+
+function particle2D(custom = true, mode = 0) {
+    const fields = Object.fromEntries([...gravity, ...radius, ...independent, 'totalParticles', '_custom'].map(name => [name, property(42)]));
+    fields.custom = property(custom);
+    fields.emitterMode = property(mode);
+    fields._custom.visible = false;
+    return component('cc.ParticleSystem2D', fields);
+}
+
+describe('particle Inspector metadata', () => {
+    it.each([false, true, false, true])('derives fresh CPU/GPU restrictions (%s)', useGPU => {
+        const { dump, renderer } = particle3D(useGPU);
+        applyParticleInspectorMetadata(dump);
+        expect({
+            trail: dump.value.trailModule.visible,
+            limit: dump.value.limitVelocityOvertimeModule.visible,
+            materials: [renderer.cpuMaterial, renderer.gpuMaterial, renderer.trailMaterial].map(field => field.readonly),
+        }).toEqual({ trail: !useGPU, limit: !useGPU, materials: [useGPU, !useGPU, useGPU] });
+    });
+
+    it.each(['field', 'renderer', 'component'])('retains %s readonly restrictions on the active material', level => {
+        const { dump, renderer } = particle3D();
+        if (level === 'field') { renderer.cpuMaterial.readonly = true; }
+        if (level === 'renderer') { dump.value.renderer.readonly = true; }
+        if (level === 'component') { dump.readonly = true; }
+        applyParticleInspectorMetadata(dump);
+        expect(renderer.cpuMaterial.readonly).toBe(true);
+    });
+
+    it('never reopens fields already hidden by engine metadata', () => {
+        const { dump, shape } = particle3D();
+        dump.value.trailModule.visible = false;
+        shape.emitFrom.visible = false;
+        applyParticleInspectorMetadata(dump);
+        const twoD = particle2D();
+        twoD.value.speed.visible = false;
+        applyParticleInspectorMetadata(twoD);
+        expect([dump.value.trailModule.visible, shape.emitFrom.visible, twoD.value.speed.visible, twoD.value._custom.visible])
+            .toEqual([false, false, false, false]);
+    });
+
+    it.each([
+        [0, ['Volume', 'Shell', 'Edge']],
+        [1, []],
+        [2, ['Base', 'Shell', 'Volume']],
+        [3, ['Volume', 'Shell']],
+        [4, ['Volume', 'Shell']],
+    ] as const)('uses the Creator choices and order for shape %s', (shapeType, names) => {
+        const { dump, shape } = particle3D(false, shapeType);
+        applyParticleInspectorMetadata(dump);
+        expect(shape.emitFrom.enumList).toEqual(names.map(name => emitLocations.find(option => option.name === name)));
+        expect(shape.emitFrom.enumList).not.toBe(emitLocations);
+        expect(shape.emitFrom.visible).toBe(shapeType !== 1);
+    });
+
+    it('does not mutate enum definitions shared by multiple instances', () => {
+        const original = structuredClone(emitLocations);
+        for (const shapeType of [0, 2, 3, 4, 1, 0]) {
+            const { dump, shape } = particle3D(false, shapeType);
+            applyParticleInspectorMetadata(dump);
+            if (shape.emitFrom.enumList?.[0]) { shape.emitFrom.enumList[0].name = 'local change'; }
+        }
+        expect(emitLocations).toEqual(original);
+    });
+
+    it.each([0, 1, 0, 1])('applies 2D emitter mode %s to main fields and Var fields', mode => {
+        const dump = particle2D(true, mode);
+        applyParticleInspectorMetadata(dump);
+        expect([...gravity, ...radius].map(name => dump.value[name].visible))
+            .toEqual([...gravity.map(() => mode === 0), ...radius.map(() => mode === 1)]);
+    });
+
+    it('keeps only Custom-independent fields visible when Custom is off', () => {
+        const dump = particle2D(false);
+        dump.value.file.visible = false;
+        applyParticleInspectorMetadata(dump);
+        expect(Object.keys(dump.value).filter(name => dump.value[name].visible))
+            .toEqual(independent.filter(name => name !== 'file'));
+    });
+
+    it('preserves values, paths and defaults even for hidden and readonly fields', () => {
+        const { dump } = particle3D(true);
+        dump.value.renderer.default = { cpuMaterial: 'default' };
+        const original = structuredClone(dump);
+        applyParticleInspectorMetadata(dump);
+        // Ignore only presentation fields when comparing the full serialized payload.
+        const payload = (value: IComponent) => JSON.stringify(value, (key, item) =>
+            ['visible', 'readonly', 'enumList'].includes(key) ? undefined : item);
+        expect(payload(dump)).toBe(payload(original));
+        const twoD = particle2D(false);
+        const previous = payload(twoD);
+        applyParticleInspectorMetadata(twoD);
+        expect(payload(twoD)).toBe(previous);
+    });
+
+    it('leaves unknown modes and incomplete enum definitions unchanged', () => {
+        const { dump, renderer, shape } = particle3D(false, 99);
+        renderer.useGPU.value = 'unknown';
+        const original = structuredClone(dump);
+        applyParticleInspectorMetadata(dump);
+        expect(dump).toEqual(original);
+        shape.shapeType.value = 0;
+        shape.emitFrom.enumList = [{ name: 'Volume', value: 3 }];
+        applyParticleInspectorMetadata(dump);
+        expect(shape.emitFrom.enumList).toEqual([{ name: 'Volume', value: 3 }]);
+        const twoD = particle2D(true, 99);
+        const original2D = structuredClone(twoD);
+        applyParticleInspectorMetadata(twoD);
+        expect(twoD).toEqual(original2D);
+        twoD.value.custom.value = 'unknown';
+        twoD.value.emitterMode.value = 0;
+        const unknownCustom = structuredClone(twoD);
+        applyParticleInspectorMetadata(twoD);
+        expect(twoD).toEqual(unknownCustom);
+    });
+
+    it('accepts missing fields and null modules without affecting other fields', () => {
+        const dump = component('cc.ParticleSystem', { renderer: property(null), shapeModule: property(null) });
+        const original = structuredClone(dump);
+        applyParticleInspectorMetadata(dump);
+        expect(dump).toEqual(original);
+        const twoD = component('cc.ParticleSystem2D', { custom: property(true), emitterMode: property(1) });
+        expect(() => applyParticleInspectorMetadata(twoD)).not.toThrow();
+    });
+
+    it('supports particle subclasses and ignores unrelated components', () => {
+        const { dump, renderer } = particle3D();
+        dump.type = 'UserParticle';
+        const original = structuredClone(dump);
+        applyParticleInspectorMetadata(dump);
+        expect(dump).toEqual(original);
+        dump.extends = ['cc.ParticleSystem', 'cc.Component'];
+        applyParticleInspectorMetadata(dump);
+        expect(renderer.gpuMaterial.readonly).toBe(true);
+    });
+});


### PR DESCRIPTION
## 问题

粒子 dump 缺少 CPU/GPU、Shape、2D Custom/EmitterMode 对应的显隐、材质只读和动态选项，导致依赖 metadata 的 Inspector 无法与 Creator 对齐。

## 产生原因

这些规则部分写在 Creator Inspector 中，没有完整声明在引擎属性装饰器里，通用 dumper 无法自动生成。

## 解决方法

对照 Creator 3.8.8，在组件 dump 的统一出口补齐 `visible`、`readonly` 和 `enumList`：包含 GPU 模块隐藏、材质禁用、Shape 的 Emit From 选项，以及 2D 模式字段及其 Var 字段的显隐。保留原有约束，未知模式不猜测，隐藏字段的数据不删除。

## 影响范围

仅影响 `cc.ParticleSystem`、`cc.ParticleSystem2D` 及其子类的展示 metadata，节点 dump 和组件查询保持一致。不新增公共 API，不修改属性值、引擎共享声明或写回及 Undo/Redo 恢复逻辑。

## 测试计划（测试）

- 打开 3D 粒子并切换 CPU/GPU：检查 Trail、Limit Velocity 显隐及三项材质只读状态。
- 切换五种 Shape：检查 Emit From 的选项、顺序和可见性，其他粒子不受影响。
- 切换 2D Custom 和 Gravity/Radius：检查主字段与 Var 字段同步显隐。
- 执行 Undo/Redo、保存重开：展示状态随模式恢复，隐藏字段的值保留。

## 验证说明

类型检查通过；58 项单测及相关回归、3 组真实 Scene RPC 测试通过。Node 场景进程验证 CPU 回退；真实 GPU 路径另在 Chromium 中完成 13 项断言，覆盖模式切换、两种 dump 入口、Undo/Redo 和保存重开。定向 ESLint 无错误，仅有原文件的 2 个既有警告。
