### PR TITLE
Add anchored node creation and notify property updates

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -6445,6 +6445,7 @@ export declare type IAssetType =
 | 'RenderFlow';
 export declare interface IBaseCreateNodeParams {
     path: string;
+    insertSide?: 'before' | 'after';
     name?: string;
     workMode?: '2d' | '3d';
     position?: IVec3;

--- a/src/api/scene/node-schema.ts
+++ b/src/api/scene/node-schema.ts
@@ -83,7 +83,7 @@ export const SchemaNodeDelete = z.object({
 }).describe('To configure options for node deletion, the Scene must be open first.'); // 删除节点的选项参数，需先打开场景
 
 const SchemaNodeCreateBase = z.object({
-    path: z.string().describe('Relative path of the created node, root node is scene node; This path is parent node path, full node path is returned by the API, and root node path is "/"'), // 创建的节点相对路径，根节点是场景节点；该路径为父节点路径，完整节点路径以接口返回值为准，根节点路径为 "/"
+    path: z.string().describe('Parent path for append creation. When insertSide is set, this is the sibling anchor path. The scene root path is "/", and the API returns the full path of the created node.'),
     insertSide: z.enum(['before', 'after']).optional().describe('Create beside the existing sibling at path. When omitted, path remains the parent and the new node appends.'),
     name: SchemaNodeName.optional().describe('Name of the node. Characters /\\:*?"<>| are not allowed. If not passed, the system will default a name.'), // Node name; defaults to a system-generated name if omitted
     workMode: z.enum(['2d', '3d']).optional().describe('Node work mode, 2D or 3D; same nodeType may support both 2d and 3d'), // 节点工作模式，2D 还是 3D; 同一个 nodeType 有些支持2d也支持3d

--- a/src/api/scene/node-schema.ts
+++ b/src/api/scene/node-schema.ts
@@ -84,6 +84,7 @@ export const SchemaNodeDelete = z.object({
 
 const SchemaNodeCreateBase = z.object({
     path: z.string().describe('Relative path of the created node, root node is scene node; This path is parent node path, full node path is returned by the API, and root node path is "/"'), // 创建的节点相对路径，根节点是场景节点；该路径为父节点路径，完整节点路径以接口返回值为准，根节点路径为 "/"
+    insertSide: z.enum(['before', 'after']).optional().describe('Create beside the existing sibling at path. When omitted, path remains the parent and the new node appends.'),
     name: SchemaNodeName.optional().describe('Name of the node. Characters /\\:*?"<>| are not allowed. If not passed, the system will default a name.'), // Node name; defaults to a system-generated name if omitted
     workMode: z.enum(['2d', '3d']).optional().describe('Node work mode, 2D or 3D; same nodeType may support both 2d and 3d'), // 节点工作模式，2D 还是 3D; 同一个 nodeType 有些支持2d也支持3d
     keepWorldTransform: z.boolean().optional().describe('Keep world transform'), // 保持世界变换

--- a/src/core/scene/common/node.ts
+++ b/src/core/scene/common/node.ts
@@ -234,7 +234,16 @@ export interface IChangeNodeLockParams {
 }
 
 interface IBaseCreateNodeParams {
+    /**
+     * Parent path for append creation. When insertSide is set, this is instead
+     * the sibling anchor path.
+     */
     path: string;
+    /**
+     * Create beside the sibling named by path. Omitting this preserves append
+     * creation under path.
+     */
+    insertSide?: 'before' | 'after';
     name?: string;
     workMode?: '2d' | '3d';
     position?: IVec3;

--- a/src/core/scene/main-process/reflection-probe-renderer.ts
+++ b/src/core/scene/main-process/reflection-probe-renderer.ts
@@ -1,6 +1,6 @@
 import type { IReflectionProbeSceneIdentity } from '../common/reflection-probe';
 import type { RemoteSocket } from 'socket.io';
-import type { DefaultEventsMap } from 'socket.io/dist/typed-events';
+import type { DefaultEventsMap } from 'socket.io';
 import { SCENE_RENDERER_ROOM, socketService } from '../../../server/socket';
 
 export interface IReflectionProbeCaptureResult {

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -60,10 +60,30 @@ interface IPrefabCanvasUndoRecord {
 
 interface ICreatePreflightToken {
     requestKey: string;
+    target: IResolvedCreateTarget;
     result: Omit<ICreateNodePreflightResult, 'preflightToken'>;
     anchorUuid?: string;
     anchorParentUuid?: string;
 }
+
+interface IResolvedTypeCreateTarget {
+    kind: 'type';
+    assetUuid: string | null;
+    canvasRequired: boolean;
+}
+
+interface IResolvedAssetIdentity {
+    kind: 'asset';
+    assetUuid: string;
+    assetType?: string;
+}
+
+interface IResolvedAssetCreateTarget extends IResolvedAssetIdentity {
+    canvasRequired: boolean;
+}
+
+type IResolvedCreateTarget = IResolvedTypeCreateTarget | IResolvedAssetCreateTarget;
+type IResolvedCreateIdentity = IResolvedTypeCreateTarget | IResolvedAssetIdentity;
 
 interface IAnchoredCreateTarget {
     anchor: Node;
@@ -88,12 +108,12 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             await Service.Editor.lock();
             const beforeNodeUuids = this._collectSceneNodeUuidsForUndo();
             const createRootPath = this._getCreateRootPathForUndo(beforeNodeUuids, params.path);
-            const { assetUuid, canvasRequired: canvasNeeded } = this._resolveTypeCreateOptions(params);
-            this._validatePreflightToken(params);
+            const target = this._resolveTypeCreateOptions(params);
+            this._validatePreflightToken(params, target, target.canvasRequired);
             const prefabCanvasUndoRecords = this._beginPrefabCanvasUndoCapture(beforeNodeUuids);
             let result: INode | null;
             try {
-                result = await this._createNode(assetUuid, canvasNeeded, params.nodeType == NodeType.EMPTY, params);
+                result = await this._createNode(target.assetUuid, target.canvasRequired, params.nodeType == NodeType.EMPTY, params);
             } finally {
                 this._endPrefabCanvasUndoCapture();
             }
@@ -113,25 +133,33 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             await Service.Editor.lock();
             const beforeNodeUuids = this._collectSceneNodeUuidsForUndo();
             const createRootPath = this._getCreateRootPathForUndo(beforeNodeUuids, params.path);
-            const assetUuid = await Rpc.getInstance().request('assetManager', 'queryUUID', [params.dbURL]);
-            if (!assetUuid) {
-                throw new Error(`Asset not found for dbURL: ${params.dbURL}`);
-            }
+            const target = await this._resolveAssetIdentity(params);
             // 阻止添加自己到当前的Prefab中，防止Prefab的循环引用
             if (Service.Editor.getCurrentEditorType() === 'prefab') {
                 const rootNode = Service.Editor.getRootNode();
                 const rootNodePrefabInfo = rootNode?.['_prefab'];
-                if (rootNodePrefabInfo && rootNodePrefabInfo.asset && rootNodePrefabInfo.asset._uuid === assetUuid) {
+                if (rootNodePrefabInfo && rootNodePrefabInfo.asset && rootNodePrefabInfo.asset._uuid === target.assetUuid) {
                     throw new Error('The prefab you are trying to add is the same with the prefab in editing, this is not allowed.');
                 }
             }
-            const assetInfo = await Rpc.getInstance().request('assetManager', 'queryAssetInfo', [assetUuid]);
-            const canvasNeeded = params.canvasRequired || false;
-            this._validatePreflightToken(params);
+
+            // Asset-derived Canvas requirement drift is validated in `_createNode` against
+            // the instantiated result. Re-querying it here would load the asset a second time.
+            const preflightRecord = this._validatePreflightToken(params, target);
             const prefabCanvasUndoRecords = this._beginPrefabCanvasUndoCapture(beforeNodeUuids);
-            let result: INode | null;
+            let result: INode | null = null;
             try {
-                result = await this._createNode(assetUuid, canvasNeeded, false, params, assetInfo?.type);
+                result = await this._createNode(
+                    target.assetUuid,
+                    // Pass only the caller's explicit Canvas requirement. The preflight-derived
+                    // value is validated against the instantiated asset below; passing it here
+                    // would mask a true-to-false requirement drift.
+                    Boolean(params.canvasRequired),
+                    false,
+                    params,
+                    target.assetType,
+                    preflightRecord?.target.kind === 'asset' ? preflightRecord.target.canvasRequired : undefined,
+                );
             } finally {
                 this._endPrefabCanvasUndoCapture();
             }
@@ -154,27 +182,14 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
                 throw new Error('Failed to preflight node creation: the scene is not opened.');
             }
 
-            let canvasRequired: boolean;
-            if ('nodeType' in params) {
-                canvasRequired = this._resolveTypeCreateOptions(params).canvasRequired;
-            } else {
-                const assetUuid = await Rpc.getInstance().request('assetManager', 'queryUUID', [params.dbURL]);
-                if (!assetUuid) {
-                    throw new Error(`Asset not found for dbURL: ${params.dbURL}`);
-                }
-                const assetInfo = await Rpc.getInstance().request('assetManager', 'queryAssetInfo', [assetUuid]);
-                const assetCanvasRequired = await queryCanvasRequiredByAsset({
-                    uuid: assetUuid,
-                    type: assetInfo?.type,
-                    workMode: params.workMode || '2d',
-                });
-                canvasRequired = Boolean(params.canvasRequired || assetCanvasRequired);
-            }
+            const target = 'nodeType' in params
+                ? this._resolveTypeCreateOptions(params)
+                : await this._resolveAssetPreflightTarget(params);
 
-            const result = this._resolveCreatePreflight(params, canvasRequired, currentScene);
+            const result = this._resolveCreatePreflight(params, target.canvasRequired, currentScene);
             return {
                 ...result,
-                preflightToken: this._createPreflightToken(params, result),
+                preflightToken: this._createPreflightToken(params, target, result),
             };
         } catch (error) {
             console.error(error);
@@ -184,7 +199,7 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         }
     }
 
-    private _resolveTypeCreateOptions(params: ICreateByNodeTypeParams): { assetUuid: string | null; canvasRequired: boolean } {
+    private _resolveTypeCreateOptions(params: ICreateByNodeTypeParams): IResolvedTypeCreateTarget {
         const explicitCanvasRequired = Boolean(params.canvasRequired);
         const nodeType = params.nodeType as string;
         const paramsArray = NodeConfig[nodeType];
@@ -199,8 +214,39 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         }
 
         return {
+            kind: 'type',
             assetUuid: config.assetUuid || null,
             canvasRequired: explicitCanvasRequired || Boolean(config.canvasRequired),
+        };
+    }
+
+    private async _resolveAssetIdentity(params: ICreateByAssetParams): Promise<IResolvedAssetIdentity> {
+        const assetInfo = await Rpc.getInstance().request('assetManager', 'queryAssetInfo', [params.dbURL]);
+        if (!assetInfo?.uuid) {
+            throw new Error(`Asset not found for dbURL: ${params.dbURL}`);
+        }
+        return {
+            kind: 'asset',
+            assetUuid: assetInfo.uuid,
+            assetType: assetInfo?.type,
+        };
+    }
+
+    /**
+     * Inspects Canvas semantics during preflight only.
+     * Final creation resolves identity, instantiates the asset once, and validates
+     * the actual Canvas requirement before mutating the scene.
+     */
+    private async _resolveAssetPreflightTarget(params: ICreateByAssetParams): Promise<IResolvedAssetCreateTarget> {
+        const identity = await this._resolveAssetIdentity(params);
+        const assetCanvasRequired = await queryCanvasRequiredByAsset({
+            uuid: identity.assetUuid,
+            type: identity.assetType,
+            workMode: params.workMode || '2d',
+        });
+        return {
+            ...identity,
+            canvasRequired: Boolean(params.canvasRequired || assetCanvasRequired),
         };
     }
 
@@ -297,6 +343,7 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
 
     private _createPreflightToken(
         params: ICreateByNodeTypeParams | ICreateByAssetParams,
+        target: IResolvedCreateTarget,
         result: Omit<ICreateNodePreflightResult, 'preflightToken'>,
     ): string {
         const token = `node-create-${Date.now().toString(36)}-${(++this._preflightTokenSequence).toString(36)}`;
@@ -308,21 +355,32 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         }
         this._preflightTokens.set(token, {
             requestKey: this._getPreflightRequestKey(params),
+            target,
             result,
             ...this._getAnchoredPreflightIdentity(params),
         });
         return token;
     }
 
-    private _validatePreflightToken(params: ICreateByNodeTypeParams | ICreateByAssetParams): void {
+    private _validatePreflightToken(
+        params: ICreateByNodeTypeParams | ICreateByAssetParams,
+        target: IResolvedCreateIdentity,
+        currentCanvasRequired?: boolean,
+    ): ICreatePreflightToken | null {
         if (!params.preflightToken) {
-            return;
+            return null;
         }
 
         const record = this._preflightTokens.get(params.preflightToken);
         this._preflightTokens.delete(params.preflightToken);
         if (!record || record.requestKey !== this._getPreflightRequestKey(params)) {
             throw new Error('The node creation preflight token is invalid or does not match the request. Run preflightCreate again.');
+        }
+        if (!this._sameResolvedCreateIdentity(record.target, target)) {
+            throw new Error('The node creation target changed after preflight. Run preflightCreate again.');
+        }
+        if (currentCanvasRequired !== undefined && record.target.canvasRequired !== currentCanvasRequired) {
+            throw new Error('The node creation Canvas requirement changed after preflight. Run preflightCreate again.');
         }
 
         const anchorIdentity = this._getAnchoredPreflightIdentity(params);
@@ -341,6 +399,13 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         if (!this._samePreflightResult(record.result, currentResult)) {
             throw new Error('Canvas context changed after preflight. Run preflightCreate again before creating the node.');
         }
+        return record;
+    }
+
+    private _sameResolvedCreateIdentity(left: IResolvedCreateTarget, right: IResolvedCreateIdentity): boolean {
+        return left.kind === right.kind
+            && left.assetUuid === right.assetUuid
+            && (left.kind !== 'asset' || right.kind !== 'asset' || left.assetType === right.assetType);
     }
 
     private _samePreflightResult(
@@ -427,7 +492,14 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         expectedParent.insertChild(node, siblingIndex);
     }
 
-    async _createNode(assetUuid: string | null, canvasNeeded: boolean, checkUITransform: boolean, params: ICreateByNodeTypeParams | ICreateByAssetParams, assetType?: string): Promise<INode | null> {
+    async _createNode(
+        assetUuid: string | null,
+        canvasNeeded: boolean,
+        checkUITransform: boolean,
+        params: ICreateByNodeTypeParams | ICreateByAssetParams,
+        assetType?: string,
+        expectedAssetCanvasRequired?: boolean,
+    ): Promise<INode | null> {
         const currentScene = Service.Editor.getRootNode();
         if (!currentScene) {
             throw new Error('Failed to create node: the scene is not opened.');
@@ -435,11 +507,6 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
 
         const workMode = params.workMode || '2d';
         const anchoredParent = params.insertSide ? this._getAnchoredCreateParent(params) : null;
-        // 使用增强的路径处理方法
-        let parent = anchoredParent ?? await this._getOrCreateNodeByPath(params.path, currentScene, params.prefabCanvasHandling);
-        if (!parent) {
-            parent = currentScene;
-        }
 
         let resultNode;
         let canvasRequired = canvasNeeded;
@@ -452,6 +519,15 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             });
             resultNode = createResult.node;
             canvasRequired = Boolean(canvasNeeded || createResult.canvasRequired);
+
+            // Compare the instantiated result with the preflight decision. This catches
+            // same-identity asset semantic drift before the node can mutate the scene.
+            if (expectedAssetCanvasRequired !== undefined && canvasRequired !== expectedAssetCanvasRequired) {
+                if (resultNode?.isValid) {
+                    resultNode.destroy();
+                }
+                throw new Error('The asset Canvas requirement changed after preflight. Run preflightCreate again.');
+            }
         }
         if (!resultNode) {
             resultNode = new cc.Node();
@@ -463,6 +539,13 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
 
         if (checkUITransform) {
             nodeMgr.ensureUITransformComponent(resultNode);
+        }
+
+        // Resolve or materialize the parent only after the preflighted asset has
+        // been instantiated and revalidated, so a stale asset cannot mutate the scene.
+        let parent = anchoredParent ?? await this._getOrCreateNodeByPath(params.path, currentScene, params.prefabCanvasHandling);
+        if (!parent) {
+            parent = currentScene;
         }
 
         const anchoredTarget = params.insertSide ? this._getAnchoredCreateTarget(params) : null;

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -37,6 +37,7 @@ import { NodeUndoHelper } from './node/node-undo';
 import { isUndoApplying } from './undo/applying-state';
 import { prefabUtils } from './prefab/utils';
 import { sceneUtils } from './scene/utils';
+import compMgr from './component/index';
 import nodeMgr from './node/index';
 import NodeConfig from './node/node-type-config';
 import { RemoveNodeCommand } from './undo/commands/remove-node-command';
@@ -44,19 +45,14 @@ import { RemoveComponentCommand } from './undo/commands/remove-component-command
 import { PrefabPreviewCanvasCommand } from './undo/commands/prefab-preview-canvas-command';
 import { broadcastAnimationPropertyCommitted } from './animation/property-commit-event';
 import { isRootNodePath, stripLeadingSlashes, validateNodeName } from '../../../engine/editor-extends/manager/path-utils';
+import {
+    createPendingPrefabCanvasMutation,
+    type IPendingPrefabCanvasMutation,
+    type IPrefabCanvasMutationEffects,
+    type IPrefabCanvasUndoRecord,
+} from './node/prefab-canvas-mutation';
 
 const NodeMgr = EditorExtends.Node;
-
-interface IPrefabCanvasUndoRecord {
-    rootNode: Node;
-    rootParentUuid: string | null;
-    rootParentPath: string;
-    rootSiblingIndex: number;
-    addedUITransform: Component | null;
-    previewCanvasNode: Node | null;
-    previewCanvasCreated: boolean;
-    workMode: string;
-}
 
 interface ICreatePreflightToken {
     requestKey: string;
@@ -90,6 +86,11 @@ interface IAnchoredCreateTarget {
     parent: Node;
 }
 
+interface ICanvasResolution {
+    parent: Node | null;
+    mutation: IPendingPrefabCanvasMutation | null;
+}
+
 /**
  * 子进程节点处理器
  * 在子进程中处理所有节点相关操作
@@ -99,6 +100,10 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
     private readonly _undo = new NodeUndoHelper((event, ...args) => this.emit(event as any, ...args));
     private _prefabCanvasUndoRecords: IPrefabCanvasUndoRecord[] | null = null;
     private _prefabCanvasUndoBeforeNodeUuids: Set<string> | null = null;
+    private readonly _prefabCanvasMutationEffects: IPrefabCanvasMutationEffects = {
+        commitRecord: record => this._pushPrefabCanvasUndoRecord(record),
+        removeAddedUITransform: component => compMgr.removeComponent(component),
+    };
     private readonly _preflightTokens = new Map<string, ICreatePreflightToken>();
     private _preflightTokenSequence = 0;
 
@@ -552,63 +557,90 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         if (anchoredTarget) {
             parent = anchoredTarget.parent;
         }
-        parent = await this._resolveCanvasRequired(
+        const canvasResolution = await this._resolveCanvasRequiredTransaction(
             workMode.toLowerCase(),
             Boolean(canvasRequired),
             parent,
             params.position as Vec3,
             params.prefabCanvasHandling,
             params.insertSide ? params : undefined,
-        ) as Node;
-        if (!parent) {
+        );
+        if (!canvasResolution.parent) {
             throw new Error('Failed to resolve a parent for node creation.');
         }
+        parent = canvasResolution.parent;
 
-        /**
-         * 默认创建节点是从 prefab 模板，所以初始是 prefab 节点
-         * 是否要 unlink 为普通节点
-         * 有 nodeType 说明是内置资源创建的，需要移除 prefab info
-         * createByAsset 时，如果 assetType 不是 cc.Prefab 或者 unlinkPrefab 为 true，也需要移除
-         */
         const shouldUnlinkPrefab = 'nodeType' in params || assetType !== 'cc.Prefab' || params.unlinkPrefab;
-        if (shouldUnlinkPrefab) {
-            Service.Prefab.removePrefabInfoFromNode(resultNode, true);
-        }
+        try {
+            /**
+             * 默认创建节点是从 prefab 模板，所以初始是 prefab 节点
+             * 是否要 unlink 为普通节点
+             * 有 nodeType 说明是内置资源创建的，需要移除 prefab info
+             * createByAsset 时，如果 assetType 不是 cc.Prefab 或者 unlinkPrefab 为 true，也需要移除
+             */
+            if (shouldUnlinkPrefab) {
+                Service.Prefab.removePrefabInfoFromNode(resultNode, true);
+            }
 
-        if (params.name) {
-            resultNode.name = params.name;
-        }
+            if (params.name) {
+                resultNode.name = params.name;
+            }
 
-        this.emit('node:before-add', resultNode);
-        if (parent) {
+            this.emit('node:before-add', resultNode);
             this.emit('node:before-change', parent);
-        }
 
-        /**
-         * 新节点的 layer 跟随父级节点，但父级节点为场景根节点除外
-         * parent.layer 可能为 0 （界面下拉框为 None），此情况下新节点不跟随
-         */
-        if (parent && parent.layer && parent !== currentScene) {
-            setLayer(resultNode, parent.layer, true);
-        }
+            /**
+             * 新节点的 layer 跟随父级节点，但父级节点为场景根节点除外
+             * parent.layer 可能为 0 （界面下拉框为 None），此情况下新节点不跟随
+             */
+            if (parent.layer && parent !== currentScene) {
+                setLayer(resultNode, parent.layer, true);
+            }
 
-        // Compared to the editor, the position is set via API, so local coordinates are used here.
-        if (params.position) {
-            resultNode.setPosition(params.position);
-        }
+            // Compared to the editor, the position is set via API, so local coordinates are used here.
+            if (params.position) {
+                resultNode.setPosition(params.position);
+            }
 
-        if (params.insertSide) {
-            if (anchoredTarget && parent === anchoredTarget.parent) {
-                // This branch reparents the Prefab root and invalidates its serialized anchor path.
-                const capturedTarget = params.prefabCanvasHandling === 'add-root-ui-transform'
-                    ? anchoredTarget
-                    : undefined;
-                this._insertAtAnchoredTarget(resultNode, params, parent, capturedTarget);
+            if (params.insertSide) {
+                if (anchoredTarget && parent === anchoredTarget.parent) {
+                    // This branch reparents the Prefab root and invalidates its serialized anchor path.
+                    const capturedTarget = params.prefabCanvasHandling === 'add-root-ui-transform'
+                        ? anchoredTarget
+                        : undefined;
+                    this._insertAtAnchoredTarget(resultNode, params, parent, capturedTarget);
+                } else {
+                    resultNode.setParent(parent, params.keepWorldTransform);
+                }
             } else {
                 resultNode.setParent(parent, params.keepWorldTransform);
             }
-        } else {
-            resultNode.setParent(parent, params.keepWorldTransform);
+            canvasResolution.mutation?.commit();
+        } catch (error) {
+            if (!canvasResolution.mutation) {
+                throw error;
+            }
+
+            const rollbackErrors: unknown[] = [];
+            try {
+                canvasResolution.mutation.rollback();
+            } catch (rollbackError) {
+                rollbackErrors.push(rollbackError);
+            }
+            if (!resultNode.parent && resultNode.isValid) {
+                try {
+                    resultNode.destroy();
+                } catch (destroyError) {
+                    rollbackErrors.push(destroyError);
+                }
+            }
+            if (rollbackErrors.length > 0) {
+                throw new AggregateError(
+                    [error, ...rollbackErrors],
+                    'Node creation failed and Prefab Canvas rollback was incomplete.',
+                );
+            }
+            throw error;
         }
         // 挂到 prefab instance 下时，setParent 相关流程可能重新补回模板 prefab 信息。
         // 但在 prefab asset 编辑器中，新节点需要保留 setParent 补齐的 prefab 元数据。
@@ -907,6 +939,27 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         prefabCanvasHandling?: PrefabCanvasHandling,
         anchoredParams?: ICreateByNodeTypeParams | ICreateByAssetParams,
     ): Promise<Node | null> {
+        const resolution = await this._resolveCanvasRequiredTransaction(
+            workMode,
+            canvasRequiredParam,
+            parent,
+            position,
+            prefabCanvasHandling,
+            anchoredParams,
+        );
+        resolution.mutation?.commit();
+        return resolution.parent;
+    }
+
+    private async _resolveCanvasRequiredTransaction(
+        workMode: string,
+        canvasRequiredParam: boolean | undefined,
+        parent: Node | null,
+        position: Vec3 | undefined,
+        prefabCanvasHandling?: PrefabCanvasHandling,
+        anchoredParams?: ICreateByNodeTypeParams | ICreateByAssetParams,
+    ): Promise<ICanvasResolution> {
+        let mutation: IPendingPrefabCanvasMutation | null = null;
 
         if (canvasRequiredParam && parent?.isValid) {
             let canvasNode: Node | null;
@@ -924,7 +977,9 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
                     if (uiTransformParentNode) {
                         canvasNode = uiTransformParentNode;
                     } else if (prefabCanvasHandling === 'add-root-ui-transform') {
-                        canvasNode = await this.ensurePrefabRootUITransform(workMode);
+                        const prefabRootResolution = await this.ensurePrefabRootUITransform(workMode);
+                        canvasNode = prefabRootResolution?.canvasNode ?? null;
+                        mutation = prefabRootResolution?.mutation ?? null;
                     } else if (!prefabCanvasHandling) {
                         canvasNode = new Node();
                     }
@@ -965,37 +1020,55 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
                 position.z = canvasNode.position.z;
             }
         }
-        return parent;
+        return { parent, mutation };
     }
 
-    private async ensurePrefabRootUITransform(workMode: string): Promise<Node | null> {
+    private async ensurePrefabRootUITransform(workMode: string): Promise<{
+        canvasNode: Node;
+        mutation: IPendingPrefabCanvasMutation;
+    } | null> {
         const rootNode = Service.Editor.getRootNode();
         if (!rootNode?.isValid) {
             return null;
         }
 
         const undoRecord = this._createPrefabCanvasUndoRecord(rootNode, workMode);
-        if (!hasOneKindOfComponent(rootNode, UITransform)) {
-            undoRecord.addedUITransform = rootNode.addComponent('cc.UITransform') as Component;
-        }
+        const mutation = createPendingPrefabCanvasMutation(
+            undoRecord,
+            this._prefabCanvasMutationEffects,
+        );
+        try {
+            if (!hasOneKindOfComponent(rootNode, UITransform)) {
+                undoRecord.addedUITransform = rootNode.addComponent('cc.UITransform') as Component;
+            }
 
-        if (rootNode.parent && !hasOneKindOfComponent(rootNode.parent, Canvas)) {
-            const canvasNode = await createShouldHideInHierarchyCanvasNode(director.getScene()!, workMode);
-            undoRecord.previewCanvasNode = canvasNode;
-            undoRecord.previewCanvasCreated = !this._prefabCanvasUndoBeforeNodeUuids?.has(canvasNode.uuid);
-            rootNode.parent = canvasNode;
-            this._pushPrefabCanvasUndoRecord(undoRecord);
-            return canvasNode;
-        }
+            if (rootNode.parent && !hasOneKindOfComponent(rootNode.parent, Canvas)) {
+                const canvasNode = await createShouldHideInHierarchyCanvasNode(director.getScene()!, workMode);
+                undoRecord.previewCanvasNode = canvasNode;
+                undoRecord.previewCanvasCreated = !this._prefabCanvasUndoBeforeNodeUuids?.has(canvasNode.uuid);
+                rootNode.parent = canvasNode;
+                return { canvasNode, mutation };
+            }
 
-        this._pushPrefabCanvasUndoRecord(undoRecord);
-        return rootNode;
+            return { canvasNode: rootNode, mutation };
+        } catch (error) {
+            try {
+                mutation.rollback();
+            } catch (rollbackError) {
+                throw new AggregateError(
+                    [error, rollbackError],
+                    'Prefab Canvas handling failed and its rollback was incomplete.',
+                );
+            }
+            throw error;
+        }
     }
 
     private _createPrefabCanvasUndoRecord(rootNode: Node, workMode: string): IPrefabCanvasUndoRecord {
         const rootParent = rootNode.parent as Node | null;
         return {
             rootNode,
+            rootParent,
             rootParentUuid: rootParent?.uuid ?? null,
             rootParentPath: rootParent ? (NodeMgr.getNodePath(rootParent) ?? '/') : '/',
             rootSiblingIndex: rootNode.getSiblingIndex(),

--- a/src/core/scene/scene-process/service/node.ts
+++ b/src/core/scene/scene-process/service/node.ts
@@ -60,8 +60,14 @@ interface IPrefabCanvasUndoRecord {
 
 interface ICreatePreflightToken {
     requestKey: string;
-    action: ICreateNodePreflightResult['action'];
-    canvasRequired: boolean;
+    result: Omit<ICreateNodePreflightResult, 'preflightToken'>;
+    anchorUuid?: string;
+    anchorParentUuid?: string;
+}
+
+interface IAnchoredCreateTarget {
+    anchor: Node;
+    parent: Node;
 }
 
 /**
@@ -140,6 +146,7 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
     }
 
     async preflightCreate(params: ICreateByNodeTypeParams | ICreateByAssetParams): Promise<ICreateNodePreflightResult> {
+        this._validateCreateParams(params);
         try {
             await Service.Editor.lock();
             const currentScene = Service.Editor.getRootNode();
@@ -197,11 +204,20 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         };
     }
 
-    private _getCreatePathPreflight(path: string | undefined, currentScene: Node): {
+    private _getCreatePathPreflight(params: ICreateByNodeTypeParams | ICreateByAssetParams, currentScene: Node): {
         parent: Node;
         materializesUITransform: boolean;
         canvasRequired: boolean;
     } {
+        if (params.insertSide) {
+            return {
+                parent: this._getAnchoredCreateParent(params),
+                materializesUITransform: false,
+                canvasRequired: false,
+            };
+        }
+
+        const { path } = params;
         if (path && !isRootNodePath(path)) {
             try {
                 const existingParent = NodeMgr.getNodeByPath(path);
@@ -254,7 +270,7 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         canvasRequired: boolean,
         currentScene: Node,
     ): Omit<ICreateNodePreflightResult, 'preflightToken'> {
-        const pathPlan = this._getCreatePathPreflight(params.path, currentScene);
+        const pathPlan = this._getCreatePathPreflight(params, currentScene);
         if (pathPlan.materializesUITransform) {
             return {
                 action: 'create',
@@ -292,8 +308,8 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         }
         this._preflightTokens.set(token, {
             requestKey: this._getPreflightRequestKey(params),
-            action: result.action,
-            canvasRequired: result.canvasRequired,
+            result,
+            ...this._getAnchoredPreflightIdentity(params),
         });
         return token;
     }
@@ -309,34 +325,106 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             throw new Error('The node creation preflight token is invalid or does not match the request. Run preflightCreate again.');
         }
 
-        if (record.action !== 'create') {
-            return;
+        const anchorIdentity = this._getAnchoredPreflightIdentity(params);
+        if (
+            record.anchorUuid !== anchorIdentity.anchorUuid
+            || record.anchorParentUuid !== anchorIdentity.anchorParentUuid
+        ) {
+            throw new Error('The node creation preflight token has a stale anchor. Run preflightCreate again.');
         }
 
         const currentScene = Service.Editor.getRootNode();
         if (!currentScene) {
             throw new Error('Failed to create node: the scene is not opened.');
         }
-        const currentResult = this._resolveCreatePreflight(params, record.canvasRequired, currentScene);
-        if (currentResult.action !== 'create') {
+        const currentResult = this._resolveCreatePreflight(params, record.result.canvasRequired, currentScene);
+        if (!this._samePreflightResult(record.result, currentResult)) {
             throw new Error('Canvas context changed after preflight. Run preflightCreate again before creating the node.');
         }
     }
 
+    private _samePreflightResult(
+        left: Omit<ICreateNodePreflightResult, 'preflightToken'>,
+        right: Omit<ICreateNodePreflightResult, 'preflightToken'>,
+    ): boolean {
+        return left.action === right.action
+            && left.canvasRequired === right.canvasRequired
+            && left.canvasPath === right.canvasPath
+            && left.uiTransformPath === right.uiTransformPath;
+    }
+
     private _getPreflightRequestKey(params: ICreateByNodeTypeParams | ICreateByAssetParams): string {
+        // Prefab Canvas handling is selected by the host after preflight, so it must not
+        // invalidate the token issued before the user makes that choice.
         return JSON.stringify('nodeType' in params ? {
             kind: 'type',
             path: params.path,
+            insertSide: params.insertSide,
             nodeType: params.nodeType,
             workMode: params.workMode ?? '2d',
             canvasRequired: Boolean(params.canvasRequired),
         } : {
             kind: 'asset',
             path: params.path,
+            insertSide: params.insertSide,
             dbURL: params.dbURL,
             workMode: params.workMode ?? '2d',
             canvasRequired: Boolean(params.canvasRequired),
         });
+    }
+
+    private _getAnchoredCreateParent(params: ICreateByNodeTypeParams | ICreateByAssetParams): Node {
+        return this._getAnchoredCreateTarget(params).parent;
+    }
+
+    private _getAnchoredCreateTarget(params: ICreateByNodeTypeParams | ICreateByAssetParams): IAnchoredCreateTarget {
+        if (!params.insertSide) {
+            throw new Error('An insertion side is required for anchored node creation.');
+        }
+        if (isRootNodePath(params.path)) {
+            throw new Error('An anchored node creation path must identify a sibling anchor, not the scene root.');
+        }
+
+        const anchor = NodeMgr.getNodeByPath(params.path) as Node | null;
+        if (!anchor?.isValid) {
+            throw new Error(`The anchored node creation target was not found at path: ${params.path}`);
+        }
+
+        const parent = anchor.parent as Node | null;
+        if (!parent?.isValid) {
+            throw new Error(`The anchored node creation target has no valid parent at path: ${params.path}`);
+        }
+        return { anchor, parent };
+    }
+
+    private _getAnchoredPreflightIdentity(params: ICreateByNodeTypeParams | ICreateByAssetParams): {
+        anchorUuid?: string;
+        anchorParentUuid?: string;
+    } {
+        if (!params.insertSide) {
+            return {};
+        }
+
+        const { anchor, parent } = this._getAnchoredCreateTarget(params);
+        return {
+            anchorUuid: anchor.uuid,
+            anchorParentUuid: parent.uuid,
+        };
+    }
+
+    private _insertAtAnchoredTarget(
+        node: Node,
+        params: ICreateByNodeTypeParams | ICreateByAssetParams,
+        expectedParent: Node,
+        capturedTarget?: IAnchoredCreateTarget,
+    ): void {
+        const { anchor, parent } = capturedTarget ?? this._getAnchoredCreateTarget(params);
+        if (!anchor.isValid || !parent.isValid || parent !== expectedParent || anchor.parent !== expectedParent) {
+            throw new Error('The anchored node creation target became stale before insertion.');
+        }
+
+        const siblingIndex = anchor.getSiblingIndex() + (params.insertSide === 'after' ? 1 : 0);
+        expectedParent.insertChild(node, siblingIndex);
     }
 
     async _createNode(assetUuid: string | null, canvasNeeded: boolean, checkUITransform: boolean, params: ICreateByNodeTypeParams | ICreateByAssetParams, assetType?: string): Promise<INode | null> {
@@ -346,8 +434,9 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         }
 
         const workMode = params.workMode || '2d';
+        const anchoredParent = params.insertSide ? this._getAnchoredCreateParent(params) : null;
         // 使用增强的路径处理方法
-        let parent = await this._getOrCreateNodeByPath(params.path, currentScene, params.prefabCanvasHandling);
+        let parent = anchoredParent ?? await this._getOrCreateNodeByPath(params.path, currentScene, params.prefabCanvasHandling);
         if (!parent) {
             parent = currentScene;
         }
@@ -376,7 +465,21 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             nodeMgr.ensureUITransformComponent(resultNode);
         }
 
-        parent = await this.checkCanvasRequired(workMode.toLowerCase(), Boolean(canvasRequired), parent, params.position as Vec3, params.prefabCanvasHandling) as Node;
+        const anchoredTarget = params.insertSide ? this._getAnchoredCreateTarget(params) : null;
+        if (anchoredTarget) {
+            parent = anchoredTarget.parent;
+        }
+        parent = await this._resolveCanvasRequired(
+            workMode.toLowerCase(),
+            Boolean(canvasRequired),
+            parent,
+            params.position as Vec3,
+            params.prefabCanvasHandling,
+            params.insertSide ? params : undefined,
+        ) as Node;
+        if (!parent) {
+            throw new Error('Failed to resolve a parent for node creation.');
+        }
 
         /**
          * 默认创建节点是从 prefab 模板，所以初始是 prefab 节点
@@ -411,7 +514,19 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
             resultNode.setPosition(params.position);
         }
 
-        resultNode.setParent(parent, params.keepWorldTransform);
+        if (params.insertSide) {
+            if (anchoredTarget && parent === anchoredTarget.parent) {
+                // This branch reparents the Prefab root and invalidates its serialized anchor path.
+                const capturedTarget = params.prefabCanvasHandling === 'add-root-ui-transform'
+                    ? anchoredTarget
+                    : undefined;
+                this._insertAtAnchoredTarget(resultNode, params, parent, capturedTarget);
+            } else {
+                resultNode.setParent(parent, params.keepWorldTransform);
+            }
+        } else {
+            resultNode.setParent(parent, params.keepWorldTransform);
+        }
         // 挂到 prefab instance 下时，setParent 相关流程可能重新补回模板 prefab 信息。
         // 但在 prefab asset 编辑器中，新节点需要保留 setParent 补齐的 prefab 元数据。
         if (shouldUnlinkPrefab && Service.Editor.getCurrentEditorType() !== 'prefab') {
@@ -451,6 +566,16 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
     private _validateCreateParams(params: ICreateByNodeTypeParams | ICreateByAssetParams): void {
         this._validateRequestedNodeName(params.name);
         this._validateRequestedNodePath(params.path);
+        if (params.insertSide !== undefined && params.insertSide !== 'before' && params.insertSide !== 'after') {
+            throw new Error(`Unsupported node insertion side: ${String(params.insertSide)}`);
+        }
+        if (
+            params.prefabCanvasHandling !== undefined
+            && params.prefabCanvasHandling !== 'add-root-ui-transform'
+            && params.prefabCanvasHandling !== 'create-canvas'
+        ) {
+            throw new Error(`Unsupported Prefab Canvas handling: ${String(params.prefabCanvasHandling)}`);
+        }
     }
 
     private _validateRequestedNodeName(name: string | undefined): void {
@@ -682,6 +807,23 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
         position: Vec3 | undefined,
         prefabCanvasHandling?: PrefabCanvasHandling,
     ): Promise<Node | null> {
+        return await this._resolveCanvasRequired(
+            workMode,
+            canvasRequiredParam,
+            parent,
+            position,
+            prefabCanvasHandling,
+        );
+    }
+
+    private async _resolveCanvasRequired(
+        workMode: string,
+        canvasRequiredParam: boolean | undefined,
+        parent: Node | null,
+        position: Vec3 | undefined,
+        prefabCanvasHandling?: PrefabCanvasHandling,
+        anchoredParams?: ICreateByNodeTypeParams | ICreateByAssetParams,
+    ): Promise<Node | null> {
 
         if (canvasRequiredParam && parent?.isValid) {
             let canvasNode: Node | null;
@@ -726,7 +868,11 @@ export class NodeService extends BaseService<INodeEvents> implements INodeServic
                 Service.Prefab.removePrefabInfoFromNode(canvasNode);
 
                 if (parent) {
-                    parent.addChild(canvasNode);
+                    if (anchoredParams) {
+                        this._insertAtAnchoredTarget(canvasNode, anchoredParams, parent);
+                    } else {
+                        parent.addChild(canvasNode);
+                    }
                 }
                 parent = canvasNode;
             }

--- a/src/core/scene/scene-process/service/node/prefab-canvas-mutation.ts
+++ b/src/core/scene/scene-process/service/node/prefab-canvas-mutation.ts
@@ -1,0 +1,126 @@
+import { type Component, type Node } from 'cc';
+import { getEditorExtends, getEditorNodeManager } from '../undo/commands/command-utils-shared';
+import nodeMgr from './index';
+
+export interface IPrefabCanvasUndoRecord {
+    rootNode: Node;
+    rootParent: Node | null;
+    rootParentUuid: string | null;
+    rootParentPath: string;
+    rootSiblingIndex: number;
+    addedUITransform: Component | null;
+    previewCanvasNode: Node | null;
+    previewCanvasCreated: boolean;
+    workMode: string;
+}
+
+/** Owns temporary Prefab Canvas changes until the created node reaches its final parent. */
+export interface IPendingPrefabCanvasMutation {
+    commit(): void;
+    rollback(): void;
+}
+
+export interface IPrefabCanvasMutationEffects {
+    commitRecord(record: IPrefabCanvasUndoRecord): void;
+    removeAddedUITransform(component: Component): boolean;
+}
+
+type MutationState = 'pending' | 'committed' | 'rolled-back';
+
+export function createPendingPrefabCanvasMutation(
+    record: IPrefabCanvasUndoRecord,
+    effects: IPrefabCanvasMutationEffects,
+): IPendingPrefabCanvasMutation {
+    let state: MutationState = 'pending';
+
+    return {
+        commit(): void {
+            if (state !== 'pending') {
+                return;
+            }
+            effects.commitRecord(record);
+            state = 'committed';
+        },
+        rollback(): void {
+            if (state === 'rolled-back') {
+                return;
+            }
+            if (state === 'committed') {
+                throw new Error('Cannot roll back a committed Prefab Canvas mutation.');
+            }
+
+            const rollbackErrors: unknown[] = [];
+            tryRollback(
+                () => restorePrefabRoot(record.rootNode, record.rootParent, record.rootSiblingIndex),
+                rollbackErrors,
+            );
+
+            if (record.previewCanvasCreated && record.previewCanvasNode?.isValid) {
+                tryRollback(() => {
+                    if (record.rootNode.parent === record.previewCanvasNode) {
+                        throw new Error('Cannot remove a preview Canvas while it still owns the Prefab root.');
+                    }
+                    removePrefabPreviewCanvasNode(record.previewCanvasNode!);
+                }, rollbackErrors);
+            }
+
+            if (record.addedUITransform?.isValid) {
+                tryRollback(() => {
+                    if (!effects.removeAddedUITransform(record.addedUITransform!)) {
+                        throw new Error('Failed to remove the UITransform added for Prefab Canvas handling.');
+                    }
+                }, rollbackErrors);
+            }
+
+            if (rollbackErrors.length > 0) {
+                throw new AggregateError(rollbackErrors, 'Failed to roll back the Prefab Canvas mutation.');
+            }
+            state = 'rolled-back';
+        },
+    };
+}
+
+export function restorePrefabRoot(rootNode: Node, parent: Node | null, siblingIndex: number): void {
+    if (rootNode.parent !== parent) {
+        if (parent) {
+            parent.addChild(rootNode);
+        } else {
+            rootNode.setParent(null);
+        }
+    }
+    if (parent && siblingIndex >= 0) {
+        rootNode.setSiblingIndex(siblingIndex);
+    }
+}
+
+export function removePrefabPreviewCanvasNode(previewCanvasNode: Node): void {
+    nodeMgr.baseRemoveNode(previewCanvasNode);
+    unregisterNodeTree(previewCanvasNode);
+}
+
+function unregisterNodeTree(node: Node): void {
+    const editorNode = getEditorNodeManager();
+    const editorComponent = getEditorExtends()?.Component;
+
+    for (const component of node.components ?? []) {
+        if (component?.uuid) {
+            editorComponent?.remove?.(component.uuid);
+        }
+    }
+
+    for (const child of node.children ?? []) {
+        unregisterNodeTree(child);
+    }
+
+    if (node.uuid) {
+        editorNode?.remove?.(node.uuid);
+    }
+}
+
+function tryRollback(action: () => void, errors: unknown[]): void {
+    try {
+        action();
+    } catch (error) {
+        errors.push(error);
+    }
+}

--- a/src/core/scene/scene-process/service/undo/commands/prefab-preview-canvas-command.ts
+++ b/src/core/scene/scene-process/service/undo/commands/prefab-preview-canvas-command.ts
@@ -1,11 +1,10 @@
 import { director, Node, Scene } from 'cc';
 import type { IUndoCommand, IUndoCommandMeta, IUndoRedoResult } from '../../../../common';
-import nodeMgr from '../../node/index';
 import { createShouldHideInHierarchyCanvasNode } from '../../node/node-create';
+import { removePrefabPreviewCanvasNode, restorePrefabRoot } from '../../node/prefab-canvas-mutation';
 import {
     createUndoId,
     failure,
-    getEditorExtends,
     getEditorNodeManager,
     getNodePath,
     isNodeInCurrentScene,
@@ -53,17 +52,11 @@ export class PrefabPreviewCanvasCommand implements IUndoCommand {
         }
 
         try {
-            if (root.parent !== parent) {
-                parent.addChild(root);
-            }
-            if (this._options.rootSiblingIndex >= 0) {
-                root.setSiblingIndex(this._options.rootSiblingIndex);
-            }
+            restorePrefabRoot(root, parent, this._options.rootSiblingIndex);
 
             const previewCanvas = this._findPreviewCanvas();
             if (this._options.removePreviewCanvasOnUndo && previewCanvas?.isValid && root.parent !== previewCanvas) {
-                nodeMgr.baseRemoveNode(previewCanvas);
-                this._unregisterNodeTree(previewCanvas);
+                removePrefabPreviewCanvasNode(previewCanvas);
             }
 
             return success(this.meta);
@@ -134,27 +127,9 @@ export class PrefabPreviewCanvasCommand implements IUndoCommand {
         try {
             const byPath = editorNode?.getNodeByPath?.(path) as Node | null;
             return isNodeInCurrentScene(byPath) ? byPath : null;
-        } catch (_error) {
+        } catch {
             return null;
         }
     }
 
-    private _unregisterNodeTree(node: Node): void {
-        const editorNode = getEditorNodeManager();
-        const editorComponent = getEditorExtends()?.Component;
-
-        for (const component of node.components ?? []) {
-            if (component?.uuid) {
-                editorComponent?.remove?.(component.uuid);
-            }
-        }
-
-        for (const child of node.children ?? []) {
-            this._unregisterNodeTree(child);
-        }
-
-        if (node.uuid) {
-            editorNode?.remove?.(node.uuid);
-        }
-    }
 }

--- a/src/core/scene/test/node-delete-prefab-filter.test.ts
+++ b/src/core/scene/test/node-delete-prefab-filter.test.ts
@@ -48,6 +48,13 @@ jest.mock('../scene-process/service/node/index', () => ({
     },
 }));
 
+jest.mock('../scene-process/service/component/index', () => ({
+    __esModule: true,
+    default: {
+        removeComponent: jest.fn(() => true),
+    },
+}));
+
 jest.mock('../scene-process/service/node/node-create', () => ({
     createNodeByAsset: jest.fn(),
     loadAny: jest.fn(),

--- a/src/core/scene/test/service-core/node-create-anchored.test.ts
+++ b/src/core/scene/test/service-core/node-create-anchored.test.ts
@@ -1,0 +1,164 @@
+import { NodeType } from '../../common';
+import {
+    createAnchoredTree,
+    MockNode,
+    mockGetRootNode,
+    mockNodeAtPath,
+    mockPrefabAsset,
+    resetNodeCreateMocks,
+} from './node-create-test-harness';
+
+type CreateKind = 'type' | 'asset';
+type InsertSide = 'before' | 'after';
+
+const placementCases: Array<{
+    kind: CreateKind;
+    insertSide: InsertSide;
+    createdName: string;
+}> = [
+    { kind: 'type', insertSide: 'before', createdName: 'Inserted' },
+    { kind: 'type', insertSide: 'after', createdName: 'Inserted' },
+    { kind: 'asset', insertSide: 'before', createdName: 'AssetInstance' },
+    { kind: 'asset', insertSide: 'after', createdName: 'AssetInstance' },
+];
+
+describe('NodeService anchored creation', () => {
+    beforeEach(() => {
+        resetNodeCreateMocks();
+    });
+
+    it.each(placementCases)(
+        'inserts a node created by $kind $insertSide the sibling anchor',
+        async ({ kind, insertSide, createdName }) => {
+            const { root, parent, anchor } = createAnchoredTree('Parent');
+            mockGetRootNode.mockReturnValue(root);
+            mockNodeAtPath('/Parent/Anchor', anchor);
+            if (kind === 'asset') {
+                mockPrefabAsset();
+            }
+
+            const { NodeService } = require('../../scene-process/service/node');
+            const service = new NodeService();
+            if (kind === 'type') {
+                await service.createByType({
+                    path: '/Parent/Anchor',
+                    insertSide,
+                    name: createdName,
+                    nodeType: NodeType.EMPTY,
+                });
+            } else {
+                await service.createByAsset({
+                    path: '/Parent/Anchor',
+                    insertSide,
+                    dbURL: 'db://assets/Asset.prefab',
+                });
+            }
+
+            expect(parent.children.map(child => child.name)).toEqual(
+                insertSide === 'before'
+                    ? ['Before', createdName, 'Anchor', 'After']
+                    : ['Before', 'Anchor', createdName, 'After'],
+            );
+            expect(anchor.children).toEqual([]);
+        },
+    );
+
+    it('keeps direct-parent append behavior for type and asset creation without an insertion side', async () => {
+        const root = new MockNode('Root');
+        const parent = new MockNode('Parent');
+        const existing = new MockNode('Existing');
+        root.addChild(parent);
+        parent.addChild(existing);
+        mockGetRootNode.mockReturnValue(root);
+        mockNodeAtPath('/Parent', parent);
+        mockPrefabAsset();
+
+        const { NodeService } = require('../../scene-process/service/node');
+        const service = new NodeService();
+        await service.createByType({ path: '/Parent', name: 'TypeInstance', nodeType: NodeType.EMPTY });
+        await service.createByAsset({ path: '/Parent', dbURL: 'db://assets/Asset.prefab' });
+
+        expect(parent.children.map(child => child.name)).toEqual(['Existing', 'TypeInstance', 'AssetInstance']);
+    });
+
+    it('rejects a missing sibling anchor without materializing a fallback path', async () => {
+        const root = new MockNode('Root');
+        mockGetRootNode.mockReturnValue(root);
+        const { NodeService } = require('../../scene-process/service/node');
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        await expect(
+            new NodeService().createByType({
+                path: '/MissingAnchor',
+                insertSide: 'before',
+                nodeType: NodeType.EMPTY,
+            }),
+        ).rejects.toThrow('anchor');
+
+        consoleError.mockRestore();
+        expect(root.children).toEqual([]);
+    });
+
+    it('binds the insertion side to the preflight token', async () => {
+        const { root, anchor } = createAnchoredTree('Parent');
+        mockGetRootNode.mockReturnValue(root);
+        mockNodeAtPath('/Parent/Anchor', anchor);
+
+        const { NodeService } = require('../../scene-process/service/node');
+        const service = new NodeService();
+        service._createNode = jest.fn().mockResolvedValue({ path: '/Parent/Inserted' });
+        const preflight = await service.preflightCreate({
+            path: '/Parent/Anchor',
+            insertSide: 'before',
+            nodeType: NodeType.EMPTY,
+            prefabCanvasHandling: 'create-canvas',
+        });
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        await expect(
+            service.createByType({
+                path: '/Parent/Anchor',
+                insertSide: 'after',
+                nodeType: NodeType.EMPTY,
+                prefabCanvasHandling: 'add-root-ui-transform',
+                preflightToken: preflight.preflightToken,
+            }),
+        ).rejects.toThrow('does not match the request');
+
+        consoleError.mockRestore();
+        expect(service._createNode).not.toHaveBeenCalled();
+    });
+
+    it('rejects a preflight token when the anchored node was replaced at the same path', async () => {
+        const { root, parent, anchor: originalAnchor } = createAnchoredTree('Parent');
+        mockGetRootNode.mockReturnValue(root);
+        let anchor = originalAnchor;
+        (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) =>
+            path === '/Parent/Anchor' ? anchor : null,
+        );
+
+        const { NodeService } = require('../../scene-process/service/node');
+        const service = new NodeService();
+        service._createNode = jest.fn().mockResolvedValue({ path: '/Parent/Inserted' });
+        const preflight = await service.preflightCreate({
+            path: '/Parent/Anchor',
+            insertSide: 'before',
+            nodeType: NodeType.EMPTY,
+        });
+        anchor = new MockNode('ReplacementAnchor');
+        parent.addChild(anchor);
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        await expect(
+            service.createByType({
+                path: '/Parent/Anchor',
+                insertSide: 'before',
+                nodeType: NodeType.EMPTY,
+                preflightToken: preflight.preflightToken,
+            }),
+        ).rejects.toThrow('stale anchor');
+
+        consoleError.mockRestore();
+        expect(service._createNode).not.toHaveBeenCalled();
+    });
+});

--- a/src/core/scene/test/service-core/node-create-asset-preflight.test.ts
+++ b/src/core/scene/test/service-core/node-create-asset-preflight.test.ts
@@ -1,0 +1,172 @@
+import {
+    MockNode,
+    mockCreateNodeByAsset,
+    mockGetRootNode,
+    mockPrefabAsset,
+    mockQueryCanvasRequiredByAsset,
+    mockRpcRequest,
+    resetNodeCreateMocks,
+} from './node-create-test-harness';
+
+interface IMutableAssetTarget {
+    uuid: string;
+    type: string;
+}
+
+const assetTargetDriftCases: Array<{
+    label: string;
+    mutate: (target: IMutableAssetTarget) => void;
+}> = [
+    {
+        label: 'resolved asset UUID',
+        mutate: target => { target.uuid = 'replacement-asset-uuid'; },
+    },
+    {
+        label: 'resolved asset type',
+        mutate: target => { target.type = 'cc.SpriteFrame'; },
+    },
+];
+
+describe('NodeService asset creation preflight', () => {
+    beforeEach(() => {
+        resetNodeCreateMocks();
+    });
+
+    it.each(assetTargetDriftCases)('rejects a preflight token when the $label changes', async ({ mutate }) => {
+        const target: IMutableAssetTarget = {
+            uuid: 'asset-uuid',
+            type: 'cc.Prefab',
+        };
+        mockGetRootNode.mockReturnValue(new MockNode('Root'));
+        mockRpcRequest.mockImplementation(async (_service: string, method: string) => {
+            if (method === 'queryAssetInfo') {
+                return {
+                    uuid: target.uuid,
+                    type: target.type,
+                    imported: true,
+                    invalid: false,
+                };
+            }
+            return undefined;
+        });
+        mockQueryCanvasRequiredByAsset.mockResolvedValue(false);
+
+        const { NodeService } = require('../../scene-process/service/node');
+        const service = new NodeService();
+        service._createNode = jest.fn().mockResolvedValue({ path: '/Inserted' });
+        const params = {
+            path: '/',
+            dbURL: 'db://assets/Asset.prefab',
+        };
+        const preflight = await service.preflightCreate(params);
+        mutate(target);
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        await expect(service.createByAsset({
+            ...params,
+            preflightToken: preflight.preflightToken,
+        })).rejects.toThrow('target changed after preflight');
+
+        consoleError.mockRestore();
+        expect(service._createNode).not.toHaveBeenCalled();
+    });
+
+    it('keeps direct asset creation on the existing single-load path', async () => {
+        mockGetRootNode.mockReturnValue(new MockNode('Root'));
+        mockPrefabAsset();
+
+        const { NodeService } = require('../../scene-process/service/node');
+        await new NodeService().createByAsset({
+            path: '/',
+            dbURL: 'db://assets/Asset.prefab',
+        });
+
+        expect(mockQueryCanvasRequiredByAsset).not.toHaveBeenCalled();
+        expect(mockRpcRequest).toHaveBeenCalledTimes(1);
+        expect(mockRpcRequest).toHaveBeenCalledWith(
+            'assetManager',
+            'queryAssetInfo',
+            ['db://assets/Asset.prefab'],
+        );
+        expect(mockCreateNodeByAsset).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps an explicit Canvas requirement authoritative when the asset does not require one', async () => {
+        mockGetRootNode.mockReturnValue(new MockNode('Root'));
+        mockPrefabAsset();
+        mockQueryCanvasRequiredByAsset.mockResolvedValue(false);
+
+        const { NodeService } = require('../../scene-process/service/node');
+        const service = new NodeService();
+        const params = {
+            path: '/',
+            dbURL: 'db://assets/Asset.prefab',
+            canvasRequired: true,
+        };
+        const preflight = await service.preflightCreate(params);
+
+        expect(preflight.canvasRequired).toBe(true);
+
+        await service.createByAsset({
+            ...params,
+            preflightToken: preflight.preflightToken,
+        });
+
+        expect(mockCreateNodeByAsset).toHaveBeenCalledWith({
+            uuid: 'asset-uuid',
+            type: 'cc.Prefab',
+            workMode: '2d',
+            canvasRequired: true,
+        });
+    });
+
+    it.each([
+        { preflightCanvasRequired: false, actualCanvasRequired: true },
+        { preflightCanvasRequired: true, actualCanvasRequired: false },
+    ])(
+        'destroys an unattached asset node when Canvas requirement changes from $preflightCanvasRequired to $actualCanvasRequired',
+        async ({ preflightCanvasRequired, actualCanvasRequired }) => {
+            const root = new MockNode('Root');
+            const createdNode = new MockNode('AssetInstance');
+            mockGetRootNode.mockReturnValue(root);
+            mockPrefabAsset();
+            mockQueryCanvasRequiredByAsset.mockResolvedValue(preflightCanvasRequired);
+            mockCreateNodeByAsset.mockResolvedValue({ node: createdNode, canvasRequired: actualCanvasRequired });
+
+            const { NodeService } = require('../../scene-process/service/node');
+            const service = new NodeService();
+            service._getOrCreateNodeByPath = jest.fn().mockResolvedValue(root);
+            const params = {
+                path: '/MissingParent',
+                dbURL: 'db://assets/Asset.prefab',
+            };
+            const preflight = await service.preflightCreate(params);
+            const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+            await expect(service.createByAsset({
+                ...params,
+                preflightToken: preflight.preflightToken,
+            })).rejects.toThrow('Canvas requirement changed after preflight');
+
+            consoleError.mockRestore();
+            expect(createdNode.destroy).toHaveBeenCalledTimes(1);
+            expect(createdNode.parent).toBeNull();
+            expect(service._getOrCreateNodeByPath).not.toHaveBeenCalled();
+            expect(mockQueryCanvasRequiredByAsset).toHaveBeenCalledTimes(1);
+            expect(mockRpcRequest).toHaveBeenCalledTimes(2);
+            expect(mockRpcRequest).toHaveBeenNthCalledWith(
+                1,
+                'assetManager',
+                'queryAssetInfo',
+                ['db://assets/Asset.prefab'],
+            );
+            expect(mockRpcRequest).toHaveBeenNthCalledWith(
+                2,
+                'assetManager',
+                'queryAssetInfo',
+                ['db://assets/Asset.prefab'],
+            );
+            expect(mockCreateNodeByAsset).toHaveBeenCalledTimes(1);
+        },
+    );
+});

--- a/src/core/scene/test/service-core/node-create-canvas-required.test.ts
+++ b/src/core/scene/test/service-core/node-create-canvas-required.test.ts
@@ -35,7 +35,22 @@ class MockNode {
     });
     setPosition = jest.fn();
     setParent = jest.fn((parent: MockNode | null) => {
+        if (this.parent) {
+            const previousIndex = this.parent.children.indexOf(this);
+            if (previousIndex >= 0) {
+                this.parent.children.splice(previousIndex, 1);
+            }
+        }
         this.parent = parent;
+        if (parent && !parent.children.includes(this)) {
+            parent.children.push(this);
+        }
+    });
+    insertChild = jest.fn((child: MockNode, siblingIndex: number) => {
+        child.setParent(this);
+        const currentIndex = this.children.indexOf(child);
+        this.children.splice(currentIndex, 1);
+        this.children.splice(siblingIndex, 0, child);
     });
     getChildByName: (name: string) => MockNode | null = jest.fn((name: string): MockNode | null => (
         this.children.find((child: MockNode): boolean => child.name === name) ?? null
@@ -62,6 +77,7 @@ class MockNode {
 (global as any).cc = {
     instantiate: mockInstantiate,
     UITransform: MockUITransform,
+    Node: MockNode,
 };
 
 jest.mock('cc', () => ({
@@ -432,6 +448,608 @@ describe('NodeService Canvas requirement handling', () => {
             workMode: '2d',
             preflightToken: preflight.preflightToken,
         })).rejects.toThrow('Canvas context changed after preflight');
+        consoleError.mockRestore();
+        expect(service._createNode).not.toHaveBeenCalled();
+    });
+
+    it('inserts a type-created node before the anchored sibling instead of nesting it', async () => {
+        const root = new MockNode('Root');
+        const parent = new MockNode('Parent');
+        const before = new MockNode('Before');
+        const anchor = new MockNode('Anchor');
+        const after = new MockNode('After');
+        root.addChild(parent);
+        parent.addChild(before);
+        parent.addChild(anchor);
+        parent.addChild(after);
+        mockGetRootNode.mockReturnValue(root);
+        (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
+            path === '/Parent/Anchor' ? anchor : null
+        ));
+
+        const { NodeService } = require('../../scene-process/service/node');
+        await new NodeService().createByType({
+            path: '/Parent/Anchor',
+            insertSide: 'before',
+            name: 'Inserted',
+            nodeType: NodeType.EMPTY,
+        } as any);
+
+        expect(parent.children.map(child => child.name)).toEqual(['Before', 'Inserted', 'Anchor', 'After']);
+        expect(anchor.children).toEqual([]);
+    });
+
+    it('inserts a type-created node after the anchored sibling', async () => {
+        const root = new MockNode('Root');
+        const parent = new MockNode('Parent');
+        const before = new MockNode('Before');
+        const anchor = new MockNode('Anchor');
+        const after = new MockNode('After');
+        root.addChild(parent);
+        parent.addChild(before);
+        parent.addChild(anchor);
+        parent.addChild(after);
+        mockGetRootNode.mockReturnValue(root);
+        (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
+            path === '/Parent/Anchor' ? anchor : null
+        ));
+
+        const { NodeService } = require('../../scene-process/service/node');
+        await new NodeService().createByType({
+            path: '/Parent/Anchor',
+            insertSide: 'after',
+            name: 'Inserted',
+            nodeType: NodeType.EMPTY,
+        } as any);
+
+        expect(parent.children.map(child => child.name)).toEqual(['Before', 'Anchor', 'Inserted', 'After']);
+    });
+
+    it('inserts an asset-created node after the anchored sibling instead of nesting it', async () => {
+        const root = new MockNode('Root');
+        const parent = new MockNode('Parent');
+        const before = new MockNode('Before');
+        const anchor = new MockNode('Anchor');
+        const after = new MockNode('After');
+        root.addChild(parent);
+        parent.addChild(before);
+        parent.addChild(anchor);
+        parent.addChild(after);
+        mockGetRootNode.mockReturnValue(root);
+        mockRpcRequest.mockImplementation(async (_service: string, method: string) => {
+            if (method === 'queryUUID') {
+                return 'asset-uuid';
+            }
+            if (method === 'queryAssetInfo') {
+                return { type: 'cc.Prefab' };
+            }
+            return undefined;
+        });
+        mockCreateNodeByAsset.mockResolvedValue({ node: new MockNode('AssetInstance'), canvasRequired: false });
+        (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
+            path === '/Parent/Anchor' ? anchor : null
+        ));
+
+        const { NodeService } = require('../../scene-process/service/node');
+        await new NodeService().createByAsset({
+            path: '/Parent/Anchor',
+            insertSide: 'after',
+            dbURL: 'db://assets/Asset.prefab',
+        } as any);
+
+        expect(parent.children.map(child => child.name)).toEqual(['Before', 'Anchor', 'AssetInstance', 'After']);
+        expect(anchor.children).toEqual([]);
+    });
+
+    it('inserts an asset-created node before the anchored sibling', async () => {
+        const root = new MockNode('Root');
+        const parent = new MockNode('Parent');
+        const before = new MockNode('Before');
+        const anchor = new MockNode('Anchor');
+        const after = new MockNode('After');
+        root.addChild(parent);
+        parent.addChild(before);
+        parent.addChild(anchor);
+        parent.addChild(after);
+        mockGetRootNode.mockReturnValue(root);
+        mockRpcRequest.mockImplementation(async (_service: string, method: string) => {
+            if (method === 'queryUUID') {
+                return 'asset-uuid';
+            }
+            if (method === 'queryAssetInfo') {
+                return { type: 'cc.Prefab' };
+            }
+            return undefined;
+        });
+        mockCreateNodeByAsset.mockResolvedValue({ node: new MockNode('AssetInstance'), canvasRequired: false });
+        (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
+            path === '/Parent/Anchor' ? anchor : null
+        ));
+
+        const { NodeService } = require('../../scene-process/service/node');
+        await new NodeService().createByAsset({
+            path: '/Parent/Anchor',
+            insertSide: 'before',
+            dbURL: 'db://assets/Asset.prefab',
+        } as any);
+
+        expect(parent.children.map(child => child.name)).toEqual(['Before', 'AssetInstance', 'Anchor', 'After']);
+    });
+
+    it('keeps direct-parent append behavior for type and asset creation without an insertion side', async () => {
+        const root = new MockNode('Root');
+        const parent = new MockNode('Parent');
+        const existing = new MockNode('Existing');
+        root.addChild(parent);
+        parent.addChild(existing);
+        mockGetRootNode.mockReturnValue(root);
+        mockRpcRequest.mockImplementation(async (_service: string, method: string) => {
+            if (method === 'queryUUID') {
+                return 'asset-uuid';
+            }
+            if (method === 'queryAssetInfo') {
+                return { type: 'cc.Prefab' };
+            }
+            return undefined;
+        });
+        mockCreateNodeByAsset.mockResolvedValue({ node: new MockNode('AssetInstance'), canvasRequired: false });
+        (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
+            path === '/Parent' ? parent : null
+        ));
+
+        const { NodeService } = require('../../scene-process/service/node');
+        const service = new NodeService();
+        await service.createByType({ path: '/Parent', name: 'TypeInstance', nodeType: NodeType.EMPTY });
+        await service.createByAsset({ path: '/Parent', dbURL: 'db://assets/Asset.prefab' });
+
+        expect(parent.children.map(child => child.name)).toEqual(['Existing', 'TypeInstance', 'AssetInstance']);
+    });
+
+    it('preflights Canvas handling from the anchored sibling parent', async () => {
+        const root = new MockNode('Root');
+        const canvas = new MockNode('Canvas');
+        const anchor = new MockNode('Anchor');
+        root.addChild(canvas);
+        canvas.addChild(anchor);
+        mockGetRootNode.mockReturnValue(root);
+        mockGetUICanvasNode.mockImplementation((node: MockNode) => node === canvas ? canvas : null);
+        (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
+            path === '/Canvas/Anchor' ? anchor : null
+        ));
+
+        const { NodeService } = require('../../scene-process/service/node');
+        await expect(new NodeService().preflightCreate({
+            path: '/Canvas/Anchor',
+            insertSide: 'before',
+            nodeType: NodeType.BUTTON,
+            workMode: '2d',
+        } as any)).resolves.toMatchObject({
+            action: 'create',
+            canvasRequired: true,
+            canvasPath: '/Canvas',
+        });
+    });
+
+    it.each(['before', 'after'] as const)(
+        'creates a Canvas wrapper at the anchored %s entry position when none exists',
+        async insertSide => {
+            const root = new MockNode('Root');
+            const before = new MockNode('Before');
+            const anchor = new MockNode('Anchor');
+            const after = new MockNode('After');
+            root.addChild(before);
+            root.addChild(anchor);
+            root.addChild(after);
+            mockGetRootNode.mockReturnValue(root);
+            mockCreateNodeByAsset.mockResolvedValue({
+                node: new MockNode('Button'),
+                canvasRequired: false,
+            });
+            (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
+                path === '/Anchor' ? anchor : null
+            ));
+
+            const { NodeService } = require('../../scene-process/service/node');
+            const service = new NodeService();
+            const params = {
+                path: '/Anchor',
+                insertSide,
+                nodeType: NodeType.BUTTON,
+                workMode: '2d',
+                canvasRequired: true,
+            } as const;
+            const preflight = await service.preflightCreate(params);
+
+            expect(preflight).toMatchObject({
+                action: 'create',
+                canvasRequired: true,
+                canvasPath: null,
+            });
+
+            await expect(service.createByType({
+                ...params,
+                preflightToken: preflight.preflightToken,
+            } as any)).resolves.toMatchObject({ path: expect.any(String) });
+
+            expect(root.children.map(child => child.name)).toEqual(
+                insertSide === 'before'
+                    ? ['Before', 'Canvas', 'Anchor', 'After']
+                    : ['Before', 'Anchor', 'Canvas', 'After'],
+            );
+            const canvas = root.children.find(child => child.name === 'Canvas');
+            expect(canvas?.children.map(child => child.name)).toEqual(['Button']);
+            expect(anchor.children).toEqual([]);
+        },
+    );
+
+    it.each(['before', 'after'] as const)(
+        'creates an asset-required Canvas wrapper at the anchored %s entry position when none exists',
+        async insertSide => {
+            const root = new MockNode('Root');
+            const before = new MockNode('Before');
+            const anchor = new MockNode('Anchor');
+            const after = new MockNode('After');
+            root.addChild(before);
+            root.addChild(anchor);
+            root.addChild(after);
+            mockGetRootNode.mockReturnValue(root);
+            mockRpcRequest.mockImplementation(async (_service: string, method: string) => {
+                if (method === 'queryUUID') {
+                    return 'asset-uuid';
+                }
+                if (method === 'queryAssetInfo') {
+                    return { type: 'cc.Prefab' };
+                }
+                return undefined;
+            });
+            mockQueryCanvasRequiredByAsset.mockResolvedValue(true);
+            mockCreateNodeByAsset.mockResolvedValue({
+                node: new MockNode('AssetInstance'),
+                canvasRequired: true,
+            });
+            (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
+                path === '/Anchor' ? anchor : null
+            ));
+
+            const { NodeService } = require('../../scene-process/service/node');
+            const service = new NodeService();
+            const params = {
+                path: '/Anchor',
+                insertSide,
+                dbURL: 'db://assets/Asset.prefab',
+                workMode: '2d',
+            } as const;
+            const preflight = await service.preflightCreate(params);
+
+            await expect(service.createByAsset({
+                ...params,
+                preflightToken: preflight.preflightToken,
+            } as any)).resolves.toMatchObject({ path: expect.any(String) });
+
+            expect(root.children.map(child => child.name)).toEqual(
+                insertSide === 'before'
+                    ? ['Before', 'Canvas', 'Anchor', 'After']
+                    : ['Before', 'Anchor', 'Canvas', 'After'],
+            );
+            const canvas = root.children.find(child => child.name === 'Canvas');
+            expect(canvas?.children.map(child => child.name)).toEqual(['AssetInstance']);
+        },
+    );
+
+    it('does not attach a new Canvas when the anchor becomes stale during Canvas loading', async () => {
+        const root = new MockNode('Root');
+        const before = new MockNode('Before');
+        const anchor = new MockNode('Anchor');
+        const after = new MockNode('After');
+        const replacementParent = new MockNode('ReplacementParent');
+        root.addChild(before);
+        root.addChild(anchor);
+        root.addChild(after);
+        mockGetRootNode.mockReturnValue(root);
+        mockCreateNodeByAsset.mockResolvedValue({
+            node: new MockNode('Button'),
+            canvasRequired: false,
+        });
+        let resolveCanvasAsset: (asset: object) => void;
+        mockLoadAny.mockImplementation(() => new Promise<object>(resolve => {
+            resolveCanvasAsset = resolve;
+        }));
+        (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
+            path === '/Anchor' ? anchor : null
+        ));
+
+        const { NodeService } = require('../../scene-process/service/node');
+        const creation = new NodeService().createByType({
+            path: '/Anchor',
+            insertSide: 'before',
+            nodeType: NodeType.BUTTON,
+            workMode: '2d',
+            canvasRequired: true,
+        } as any);
+        await new Promise<void>(resolve => setImmediate(resolve));
+        anchor.setParent(replacementParent);
+        resolveCanvasAsset!({});
+
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        await expect(creation).rejects.toThrow('stale');
+        consoleError.mockRestore();
+        expect(root.children.map(child => child.name)).toEqual(['Before', 'After']);
+        expect(root.children.some(child => child.name === 'Canvas')).toBe(false);
+    });
+
+    it.each(['before', 'after'] as const)(
+        'places a Prefab Canvas wrapper at the anchored %s entry position after the host chooses create-canvas',
+        async insertSide => {
+            const root = new MockNode('PrefabRoot');
+            const before = new MockNode('Before');
+            const anchor = new MockNode('Anchor');
+            const after = new MockNode('After');
+            root.addChild(before);
+            root.addChild(anchor);
+            root.addChild(after);
+            mockGetCurrentEditorType.mockReturnValue('prefab');
+            mockGetRootNode.mockReturnValue(root);
+            mockCreateNodeByAsset.mockResolvedValue({
+                node: new MockNode('Button'),
+                canvasRequired: false,
+            });
+            (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
+                path === '/Anchor' ? anchor : null
+            ));
+
+            const { NodeService } = require('../../scene-process/service/node');
+            const service = new NodeService();
+            const params = {
+                path: '/Anchor',
+                insertSide,
+                nodeType: NodeType.BUTTON,
+                workMode: '2d',
+                canvasRequired: true,
+            } as const;
+            const preflight = await service.preflightCreate(params);
+
+            expect(preflight).toMatchObject({
+                action: 'choose-prefab-canvas-handling',
+                canvasRequired: true,
+            });
+
+            await expect(service.createByType({
+                ...params,
+                preflightToken: preflight.preflightToken,
+                prefabCanvasHandling: 'create-canvas',
+            } as any)).resolves.toMatchObject({ path: expect.any(String) });
+
+            expect(root.children.map(child => child.name)).toEqual(
+                insertSide === 'before'
+                    ? ['Before', 'Canvas', 'Anchor', 'After']
+                    : ['Before', 'Anchor', 'Canvas', 'After'],
+            );
+            const canvas = root.children.find(child => child.name === 'Canvas');
+            expect(canvas?.children.map(child => child.name)).toEqual(['Button']);
+        },
+    );
+
+    it('keeps the captured anchor when add-root-ui-transform reparents the Prefab root', async () => {
+        const root = new MockNode('PrefabRoot');
+        const host = new MockNode('SceneHost');
+        const before = new MockNode('Before');
+        const anchor = new MockNode('Anchor');
+        const after = new MockNode('After');
+        const previewCanvas = new MockNode('PreviewCanvas');
+        root.parent = host;
+        root.addChild(before);
+        root.addChild(anchor);
+        root.addChild(after);
+        mockGetCurrentEditorType.mockReturnValue('prefab');
+        mockGetRootNode.mockReturnValue(root);
+        mockCreateNodeByAsset.mockResolvedValue({
+            node: new MockNode('Button'),
+            canvasRequired: false,
+        });
+        let anchorPathIsResolvable = true;
+        mockCreateShouldHideInHierarchyCanvasNode.mockImplementation(async () => {
+            anchorPathIsResolvable = false;
+            return previewCanvas;
+        });
+        (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
+            path === '/Anchor' && anchorPathIsResolvable ? anchor : null
+        ));
+
+        const { NodeService } = require('../../scene-process/service/node');
+        const service = new NodeService();
+        const params = {
+            path: '/Anchor',
+            insertSide: 'before',
+            nodeType: NodeType.BUTTON,
+            workMode: '2d',
+            canvasRequired: true,
+        } as const;
+        const preflight = await service.preflightCreate(params);
+
+        await expect(service.createByType({
+            ...params,
+            preflightToken: preflight.preflightToken,
+            prefabCanvasHandling: 'add-root-ui-transform',
+        } as any)).resolves.toMatchObject({ path: expect.any(String) });
+
+        expect(root.children.map(child => child.name)).toEqual(['Before', 'Button', 'Anchor', 'After']);
+        expect(root.components.some(component => component instanceof MockUITransform)).toBe(true);
+    });
+
+    it.each(['before', 'after'] as const)(
+        'keeps an anchored %s create beside its anchor inside an existing Canvas ancestor',
+        async insertSide => {
+            const root = new MockNode('Root');
+            const canvas = new MockNode('Canvas');
+            const container = new MockNode('Container');
+            const before = new MockNode('Before');
+            const anchor = new MockNode('Anchor');
+            const after = new MockNode('After');
+            root.addChild(canvas);
+            canvas.addChild(container);
+            container.addChild(before);
+            container.addChild(anchor);
+            container.addChild(after);
+            mockGetRootNode.mockReturnValue(root);
+            // getUICanvasNode returns the requested node when one of its ancestors is a Canvas.
+            mockGetUICanvasNode.mockImplementation((node: MockNode) =>
+                node === container ? container : null,
+            );
+            mockCreateNodeByAsset.mockResolvedValue({
+                node: new MockNode('Button'),
+                canvasRequired: false,
+            });
+            (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
+                path === '/Canvas/Container/Anchor' ? anchor : null
+            ));
+
+            const { NodeService } = require('../../scene-process/service/node');
+            const service = new NodeService();
+            const params = {
+                path: '/Canvas/Container/Anchor',
+                insertSide,
+                nodeType: NodeType.BUTTON,
+                workMode: '2d',
+            } as const;
+            const preflight = await service.preflightCreate(params);
+
+            await expect(service.createByType({
+                ...params,
+                preflightToken: preflight.preflightToken,
+            } as any)).resolves.toMatchObject({ path: expect.any(String) });
+
+            expect(container.children.map(child => child.name)).toEqual(
+                insertSide === 'before'
+                    ? ['Before', 'Button', 'Anchor', 'After']
+                    : ['Before', 'Anchor', 'Button', 'After'],
+            );
+            expect(anchor.children).toEqual([]);
+        },
+    );
+
+    it('reuses an existing Canvas child instead of creating a second wrapper', async () => {
+        const root = new MockNode('Root');
+        const parent = new MockNode('Parent');
+        const before = new MockNode('Before');
+        const anchor = new MockNode('Anchor');
+        const after = new MockNode('After');
+        const canvas = new MockNode('Canvas');
+        root.addChild(parent);
+        parent.addChild(before);
+        parent.addChild(anchor);
+        parent.addChild(after);
+        parent.addChild(canvas);
+        mockGetRootNode.mockReturnValue(root);
+        mockGetUICanvasNode.mockImplementation((node: MockNode) => node === parent ? canvas : null);
+        mockCreateNodeByAsset.mockResolvedValue({
+            node: new MockNode('Button'),
+            canvasRequired: false,
+        });
+        (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
+            path === '/Parent/Anchor' ? anchor : null
+        ));
+
+        const { NodeService } = require('../../scene-process/service/node');
+        const service = new NodeService();
+        const params = {
+            path: '/Parent/Anchor',
+            insertSide: 'before',
+            nodeType: NodeType.BUTTON,
+            workMode: '2d',
+        } as const;
+        const preflight = await service.preflightCreate(params);
+
+        await expect(service.createByType({
+            ...params,
+            preflightToken: preflight.preflightToken,
+        } as any)).resolves.toMatchObject({ path: expect.any(String) });
+
+        expect(parent.children.map(child => child.name)).toEqual(['Before', 'Anchor', 'After', 'Canvas']);
+        expect(canvas.children.map(child => child.name)).toEqual(['Button']);
+        expect(mockInstantiate).not.toHaveBeenCalled();
+    });
+
+    it('rejects an anchored request when the sibling is missing without materializing a fallback path', async () => {
+        const root = new MockNode('Root');
+        mockGetRootNode.mockReturnValue(root);
+        const { NodeService } = require('../../scene-process/service/node');
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        await expect(new NodeService().createByType({
+            path: '/MissingAnchor',
+            insertSide: 'before',
+            nodeType: NodeType.EMPTY,
+        } as any)).rejects.toThrow('anchor');
+
+        consoleError.mockRestore();
+        expect(root.children).toEqual([]);
+    });
+
+    it('binds insertion side to the preflight token', async () => {
+        const root = new MockNode('Root');
+        const parent = new MockNode('Parent');
+        const anchor = new MockNode('Anchor');
+        root.addChild(parent);
+        parent.addChild(anchor);
+        mockGetRootNode.mockReturnValue(root);
+        (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
+            path === '/Parent/Anchor' ? anchor : null
+        ));
+
+        const { NodeService } = require('../../scene-process/service/node');
+        const service = new NodeService();
+        service._createNode = jest.fn().mockResolvedValue({ path: '/Parent/Inserted' });
+        const preflight = await service.preflightCreate({
+            path: '/Parent/Anchor',
+            insertSide: 'before',
+            nodeType: NodeType.EMPTY,
+            prefabCanvasHandling: 'create-canvas',
+        } as any);
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        await expect(service.createByType({
+            path: '/Parent/Anchor',
+            insertSide: 'after',
+            nodeType: NodeType.EMPTY,
+            prefabCanvasHandling: 'add-root-ui-transform',
+            preflightToken: preflight.preflightToken,
+        } as any)).rejects.toThrow('does not match the request');
+
+        consoleError.mockRestore();
+        expect(service._createNode).not.toHaveBeenCalled();
+    });
+
+    it('rejects a preflight token when its anchored node was replaced at the same path', async () => {
+        const root = new MockNode('Root');
+        const parent = new MockNode('Parent');
+        const originalAnchor = new MockNode('Anchor');
+        root.addChild(parent);
+        parent.addChild(originalAnchor);
+        mockGetRootNode.mockReturnValue(root);
+        let anchor = originalAnchor;
+        (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
+            path === '/Parent/Anchor' ? anchor : null
+        ));
+
+        const { NodeService } = require('../../scene-process/service/node');
+        const service = new NodeService();
+        service._createNode = jest.fn().mockResolvedValue({ path: '/Parent/Inserted' });
+        const preflight = await service.preflightCreate({
+            path: '/Parent/Anchor',
+            insertSide: 'before',
+            nodeType: NodeType.EMPTY,
+        } as any);
+        anchor = new MockNode('ReplacementAnchor');
+        parent.addChild(anchor);
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        await expect(service.createByType({
+            path: '/Parent/Anchor',
+            insertSide: 'before',
+            nodeType: NodeType.EMPTY,
+            preflightToken: preflight.preflightToken,
+        } as any)).rejects.toThrow('stale anchor');
+
         consoleError.mockRestore();
         expect(service._createNode).not.toHaveBeenCalled();
     });

--- a/src/core/scene/test/service-core/node-create-canvas-required.test.ts
+++ b/src/core/scene/test/service-core/node-create-canvas-required.test.ts
@@ -1,189 +1,28 @@
-const mockLock = jest.fn(async () => undefined);
-const mockUnlock = jest.fn();
-const mockGetCurrentEditorType = jest.fn(() => 'scene');
-const mockGetRootNode = jest.fn();
-const mockRemovePrefabInfoFromNode = jest.fn();
-const mockCreateNodeByAsset = jest.fn();
-const mockCreateShouldHideInHierarchyCanvasNode = jest.fn();
-const mockLoadAny = jest.fn();
-const mockQueryCanvasRequiredByAsset = jest.fn();
-const mockRpcRequest = jest.fn();
-const mockGetUICanvasNode = jest.fn();
-const mockGetUITransformParentNode = jest.fn();
-const mockInstantiate = jest.fn();
-const mockScene = { name: 'Scene' };
-
-class MockCanvas {}
-class MockUITransform {}
-
-class MockNode {
-    uuid: string;
-    name: string;
-    parent: MockNode | null = null;
-    children: MockNode[] = [];
-    components: any[] = [];
-    layer = 0;
-    position = { z: 0 };
-    addChild = jest.fn((node: MockNode) => {
-        this.children.push(node);
-        node.parent = this;
-    });
-    addComponent = jest.fn((component: any) => {
-        const instance = component === 'cc.UITransform' ? new MockUITransform() : new component();
-        this.components.push(instance);
-        return instance;
-    });
-    setPosition = jest.fn();
-    setParent = jest.fn((parent: MockNode | null) => {
-        if (this.parent) {
-            const previousIndex = this.parent.children.indexOf(this);
-            if (previousIndex >= 0) {
-                this.parent.children.splice(previousIndex, 1);
-            }
-        }
-        this.parent = parent;
-        if (parent && !parent.children.includes(this)) {
-            parent.children.push(this);
-        }
-    });
-    insertChild = jest.fn((child: MockNode, siblingIndex: number) => {
-        child.setParent(this);
-        const currentIndex = this.children.indexOf(child);
-        this.children.splice(currentIndex, 1);
-        this.children.splice(siblingIndex, 0, child);
-    });
-    getChildByName: (name: string) => MockNode | null = jest.fn((name: string): MockNode | null => (
-        this.children.find((child: MockNode): boolean => child.name === name) ?? null
-    ));
-    getSiblingIndex = jest.fn(() => this.parent?.children.indexOf(this) ?? 0);
-
-    constructor(name = 'Node') {
-        this.name = name;
-        this.uuid = `${name}-uuid`;
-    }
-
-    get isValid() {
-        return true;
-    }
-}
-
-(global as any).EditorExtends = {
-    Node: {
-        getNodeByPath: jest.fn(),
-        getNodePath: jest.fn((node: MockNode) => `/${node.name}`),
-    },
-};
-
-(global as any).cc = {
-    instantiate: mockInstantiate,
-    UITransform: MockUITransform,
-    Node: MockNode,
-};
-
-jest.mock('cc', () => ({
-    Canvas: MockCanvas,
-    CCClass: { getInheritanceChain: jest.fn(() => []) },
-    CCObject: { Flags: { HideInHierarchy: 1, LockedInEditor: 2 } },
-    Component: class Component {},
-    director: { getScene: jest.fn(() => mockScene) },
-    Node: MockNode,
-    Prefab: class Prefab {},
-    Quat: class Quat {},
-    UITransform: MockUITransform,
-    Vec3: class Vec3 {},
-}));
-
-jest.mock('../../scene-process/service/core', () => ({
-    BaseService: class BaseService {
-        emit = jest.fn();
-    },
-    register: () => () => undefined,
-    Service: {
-        Editor: {
-            lock: mockLock,
-            unlock: mockUnlock,
-            getCurrentEditorType: mockGetCurrentEditorType,
-            getRootNode: mockGetRootNode,
-        },
-        Prefab: {
-            removePrefabInfoFromNode: mockRemovePrefabInfoFromNode,
-        },
-        Undo: {
-            push: jest.fn(),
-        },
-    },
-}));
-
-jest.mock('../../scene-process/rpc', () => ({
-    Rpc: { getInstance: () => ({ request: mockRpcRequest }) },
-}));
-
-jest.mock('../../scene-process/service/node/node-create', () => ({
-    createNodeByAsset: mockCreateNodeByAsset,
-    createShouldHideInHierarchyCanvasNode: mockCreateShouldHideInHierarchyCanvasNode,
-    loadAny: mockLoadAny,
-    queryCanvasRequiredByAsset: mockQueryCanvasRequiredByAsset,
-}));
-
-jest.mock('../../scene-process/service/node/node-utils', () => ({
-    getUICanvasNode: mockGetUICanvasNode,
-    getUITransformParentNode: mockGetUITransformParentNode,
-    hasOneKindOfComponent: (node: MockNode, kind: any) => node.components.some((component) => component instanceof kind),
-    setLayer: jest.fn(),
-}));
-
-jest.mock('../../scene-process/service/node/node-undo', () => ({
-    NodeUndoHelper: jest.fn().mockImplementation(() => ({
-        shouldRecordStructureCommand: jest.fn(() => false),
-        collectSceneNodeUuids: jest.fn(() => new Set()),
-        getCreateRootPath: jest.fn(() => null),
-        recordCreateNodeCommand: jest.fn(),
-    })),
-}));
-
-jest.mock('../../scene-process/service/node/index', () => ({
-    __esModule: true,
-    default: {
-        ensureUITransformComponent: jest.fn((node: MockNode) => node.addComponent('cc.UITransform')),
-    },
-}));
-
-jest.mock('../../scene-process/service/prefab/utils', () => ({
-    prefabUtils: { getPrefabStateInfo: jest.fn(() => ({})) },
-}));
-
-jest.mock('../../scene-process/service/scene/utils', () => ({
-    sceneUtils: {
-        generateNodeDump: jest.fn((node: MockNode) => ({ path: `/${node.name}` })),
-    },
-}));
-
-jest.mock('../../scene-process/service/undo/commands/remove-node-command', () => ({
-    RemoveNodeCommand: {},
-}));
-
-jest.mock('../../scene-process/service/undo/commands/remove-component-command', () => ({
-    RemoveComponentCommand: {},
-}));
-
-jest.mock('../../scene-process/service/animation/property-commit-event', () => ({
-    broadcastAnimationPropertyCommitted: jest.fn(),
-}));
-
 import { NodeType } from '../../common';
+import {
+    createAnchoredTree,
+    MockCanvas,
+    MockNode,
+    MockUITransform,
+    mockCreateShouldHideInHierarchyCanvasNode,
+    mockGetCurrentEditorType,
+    mockGetRootNode,
+    mockGetUICanvasNode,
+    mockGetUITransformParentNode,
+    mockInstantiate,
+    mockLoadAny,
+    mockNodeAtPath,
+    mockPrefabAsset,
+    mockQueryCanvasRequiredByAsset,
+    mockRemovePrefabInfoFromNode,
+    mockRpcRequest,
+    mockScene,
+    resetNodeCreateMocks,
+} from './node-create-test-harness';
 
 describe('NodeService Canvas requirement handling', () => {
     beforeEach(() => {
-        jest.clearAllMocks();
-        mockGetCurrentEditorType.mockReturnValue('scene');
-        mockGetRootNode.mockReturnValue(new MockNode('Root'));
-        mockGetUICanvasNode.mockReturnValue(null);
-        mockGetUITransformParentNode.mockReturnValue(null);
-        mockLoadAny.mockResolvedValue({});
-        mockInstantiate.mockImplementation(() => new MockNode('Canvas'));
-        mockQueryCanvasRequiredByAsset.mockResolvedValue(false);
-        mockRpcRequest.mockReset();
-        (global as any).EditorExtends.Node.getNodeByPath.mockReturnValue(null);
+        resetNodeCreateMocks();
     });
 
     it('keeps empty nodes plain unless Canvas is explicitly requested', async () => {
@@ -401,8 +240,14 @@ describe('NodeService Canvas requirement handling', () => {
         mockGetCurrentEditorType.mockReturnValue('prefab');
         mockGetRootNode.mockReturnValue(new MockNode('PrefabRoot'));
         mockRpcRequest.mockImplementation((_service: string, method: string) => {
-            if (method === 'queryUUID') return 'asset-uuid';
-            if (method === 'queryAssetInfo') return { type: 'cc.BitmapFont' };
+            if (method === 'queryAssetInfo') {
+                return {
+                    uuid: 'asset-uuid',
+                    type: 'cc.BitmapFont',
+                    imported: true,
+                    invalid: false,
+                };
+            }
             return null;
         });
         mockQueryCanvasRequiredByAsset.mockResolvedValue(true);
@@ -452,159 +297,6 @@ describe('NodeService Canvas requirement handling', () => {
         expect(service._createNode).not.toHaveBeenCalled();
     });
 
-    it('inserts a type-created node before the anchored sibling instead of nesting it', async () => {
-        const root = new MockNode('Root');
-        const parent = new MockNode('Parent');
-        const before = new MockNode('Before');
-        const anchor = new MockNode('Anchor');
-        const after = new MockNode('After');
-        root.addChild(parent);
-        parent.addChild(before);
-        parent.addChild(anchor);
-        parent.addChild(after);
-        mockGetRootNode.mockReturnValue(root);
-        (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
-            path === '/Parent/Anchor' ? anchor : null
-        ));
-
-        const { NodeService } = require('../../scene-process/service/node');
-        await new NodeService().createByType({
-            path: '/Parent/Anchor',
-            insertSide: 'before',
-            name: 'Inserted',
-            nodeType: NodeType.EMPTY,
-        } as any);
-
-        expect(parent.children.map(child => child.name)).toEqual(['Before', 'Inserted', 'Anchor', 'After']);
-        expect(anchor.children).toEqual([]);
-    });
-
-    it('inserts a type-created node after the anchored sibling', async () => {
-        const root = new MockNode('Root');
-        const parent = new MockNode('Parent');
-        const before = new MockNode('Before');
-        const anchor = new MockNode('Anchor');
-        const after = new MockNode('After');
-        root.addChild(parent);
-        parent.addChild(before);
-        parent.addChild(anchor);
-        parent.addChild(after);
-        mockGetRootNode.mockReturnValue(root);
-        (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
-            path === '/Parent/Anchor' ? anchor : null
-        ));
-
-        const { NodeService } = require('../../scene-process/service/node');
-        await new NodeService().createByType({
-            path: '/Parent/Anchor',
-            insertSide: 'after',
-            name: 'Inserted',
-            nodeType: NodeType.EMPTY,
-        } as any);
-
-        expect(parent.children.map(child => child.name)).toEqual(['Before', 'Anchor', 'Inserted', 'After']);
-    });
-
-    it('inserts an asset-created node after the anchored sibling instead of nesting it', async () => {
-        const root = new MockNode('Root');
-        const parent = new MockNode('Parent');
-        const before = new MockNode('Before');
-        const anchor = new MockNode('Anchor');
-        const after = new MockNode('After');
-        root.addChild(parent);
-        parent.addChild(before);
-        parent.addChild(anchor);
-        parent.addChild(after);
-        mockGetRootNode.mockReturnValue(root);
-        mockRpcRequest.mockImplementation(async (_service: string, method: string) => {
-            if (method === 'queryUUID') {
-                return 'asset-uuid';
-            }
-            if (method === 'queryAssetInfo') {
-                return { type: 'cc.Prefab' };
-            }
-            return undefined;
-        });
-        mockCreateNodeByAsset.mockResolvedValue({ node: new MockNode('AssetInstance'), canvasRequired: false });
-        (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
-            path === '/Parent/Anchor' ? anchor : null
-        ));
-
-        const { NodeService } = require('../../scene-process/service/node');
-        await new NodeService().createByAsset({
-            path: '/Parent/Anchor',
-            insertSide: 'after',
-            dbURL: 'db://assets/Asset.prefab',
-        } as any);
-
-        expect(parent.children.map(child => child.name)).toEqual(['Before', 'Anchor', 'AssetInstance', 'After']);
-        expect(anchor.children).toEqual([]);
-    });
-
-    it('inserts an asset-created node before the anchored sibling', async () => {
-        const root = new MockNode('Root');
-        const parent = new MockNode('Parent');
-        const before = new MockNode('Before');
-        const anchor = new MockNode('Anchor');
-        const after = new MockNode('After');
-        root.addChild(parent);
-        parent.addChild(before);
-        parent.addChild(anchor);
-        parent.addChild(after);
-        mockGetRootNode.mockReturnValue(root);
-        mockRpcRequest.mockImplementation(async (_service: string, method: string) => {
-            if (method === 'queryUUID') {
-                return 'asset-uuid';
-            }
-            if (method === 'queryAssetInfo') {
-                return { type: 'cc.Prefab' };
-            }
-            return undefined;
-        });
-        mockCreateNodeByAsset.mockResolvedValue({ node: new MockNode('AssetInstance'), canvasRequired: false });
-        (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
-            path === '/Parent/Anchor' ? anchor : null
-        ));
-
-        const { NodeService } = require('../../scene-process/service/node');
-        await new NodeService().createByAsset({
-            path: '/Parent/Anchor',
-            insertSide: 'before',
-            dbURL: 'db://assets/Asset.prefab',
-        } as any);
-
-        expect(parent.children.map(child => child.name)).toEqual(['Before', 'AssetInstance', 'Anchor', 'After']);
-    });
-
-    it('keeps direct-parent append behavior for type and asset creation without an insertion side', async () => {
-        const root = new MockNode('Root');
-        const parent = new MockNode('Parent');
-        const existing = new MockNode('Existing');
-        root.addChild(parent);
-        parent.addChild(existing);
-        mockGetRootNode.mockReturnValue(root);
-        mockRpcRequest.mockImplementation(async (_service: string, method: string) => {
-            if (method === 'queryUUID') {
-                return 'asset-uuid';
-            }
-            if (method === 'queryAssetInfo') {
-                return { type: 'cc.Prefab' };
-            }
-            return undefined;
-        });
-        mockCreateNodeByAsset.mockResolvedValue({ node: new MockNode('AssetInstance'), canvasRequired: false });
-        (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
-            path === '/Parent' ? parent : null
-        ));
-
-        const { NodeService } = require('../../scene-process/service/node');
-        const service = new NodeService();
-        await service.createByType({ path: '/Parent', name: 'TypeInstance', nodeType: NodeType.EMPTY });
-        await service.createByAsset({ path: '/Parent', dbURL: 'db://assets/Asset.prefab' });
-
-        expect(parent.children.map(child => child.name)).toEqual(['Existing', 'TypeInstance', 'AssetInstance']);
-    });
-
     it('preflights Canvas handling from the anchored sibling parent', async () => {
         const root = new MockNode('Root');
         const canvas = new MockNode('Canvas');
@@ -633,21 +325,10 @@ describe('NodeService Canvas requirement handling', () => {
     it.each(['before', 'after'] as const)(
         'creates a Canvas wrapper at the anchored %s entry position when none exists',
         async insertSide => {
-            const root = new MockNode('Root');
-            const before = new MockNode('Before');
-            const anchor = new MockNode('Anchor');
-            const after = new MockNode('After');
-            root.addChild(before);
-            root.addChild(anchor);
-            root.addChild(after);
+            const { root, anchor } = createAnchoredTree();
             mockGetRootNode.mockReturnValue(root);
-            mockCreateNodeByAsset.mockResolvedValue({
-                node: new MockNode('Button'),
-                canvasRequired: false,
-            });
-            (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
-                path === '/Anchor' ? anchor : null
-            ));
+            mockPrefabAsset('Button');
+            mockNodeAtPath('/Anchor', anchor);
 
             const { NodeService } = require('../../scene-process/service/node');
             const service = new NodeService();
@@ -685,31 +366,11 @@ describe('NodeService Canvas requirement handling', () => {
     it.each(['before', 'after'] as const)(
         'creates an asset-required Canvas wrapper at the anchored %s entry position when none exists',
         async insertSide => {
-            const root = new MockNode('Root');
-            const before = new MockNode('Before');
-            const anchor = new MockNode('Anchor');
-            const after = new MockNode('After');
-            root.addChild(before);
-            root.addChild(anchor);
-            root.addChild(after);
+            const { root, anchor } = createAnchoredTree();
             mockGetRootNode.mockReturnValue(root);
-            mockRpcRequest.mockImplementation(async (_service: string, method: string) => {
-                if (method === 'queryUUID') {
-                    return 'asset-uuid';
-                }
-                if (method === 'queryAssetInfo') {
-                    return { type: 'cc.Prefab' };
-                }
-                return undefined;
-            });
+            mockPrefabAsset('AssetInstance', true);
             mockQueryCanvasRequiredByAsset.mockResolvedValue(true);
-            mockCreateNodeByAsset.mockResolvedValue({
-                node: new MockNode('AssetInstance'),
-                canvasRequired: true,
-            });
-            (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
-                path === '/Anchor' ? anchor : null
-            ));
+            mockNodeAtPath('/Anchor', anchor);
 
             const { NodeService } = require('../../scene-process/service/node');
             const service = new NodeService();
@@ -737,26 +398,15 @@ describe('NodeService Canvas requirement handling', () => {
     );
 
     it('does not attach a new Canvas when the anchor becomes stale during Canvas loading', async () => {
-        const root = new MockNode('Root');
-        const before = new MockNode('Before');
-        const anchor = new MockNode('Anchor');
-        const after = new MockNode('After');
+        const { root, anchor } = createAnchoredTree();
         const replacementParent = new MockNode('ReplacementParent');
-        root.addChild(before);
-        root.addChild(anchor);
-        root.addChild(after);
         mockGetRootNode.mockReturnValue(root);
-        mockCreateNodeByAsset.mockResolvedValue({
-            node: new MockNode('Button'),
-            canvasRequired: false,
-        });
+        mockPrefabAsset('Button');
         let resolveCanvasAsset: (asset: object) => void;
         mockLoadAny.mockImplementation(() => new Promise<object>(resolve => {
             resolveCanvasAsset = resolve;
         }));
-        (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
-            path === '/Anchor' ? anchor : null
-        ));
+        mockNodeAtPath('/Anchor', anchor);
 
         const { NodeService } = require('../../scene-process/service/node');
         const creation = new NodeService().createByType({
@@ -780,22 +430,11 @@ describe('NodeService Canvas requirement handling', () => {
     it.each(['before', 'after'] as const)(
         'places a Prefab Canvas wrapper at the anchored %s entry position after the host chooses create-canvas',
         async insertSide => {
-            const root = new MockNode('PrefabRoot');
-            const before = new MockNode('Before');
-            const anchor = new MockNode('Anchor');
-            const after = new MockNode('After');
-            root.addChild(before);
-            root.addChild(anchor);
-            root.addChild(after);
+            const { root, anchor } = createAnchoredTree(undefined, 'PrefabRoot');
             mockGetCurrentEditorType.mockReturnValue('prefab');
             mockGetRootNode.mockReturnValue(root);
-            mockCreateNodeByAsset.mockResolvedValue({
-                node: new MockNode('Button'),
-                canvasRequired: false,
-            });
-            (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
-                path === '/Anchor' ? anchor : null
-            ));
+            mockPrefabAsset('Button');
+            mockNodeAtPath('/Anchor', anchor);
 
             const { NodeService } = require('../../scene-process/service/node');
             const service = new NodeService();
@@ -830,22 +469,13 @@ describe('NodeService Canvas requirement handling', () => {
     );
 
     it('keeps the captured anchor when add-root-ui-transform reparents the Prefab root', async () => {
-        const root = new MockNode('PrefabRoot');
+        const { root, anchor } = createAnchoredTree(undefined, 'PrefabRoot');
         const host = new MockNode('SceneHost');
-        const before = new MockNode('Before');
-        const anchor = new MockNode('Anchor');
-        const after = new MockNode('After');
         const previewCanvas = new MockNode('PreviewCanvas');
         root.parent = host;
-        root.addChild(before);
-        root.addChild(anchor);
-        root.addChild(after);
         mockGetCurrentEditorType.mockReturnValue('prefab');
         mockGetRootNode.mockReturnValue(root);
-        mockCreateNodeByAsset.mockResolvedValue({
-            node: new MockNode('Button'),
-            canvasRequired: false,
-        });
+        mockPrefabAsset('Button');
         let anchorPathIsResolvable = true;
         mockCreateShouldHideInHierarchyCanvasNode.mockImplementation(async () => {
             anchorPathIsResolvable = false;
@@ -879,29 +509,17 @@ describe('NodeService Canvas requirement handling', () => {
     it.each(['before', 'after'] as const)(
         'keeps an anchored %s create beside its anchor inside an existing Canvas ancestor',
         async insertSide => {
-            const root = new MockNode('Root');
+            const { root, parent: container, anchor } = createAnchoredTree('Container');
             const canvas = new MockNode('Canvas');
-            const container = new MockNode('Container');
-            const before = new MockNode('Before');
-            const anchor = new MockNode('Anchor');
-            const after = new MockNode('After');
+            container.setParent(canvas);
             root.addChild(canvas);
-            canvas.addChild(container);
-            container.addChild(before);
-            container.addChild(anchor);
-            container.addChild(after);
             mockGetRootNode.mockReturnValue(root);
             // getUICanvasNode returns the requested node when one of its ancestors is a Canvas.
             mockGetUICanvasNode.mockImplementation((node: MockNode) =>
                 node === container ? container : null,
             );
-            mockCreateNodeByAsset.mockResolvedValue({
-                node: new MockNode('Button'),
-                canvasRequired: false,
-            });
-            (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
-                path === '/Canvas/Container/Anchor' ? anchor : null
-            ));
+            mockPrefabAsset('Button');
+            mockNodeAtPath('/Canvas/Container/Anchor', anchor);
 
             const { NodeService } = require('../../scene-process/service/node');
             const service = new NodeService();
@@ -928,26 +546,13 @@ describe('NodeService Canvas requirement handling', () => {
     );
 
     it('reuses an existing Canvas child instead of creating a second wrapper', async () => {
-        const root = new MockNode('Root');
-        const parent = new MockNode('Parent');
-        const before = new MockNode('Before');
-        const anchor = new MockNode('Anchor');
-        const after = new MockNode('After');
+        const { root, parent, anchor } = createAnchoredTree('Parent');
         const canvas = new MockNode('Canvas');
-        root.addChild(parent);
-        parent.addChild(before);
-        parent.addChild(anchor);
-        parent.addChild(after);
         parent.addChild(canvas);
         mockGetRootNode.mockReturnValue(root);
         mockGetUICanvasNode.mockImplementation((node: MockNode) => node === parent ? canvas : null);
-        mockCreateNodeByAsset.mockResolvedValue({
-            node: new MockNode('Button'),
-            canvasRequired: false,
-        });
-        (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
-            path === '/Parent/Anchor' ? anchor : null
-        ));
+        mockPrefabAsset('Button');
+        mockNodeAtPath('/Parent/Anchor', anchor);
 
         const { NodeService } = require('../../scene-process/service/node');
         const service = new NodeService();
@@ -967,91 +572,6 @@ describe('NodeService Canvas requirement handling', () => {
         expect(parent.children.map(child => child.name)).toEqual(['Before', 'Anchor', 'After', 'Canvas']);
         expect(canvas.children.map(child => child.name)).toEqual(['Button']);
         expect(mockInstantiate).not.toHaveBeenCalled();
-    });
-
-    it('rejects an anchored request when the sibling is missing without materializing a fallback path', async () => {
-        const root = new MockNode('Root');
-        mockGetRootNode.mockReturnValue(root);
-        const { NodeService } = require('../../scene-process/service/node');
-        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
-
-        await expect(new NodeService().createByType({
-            path: '/MissingAnchor',
-            insertSide: 'before',
-            nodeType: NodeType.EMPTY,
-        } as any)).rejects.toThrow('anchor');
-
-        consoleError.mockRestore();
-        expect(root.children).toEqual([]);
-    });
-
-    it('binds insertion side to the preflight token', async () => {
-        const root = new MockNode('Root');
-        const parent = new MockNode('Parent');
-        const anchor = new MockNode('Anchor');
-        root.addChild(parent);
-        parent.addChild(anchor);
-        mockGetRootNode.mockReturnValue(root);
-        (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
-            path === '/Parent/Anchor' ? anchor : null
-        ));
-
-        const { NodeService } = require('../../scene-process/service/node');
-        const service = new NodeService();
-        service._createNode = jest.fn().mockResolvedValue({ path: '/Parent/Inserted' });
-        const preflight = await service.preflightCreate({
-            path: '/Parent/Anchor',
-            insertSide: 'before',
-            nodeType: NodeType.EMPTY,
-            prefabCanvasHandling: 'create-canvas',
-        } as any);
-        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
-
-        await expect(service.createByType({
-            path: '/Parent/Anchor',
-            insertSide: 'after',
-            nodeType: NodeType.EMPTY,
-            prefabCanvasHandling: 'add-root-ui-transform',
-            preflightToken: preflight.preflightToken,
-        } as any)).rejects.toThrow('does not match the request');
-
-        consoleError.mockRestore();
-        expect(service._createNode).not.toHaveBeenCalled();
-    });
-
-    it('rejects a preflight token when its anchored node was replaced at the same path', async () => {
-        const root = new MockNode('Root');
-        const parent = new MockNode('Parent');
-        const originalAnchor = new MockNode('Anchor');
-        root.addChild(parent);
-        parent.addChild(originalAnchor);
-        mockGetRootNode.mockReturnValue(root);
-        let anchor = originalAnchor;
-        (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((path: string) => (
-            path === '/Parent/Anchor' ? anchor : null
-        ));
-
-        const { NodeService } = require('../../scene-process/service/node');
-        const service = new NodeService();
-        service._createNode = jest.fn().mockResolvedValue({ path: '/Parent/Inserted' });
-        const preflight = await service.preflightCreate({
-            path: '/Parent/Anchor',
-            insertSide: 'before',
-            nodeType: NodeType.EMPTY,
-        } as any);
-        anchor = new MockNode('ReplacementAnchor');
-        parent.addChild(anchor);
-        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
-
-        await expect(service.createByType({
-            path: '/Parent/Anchor',
-            insertSide: 'before',
-            nodeType: NodeType.EMPTY,
-            preflightToken: preflight.preflightToken,
-        } as any)).rejects.toThrow('stale anchor');
-
-        consoleError.mockRestore();
-        expect(service._createNode).not.toHaveBeenCalled();
     });
 
 });

--- a/src/core/scene/test/service-core/node-create-canvas-required.test.ts
+++ b/src/core/scene/test/service-core/node-create-canvas-required.test.ts
@@ -4,7 +4,9 @@ import {
     MockCanvas,
     MockNode,
     MockUITransform,
+    mockBaseRemoveNode,
     mockCreateShouldHideInHierarchyCanvasNode,
+    mockCreateNodeByAsset,
     mockGetCurrentEditorType,
     mockGetRootNode,
     mockGetUICanvasNode,
@@ -14,9 +16,12 @@ import {
     mockNodeAtPath,
     mockPrefabAsset,
     mockQueryCanvasRequiredByAsset,
+    mockCollectSceneNodeUuids,
+    mockRemoveComponent,
     mockRemovePrefabInfoFromNode,
     mockRpcRequest,
     mockScene,
+    mockShouldRecordStructureCommand,
     resetNodeCreateMocks,
 } from './node-create-test-harness';
 
@@ -487,6 +492,7 @@ describe('NodeService Canvas requirement handling', () => {
 
         const { NodeService } = require('../../scene-process/service/node');
         const service = new NodeService();
+        const pushUndoRecord = jest.spyOn(service, '_pushPrefabCanvasUndoRecord');
         const params = {
             path: '/Anchor',
             insertSide: 'before',
@@ -504,7 +510,78 @@ describe('NodeService Canvas requirement handling', () => {
 
         expect(root.children.map(child => child.name)).toEqual(['Before', 'Button', 'Anchor', 'After']);
         expect(root.components.some(component => component instanceof MockUITransform)).toBe(true);
+        expect(pushUndoRecord).toHaveBeenCalledTimes(1);
     });
+
+    it.each([
+        { previewExistedBefore: false },
+        { previewExistedBefore: true },
+    ])(
+        'rolls back add-root-ui-transform with previewExistedBefore=$previewExistedBefore when the anchor becomes stale',
+        async ({ previewExistedBefore }) => {
+            const { root, anchor } = createAnchoredTree(undefined, 'PrefabRoot');
+            const host = new MockNode('SceneHost');
+            const hostBefore = new MockNode('HostBefore');
+            const hostAfter = new MockNode('HostAfter');
+            const replacementParent = new MockNode('ReplacementParent');
+            const previewCanvas = new MockNode('PreviewCanvas');
+            const resultNode = new MockNode('Button');
+            host.addChild(hostBefore);
+            host.addChild(root);
+            host.addChild(hostAfter);
+            mockGetCurrentEditorType.mockReturnValue('prefab');
+            mockGetRootNode.mockReturnValue(root);
+            mockCreateNodeByAsset.mockResolvedValue({ node: resultNode, canvasRequired: false });
+            mockNodeAtPath('/Anchor', anchor);
+            mockShouldRecordStructureCommand.mockReturnValue(true);
+            mockCollectSceneNodeUuids.mockReturnValue(new Set(
+                previewExistedBefore ? [previewCanvas.uuid] : [],
+            ));
+            let resolvePreviewCanvas: (canvas: MockNode) => void;
+            mockCreateShouldHideInHierarchyCanvasNode.mockImplementation(() => new Promise<MockNode>(resolve => {
+                resolvePreviewCanvas = resolve;
+            }));
+
+            const { NodeService } = require('../../scene-process/service/node');
+            const service = new NodeService();
+            const pushUndoRecord = jest.spyOn(service, '_pushPrefabCanvasUndoRecord');
+            const params = {
+                path: '/Anchor',
+                insertSide: 'before' as const,
+                nodeType: NodeType.BUTTON,
+                workMode: '2d' as const,
+                canvasRequired: true,
+            };
+            const preflight = await service.preflightCreate(params);
+            const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+            const creation = service.createByType({
+                ...params,
+                preflightToken: preflight.preflightToken,
+                prefabCanvasHandling: 'add-root-ui-transform',
+            });
+            await new Promise<void>(resolve => setImmediate(resolve));
+            anchor.setParent(replacementParent);
+            resolvePreviewCanvas!(previewCanvas);
+
+            await expect(creation).rejects.toThrow('stale');
+
+            consoleError.mockRestore();
+            expect(root.parent).toBe(host);
+            expect(host.children).toEqual([hostBefore, root, hostAfter]);
+            expect(anchor.parent).toBe(replacementParent);
+            expect(root.components.some(component => component instanceof MockUITransform)).toBe(false);
+            expect(mockRemoveComponent).toHaveBeenCalledTimes(1);
+            if (previewExistedBefore) {
+                expect(mockBaseRemoveNode).not.toHaveBeenCalled();
+                expect(previewCanvas.isValid).toBe(true);
+            } else {
+                expect(mockBaseRemoveNode).toHaveBeenCalledWith(previewCanvas);
+                expect(previewCanvas.isValid).toBe(false);
+            }
+            expect(resultNode.destroy).toHaveBeenCalledTimes(1);
+            expect(pushUndoRecord).not.toHaveBeenCalled();
+        },
+    );
 
     it.each(['before', 'after'] as const)(
         'keeps an anchored %s create beside its anchor inside an existing Canvas ancestor',

--- a/src/core/scene/test/service-core/node-create-root-path-prefab.test.ts
+++ b/src/core/scene/test/service-core/node-create-root-path-prefab.test.ts
@@ -144,6 +144,13 @@ jest.mock('../../scene-process/service/node/index', () => ({
     },
 }));
 
+jest.mock('../../scene-process/service/component/index', () => ({
+    __esModule: true,
+    default: {
+        removeComponent: jest.fn(() => true),
+    },
+}));
+
 jest.mock('../../scene-process/service/prefab/utils', () => ({
     prefabUtils: { getPrefabStateInfo: jest.fn(() => ({})) },
 }));

--- a/src/core/scene/test/service-core/node-create-test-harness.ts
+++ b/src/core/scene/test/service-core/node-create-test-harness.ts
@@ -1,0 +1,233 @@
+export const mockLock = jest.fn(async () => undefined);
+export const mockUnlock = jest.fn();
+export const mockGetCurrentEditorType = jest.fn(() => 'scene');
+export const mockGetRootNode = jest.fn();
+export const mockRemovePrefabInfoFromNode = jest.fn();
+export const mockCreateNodeByAsset = jest.fn();
+export const mockCreateShouldHideInHierarchyCanvasNode = jest.fn();
+export const mockLoadAny = jest.fn();
+export const mockQueryCanvasRequiredByAsset = jest.fn();
+export const mockRpcRequest = jest.fn();
+export const mockGetUICanvasNode = jest.fn();
+export const mockGetUITransformParentNode = jest.fn();
+export const mockInstantiate = jest.fn();
+export const mockScene = { name: 'Scene' };
+
+export class MockCanvas {}
+export class MockUITransform {}
+
+export class MockNode {
+    uuid: string;
+    name: string;
+    parent: MockNode | null = null;
+    children: MockNode[] = [];
+    components: any[] = [];
+    layer = 0;
+    position = { z: 0 };
+    addChild = jest.fn((node: MockNode) => {
+        this.children.push(node);
+        node.parent = this;
+    });
+    addComponent = jest.fn((component: any) => {
+        const instance = component === 'cc.UITransform' ? new MockUITransform() : new component();
+        this.components.push(instance);
+        return instance;
+    });
+    setPosition = jest.fn();
+    destroy = jest.fn();
+    setParent = jest.fn((parent: MockNode | null) => {
+        if (this.parent) {
+            const previousIndex = this.parent.children.indexOf(this);
+            if (previousIndex >= 0) {
+                this.parent.children.splice(previousIndex, 1);
+            }
+        }
+        this.parent = parent;
+        if (parent && !parent.children.includes(this)) {
+            parent.children.push(this);
+        }
+    });
+    insertChild = jest.fn((child: MockNode, siblingIndex: number) => {
+        child.setParent(this);
+        const currentIndex = this.children.indexOf(child);
+        this.children.splice(currentIndex, 1);
+        this.children.splice(siblingIndex, 0, child);
+    });
+    getChildByName: (name: string) => MockNode | null = jest.fn(
+        (name: string): MockNode | null =>
+            this.children.find((child: MockNode): boolean => child.name === name) ?? null,
+    );
+    getSiblingIndex = jest.fn(() => this.parent?.children.indexOf(this) ?? 0);
+
+    constructor(name = 'Node') {
+        this.name = name;
+        this.uuid = `${name}-uuid`;
+    }
+
+    get isValid() {
+        return true;
+    }
+}
+
+(global as any).EditorExtends = {
+    Node: {
+        getNodeByPath: jest.fn(),
+        getNodePath: jest.fn((node: MockNode) => `/${node.name}`),
+    },
+};
+
+(global as any).cc = {
+    instantiate: mockInstantiate,
+    UITransform: MockUITransform,
+    Node: MockNode,
+};
+
+jest.mock('cc', () => ({
+    Canvas: MockCanvas,
+    CCClass: { getInheritanceChain: jest.fn(() => []) },
+    CCObject: { Flags: { HideInHierarchy: 1, LockedInEditor: 2 } },
+    Component: class Component {},
+    director: { getScene: jest.fn(() => mockScene) },
+    Node: MockNode,
+    Prefab: class Prefab {},
+    Quat: class Quat {},
+    UITransform: MockUITransform,
+    Vec3: class Vec3 {},
+}));
+
+jest.mock('../../scene-process/service/core', () => ({
+    BaseService: class BaseService {
+        emit = jest.fn();
+    },
+    register: () => () => undefined,
+    Service: {
+        Editor: {
+            lock: mockLock,
+            unlock: mockUnlock,
+            getCurrentEditorType: mockGetCurrentEditorType,
+            getRootNode: mockGetRootNode,
+        },
+        Prefab: {
+            removePrefabInfoFromNode: mockRemovePrefabInfoFromNode,
+        },
+        Undo: {
+            push: jest.fn(),
+        },
+    },
+}));
+
+jest.mock('../../scene-process/rpc', () => ({
+    Rpc: { getInstance: () => ({ request: mockRpcRequest }) },
+}));
+
+jest.mock('../../scene-process/service/node/node-create', () => ({
+    createNodeByAsset: mockCreateNodeByAsset,
+    createShouldHideInHierarchyCanvasNode: mockCreateShouldHideInHierarchyCanvasNode,
+    loadAny: mockLoadAny,
+    queryCanvasRequiredByAsset: mockQueryCanvasRequiredByAsset,
+}));
+
+jest.mock('../../scene-process/service/node/node-utils', () => ({
+    getUICanvasNode: mockGetUICanvasNode,
+    getUITransformParentNode: mockGetUITransformParentNode,
+    hasOneKindOfComponent: (node: MockNode, kind: any) => node.components.some(component => component instanceof kind),
+    setLayer: jest.fn(),
+}));
+
+jest.mock('../../scene-process/service/node/node-undo', () => ({
+    NodeUndoHelper: jest.fn().mockImplementation(() => ({
+        shouldRecordStructureCommand: jest.fn(() => false),
+        collectSceneNodeUuids: jest.fn(() => new Set()),
+        getCreateRootPath: jest.fn(() => null),
+        recordCreateNodeCommand: jest.fn(),
+    })),
+}));
+
+jest.mock('../../scene-process/service/node/index', () => ({
+    __esModule: true,
+    default: {
+        ensureUITransformComponent: jest.fn((node: MockNode) => node.addComponent('cc.UITransform')),
+    },
+}));
+
+jest.mock('../../scene-process/service/prefab/utils', () => ({
+    prefabUtils: { getPrefabStateInfo: jest.fn(() => ({})) },
+}));
+
+jest.mock('../../scene-process/service/scene/utils', () => ({
+    sceneUtils: {
+        generateNodeDump: jest.fn((node: MockNode) => ({ path: `/${node.name}` })),
+    },
+}));
+
+jest.mock('../../scene-process/service/undo/commands/remove-node-command', () => ({
+    RemoveNodeCommand: {},
+}));
+
+jest.mock('../../scene-process/service/undo/commands/remove-component-command', () => ({
+    RemoveComponentCommand: {},
+}));
+
+jest.mock('../../scene-process/service/animation/property-commit-event', () => ({
+    broadcastAnimationPropertyCommitted: jest.fn(),
+}));
+
+export interface IAnchoredTree {
+    root: MockNode;
+    parent: MockNode;
+    before: MockNode;
+    anchor: MockNode;
+    after: MockNode;
+}
+
+export function createAnchoredTree(parentName?: string, rootName = 'Root'): IAnchoredTree {
+    const root = new MockNode(rootName);
+    const parent = parentName ? new MockNode(parentName) : root;
+    const before = new MockNode('Before');
+    const anchor = new MockNode('Anchor');
+    const after = new MockNode('After');
+    if (parent !== root) {
+        root.addChild(parent);
+    }
+    parent.addChild(before);
+    parent.addChild(anchor);
+    parent.addChild(after);
+    return { root, parent, before, anchor, after };
+}
+
+export function mockNodeAtPath(path: string, node: MockNode): void {
+    (global as any).EditorExtends.Node.getNodeByPath.mockImplementation((candidate: string) =>
+        candidate === path ? node : null,
+    );
+}
+
+export function mockPrefabAsset(nodeName = 'AssetInstance', canvasRequired = false): void {
+    mockRpcRequest.mockImplementation(async (_service: string, method: string) => {
+        if (method === 'queryAssetInfo') {
+            return {
+                uuid: 'asset-uuid',
+                type: 'cc.Prefab',
+                imported: true,
+                invalid: false,
+            };
+        }
+        return undefined;
+    });
+    mockCreateNodeByAsset.mockResolvedValue({
+        node: new MockNode(nodeName),
+        canvasRequired,
+    });
+}
+
+export function resetNodeCreateMocks(): void {
+    jest.clearAllMocks();
+    mockGetCurrentEditorType.mockReturnValue('scene');
+    mockGetRootNode.mockReturnValue(new MockNode('Root'));
+    mockGetUICanvasNode.mockReturnValue(null);
+    mockGetUITransformParentNode.mockReturnValue(null);
+    mockLoadAny.mockResolvedValue({});
+    mockInstantiate.mockImplementation(() => new MockNode('Canvas'));
+    mockQueryCanvasRequiredByAsset.mockResolvedValue(false);
+    mockRpcRequest.mockReset();
+    (global as any).EditorExtends.Node.getNodeByPath.mockReturnValue(null);
+}

--- a/src/core/scene/test/service-core/node-create-test-harness.ts
+++ b/src/core/scene/test/service-core/node-create-test-harness.ts
@@ -11,10 +11,21 @@ export const mockRpcRequest = jest.fn();
 export const mockGetUICanvasNode = jest.fn();
 export const mockGetUITransformParentNode = jest.fn();
 export const mockInstantiate = jest.fn();
+export const mockBaseRemoveNode = jest.fn();
+export const mockRemoveComponent = jest.fn();
+export const mockUndoPush = jest.fn();
+export const mockShouldRecordStructureCommand = jest.fn(() => false);
+export const mockCollectSceneNodeUuids = jest.fn(() => new Set<string>());
+export const mockRecordCreateNodeCommand = jest.fn();
 export const mockScene = { name: 'Scene' };
 
 export class MockCanvas {}
-export class MockUITransform {}
+export class MockUITransform {
+    uuid = 'ui-transform-uuid';
+    isValid = true;
+
+    constructor(public node: MockNode | null = null) {}
+}
 
 export class MockNode {
     uuid: string;
@@ -24,17 +35,24 @@ export class MockNode {
     components: any[] = [];
     layer = 0;
     position = { z: 0 };
+    private _valid = true;
     addChild = jest.fn((node: MockNode) => {
-        this.children.push(node);
-        node.parent = this;
+        node.setParent(this);
     });
     addComponent = jest.fn((component: any) => {
-        const instance = component === 'cc.UITransform' ? new MockUITransform() : new component();
+        const instance = component === 'cc.UITransform' ? new MockUITransform(this) : new component();
         this.components.push(instance);
         return instance;
     });
+    removeComponent = jest.fn((component: MockUITransform) => {
+        this.components = this.components.filter(current => current !== component);
+        component.isValid = false;
+    });
     setPosition = jest.fn();
-    destroy = jest.fn();
+    destroy = jest.fn(() => {
+        this.setParent(null);
+        this._valid = false;
+    });
     setParent = jest.fn((parent: MockNode | null) => {
         if (this.parent) {
             const previousIndex = this.parent.children.indexOf(this);
@@ -46,6 +64,16 @@ export class MockNode {
         if (parent && !parent.children.includes(this)) {
             parent.children.push(this);
         }
+    });
+    setSiblingIndex = jest.fn((siblingIndex: number) => {
+        if (!this.parent) {
+            return;
+        }
+        const currentIndex = this.parent.children.indexOf(this);
+        if (currentIndex >= 0) {
+            this.parent.children.splice(currentIndex, 1);
+        }
+        this.parent.children.splice(siblingIndex, 0, this);
     });
     insertChild = jest.fn((child: MockNode, siblingIndex: number) => {
         child.setParent(this);
@@ -65,7 +93,7 @@ export class MockNode {
     }
 
     get isValid() {
-        return true;
+        return this._valid;
     }
 }
 
@@ -73,6 +101,10 @@ export class MockNode {
     Node: {
         getNodeByPath: jest.fn(),
         getNodePath: jest.fn((node: MockNode) => `/${node.name}`),
+        remove: jest.fn(),
+    },
+    Component: {
+        remove: jest.fn(),
     },
 };
 
@@ -111,7 +143,7 @@ jest.mock('../../scene-process/service/core', () => ({
             removePrefabInfoFromNode: mockRemovePrefabInfoFromNode,
         },
         Undo: {
-            push: jest.fn(),
+            push: mockUndoPush,
         },
     },
 }));
@@ -134,12 +166,19 @@ jest.mock('../../scene-process/service/node/node-utils', () => ({
     setLayer: jest.fn(),
 }));
 
+jest.mock('../../scene-process/service/component/index', () => ({
+    __esModule: true,
+    default: {
+        removeComponent: mockRemoveComponent,
+    },
+}));
+
 jest.mock('../../scene-process/service/node/node-undo', () => ({
     NodeUndoHelper: jest.fn().mockImplementation(() => ({
-        shouldRecordStructureCommand: jest.fn(() => false),
-        collectSceneNodeUuids: jest.fn(() => new Set()),
+        shouldRecordStructureCommand: mockShouldRecordStructureCommand,
+        collectSceneNodeUuids: mockCollectSceneNodeUuids,
         getCreateRootPath: jest.fn(() => null),
-        recordCreateNodeCommand: jest.fn(),
+        recordCreateNodeCommand: mockRecordCreateNodeCommand,
     })),
 }));
 
@@ -147,6 +186,7 @@ jest.mock('../../scene-process/service/node/index', () => ({
     __esModule: true,
     default: {
         ensureUITransformComponent: jest.fn((node: MockNode) => node.addComponent('cc.UITransform')),
+        baseRemoveNode: mockBaseRemoveNode,
     },
 }));
 
@@ -229,5 +269,12 @@ export function resetNodeCreateMocks(): void {
     mockInstantiate.mockImplementation(() => new MockNode('Canvas'));
     mockQueryCanvasRequiredByAsset.mockResolvedValue(false);
     mockRpcRequest.mockReset();
+    mockShouldRecordStructureCommand.mockReturnValue(false);
+    mockCollectSceneNodeUuids.mockReturnValue(new Set());
+    mockRemoveComponent.mockImplementation((component: MockUITransform) => {
+        component.node?.removeComponent(component);
+        return true;
+    });
+    mockBaseRemoveNode.mockImplementation((node: MockNode) => node.destroy());
     (global as any).EditorExtends.Node.getNodeByPath.mockReturnValue(null);
 }

--- a/src/core/scene/test/service-core/prefab-canvas-mutation.test.ts
+++ b/src/core/scene/test/service-core/prefab-canvas-mutation.test.ts
@@ -1,0 +1,177 @@
+const mockRemoveComponent = jest.fn();
+const mockBaseRemoveNode = jest.fn();
+
+class MockComponent {
+    uuid = 'ui-transform-uuid';
+    isValid = true;
+
+    constructor(public node: MockNode) {}
+}
+
+class MockNode {
+    uuid: string;
+    parent: MockNode | null = null;
+    children: MockNode[] = [];
+    components: MockComponent[] = [];
+    isValid = true;
+
+    constructor(public name: string) {
+        this.uuid = `${name}-uuid`;
+    }
+
+    addChild(node: MockNode): void {
+        node.setParent(this);
+    }
+
+    setParent(parent: MockNode | null): void {
+        if (this.parent) {
+            this.parent.children = this.parent.children.filter(child => child !== this);
+        }
+        this.parent = parent;
+        if (parent && !parent.children.includes(this)) {
+            parent.children.push(this);
+        }
+    }
+
+    setSiblingIndex(index: number): void {
+        if (!this.parent) {
+            return;
+        }
+        this.parent.children = this.parent.children.filter(child => child !== this);
+        this.parent.children.splice(index, 0, this);
+    }
+}
+
+const removedNodeUuids: string[] = [];
+const removedComponentUuids: string[] = [];
+
+(global as any).EditorExtends = {
+    Node: {
+        remove: jest.fn((uuid: string) => removedNodeUuids.push(uuid)),
+    },
+    Component: {
+        remove: jest.fn((uuid: string) => removedComponentUuids.push(uuid)),
+    },
+};
+
+(global as any).cc = { EditorExtends: (global as any).EditorExtends };
+
+jest.mock('cc', () => ({
+    Component: MockComponent,
+    Node: MockNode,
+}));
+
+jest.mock('../../scene-process/service/node/index', () => ({
+    __esModule: true,
+    default: { baseRemoveNode: mockBaseRemoveNode },
+}));
+
+import {
+    createPendingPrefabCanvasMutation,
+    type IPrefabCanvasMutationEffects,
+    type IPrefabCanvasUndoRecord,
+} from '../../scene-process/service/node/prefab-canvas-mutation';
+
+function createEffects(commitRecord = jest.fn()): IPrefabCanvasMutationEffects {
+    return {
+        commitRecord,
+        removeAddedUITransform: mockRemoveComponent,
+    };
+}
+
+function createMutationFixture(previewCanvasCreated: boolean) {
+    const host = new MockNode('Host');
+    const before = new MockNode('Before');
+    const root = new MockNode('PrefabRoot');
+    const after = new MockNode('After');
+    const preview = new MockNode('PreviewCanvas');
+    host.addChild(before);
+    host.addChild(root);
+    host.addChild(after);
+    const originalIndex = host.children.indexOf(root);
+    const uiTransform = new MockComponent(root);
+    root.components.push(uiTransform);
+    preview.addChild(root);
+
+    const record: IPrefabCanvasUndoRecord = {
+        rootNode: root as any,
+        rootParent: host as any,
+        rootParentUuid: host.uuid,
+        rootParentPath: '/Host',
+        rootSiblingIndex: originalIndex,
+        addedUITransform: uiTransform as any,
+        previewCanvasNode: preview as any,
+        previewCanvasCreated,
+        workMode: '2d',
+    };
+    return { host, before, root, after, preview, uiTransform, record };
+}
+
+describe('Prefab Canvas mutation', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        removedNodeUuids.length = 0;
+        removedComponentUuids.length = 0;
+        mockRemoveComponent.mockImplementation((component: MockComponent) => {
+            component.node.components = component.node.components.filter(current => current !== component);
+            component.isValid = false;
+            return true;
+        });
+        mockBaseRemoveNode.mockImplementation((node: MockNode) => {
+            node.setParent(null);
+            node.isValid = false;
+        });
+    });
+
+    it('restores the Prefab root and removes changes owned by a failed mutation', () => {
+        const { host, before, root, after, preview, uiTransform, record } = createMutationFixture(true);
+        const commitRecord = jest.fn();
+        const mutation = createPendingPrefabCanvasMutation(record, createEffects(commitRecord));
+
+        mutation.rollback();
+
+        expect(root.parent).toBe(host);
+        expect(host.children).toEqual([before, root, after]);
+        expect(preview.isValid).toBe(false);
+        expect(uiTransform.isValid).toBe(false);
+        expect(removedNodeUuids).toContain(preview.uuid);
+        expect(commitRecord).not.toHaveBeenCalled();
+    });
+
+    it('keeps a preview Canvas that existed before the mutation', () => {
+        const { host, root, preview, record } = createMutationFixture(false);
+        const mutation = createPendingPrefabCanvasMutation(record, createEffects());
+
+        mutation.rollback();
+
+        expect(root.parent).toBe(host);
+        expect(preview.isValid).toBe(true);
+        expect(mockBaseRemoveNode).not.toHaveBeenCalled();
+    });
+
+    it('commits its Undo record exactly once', () => {
+        const { record } = createMutationFixture(true);
+        const commitRecord = jest.fn();
+        const mutation = createPendingPrefabCanvasMutation(record, createEffects(commitRecord));
+
+        mutation.commit();
+        mutation.commit();
+
+        expect(commitRecord).toHaveBeenCalledTimes(1);
+        expect(commitRecord).toHaveBeenCalledWith(record);
+        expect(() => mutation.rollback()).toThrow('committed');
+    });
+
+    it('attempts every cleanup step when restoring the root fails', () => {
+        const { root, preview, uiTransform, record } = createMutationFixture(true);
+        root.setSiblingIndex = jest.fn(() => {
+            throw new Error('restore failed');
+        });
+        const mutation = createPendingPrefabCanvasMutation(record, createEffects());
+
+        expect(() => mutation.rollback()).toThrow(AggregateError);
+
+        expect(preview.isValid).toBe(false);
+        expect(uiTransform.isValid).toBe(false);
+    });
+});


### PR DESCRIPTION
This pull request introduces support for anchored node creation in the scene graph, allowing new nodes to be inserted before or after a specified sibling node rather than only as children of a parent. It also refactors Prefab Canvas mutation logic for better maintainability and adds comprehensive tests for the new anchored creation and asset preflight behaviors.

**Anchored Node Creation Support:**

* Added an optional `insertSide` parameter to node creation APIs and types (`IBaseCreateNodeParams`) to specify insertion before or after a sibling anchor, with updated descriptions and validation in both type definitions and schema validation (`src/api/scene/node-schema.ts`, `src/core/scene/common/node.ts`, `packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap`). [[1]](diffhunk://#diff-a8348e31674835a05155d991b06289ab32594d5ea8f97984df20bd3ddb354d1dR6448) [[2]](diffhunk://#diff-13ecf35482d2ef3295a4fe8b65be6d8d999d9caf486f844cc00d6bf00292eebdL86-R87) [[3]](diffhunk://#diff-392a2cb831f7d167643e94322ac302ab0b38750a970cb232024d00a267bbc94aR237-R246)

**Prefab Canvas Mutation Refactor:**

* Extracted Prefab Canvas mutation logic into a new module (`prefab-canvas-mutation.ts`), providing clear commit/rollback semantics and utility functions for restoring node hierarchy and unregistering editor nodes. This logic is now reused in undo commands (`prefab-preview-canvas-command.ts`). [[1]](diffhunk://#diff-8aee88b705eb2c218ef16be6eeb06331edbfc85bec5e19fcc557ea2021bce6edR1-R126) [[2]](diffhunk://#diff-905f6fc50d23b0eed9157e7eed4b299bf37cec40867b54b70db7220e72bcf7daL3-L8) [[3]](diffhunk://#diff-905f6fc50d23b0eed9157e7eed4b299bf37cec40867b54b70db7220e72bcf7daL56-R59) [[4]](diffhunk://#diff-905f6fc50d23b0eed9157e7eed4b299bf37cec40867b54b70db7220e72bcf7daL137-L159)

**Testing Enhancements:**

* Added extensive tests for anchored node creation, covering correct sibling insertion, fallback to parent append, error handling for missing anchors, preflight token validation, and anchor replacement scenarios (`node-create-anchored.test.ts`).
* Added tests for asset creation preflight, verifying rejection on asset target mutation, Canvas requirement mismatches, and correct asset instantiation (`node-create-asset-preflight.test.ts`).

**Dependency and Import Cleanups:**

* Updated imports to use correct `DefaultEventsMap` type from `socket.io` to fix type resolution issues (`reflection-probe-renderer.ts`).

These changes collectively improve the flexibility and reliability of node creation in the scene editor, and ensure robust handling of edge cases through comprehensive testing.