### PR TITLE
fix(scene): 修复字段 Reset 撤销与粒子组件重置

### DIFF
--- a/src/core/scene/scene-process/service/component.ts
+++ b/src/core/scene/scene-process/service/component.ts
@@ -552,6 +552,28 @@ export class ComponentService extends BaseService<IComponentEvents> implements I
         return result;
     }
 
+    /** Internal entry used by Node.resetProperty for component paths. */
+    async resetProperty(options: ISetPropertyOptions): Promise<boolean> {
+        const node = resolveNodeByPath(options.nodePath);
+        if (!node || !this._resolveComponentPropertyTarget(node, options.path)) {
+            return false;
+        }
+        return this._recordComponentPropertySnapshot(node, {
+            label: `Reset ${options.path}`,
+            type: 'component:reset-property',
+            nodePath: options.nodePath,
+            path: options.path,
+            record: options.record,
+        }, async () => {
+            this.emit('node:before-change', node);
+            await dumpUtil.resetProperty(node, options.path);
+            this.emit('node:change', node, {
+                type: NodeEventType.SET_PROPERTY, propPath: options.path, record: options.record,
+            });
+            return true;
+        });
+    }
+
     private _shouldRecordComponentCommand(): boolean {
         return !Service.Undo?.isApplying?.();
     }

--- a/src/core/scene/scene-process/service/component/index.ts
+++ b/src/core/scene/scene-process/service/component/index.ts
@@ -165,23 +165,38 @@ export class CompManager {
             '__eventTargets',
         ];
 
