### PR TITLE
fix: align animation graph and scene preview metadata

### DIFF
--- a/src/core/assets/animation-graph-service.ts
+++ b/src/core/assets/animation-graph-service.ts
@@ -33,7 +33,7 @@ import type {
     SetAnimationGraphInspectorPropertyRequest,
 } from './@types/public';
 import type { IProperty } from '../scene/@types/public';
-import { deserialize as deserializeAssetSource } from './asset-handler/utils';
+import { deserialize as deserializeAssetSource, i18nTranslate } from './asset-handler/utils';
 import assetOperation from './manager/operation';
 import assetQuery from './manager/query';
 import {
@@ -2399,19 +2399,124 @@ function isVec2Like(value: unknown): value is { x: number; y: number } {
 }
 
 function getNodeTitle(node: any): string {
-    // GetVariable 系列节点：标题固定为 `Variable {variableName}`，
-    // 引擎 getTitle 返回的是 i18n key 数组且 variableName 为空时为 undefined。
-    if (typeof node.variableName === 'string') {
-        return `Variable ${node.variableName}`.trim();
-    }
     const title = node.getTitle?.();
     if (typeof title === 'string') {
         return title;
     }
     if (Array.isArray(title) && typeof title[0] === 'string') {
-        return title[0];
+        return translatePoseNodeTitle(title[0], title[1]);
     }
-    return getClassName(node);
+    const className = getClassName(node);
+    // The CLI runs the engine with EDITOR=false, so editor-only getTitle
+    // implementations are not installed. Keep the built-in behavior aligned
+    // with the old pose-expr-graph editor before falling back to displayName.
+    const builtInTitle = getBuiltInPoseNodeTitle(node, className);
+    if (builtInTitle !== undefined) {
+        return builtInTitle;
+    }
+    if (className) {
+        const displayNameKey = `ENGINE.classes.${className}.displayName`;
+        const displayName = i18nTranslate(displayNameKey as any);
+        if (displayName !== displayNameKey) {
+            return displayName;
+        }
+    }
+    return className || node.constructor?.name || 'Unknown';
+}
+
+function getBuiltInPoseNodeTitle(node: any, className: string): string | undefined {
+    if (className.startsWith('cc.animation.PVNodeGetVariable')) {
+        const variableName = nonEmptyString(node.variableName);
+        return variableName === undefined
+            ? undefined
+            : translatePoseNodeTitle(
+                'ENGINE.classes.cc.animation.PVNodeGetVariableBase.title',
+                { variableName },
+            );
+    }
+    switch (className) {
+        case 'cc.animation.PoseNodeStateMachine':
+            return nonEmptyString(node.name);
+        case 'cc.animation.PoseNodeUseStashedPose': {
+            const stashName = nonEmptyString(node.stashName);
+            return stashName === undefined
+                ? undefined
+                : translatePoseNodeTitle(
+                    'ENGINE.classes.cc.animation.PoseNodeUseStashedPose.title',
+                    { stashName },
+                );
+        }
+        case 'cc.animation.PoseNodePlayMotion':
+            return getMotionPoseNodeTitle(node.motion, 'PoseNodePlayMotion', 'Play');
+        case 'cc.animation.PoseNodeSampleMotion':
+            return getMotionPoseNodeTitle(node.motion, 'PoseNodeSampleMotion', 'Sample');
+        case 'cc.animation.PoseNodeApplyTransform': {
+            const nodeName = nonEmptyString(node.node);
+            return nodeName === undefined
+                ? undefined
+                : translatePoseNodeTitle(
+                    'ENGINE.classes.cc.animation.PoseNodeApplyTransform.title',
+                    { nodeName },
+                );
+        }
+        case 'cc.animation.PoseNodeCopyTransform': {
+            const sourceNodeName = nonEmptyString(node.sourceNodeName);
+            const targetNodeName = nonEmptyString(node.targetNodeName);
+            return sourceNodeName === undefined || targetNodeName === undefined
+                ? undefined
+                : translatePoseNodeTitle(
+                    'ENGINE.classes.cc.animation.PoseNodeCopyTransform.title',
+                    { sourceNodeName, targetNodeName },
+                );
+        }
+        case 'cc.animation.PoseNodeSetAuxiliaryCurve': {
+            const curveName = nonEmptyString(node.curveName);
+            return curveName === undefined
+                ? undefined
+                : translatePoseNodeTitle(
+                    'ENGINE.classes.cc.animation.PoseNodeSetAuxiliaryCurve.title',
+                    { curveName },
+                );
+        }
+        case 'cc.animation.PoseNodeTwoBoneIKSolver': {
+            const endEffectorBoneName = nonEmptyString(node.endEffectorBoneName);
+            return endEffectorBoneName === undefined
+                ? undefined
+                : translatePoseNodeTitle(
+                    'ENGINE.classes.cc.animation.PoseNodeTwoBoneIKSolver.title',
+                    { endEffectorBoneName },
+                );
+        }
+        default:
+            return undefined;
+    }
+}
+
+function getMotionPoseNodeTitle(motion: any, className: string, fallbackPrefix: string): string | undefined {
+    const motionName = getPoseMotionTitleName(motion);
+    return motionName === undefined
+        ? undefined
+        : translatePoseNodeTitle(
+            `ENGINE.classes.cc.animation.${className}.title`,
+            { motionName },
+            `${fallbackPrefix} ${motionName}`,
+        );
+}
+
+function getPoseMotionTitleName(motion: any): string | undefined {
+    if (getClassName(motion) === 'cc.animation.ClipMotion') {
+        return nonEmptyString(motion?.clip?.name);
+    }
+    return 'Unnamed Animation Blend';
+}
+
+function translatePoseNodeTitle(key: string, params?: Record<string, string>, fallback?: string): string {
+    const translated = i18nTranslate(key as any, params);
+    return translated === key ? fallback ?? key : translated;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
 function getPoseInputDisplayName(key: unknown, metadata: any): string {

--- a/src/core/assets/test/animation-graph-service.test.ts
+++ b/src/core/assets/test/animation-graph-service.test.ts
@@ -361,6 +361,7 @@ describe('animation graph asset service', () => {
         const poseState = withPoseState.graph.layers[0].stateMachine.states.find((state) => state.name === 'Pose');
         expect(poseState?.poseGraph?.nodes.length).toBeGreaterThan(0);
         const outputNodeId = poseState!.poseGraph!.rootOutputNodeId;
+        expect(poseState!.poseGraph!.nodes.find((node) => node.id === outputNodeId)?.title).toBe('Output Pose');
         const poseInspector = await assetManager.queryAnimationGraphInspector(asset.uuid, {
             kind: 'pose-node',
             layerIndex: 0,
@@ -383,6 +384,7 @@ describe('animation graph asset service', () => {
         const blendNode = withPoseNode.graph.layers[0].stateMachine.states[poseState!.index].poseGraph!.nodes.find((node) => (
             node.id !== outputNodeId && node.type.includes('PoseNodeBlendTwoPose')
         ));
+        expect(blendNode?.title).toBe('Blend Two Pose');
         const ratioInput = blendNode!.inputs.find((input) => input.id.includes('ratio'));
         expect(ratioInput?.value).toMatchObject({ path: 'value', type: 'Number', value: 1 });
         const inputTarget = {
@@ -702,6 +704,7 @@ describe('animation graph asset service', () => {
         const stateMachineNode = updatedStash.nodes.find((node) => node.type.includes('PoseNodeStateMachine'))!;
         expect(stateMachineNode.stateMachine?.states.map((state) => state.type)).toEqual(['entry', 'exit', 'any']);
         expect(stateMachineNode.enterInfo).toEqual({ type: 'state-machine' });
+        expect(stateMachineNode.title).toBe('State Machine');
 
         snapshot = await assetManager.executeAnimationGraphCommand(asset.uuid, {
             command: {
@@ -735,6 +738,7 @@ describe('animation graph asset service', () => {
         const motionNode = snapshot.graph.layers[0].stashPoseGraphs.find((stash) => stash.name === 'Nested')!
             .poseGraph.nodes.find((node) => node.type.includes('PoseNodePlayMotion'))!;
         expect(motionNode.motion?.type).toBe('blend-1d');
+        expect(motionNode.title).toBe('Play Unnamed Animation Blend');
         snapshot = await assetManager.executeAnimationGraphCommand(asset.uuid, {
             command: { type: 'add-motion-child', target: motionNode.motion!.target, motionType: 'clip' },
             expected: snapshot,
@@ -803,6 +807,7 @@ describe('animation graph asset service', () => {
         const applyTransformNode = snapshot.graph.layers[0].stashPoseGraphs.find((stash) => stash.name === 'Nested')!
             .poseGraph.nodes.find((node) => node.id === stateMachineNode.id)!.stateMachine!.states[poseStateIndex].poseGraph!
             .nodes.find((node) => node.type.includes('PoseNodeApplyTransform'))!;
+        expect(applyTransformNode.title).toBe('Apply Transform');
         const poseNodeTarget = { kind: 'pose-node' as const, poseGraph: nestedPoseGraph.context, nodeId: applyTransformNode.id };
         let inspector = await assetManager.queryAnimationGraphInspector(asset.uuid, poseNodeTarget);
         inspector = await assetManager.setAnimationGraphInspectorProperty(asset.uuid, {

--- a/src/core/scene/scene-process/engine-bootstrap.test.ts
+++ b/src/core/scene/scene-process/engine-bootstrap.test.ts
@@ -133,8 +133,12 @@ describe('scene-process engine bootstrap', () => {
             ResolutionPolicy: {
                 SHOW_ALL: 'show-all',
             },
+            macro: {
+                ORIENTATION_PORTRAIT: 1,
+            },
             view: {
                 setDesignResolutionSize: jest.fn(),
+                setOrientation: jest.fn(),
             },
             director: {
                 runSceneImmediate: jest.fn(),

--- a/src/core/scene/scene-process/engine-bootstrap.ts
+++ b/src/core/scene/scene-process/engine-bootstrap.ts
@@ -120,6 +120,9 @@ export async function startup(options: {
     cc.physics.selector.runInEditor = true;
 
     await cc.game.init(config);
+    // scene 进程运行在编辑器内嵌视图中，屏幕方向无意义；项目设置默认 'auto' 会让
+    // screenAdapter.orientation 停在 Orientation.AUTO(13)，引擎 resize 时对未映射方向打 DEBUG 告警，这里固定为竖屏。
+    cc.view.setOrientation(cc.macro.ORIENTATION_PORTRAIT);
     await syncSceneEditorBundles(serverURL, sceneEditorSettings?.bundleConfigs);
 
     let backend = 'builtin';

--- a/src/core/scene/scene-process/service/camera/utils.ts
+++ b/src/core/scene/scene-process/service/camera/utils.ts
@@ -135,7 +135,8 @@ export class CameraUtils {
     }
 
     static createGrid(effectName: string, parentNode: Node) {
-        const node = new cc.Node(effectName);
+        // 节点名不允许包含 /\:*?"<>|；effectName 是资源路径（如 'internal/editor/grid-2d'），脱敏后用作节点名
+        const node = new cc.Node(effectName.replace(/[/\\:*?"<>|]/g, '-'));
         node.layer = cc.Layers.Enum.EDITOR | cc.Layers.Enum.IGNORE_RAYCAST;
         node._objFlags |= CCObject.Flags.DontSave;
         node.parent = parentNode;

--- a/src/core/scene/scene-process/service/preview/interactive-preview.ts
+++ b/src/core/scene/scene-process/service/preview/interactive-preview.ts
@@ -156,8 +156,14 @@ class InteractivePreview extends PreviewBase implements IPreviewInstance {
         Service.Engine.repaintInEditMode();
     }
 
+    // 引擎节点名不允许包含 /\:*?"<>|，registerName（如 "scene:model-preview"）含 ':'；
+    // registerName 本身用于服务/消息注册保持不变，此处仅对实际 Scene/Node 名称脱敏，避免引擎告警。
+    private static sanitizeNodeName(name: string): string {
+        return name.replace(/[/\\:*?"<>|]/g, '-');
+    }
+
     public initScene(registerName: string, queryName: string) {
-        this.scene = new Scene(registerName);
+        this.scene = new Scene(InteractivePreview.sanitizeNodeName(registerName));
         if (this.enableSkybox) {
             this.skybox = this.scene.globals.skybox;
             this.scene.globals.skybox.enabled = true;
@@ -169,7 +175,7 @@ class InteractivePreview extends PreviewBase implements IPreviewInstance {
     }
 
     public createCamera(registerName: string) {
-        this.cameraComp = new Node(registerName + 'camera').addComponent(Camera);
+        this.cameraComp = new Node(InteractivePreview.sanitizeNodeName(registerName) + 'camera').addComponent(Camera);
         this.cameraComp.node.setParent(this.scene);
     }
 


### PR DESCRIPTION
## 变更说明

- 对齐 cocos-cli 返回的 Pose 节点标题与旧版 Animation Graph 编辑器规则，包括 State Machine、Motion、Transform、Stash、Variable 等节点。
- 为 Pose 标题补充引擎未运行 Editor 模式时的内置 fallback，并覆盖标题回归测试。
- 对 Scene/Camera 预览中由注册名生成的节点名称进行字符清理，避免资源路径或注册名触发引擎节点名告警。

## 验证结果

- `npm test -- --runInBand src/core/assets/test/animation-graph-service.test.ts`: 1 suite passed, 15 tests passed。
- 测试过程中出现 Scene process restart/CustomGC 日志，但 Jest 最终正常退出并报告通过。

## QA 验证步骤

1. 启动 cocos-cli 的测试 fixture。
2. 查询 Animation Graph Pose Graph。
3. 确认节点标题与旧版规则一致，尤其是 `PoseNodeApplyTransform`。
4. 启动 Scene/preview 服务并检查生成的 Scene/Camera 节点名称不含非法字符。