+        const before = dumpUtil.dumpComponent(component);
+        const node = new cc.Node();
         try {
-            const node = new cc.Node();
             const newComp = node.addComponent(component.constructor);
-            const dump = dumpUtil.dumpComponent(newComp);
-
-            for (const key in dump.value) {
-                if (skipCompProps.includes(key)) {
-                    continue;
+            if (before?.type === 'cc.ParticleSystem') {
+                // Headless particles leave optional modules null. Reset initialized
+                // modules to fresh defaults without discarding their live bindings.
+                for (const [key, property] of Object.entries(before.value)) {
+                    if (!key.startsWith('_') && key.endsWith('Module') && property.value && !newComp[key]) {
+                        const Module = cc.js.getClassByName(property.type);
+                        if (Module) { newComp[key] = new Module(); }
+                    }
                 }
-
-                await dumpUtil.restoreProperty(component, key, dump.value[key]);
             }
+            const dump = dumpUtil.dumpComponent(newComp);
+            // Keep Reset's identity/enabled policy while sharing the mode-aware
+            // particle material restoration used by Undo/Redo.
+            const value = Object.fromEntries(Object.entries(dump.value).filter(([key]) => !skipCompProps.includes(key)));
+            await dumpUtil.restoreComponentSnapshotProperties(component, { ...dump, value });
             component?.resetInEditor?.();
             component?.onRestore?.();
         } catch (error) {
             console.error(error);
+            try {
+                await dumpUtil.restoreComponentSnapshotProperties(component, before);
+                component?.onRestore?.();
+            } catch (restoreError) {
+                console.error('Failed to restore component after Reset failed:', restoreError);
+            }
             return false;
+        } finally {
+            node.destroy();
         }
 
         return true;

--- a/src/core/scene/scene-process/service/dump/decode.ts
+++ b/src/core/scene/scene-process/service/dump/decode.ts
@@ -646,7 +646,24 @@ export function resetProperty(node: any, path: string) {
         setNodeSpecialProperty(data, info.key, value);
     } else {
         const attr = cc.Class.attr(data.constructor, info.key);
-        data[info.key] = getDefaultAttrData(attr);
+        if (attr?.default !== undefined) {
+            data[info.key] = getDefaultAttrData(attr);
+        } else {
+            // Accessors such as ParticleSystem.capacity have no attribute.default;
+            // their initial value lives in the constructor (capacity's setter maps
+            // undefined to 0). Read a fresh instance instead of writing undefined.
+            const temporaryNode = data instanceof Component ? new Node() : undefined;
+            try {
+                const defaults = temporaryNode ? temporaryNode.addComponent(data.constructor) : new data.constructor();
+                const value = defaults[info.key];
+                if (value === undefined) {
+                    throw new Error(`Cannot reset property without a default: ${path}`);
+                }
+                data[info.key] = value;
+            } finally {
+                temporaryNode?.destroy();
+            }
+        }
     }
 }
 

--- a/src/core/scene/scene-process/service/dump/particle-snapshot.ts
+++ b/src/core/scene/scene-process/service/dump/particle-snapshot.ts
@@ -95,7 +95,15 @@ export async function restoreParticleSystemSnapshot(
         if (key.startsWith('_') && key.endsWith('Module') && properties[key.slice(1)]?.value) {
             continue;
         }
-        await restore(component, key, property);
+        if (key.endsWith('Module') && property.value?.enable && property.value?._enable) {
+            // Writing _enable first makes the public setter skip enableModule(),
+            // leaving the processor's execution lists out of sync with the dump.
+            const value: Record<string, IProperty> = { ...property.value };
+            delete value._enable;
+            await restore(component, key, { ...property, value });
+        } else {
+            await restore(component, key, property);
+        }
     }
     for (const [key, property] of Object.entries(fields)) {
         if (!rendererMaterialKeys.has(key)) {

--- a/src/core/scene/scene-process/service/dump/particle-snapshot.ts
+++ b/src/core/scene/scene-process/service/dump/particle-snapshot.ts
@@ -1,4 +1,5 @@
 import type { Material, ParticleSystem } from 'cc';
+import { builtinResMgr } from 'cc';
 import type { IProperty } from '../../../@types/public';
 import { COMPONENT_SNAPSHOT_RESTORE_SKIP_KEYS } from './restore-policy';
 
@@ -10,11 +11,12 @@ interface ParticleRendererState {
     _gpuMaterial: Material | null;
     useGPU: boolean;
     particleMaterial: Material | null;
+    trailMaterial: Material | null;
 }
 
 const rendererMaterialKeys = new Set([
     'cpuMaterial', '_cpuMaterial', 'gpuMaterial', '_gpuMaterial',
-    'particleMaterial', 'useGPU', '_useGPU',
+    'particleMaterial', 'trailMaterial', 'useGPU', '_useGPU',
 ]);
 
 /**
@@ -51,6 +53,22 @@ export async function restoreParticleSystemSnapshot(
     ]);
     // particleMaterial is the effective material, including the engine's default fallback.
     const activeMaterial = await material(fields.particleMaterial, targetGPU ? gpuMaterial : cpuMaterial);
+    function defaultMaterial(name: string): Material {
+        const value = builtinResMgr.get<Material>(name);
+        if (!value?.passes.length) {
+            throw new Error(`Cannot restore particle default material: ${name}`);
+        }
+        return value;
+    }
+    // A fresh component's Reset dump has null materials. Cocos 3.8's renderer
+    // destroys the live material instance when assigned null, then reuses that
+    // same destroyed instance through its _defaultMat cache. Assign the built-in
+    // asset explicitly so the renderer can create a valid instance instead.
+    const effectiveMaterial = activeMaterial ?? defaultMaterial(targetGPU ? 'default-particle-gpu-material' : 'default-particle-material');
+    const cpuFallback = targetGPU ? cpuMaterial ?? defaultMaterial('default-particle-material') : effectiveMaterial;
+    const trailMaterial = fields.trailMaterial
+        ? await material(fields.trailMaterial, null) ?? defaultMaterial('default-trail-material')
+        : undefined;
 
     // Cache both modes before switching processor. Never set _useGPU directly: its setter
     // must rebuild the processor when Undo/Redo crosses CPU/GPU modes.
@@ -58,12 +76,23 @@ export async function restoreParticleSystemSnapshot(
     renderer._gpuMaterial = gpuMaterial;
     renderer.useGPU = targetGPU;
     renderer.particleMaterial = renderer.useGPU === targetGPU
-        ? activeMaterial
-        : renderer.useGPU ? gpuMaterial : cpuMaterial;
+        ? effectiveMaterial
+        : cpuFallback;
+    // Restore the Trail asset before enabling its module. Its default instance
+    // cache has the same null-material lifetime constraint as the main renderer.
+    if (trailMaterial !== undefined) {
+        renderer.trailMaterial = trailMaterial;
+    }
 
     for (const [key, property] of Object.entries(properties)) {
         if (COMPONENT_SNAPSHOT_RESTORE_SKIP_KEYS.includes(key as typeof COMPONENT_SNAPSHOT_RESTORE_SKIP_KEYS[number])
             || key === 'renderer' || key === 'sharedMaterials' || key === '_materials') {
+            continue;
+        }
+        // The private/public module aliases refer to the same live object. A
+        // private null from a fresh dump must not remove its processor binding
+        // before the public default fields are restored (notably Trail.onInit).
+        if (key.startsWith('_') && key.endsWith('Module') && properties[key.slice(1)]?.value) {
             continue;
         }
         await restore(component, key, property);

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -1,4 +1,6 @@
 import { register, BaseService, Service } from './core';
+import { queryRegisteredService } from './core/decorator';
+import type { ComponentService } from './component';
 import {
     type ICreateByAssetParams,
     type ICreateByNodeTypeParams,
@@ -864,6 +866,14 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
     }
 
     public async resetProperty(options: ISetPropertyOptions): Promise<boolean> {
+        // Node snapshots deliberately skip components during restoration.
+        if (/^__comps__\.\d+\./.test(options.path)) {
+            const componentService = queryRegisteredService<ComponentService>('Component');
+            if (!componentService) {
+                throw new Error('Component service is not registered');
+            }
+            return componentService.resetProperty(options);
+        }
         const node = NodeMgr.getNodeByPath(options.nodePath);
         if (!node) {
             return false;

--- a/src/core/scene/test/component-reset.test.ts
+++ b/src/core/scene/test/component-reset.test.ts
@@ -1,0 +1,94 @@
+const mockDestroy = jest.fn();
+const mockAddComponent = jest.fn();
+const mockDumpComponent = jest.fn();
+const mockRestoreSnapshot = jest.fn();
+const mockRestoreProperty = jest.fn();
+
+jest.mock('cc', () => ({
+    Component: class Component {},
+    MissingScript: class MissingScript {},
+    Node: class Node {
+        addComponent = mockAddComponent;
+        destroy = mockDestroy;
+    },
+}));
+jest.mock('../scene-process/service/component/utils', () => ({ __esModule: true, default: {} }));
+jest.mock('../scene-process/service/dump', () => ({
+    __esModule: true,
+    default: {
+        dumpComponent: mockDumpComponent,
+        restoreComponentSnapshotProperties: mockRestoreSnapshot,
+        restoreProperty: mockRestoreProperty,
+    },
+}));
+jest.mock('../scene-process/service/dump/service-access', () => ({ registerDumpComponentAccess: jest.fn() }));
+jest.mock('../scene-process/service/core/global-events', () => ({ ServiceEvents: {} }));
+jest.mock('../scene-process/service/core/decorator', () => ({ queryRegisteredService: jest.fn() }));
+
+describe('component Reset restoration', () => {
+    let manager: import('../scene-process/service/component/index').CompManager;
+    const previousCC = (globalThis as any).cc;
+    const previousEditor = (globalThis as any).EditorExtends;
+    const before = { value: { uuid: { value: 'original' }, capacity: { value: 37 }, enabled: { value: false } } };
+    const defaults = { value: {
+        uuid: { value: 'temporary' }, node: { value: 'temporary-node' }, name: { value: '' },
+        enabled: { value: true }, _objFlags: { value: 0 }, capacity: { value: 100 },
+        renderer: { value: { useGPU: { value: false } } },
+    } };
+    const component = { resetInEditor: jest.fn(), onRestore: jest.fn() };
+
+    beforeAll(async () => {
+        (globalThis as any).cc = require('cc');
+        (globalThis as any).EditorExtends = { Component: {} };
+        const { CompManager } = await import('../scene-process/service/component/index');
+        manager = new CompManager();
+    });
+    afterAll(() => {
+        (globalThis as any).cc = previousCC;
+        (globalThis as any).EditorExtends = previousEditor;
+    });
+    beforeEach(() => {
+        jest.resetAllMocks();
+        mockAddComponent.mockReturnValue({});
+        mockDumpComponent.mockReturnValueOnce(before).mockReturnValueOnce(defaults);
+        mockRestoreSnapshot.mockResolvedValue(undefined);
+    });
+
+    it('uses the shared restoration entry and preserves Reset identity/enabled restrictions', async () => {
+        expect(await manager.resetComponent(component)).toBe(true);
+        expect(mockRestoreSnapshot).toHaveBeenCalledWith(component, { value: {
+            capacity: { value: 100 }, renderer: defaults.value.renderer,
+        } });
+        expect(mockRestoreProperty).not.toHaveBeenCalled();
+        expect(component.resetInEditor).toHaveBeenCalledTimes(1);
+        expect(component.onRestore).toHaveBeenCalledTimes(1);
+        expect(defaults.value.uuid.value).toBe('temporary');
+        expect(mockDestroy).toHaveBeenCalledTimes(1);
+    });
+
+    it('restores the previous snapshot after a partial Reset failure and disposes the temporary node', async () => {
+        const error = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        try {
+            mockRestoreSnapshot.mockRejectedValueOnce(new Error('material restoration failed'));
+            expect(await manager.resetComponent(component)).toBe(false);
+            expect(mockRestoreSnapshot).toHaveBeenNthCalledWith(2, component, before);
+            expect(component.resetInEditor).not.toHaveBeenCalled();
+            expect(component.onRestore).toHaveBeenCalledTimes(1);
+            expect(mockDestroy).toHaveBeenCalledTimes(1);
+        } finally {
+            error.mockRestore();
+        }
+    });
+
+    it('also rolls back a failing resetInEditor hook', async () => {
+        const error = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        try {
+            component.resetInEditor.mockImplementationOnce(() => { throw new Error('hook failed'); });
+            expect(await manager.resetComponent(component)).toBe(false);
+            expect(mockRestoreSnapshot).toHaveBeenNthCalledWith(2, component, before);
+            expect(mockDestroy).toHaveBeenCalledTimes(1);
+        } finally {
+            error.mockRestore();
+        }
+    });
+});

--- a/src/core/scene/test/component-reset.test.ts
+++ b/src/core/scene/test/component-reset.test.ts
@@ -1,3 +1,5 @@
+import type { CompManager } from '../scene-process/service/component/index';
+
 const mockDestroy = jest.fn();
 const mockAddComponent = jest.fn();
 const mockDumpComponent = jest.fn();
@@ -26,7 +28,7 @@ jest.mock('../scene-process/service/core/global-events', () => ({ ServiceEvents:
 jest.mock('../scene-process/service/core/decorator', () => ({ queryRegisteredService: jest.fn() }));
 
 describe('component Reset restoration', () => {
-    let manager: import('../scene-process/service/component/index').CompManager;
+    let manager: CompManager;
     const previousCC = (globalThis as any).cc;
     const previousEditor = (globalThis as any).EditorExtends;
     const before = { value: { uuid: { value: 'original' }, capacity: { value: 37 }, enabled: { value: false } } };

--- a/src/core/scene/test/particle-reset.e2e.test.ts
+++ b/src/core/scene/test/particle-reset.e2e.test.ts
@@ -1,0 +1,140 @@
+import { mkdtemp, remove } from 'fs-extra';
+import { basename, join } from 'path';
+import type { IComponent, INode, ISetPropertyOptions } from '../common';
+import type { IProperty } from '../@types/public';
+import { NodeType } from '../common';
+import { Rpc } from '../main-process/rpc';
+import { EditorProxy } from '../main-process/proxy/editor-proxy';
+import { TestGlobalEnv } from '../../../tests/global-env';
+
+type Particle = { nodePath: string; path: string; index: number };
+
+describe('particle Reset through real scene RPC', () => {
+    let directory: string;
+    let sceneUrl: string;
+
+    beforeAll(async () => {
+        const { globalSetup } = await import('../../test/global-setup');
+        const server = await import('../../../server');
+        const { getAvailablePort } = await import('../../../server/utils');
+        const port = await getAvailablePort(19527);
+        const startServer = server.startServer;
+        // Isolate the test server from an editor already listening on localhost.
+        const start = jest.spyOn(server, 'startServer').mockImplementationOnce(() => startServer(port, '127.0.0.1'));
+        try {
+            await globalSetup();
+        } finally {
+            start.mockRestore();
+        }
+        directory = await mkdtemp(join(TestGlobalEnv.projectRoot, 'assets/particle-reset-'));
+        const { assetManager } = await import('../../assets');
+        await assetManager.refreshAsset(directory);
+        const { loadSceneI18n } = await import('../index');
+        await loadSceneI18n();
+        const asset = await EditorProxy.create({
+            type: 'scene', baseName: 'reset', targetDirectory: `db://assets/${basename(directory)}`,
+        });
+        if (!asset) { throw new Error('Failed to create Reset test scene'); }
+        sceneUrl = asset.assetUrl;
+        await EditorProxy.open({ urlOrUUID: sceneUrl });
+    }, 180000);
+
+    afterAll(async () => {
+        try {
+            if (sceneUrl) { await EditorProxy.close({ save: false }); }
+        } finally {
+            const { projectManager } = await import('../../project-manager');
+            await projectManager.close();
+            if (directory) {
+                await remove(directory);
+                await remove(`${directory}.meta`);
+            }
+        }
+    });
+
+    async function create(name: string, type: string): Promise<Particle> {
+        const rpc = Rpc.getInstance();
+        expect(await rpc.request('Node', 'createByType', [{ path: '', name, nodeType: NodeType.EMPTY }])).toBeTruthy();
+        expect(await rpc.request('Component', 'add', [{ nodePath: name, component: type }])).toBeTruthy();
+        const node = await rpc.request('Node', 'query', [{ path: name, includeComponents: true }]) as INode;
+        const index = node.__comps__.findIndex(item => item.type === type);
+        expect(index).toBeGreaterThanOrEqual(0);
+        return { nodePath: name, path: `${name}/${type}`, index };
+    }
+
+    async function query(p: Particle): Promise<IComponent> {
+        const dump = await Rpc.getInstance().request('Component', 'query', [{ path: p.path }]);
+        if (!dump) { throw new Error(`Missing ${p.path}`); }
+        const node = await Rpc.getInstance().request('Node', 'query', [{ path: p.nodePath, includeComponents: true }]) as INode;
+        const withoutPaths = (value: IComponent) => JSON.parse(JSON.stringify(value, (key, item) => key === 'path' ? undefined : item));
+        expect(withoutPaths(node.__comps__[p.index])).toEqual(withoutPaths(dump));
+        return dump;
+    }
+
+    async function field(p: Particle, path: string): Promise<IProperty> {
+        let property: IProperty = await query(p);
+        for (const key of path.split('.')) { property = property.value[key]; }
+        return property;
+    }
+
+    async function write(p: Particle, path: string, value: IProperty['value'], reset = false, record = true): Promise<void> {
+        const property = await field(p, path);
+        const rpc = Rpc.getInstance() as unknown as {
+            request(service: string, method: string, args: [ISetPropertyOptions]): Promise<boolean>;
+        };
+        expect(await rpc.request(reset ? 'Node' : 'Component', reset ? 'resetProperty' : 'setProperty', [{
+            nodePath: p.nodePath, path: `__comps__.${p.index}.${path}`, dump: { ...property, value }, record,
+        }])).toBe(true);
+    }
+
+    async function history(redo = false): Promise<void> {
+        const rpc = Rpc.getInstance();
+        const result = redo ? await rpc.request('Redo', 'redo', [{}]) : await rpc.request('Undo', 'undo', [{}]);
+        if (!result.success) { throw new Error(JSON.stringify(result)); }
+        expect(result).toMatchObject({ success: true });
+    }
+
+    async function reload(): Promise<void> {
+        await EditorProxy.save({ urlOrUUID: sceneUrl });
+        await EditorProxy.close({ save: false });
+        await EditorProxy.open({ urlOrUUID: sceneUrl });
+    }
+
+    it.each([
+        ['Reset3DField', 'cc.ParticleSystem', 'capacity', 37, 100],
+        ['Reset2DField', 'cc.ParticleSystem2D', 'life', 2.5, 1],
+        ['ResetNestedField', 'cc.ParticleSystem', 'renderer.velocityScale', 3, 1],
+    ])('restores defaults and undo history for %s', async (name, type, key, modified, initial) => {
+        const p = await create(name, type);
+        const other = await create(`${name}Other`, type);
+        const identity = (await query(p)).value.uuid.value;
+        await write(other, key, modified + 1);
+        for (let i = 0; i < 2; i++) {
+            await write(p, key, modified);
+            await write(p, key, null, true);
+            expect((await field(p, key)).value).toBe(initial);
+            await history();
+            expect((await field(p, key)).value).toBe(modified);
+            await history(true);
+            expect((await field(p, key)).value).toBe(initial);
+            expect((await field(other, key)).value).toBe(modified + 1);
+            expect((await query(p)).value.uuid.value).toBe(identity);
+        }
+        await reload();
+        expect((await field(p, key)).value).toBe(initial);
+        expect((await field(other, key)).value).toBe(modified + 1);
+    });
+
+    it('does not record a no-op Reset or a Reset with record:false', async () => {
+        const p = await create('ResetNoRecord', 'cc.ParticleSystem2D');
+        await write(p, 'life', 2.5);
+        await write(p, 'life', null, true);
+        await write(p, 'life', null, true);
+        await history();
+        expect((await field(p, 'life')).value).toBe(2.5);
+        await write(p, 'life', null, true, false);
+        await history();
+        expect((await field(p, 'life')).value).toBe(1);
+    });
+
+});

--- a/src/core/scene/test/particle-reset.e2e.test.ts
+++ b/src/core/scene/test/particle-reset.e2e.test.ts
@@ -125,6 +125,30 @@ describe('particle Reset through real scene RPC', () => {
         expect((await field(other, key)).value).toBe(modified + 1);
     });
 
+    it.each([
+        ['Reset3DComponent', 'cc.ParticleSystem', 'capacity', 37, 100],
+        ['Reset2DComponent', 'cc.ParticleSystem2D', 'life', 2.5, 1],
+    ])('resets %s without changing identity or enabled state', async (name, type, key, modified, initial) => {
+        const p = await create(name, type);
+        await write(p, 'enabled', false);
+        await write(p, key, modified);
+        const identity = (await query(p)).value.uuid.value;
+        const rpc = Rpc.getInstance() as unknown as {
+            request(service: 'Component', method: 'reset', args: [{ path: string }]): Promise<boolean>;
+        };
+        expect(await rpc.request('Component', 'reset', [{ path: p.path }])).toBe(true);
+        expect((await field(p, key)).value).toBe(initial);
+        expect((await field(p, 'enabled')).value).toBe(false);
+        await history();
+        expect((await field(p, key)).value).toBe(modified);
+        await history(true);
+        expect((await field(p, key)).value).toBe(initial);
+        await reload();
+        expect((await field(p, key)).value).toBe(initial);
+        expect((await field(p, 'enabled')).value).toBe(false);
+        expect((await query(p)).value.uuid.value).toBe(identity);
+    });
+
     it('does not record a no-op Reset or a Reset with record:false', async () => {
         const p = await create('ResetNoRecord', 'cc.ParticleSystem2D');
         await write(p, 'life', 2.5);
@@ -137,4 +161,32 @@ describe('particle Reset through real scene RPC', () => {
         expect((await field(p, 'life')).value).toBe(1);
     });
 
+    it('restores an initialized Trail after component Reset', async () => {
+        const p = await create('ResetTrail', 'cc.ParticleSystem');
+        await write(p, 'enabled', false);
+        const trail = await field(p, 'trailModule');
+        if (trail.value === null) {
+            const rpc = Rpc.getInstance() as unknown as {
+                request(service: string, method: string, args: [ISetPropertyOptions]): Promise<boolean>;
+            };
+            expect(await rpc.request('Node', 'updatePropertyFromNull', [{
+                nodePath: p.nodePath, path: `__comps__.${p.index}.trailModule`, dump: trail, record: false,
+            }])).toBe(true);
+        }
+        // Build a serialized fixture. Fresh editor-created Trail modules are not
+        // initialized until scene load; enabling one directly is a separate issue.
+        await write(p, 'trailModule._enable', true);
+        await write(p, 'capacity', 37);
+        await reload();
+        const rpc = Rpc.getInstance() as unknown as {
+            request(service: 'Component', method: 'reset', args: [{ path: string }]): Promise<boolean>;
+        };
+        expect(await rpc.request('Component', 'reset', [{ path: p.path }])).toBe(true);
+        expect((await field(p, 'trailModule')).value.enable.value).toBe(false);
+        await history();
+        expect((await field(p, 'trailModule')).value.enable.value).toBe(true);
+        expect((await field(p, 'capacity')).value).toBe(37);
+        await history(true);
+        expect((await field(p, 'capacity')).value).toBe(100);
+    });
 });

--- a/src/core/scene/test/particle-snapshot-restore.test.ts
+++ b/src/core/scene/test/particle-snapshot-restore.test.ts
@@ -54,7 +54,16 @@ function fixture(useGPU = false, supportsGPU = true) {
         let parent = target as Record<string, unknown>;
         for (const key of keys.slice(0, -1)) { parent = parent[key] as Record<string, unknown>; }
         const uuid = (dump.value as { uuid?: keyof typeof assets } | null)?.uuid;
-        parent[keys.at(-1)!] = dump.type === 'cc.Material' ? (uuid ? assets[uuid] : null) : dump.value;
+        const key = keys.at(-1)!;
+        if (dump.type === 'cc.Material') {
+            parent[key] = uuid ? assets[uuid] : null;
+        } else if (dump.value && typeof dump.value === 'object' && !Array.isArray(dump.value)) {
+            for (const [field, value] of Object.entries(dump.value as Record<string, IProperty>)) {
+                await restore(parent[key] as object, field, value);
+            }
+        } else {
+            parent[key] = dump.value;
+        }
     };
     const snapshot = (targetGPU: boolean, cpuUuid = 'cpu', gpuUuid = 'gpu', activeUuid = targetGPU ? gpuUuid : cpuUuid) => property({
         uuid: property('component-id', 'String'),
@@ -145,6 +154,55 @@ describe('particle snapshot material restoration', () => {
         await f.apply(dump);
         expect(f.renderer.trailMaterial?.uuid).toBe('default-trail-material');
     });
+
+    it.each(['private-first', 'public-first', 'public-only'])(
+        'synchronizes module execution through Reset, Undo and Redo with %s aliases', async aliases => {
+            const f = fixture();
+            const executingModules = new Set(['velocity']);
+            const target = {
+                enableModule(name: string, enabled: boolean) {
+                    if (enabled) { executingModules.add(name); }
+                    else { executingModules.delete(name); }
+                },
+            };
+            const module = {
+                _enable: true,
+                target,
+                get enable() { return this._enable; },
+                set enable(value: boolean) {
+                    // Cocos short-circuits this setter if the backing field already matches.
+                    if (value === this._enable) { return; }
+                    this._enable = value;
+                    this.target.enableModule('velocity', value);
+                },
+            };
+            const component = Object.assign(f.component, {
+                velocityOvertimeModule: module,
+                _velocityOvertimeModule: module,
+            });
+            for (const enabled of [false, true, false]) {
+                const dump = f.snapshot(false);
+                const moduleDump = property({
+                    _enable: property(enabled, 'Boolean'),
+                    enable: property(enabled, 'Boolean'),
+                }, 'cc.VelocityOvertimeModule');
+                const publicEntry = { velocityOvertimeModule: moduleDump };
+                const privateEntry = { _velocityOvertimeModule: moduleDump };
+                Object.assign(dump.value, aliases === 'public-only' ? publicEntry
+                    : aliases === 'public-first' ? { ...publicEntry, ...privateEntry }
+                        : { ...privateEntry, ...publicEntry });
+                const original = JSON.stringify(dump);
+
+                await f.apply(dump);
+
+                expect({ enabled: module.enable, executing: executingModules.has('velocity') })
+                    .toEqual({ enabled, executing: enabled });
+                expect(component.velocityOvertimeModule).toBe(module);
+                expect(module.target).toBe(target);
+                expect(JSON.stringify(dump)).toBe(original);
+            }
+        },
+    );
 
     it('rejects a missing built-in default before changing the live renderer', async () => {
         const { builtinResMgr } = require('cc');

--- a/src/core/scene/test/particle-snapshot-restore.test.ts
+++ b/src/core/scene/test/particle-snapshot-restore.test.ts
@@ -2,11 +2,15 @@ import type { ParticleSystem } from 'cc';
 import type { IProperty } from '../@types/public';
 import { restoreParticleSystemSnapshot } from '../scene-process/service/dump/particle-snapshot';
 
+jest.mock('cc', () => ({
+    builtinResMgr: { get: jest.fn((name: string) => ({ uuid: name, passes: [{}] })) },
+}));
+
 function property(value: unknown, type = 'Number'): IProperty {
     return { type, path: '', value } as IProperty;
 }
 
-function fixture(useGPU = false) {
+function fixture(useGPU = false, supportsGPU = true) {
     const cpu = { uuid: 'cpu', passes: [{}] };
     const gpu = { uuid: 'gpu', passes: [{}] };
     const fallback = { uuid: 'default', passes: [{}] };
@@ -21,10 +25,10 @@ function fixture(useGPU = false) {
         get useGPU() { return this._useGPU; },
         set useGPU(value: boolean) {
             if (this._useGPU === value) { return; }
-            this._useGPU = value;
-            processorGPU = value;
-            writes.push(`processor:${value}`);
-            this.particleMaterial = value ? this._gpuMaterial : this._cpuMaterial;
+            this._useGPU = value && supportsGPU;
+            processorGPU = this._useGPU;
+            writes.push(`processor:${this._useGPU}`);
+            this.particleMaterial = this._useGPU ? this._gpuMaterial : this._cpuMaterial;
         },
         get cpuMaterial() { return this._cpuMaterial; },
         set cpuMaterial(value: typeof cpu | null) {
@@ -98,6 +102,57 @@ describe('particle snapshot material restoration', () => {
         const f = fixture();
         await f.apply(f.snapshot(false, '', '', 'default'));
         expect(f.state()).toEqual({ active: 'default', cpu: undefined, gpu: undefined, processorGPU: false });
+    });
+
+    it.each([false, true])('resets empty materials to a usable built-in asset in GPU=%s mode', async useGPU => {
+        const f = fixture(useGPU);
+        const dump = f.snapshot(useGPU, '', '', '');
+        const original = JSON.stringify(dump);
+        await f.apply(dump);
+        expect(f.state()).toEqual({
+            active: useGPU ? 'default-particle-gpu-material' : 'default-particle-material',
+            cpu: undefined, gpu: undefined, processorGPU: useGPU,
+        });
+        expect(f.writes).not.toContain('active:null');
+        expect(JSON.stringify(dump)).toBe(original);
+    });
+
+    it('uses the CPU default if the device rejects a GPU snapshot with empty materials', async () => {
+        const f = fixture(false, false);
+        await f.apply(f.snapshot(true, '', '', ''));
+        expect(f.state()).toEqual({
+            active: 'default-particle-material', cpu: undefined, gpu: undefined, processorGPU: false,
+        });
+    });
+
+    it('does not clear initialized modules through private null aliases during Reset', async () => {
+        const f = fixture();
+        const dump = f.snapshot(false);
+        dump.value._trailModule = property(null, 'cc.TrailModule');
+        dump.value.trailModule = property({ enable: property(false, 'Boolean') }, 'cc.TrailModule');
+        const writes: string[] = [];
+        await restoreParticleSystemSnapshot(f.component as unknown as ParticleSystem, dump, async (_target, path) => {
+            writes.push(path);
+        });
+        expect(writes).toContain('trailModule');
+        expect(writes).not.toContain('_trailModule');
+    });
+
+    it('restores a valid default Trail asset before restoring module fields', async () => {
+        const f = fixture();
+        const dump = f.snapshot(false);
+        dump.value.renderer.value.trailMaterial = property(null, 'cc.Material');
+        await f.apply(dump);
+        expect(f.renderer.trailMaterial?.uuid).toBe('default-trail-material');
+    });
+
+    it('rejects a missing built-in default before changing the live renderer', async () => {
+        const { builtinResMgr } = require('cc');
+        builtinResMgr.get.mockReturnValueOnce(undefined);
+        const f = fixture();
+        await expect(f.apply(f.snapshot(false, '', '', ''))).rejects.toThrow('Cannot restore particle default material');
+        expect(f.state()).toEqual({ active: 'cpu', cpu: 'cpu', gpu: 'gpu', processorGPU: false });
+        expect(f.writes).toEqual([]);
     });
 
     it('switches the processor on Undo and Redo without replaying the raw mode alias', async () => {


### PR DESCRIPTION
## 问题

- 字段 Reset 将 Capacity 从 37 重置为 0，而非默认值 100；Capacity / Life 重置后 Undo 无法恢复原值。
- 3D 粒子组件 Reset / Redo 可能触发 getHandle、setUniform 异常，破坏材质运行态。

## 原因

字段重置只读取属性声明，遗漏访问器的构造默认值；组件字段错误地使用了不恢复组件数据的节点快照。组件 Reset 又逐字段恢复 dump，未复用粒子材质专项恢复逻辑，空材质会导致失效实例被重新使用，模块私有别名也可能覆盖已有绑定。

## 解决方法

- 缺少声明默认值时读取新实例的默认值；组件字段 Reset 改用组件快照记录 Undo/Redo。
- 组件 Reset 复用粒子快照恢复，按 CPU/GPU 模式恢复有效材质，先恢复 Trail 材质再恢复模块，保留已初始化模块绑定。
- Reset 失败时尝试恢复原快照，并清理临时节点。

## 影响范围

涉及通用字段默认值解析、组件字段 Reset 历史记录、组件 Reset 共享入口，以及 3D 粒子的 Reset / Undo / Redo 材质恢复。不新增公共 API 或协议字段，不修改 PinK UI 和引擎源码。

## 测试方法

- TypeScript 检查通过；定向 ESLint 无错误，保留 4 项既有警告。
- component-reset、particle-snapshot-restore、undo-node-restore、undo-manager 共 44 项单测通过。
- particle-reset.e2e.test.ts 的 7 项真实 Scene RPC 测试通过，覆盖字段默认值、撤销重做、组件重置和持久化。
- 真实 PinK 验证：3D Capacity 37 → Reset 100 → Undo 37 → Redo 100；GPU 起始状态可随 Undo 恢复；2D Life / Custom 为 2.5 / true → 1 / false，并可撤销重做。保存、关闭、重开后值与组件 UUID 保留，未复现上述材质错误。

