### PR TITLE
[break] feat(terrain): add default layer creation and paint falloff

### DIFF
--- a/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
+++ b/packages/cocos-cli-types/__tests__/__snapshots__/dts-snapshot.test.ts.snap
@@ -5707,7 +5707,8 @@ export { }
 `;
 
 exports[`DTS API compatibility cli.d.ts should match snapshot 1`] = `
-"import type { Component } from 'cc';
+"import type { Camera } from 'cc';
+import type { Component } from 'cc';
 import type { Node as Node_2 } from 'cc';
 import type { Scene } from 'cc';
 import type { Terrain } from 'cc';
@@ -6494,6 +6495,7 @@ export declare interface ICameraService {
     setGridColor(color: number[], persist?: boolean): void;
     setOriginAxes2D(config: IOriginAxesConfig): void;
     setOriginAxes3D(config: IOriginAxesConfig): void;
+    getCamera(): Camera | undefined;
     onUpdate(deltaTime: number): void;
 }
 export declare interface IChangeNodeLockParams {
@@ -7421,11 +7423,17 @@ export declare interface ITerrainManageState {
     lightMapSize: number;
     blockCount: [number, number];
 }
+export declare interface ITerrainPaintBrushPatch extends ITerrainBrushPatch {
+    falloff?: number;
+}
+export declare interface ITerrainPaintBrushState extends ITerrainBrushState {
+    falloff: number;
+}
 export declare interface ITerrainPaintSessionPatch {
-    brush?: ITerrainBrushPatch;
+    brush?: ITerrainPaintBrushPatch;
 }
 export declare interface ITerrainPaintState {
-    brush: ITerrainBrushState;
+    brush: ITerrainPaintBrushState;
 }
 export declare interface ITerrainSculptSessionPatch {
     tool?: TerrainSculptTool;
@@ -7456,7 +7464,7 @@ export declare interface ITerrainService {
     setPaintBrushAsset(target: ITerrainTarget, assetUuid: string | null): Promise<TerrainReadResult>;
     setPaintSession(target: ITerrainTarget, patch: ITerrainPaintSessionPatch): TerrainReadResult;
     saveManage(target: ITerrainTarget, manage: ITerrainManageState): Promise<TerrainReadResult>;
-    addLayer(target: ITerrainTarget, layer: ITerrainLayerState): Promise<TerrainReadResult>;
+    addLayer(target: ITerrainTarget, layer?: ITerrainLayerState): Promise<TerrainReadResult>;
     removeLayer(target: ITerrainTarget, index: number): Promise<TerrainReadResult>;
     updateLayer(target: ITerrainTarget, index: number, patch: ITerrainLayerPatch): Promise<TerrainReadResult>;
     readBlock(target: ITerrainTarget): TerrainBlockReadResult;

--- a/src/core/scene/common/camera.ts
+++ b/src/core/scene/common/camera.ts
@@ -1,4 +1,4 @@
-import type { Vec3 } from 'cc';
+import type { Camera, Vec3 } from 'cc';
 import type { ICameraConfig, IOriginAxesConfig } from '../scene-configs';
 
 export type { ICameraConfig, IOriginAxesConfig };
@@ -26,6 +26,8 @@ export interface ICameraService {
     setGridColor(color: number[], persist?: boolean): void;
     setOriginAxes2D(config: IOriginAxesConfig): void;
     setOriginAxes3D(config: IOriginAxesConfig): void;
+    /** Returns the editor camera when it has been created for the active Scene. */
+    getCamera(): Camera | undefined;
     onUpdate(deltaTime: number): void;
 }
 

--- a/src/core/scene/common/terrain.ts
+++ b/src/core/scene/common/terrain.ts
@@ -1,5 +1,13 @@
 import type { Terrain } from 'cc';
 
+/** Runtime fields installed by the Scene Terrain service on engine Terrain components. */
+declare module 'cc' {
+    interface Terrain {
+        manager?: ITerrainService | null;
+        isTerrainChange?: boolean;
+    }
+}
+
 /** Identifies one Terrain component without relying on the active gizmo selection. */
 export interface ITerrainTarget {
     nodeUuid: string;
@@ -49,6 +57,11 @@ export interface ITerrainBrushState {
     setHeight: number;
 }
 
+/** JSON-safe Paint brush state. Falloff belongs to the Paint circle brush only. */
+export interface ITerrainPaintBrushState extends ITerrainBrushState {
+    falloff: number;
+}
+
 /** Canonical Sculpt session state for a valid Terrain target. */
 export interface ITerrainSculptState {
     tool: TerrainSculptTool;
@@ -57,7 +70,7 @@ export interface ITerrainSculptState {
 
 /** Canonical Paint session state for a valid Terrain target. */
 export interface ITerrainPaintState {
-    brush: ITerrainBrushState;
+    brush: ITerrainPaintBrushState;
 }
 
 /** The canonical editor-session state for one valid Terrain target. */
@@ -87,12 +100,32 @@ export interface ITerrainInvalidSnapshot {
 /** Discriminated read result. Callers must replace cached state when `valid` is `false`. */
 export type TerrainReadResult = ITerrainSnapshot | ITerrainInvalidSnapshot;
 
+/** Stable codes for internal Terrain layer authoring failures. */
+export type TerrainLayerErrorCode = 'DEFAULT_DETAIL_MAP_UNAVAILABLE';
+
+/** Reports an internal Terrain layer authoring failure without mutating the selected target. */
+export class TerrainLayerError extends Error {
+    constructor(
+        readonly code: TerrainLayerErrorCode,
+        message: string,
+        options?: ErrorOptions,
+    ) {
+        super(message, options);
+        this.name = 'TerrainLayerError';
+    }
+}
+
 /** A partial, non-asset numeric brush-session update. Brush image selection is controlled by dedicated asset commands. */
 export interface ITerrainBrushPatch {
     radius?: number;
     strength?: number;
     rotation?: number;
     setHeight?: number;
+}
+
+/** A partial Paint brush update. Falloff is constrained to the inclusive [0, 1] range by TerrainService. */
+export interface ITerrainPaintBrushPatch extends ITerrainBrushPatch {
+    falloff?: number;
 }
 
 /** A partial Sculpt session update that does not assign brush assets or create Scene Undo entries. */
@@ -103,7 +136,7 @@ export interface ITerrainSculptSessionPatch {
 
 /** A partial Paint session update that does not assign brush assets or create Scene Undo entries. */
 export interface ITerrainPaintSessionPatch {
-    brush?: ITerrainBrushPatch;
+    brush?: ITerrainPaintBrushPatch;
 }
 
 /** One Terrain layer assigned to an RGBA channel in a selected Terrain block. */
@@ -180,8 +213,8 @@ export interface ITerrainService {
     setPaintSession(target: ITerrainTarget, patch: ITerrainPaintSessionPatch): TerrainReadResult;
     /** Commits a complete Manage draft as one TerrainInfo/Undo mutation. */
     saveManage(target: ITerrainTarget, manage: ITerrainManageState): Promise<TerrainReadResult>;
-    /** Adds a fully specified Terrain layer; `detailMapUuid` must identify a compatible Texture2D. */
-    addLayer(target: ITerrainTarget, layer: ITerrainLayerState): Promise<TerrainReadResult>;
+    /** Adds a complete layer, or uses the CLI-owned built-in texture and material defaults when omitted. */
+    addLayer(target: ITerrainTarget, layer?: ITerrainLayerState): Promise<TerrainReadResult>;
     /** Removes one Terrain layer slot and returns the authoritative state. */
     removeLayer(target: ITerrainTarget, index: number): Promise<TerrainReadResult>;
     /** Applies one explicit layer patch and returns the authoritative state. */

--- a/src/core/scene/scene-process/service/camera.ts
+++ b/src/core/scene/scene-process/service/camera.ts
@@ -19,7 +19,7 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
     private _controller2D!: CameraController2D;
     private _controller3D!: CameraController3D;
     private _controller!: CameraControllerBase;
-    private _camera!: EditorCameraComponent;
+    private _camera?: EditorCameraComponent;
     private _controllerFirstChange = false;
     private _currentUuid = '';
     private _cameraInfos: Record<string, any> = {};
@@ -361,22 +361,23 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
     }
 
     setCameraProperty(options: any, persist = true): void {
-        if (typeof options !== 'object' || !this._camera) return;
+        const camera = this._camera;
+        if (typeof options !== 'object' || !camera) return;
         Object.keys(options).forEach((key) => {
             if (options[key] == null) return;
             if (key === 'clearColor') {
-                this._camera[key] = cc.color(
+                camera[key] = cc.color(
                     options[key][0], options[key][1],
                     options[key][2], options[key][3],
                 );
             } else if (key === 'near' || key === 'far') {
                 (this._controller as any)[key] = options[key];
-                (this._camera as any)[key] = options[key];
+                (camera as any)[key] = options[key];
             } else if (key === 'fov') {
                 this.emit('camera:fov-changed', options[key]);
-                (this._camera as any)[key] = options[key];
+                (camera as any)[key] = options[key];
             } else {
-                (this._camera as any)[key] = options[key];
+                (camera as any)[key] = options[key];
             }
         });
         Service.Engine.repaintInEditMode();
@@ -465,7 +466,7 @@ export class CameraService extends BaseService<ICameraEvents> implements ICamera
         this._controller?.refresh();
     }
 
-    getCamera() {
+    getCamera(): Camera | undefined {
         return this._camera;
     }
 

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/gizmo-persistent.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/gizmo-persistent.ts
@@ -10,7 +10,7 @@ import type TerrainGizmo from './gizmo-select';
 export default class TerrainPersistentGizmo extends GizmoBase<Terrain> {
     private _controller!: TerrainController;
     private get selectGizmo(): TerrainGizmo | null {
-        return this.target ? Service.Gizmo.getComponentGizmo(this.target) as TerrainGizmo | null : null;
+        return this.target ? (Service.Gizmo.getComponentGizmo(this.target) as TerrainGizmo | null) : null;
     }
     protected init() {
         this._controller = new TerrainController(this.getGizmoRoot());
@@ -22,23 +22,43 @@ export default class TerrainPersistentGizmo extends GizmoBase<Terrain> {
     }
     private updateController() {
         if (!this._controller) return;
-        if (!this.target) { this._controller.hide(); return; }
+        if (!this.target) {
+            this._controller.hide();
+            return;
+        }
         this._controller.updateWorldPosition(this.target.node.getWorldPosition());
         const info = this.target.info;
         this._controller.updateSize(info.size.width, info.size.height);
-        this._controller.show(); Service.Engine.repaintInEditMode();
+        this._controller.show();
+        Service.Engine.repaintInEditMode();
     }
-    public onTargetUpdate() { this.updateController(); }
-    public onNodeChanged() { this.updateController(); }
+    public onTargetUpdate() {
+        this.updateController();
+    }
+    public onNodeChanged() {
+        this.updateController();
+    }
     onControllerMouseDown(event: GizmoMouseEvent) {
         if (!this.target) return;
         const path = getEditorNodePath(this.target.node);
         if (Service.Selection.query()[0] !== path) {
-            event.propagationStopped = true; Service.Selection.select(path); return;
+            event.propagationStopped = true;
+            Service.Selection.select(path);
+            return;
         }
-        const gizmo = this.selectGizmo; if (gizmo?.visible()) gizmo.onControllerMouseDown(event);
+        const gizmo = this.selectGizmo;
+        if (gizmo?.visible()) gizmo.onControllerMouseDown(event);
     }
-    onControllerMouseMove(event: GizmoMouseEvent) { const gizmo = this.selectGizmo; if (gizmo?.visible()) gizmo.onControllerMouseMove(event); }
-    onControllerMouseUp(event: GizmoMouseEvent) { const gizmo = this.selectGizmo; if (gizmo?.visible()) gizmo.onControllerMouseUp(event); }
-    onControllerHoverOut() { const gizmo = this.selectGizmo; if (gizmo?.visible()) gizmo.onControllerHoverOut(); }
+    onControllerMouseMove(event: GizmoMouseEvent) {
+        const gizmo = this.selectGizmo;
+        if (gizmo?.visible()) gizmo.onControllerMouseMove(event);
+    }
+    onControllerMouseUp(event: GizmoMouseEvent) {
+        const gizmo = this.selectGizmo;
+        if (gizmo?.visible()) gizmo.onControllerMouseUp(event);
+    }
+    onControllerHoverOut() {
+        const gizmo = this.selectGizmo;
+        if (gizmo?.visible()) gizmo.onControllerHoverOut();
+    }
 }

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/gizmo-select.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/gizmo-select.ts
@@ -6,7 +6,7 @@ import GizmoBase from '../../base/gizmo-base';
 import { TerrainEditor } from './terrain-editor';
 import { TerrainEditorPaint } from './terrain-editor-paint';
 import { TerrainEditorSculpt } from './terrain-editor-sculpt';
-import { eTerrainEditorMode } from './terrain-editor-mode';
+import { TerrainEditorModeType } from './terrain-editor-mode';
 import { TerrainBrushType, TerrainCircleBrush, TerrainImageBrush } from './terrain-brush';
 import type {
     ITerrainBlockData,
@@ -22,12 +22,39 @@ import type {
 import type { GizmoMouseEvent } from '../../utils/defines';
 import type { ISceneKeyboardEvent } from '../../../operation/types';
 
-interface IBrush { radius: number; strength: number; _setHeight: number; }
-interface IPaintBrush extends IBrush { falloff: number; }
-interface IBrushSetting { radius?: number; strength?: number; _setHeight?: number; _rotation?: number; falloff?: number; }
-interface ITerrainLayerValue { tileSize?: number; metallic?: number; roughness?: number; normalMap?: string | null; }
-interface ITerrainEditModeOption { isSculptDown?: boolean; isSmooth?: boolean; isFlatten?: boolean; isSetHeight?: boolean; }
-interface ITerrainInfo { tileSize: number; weightMapSize: number; lightMapSize: number; blockCount: [number, number]; }
+interface IBrush {
+    radius: number;
+    strength: number;
+    _setHeight: number;
+}
+interface IPaintBrush extends IBrush {
+    falloff: number;
+}
+interface IBrushSetting {
+    radius?: number;
+    strength?: number;
+    _setHeight?: number;
+    _rotation?: number;
+    falloff?: number;
+}
+interface ITerrainLayerValue {
+    tileSize?: number;
+    metallic?: number;
+    roughness?: number;
+    normalMap?: string | null;
+}
+interface ITerrainEditModeOption {
+    isSculptDown?: boolean;
+    isSmooth?: boolean;
+    isFlatten?: boolean;
+    isSetHeight?: boolean;
+}
+interface ITerrainInfo {
+    tileSize: number;
+    weightMapSize: number;
+    lightMapSize: number;
+    blockCount: [number, number];
+}
 
 /** Component gizmo containing all Terrain editing operations. */
 export default class TerrainGizmo extends GizmoBase<Terrain> {
@@ -39,15 +66,32 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
     private _isFlatten = false;
     private _isSetHeight = false;
 
-    public get editor() { return this._editor; }
-    public get isConcave() { return this._isConcave; }
-    public get isSmooth() { return this._isSmooth; }
-    public get isFlatten() { return this._isFlatten; }
-    public get isSetHeight() { return this._isSetHeight; }
-    public applySmooth(value: boolean) { this._isSmooth = value; }
-    public get isTerrainChange() { return !!this.target && Service.Terrain.isTerrainChange; }
+    public get editor() {
+        return this._editor;
+    }
+    public get isConcave() {
+        return this._isConcave;
+    }
+    public get isSmooth() {
+        return this._isSmooth;
+    }
+    public get isFlatten() {
+        return this._isFlatten;
+    }
+    public get isSetHeight() {
+        return this._isSetHeight;
+    }
+    public applySmooth(value: boolean) {
+        this._isSmooth = value;
+    }
+    public get isTerrainChange() {
+        return !!this.target && Service.Terrain.isTerrainChange;
+    }
     public set isTerrainChange(value: boolean) {
-        if (this.target) { this.target.manager = Service.Terrain; this.target.isTerrainChange = value; }
+        if (this.target) {
+            this.target.manager = Service.Terrain;
+            this.target.isTerrainChange = value;
+        }
         if (value && this.target) Service.Terrain.select(this.target.node.uuid);
     }
 
@@ -55,11 +99,15 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
         this._editor = new TerrainEditor(Service.Camera.getCamera() ?? null, this);
     }
     protected onShow() {
-        this.registerCameraMovedEvent(); this.initEditor(); this._editor.updateBlockDepthOffset();
+        this.registerCameraMovedEvent();
+        this.initEditor();
+        this._editor.updateBlockDepthOffset();
     }
     protected onHide() {
-        this._isEditorInit = false; this.unregisterCameraMoveEvent();
-        this._editor?.clearBrush(); this._editor?.setEditTerrain(null); this._editor?.setCurrentLayer(0);
+        this._isEditorInit = false;
+        this.unregisterCameraMoveEvent();
+        this._editor?.setEditTerrain(null);
+        this._editor?.setCurrentLayer(0);
         Service.Engine.repaintInEditMode();
     }
     public onTargetUpdate() {
@@ -71,8 +119,12 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
         }
         if (this._isInitialized) this.initEditor();
     }
-    public onNodeChanged() { if (this._isInitialized) this.initEditor(); }
-    public onEditorCameraMoved() { this._editor?.updateBlockDepthOffset(); }
+    public onNodeChanged() {
+        if (this._isInitialized) this.initEditor();
+    }
+    public onEditorCameraMoved() {
+        this._editor?.updateBlockDepthOffset();
+    }
     private initEditor() {
         const target = this.target;
         if (!target || !this._editor) {
@@ -90,7 +142,12 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
      * instead of exposing this gizmo or its editor internals to Scene callers.
      */
     public readTerrainState(): ITerrainEditorState {
-        const info = this.queryTerrainInfo() ?? { tileSize: 0, weightMapSize: 0, lightMapSize: 0, blockCount: [0, 0] as [number, number] };
+        const info = this.queryTerrainInfo() ?? {
+            tileSize: 0,
+            weightMapSize: 0,
+            lightMapSize: 0,
+            blockCount: [0, 0] as [number, number],
+        };
         return {
             manage: {
                 tileSize: info.tileSize,
@@ -98,18 +155,22 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
                 lightMapSize: info.lightMapSize,
                 blockCount: [info.blockCount[0] ?? 0, info.blockCount[1] ?? 0],
             },
-            layers: this.getLayers().map((layer) => layer ? ({
-                detailMapUuid: layer.detailMap,
-                normalMapUuid: layer.normalMap,
-                metallic: layer.metallic,
-                roughness: layer.roughness,
-                tileSize: layer.tileSize,
-            }) : null),
+            layers: this.getLayers().map(layer =>
+                layer
+                    ? {
+                          detailMapUuid: layer.detailMap,
+                          normalMapUuid: layer.normalMap,
+                          metallic: layer.metallic,
+                          roughness: layer.roughness,
+                          tileSize: layer.tileSize,
+                      }
+                    : null,
+            ),
             mode: this.getTerrainMode(),
             currentLayer: this._editor.getCurrentLayer(),
             sculpt: {
                 tool: this.getTerrainSculptTool(),
-                brush: this.getTerrainBrushState(eTerrainEditorMode.SCULPT),
+                brush: this.getTerrainBrushState(TerrainEditorModeType.SCULPT),
             },
             paint: {
                 brush: this.getTerrainPaintBrushState(),
@@ -118,11 +179,11 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
     }
 
     public setTerrainMode(mode: TerrainEditorMode): void {
-        const internalMode: Record<TerrainEditorMode, eTerrainEditorMode> = {
-            manage: eTerrainEditorMode.MANAGE,
-            sculpt: eTerrainEditorMode.SCULPT,
-            paint: eTerrainEditorMode.PAINT,
-            block: eTerrainEditorMode.SELECT,
+        const internalMode: Record<TerrainEditorMode, TerrainEditorModeType> = {
+            manage: TerrainEditorModeType.MANAGE,
+            sculpt: TerrainEditorModeType.SCULPT,
+            paint: TerrainEditorModeType.PAINT,
+            block: TerrainEditorModeType.SELECT,
         };
         this._editor.setMode(internalMode[mode]);
         Service.Engine.repaintInEditMode();
@@ -137,40 +198,47 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
 
     public updateTerrainSculptSession(patch: ITerrainSculptSessionPatch): void {
         if (patch.tool) this.setTerrainSculptTool(patch.tool);
-        if (patch.brush) this.updateTerrainBrush(eTerrainEditorMode.SCULPT, patch.brush);
+        if (patch.brush) this.updateTerrainBrush(TerrainEditorModeType.SCULPT, patch.brush);
         Service.Engine.repaintInEditMode();
     }
 
     public updateTerrainPaintSession(patch: ITerrainPaintSessionPatch): void {
         if (patch.brush) {
-            this.updateTerrainBrush(eTerrainEditorMode.PAINT, patch.brush);
-            if (typeof patch.brush.falloff === 'number') this.getTerrainCircleBrush(eTerrainEditorMode.PAINT).setFalloff(patch.brush.falloff);
+            this.updateTerrainBrush(TerrainEditorModeType.PAINT, patch.brush);
+            if (typeof patch.brush.falloff === 'number')
+                this.getTerrainCircleBrush(TerrainEditorModeType.PAINT).setFalloff(patch.brush.falloff);
         }
         Service.Engine.repaintInEditMode();
     }
 
     public readTerrainBlock(): ITerrainBlockData | null {
-        const select = this._editor.getMode(eTerrainEditorMode.SELECT);
+        const select = this._editor.getMode(TerrainEditorModeType.SELECT);
         const index = select.getCurrentBlockIndex();
         if (!index) return null;
         const weight = select.getCurrentWeightData();
         return {
             index: { x: index[0], y: index[1] },
             layers: select.getCurrentBlockLayerSlots(),
-            weight: weight ? {
-                width: weight.width,
-                height: weight.height,
-                data: new Uint8Array(weight.data),
-            } : null,
+            weight: weight
+                ? {
+                      width: weight.width,
+                      height: weight.height,
+                      data: new Uint8Array(weight.data),
+                  }
+                : null,
         };
     }
 
     private getTerrainMode(): TerrainEditorMode {
         switch (this._editor.getCurrentModeType()) {
-            case eTerrainEditorMode.MANAGE: return 'manage';
-            case eTerrainEditorMode.SCULPT: return 'sculpt';
-            case eTerrainEditorMode.PAINT: return 'paint';
-            default: return 'block';
+            case TerrainEditorModeType.MANAGE:
+                return 'manage';
+            case TerrainEditorModeType.SCULPT:
+                return 'sculpt';
+            case TerrainEditorModeType.PAINT:
+                return 'paint';
+            default:
+                return 'block';
         }
     }
 
@@ -189,7 +257,7 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
         this._isSetHeight = tool === 'set-height';
     }
 
-    private getTerrainBrushState(mode: eTerrainEditorMode.SCULPT | eTerrainEditorMode.PAINT): ITerrainBrushState {
+    private getTerrainBrushState(mode: TerrainEditorModeType.SCULPT | TerrainEditorModeType.PAINT): ITerrainBrushState {
         const editor = this.getTerrainBrushEditor(mode);
         const brush = editor.getCurrentBrush();
         const image = editor.getBrush(TerrainBrushType.IMAGE) as TerrainImageBrush;
@@ -206,12 +274,15 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
     /** Paint falloff is retained by the circle brush even while an image brush is selected. */
     private getTerrainPaintBrushState(): ITerrainPaintBrushState {
         return {
-            ...this.getTerrainBrushState(eTerrainEditorMode.PAINT),
-            falloff: this.getTerrainCircleBrush(eTerrainEditorMode.PAINT).getFalloff(),
+            ...this.getTerrainBrushState(TerrainEditorModeType.PAINT),
+            falloff: this.getTerrainCircleBrush(TerrainEditorModeType.PAINT).getFalloff(),
         };
     }
 
-    private updateTerrainBrush(mode: eTerrainEditorMode.SCULPT | eTerrainEditorMode.PAINT, patch: ITerrainBrushPatch): void {
+    private updateTerrainBrush(
+        mode: TerrainEditorModeType.SCULPT | TerrainEditorModeType.PAINT,
+        patch: ITerrainBrushPatch,
+    ): void {
         const editor = this.getTerrainBrushEditor(mode);
         const image = editor.getBrush(TerrainBrushType.IMAGE) as TerrainImageBrush;
         const brush = editor.getCurrentBrush();
@@ -221,125 +292,202 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
         if (typeof patch.setHeight === 'number') brush._setHeight = patch.setHeight;
     }
 
-    private getTerrainBrushEditor(mode: eTerrainEditorMode.SCULPT | eTerrainEditorMode.PAINT): TerrainEditorSculpt | TerrainEditorPaint {
-        return mode === eTerrainEditorMode.SCULPT
-            ? this._editor.getMode(eTerrainEditorMode.SCULPT)
-            : this._editor.getMode(eTerrainEditorMode.PAINT);
+    private getTerrainBrushEditor(
+        mode: TerrainEditorModeType.SCULPT | TerrainEditorModeType.PAINT,
+    ): TerrainEditorSculpt | TerrainEditorPaint {
+        return mode === TerrainEditorModeType.SCULPT
+            ? this._editor.getMode(TerrainEditorModeType.SCULPT)
+            : this._editor.getMode(TerrainEditorModeType.PAINT);
     }
 
-    private getTerrainCircleBrush(mode: eTerrainEditorMode.SCULPT | eTerrainEditorMode.PAINT): TerrainCircleBrush {
+    private getTerrainCircleBrush(
+        mode: TerrainEditorModeType.SCULPT | TerrainEditorModeType.PAINT,
+    ): TerrainCircleBrush {
         return this.getTerrainBrushEditor(mode).getBrush(TerrainBrushType.CIRCLE) as TerrainCircleBrush;
     }
 
     async addLayerByUuid(uuid: string) {
         if (!this.target) return -1;
         const texture = await loadAny<Texture2D>(uuid);
-        const layer = new TerrainLayer(); layer.detailMap = texture; layer.tileSize = 1;
-        const index = this.target.addLayer(layer); this.updateTerrainAsset(); this.isTerrainChange = true; this.emitNodeChange();
-        Service.Engine.repaintInEditMode(); return index;
+        const layer = new TerrainLayer();
+        layer.detailMap = texture;
+        layer.tileSize = 1;
+        const index = this.target.addLayer(layer);
+        this.updateTerrainAsset();
+        this.isTerrainChange = true;
+        this.emitNodeChange();
+        Service.Engine.repaintInEditMode();
+        return index;
     }
 
     /** Applies a service-validated Sculpt brush texture without changing Terrain asset state. */
     public setSculptBrushTexture(texture: Texture2D | null): void {
-        const sculpt = this.getTerrainBrushEditor(eTerrainEditorMode.SCULPT);
+        const sculpt = this.getTerrainBrushEditor(TerrainEditorModeType.SCULPT);
         sculpt.setBrushImage(texture);
         Service.Engine.repaintInEditMode();
     }
 
     /** Applies a service-validated Paint brush texture without changing Terrain asset state. */
     public setPaintBrushTexture(texture: Texture2D | null): void {
-        const paint = this.getTerrainBrushEditor(eTerrainEditorMode.PAINT);
+        const paint = this.getTerrainBrushEditor(TerrainEditorModeType.PAINT);
         paint.setBrushImage(texture);
         Service.Engine.repaintInEditMode();
     }
     async setSculptBrushRotation(rotation: number) {
-        this._editor.getMode(eTerrainEditorMode.SCULPT).setSculptBrushRotation(rotation);
+        this._editor.getMode(TerrainEditorModeType.SCULPT).setSculptBrushRotation(rotation);
     }
     async setLayerValue(index: number, uuid: string, extVal?: ITerrainLayerValue) {
         if (!this.target) return null;
-        const layer = this.target.getLayer(index); if (!layer) return null;
+        const layer = this.target.getLayer(index);
+        if (!layer) return null;
         if (extVal) {
             if (extVal.tileSize !== undefined) layer.tileSize = extVal.tileSize;
             if (extVal.metallic !== undefined) layer.metallic = extVal.metallic;
             if (extVal.roughness !== undefined) layer.roughness = extVal.roughness;
-            if ('normalMap' in extVal) layer.normalMap = extVal.normalMap ? await loadAny<Texture2D>(extVal.normalMap) : null;
+            if ('normalMap' in extVal)
+                layer.normalMap = extVal.normalMap ? await loadAny<Texture2D>(extVal.normalMap) : null;
         }
         if (uuid) layer.detailMap = await loadAny<Texture2D>(uuid);
-        this.updateTerrainAsset(); this.isTerrainChange = true; this.emitNodeChange(); Service.Engine.repaintInEditMode();
+        this.updateTerrainAsset();
+        this.isTerrainChange = true;
+        this.emitNodeChange();
+        Service.Engine.repaintInEditMode();
         return index;
     }
     removeLayerByIndex(index: number) {
         if (!this.target) return;
-        this.target.removeLayer(index); this.updateTerrainAsset(); this.isTerrainChange = true; this.emitNodeChange(); Service.Engine.repaintInEditMode();
+        this.target.removeLayer(index);
+        this.updateTerrainAsset();
+        this.isTerrainChange = true;
+        this.emitNodeChange();
+        Service.Engine.repaintInEditMode();
     }
-    setCurrentEditLayer(index: number) { this._editor.setCurrentLayer(index); Service.Engine.repaintInEditMode(); }
+    setCurrentEditLayer(index: number) {
+        this._editor.setCurrentLayer(index);
+        Service.Engine.repaintInEditMode();
+    }
     getLayers() {
         if (!this.target) return [];
         return Array.from({ length: TERRAIN_MAX_LAYER_COUNT }, (_, index) => {
             const layer = this.target!.getLayer(index);
-            return layer ? {
-                detailMap: layer.detailMap?._uuid ?? null, metallic: layer.metallic,
-                normalMap: layer.normalMap?._uuid ?? null, roughness: layer.roughness, tileSize: layer.tileSize,
-            } : null;
+            return layer
+                ? {
+                      detailMap: layer.detailMap?._uuid ?? null,
+                      metallic: layer.metallic,
+                      normalMap: layer.normalMap?._uuid ?? null,
+                      roughness: layer.roughness,
+                      tileSize: layer.tileSize,
+                  }
+                : null;
         });
     }
-    getCurrentEditLayer() { return this._editor.getCurrentLayer(); }
-    setCurrentEditMode(mode: eTerrainEditorMode, option?: ITerrainEditModeOption) {
-        const config = Object.assign({ isSculptDown: false, isSmooth: false, isFlatten: false, isSetHeight: false }, option || {});
-        this._isConcave = this._isShiftDown = !!config.isSculptDown; this._isSmooth = !!config.isSmooth;
-        this._isFlatten = !!config.isFlatten; this._isSetHeight = !!config.isSetHeight;
-        this._editor.setMode(mode); Service.Engine.repaintInEditMode();
+    getCurrentEditLayer() {
+        return this._editor.getCurrentLayer();
+    }
+    setCurrentEditMode(mode: TerrainEditorModeType, option?: ITerrainEditModeOption) {
+        const config = Object.assign(
+            { isSculptDown: false, isSmooth: false, isFlatten: false, isSetHeight: false },
+            option || {},
+        );
+        this._isConcave = this._isShiftDown = !!config.isSculptDown;
+        this._isSmooth = !!config.isSmooth;
+        this._isFlatten = !!config.isFlatten;
+        this._isSetHeight = !!config.isSetHeight;
+        this._editor.setMode(mode);
+        Service.Engine.repaintInEditMode();
     }
     queryTerrainInfo(): ITerrainInfo | null {
-        const info = this.target?.info; return info ? {
-            tileSize: info.tileSize, weightMapSize: info.weightMapSize, lightMapSize: info.lightMapSize, blockCount: [info.blockCount[0], info.blockCount[1]],
-        } : null;
+        const info = this.target?.info;
+        return info
+            ? {
+                  tileSize: info.tileSize,
+                  weightMapSize: info.weightMapSize,
+                  lightMapSize: info.lightMapSize,
+                  blockCount: [info.blockCount[0], info.blockCount[1]],
+              }
+            : null;
     }
     changeTerrainInfo(info: ITerrainInfo) {
         if (!this.target) return;
-        const terrainInfo = new TerrainInfo(); Object.assign(terrainInfo, info); this.target.rebuild(terrainInfo);
-        this.isTerrainChange = true; this.emitNodeChange(); Service.Engine.repaintInEditMode();
+        const terrainInfo = new TerrainInfo();
+        Object.assign(terrainInfo, info);
+        this.target.rebuild(terrainInfo);
+        this.isTerrainChange = true;
+        this.emitNodeChange();
+        Service.Engine.repaintInEditMode();
     }
-    queryBrushOfMode(mode: eTerrainEditorMode.SCULPT): IBrush;
-    queryBrushOfMode(mode: eTerrainEditorMode.PAINT): IPaintBrush;
-    queryBrushOfMode(mode: eTerrainEditorMode.MANAGE | eTerrainEditorMode.SELECT): null;
-    queryBrushOfMode(mode: eTerrainEditorMode): IBrush | IPaintBrush | null;
-    queryBrushOfMode(mode: eTerrainEditorMode): IBrush | IPaintBrush | null {
-        if (mode !== eTerrainEditorMode.SCULPT && mode !== eTerrainEditorMode.PAINT) return null;
+    queryBrushOfMode(mode: TerrainEditorModeType.SCULPT): IBrush;
+    queryBrushOfMode(mode: TerrainEditorModeType.PAINT): IPaintBrush;
+    queryBrushOfMode(mode: TerrainEditorModeType.MANAGE | TerrainEditorModeType.SELECT): null;
+    queryBrushOfMode(mode: TerrainEditorModeType): IBrush | IPaintBrush | null;
+    queryBrushOfMode(mode: TerrainEditorModeType): IBrush | IPaintBrush | null {
+        if (mode !== TerrainEditorModeType.SCULPT && mode !== TerrainEditorModeType.PAINT) return null;
         const brush = this._editor.getMode(mode).getCurrentBrush();
-        if (mode === eTerrainEditorMode.PAINT) {
-            return { radius: brush.radius, strength: brush.strength, _setHeight: brush._setHeight, falloff: this.getTerrainCircleBrush(mode).getFalloff() };
+        if (mode === TerrainEditorModeType.PAINT) {
+            return {
+                radius: brush.radius,
+                strength: brush.strength,
+                _setHeight: brush._setHeight,
+                falloff: this.getTerrainCircleBrush(mode).getFalloff(),
+            };
         }
         return { radius: brush.radius, strength: brush.strength, _setHeight: brush._setHeight };
     }
-    setBrushOfMode(mode: eTerrainEditorMode, setting?: IBrushSetting) {
-        if (mode !== eTerrainEditorMode.SCULPT && mode !== eTerrainEditorMode.PAINT) return;
+    setBrushOfMode(mode: TerrainEditorModeType, setting?: IBrushSetting) {
+        if (mode !== TerrainEditorModeType.SCULPT && mode !== TerrainEditorModeType.PAINT) return;
         const brush = this._editor.getMode(mode).getCurrentBrush();
         if (!setting) return;
         if (setting.radius !== undefined) brush.radius = setting.radius;
         if (setting.strength !== undefined) brush.strength = setting.strength;
         if (setting._setHeight !== undefined) brush._setHeight = setting._setHeight;
         if (setting._rotation !== undefined) brush._rotation = setting._rotation;
-        if (mode === eTerrainEditorMode.PAINT && setting.falloff !== undefined) this.getTerrainCircleBrush(mode).setFalloff(setting.falloff);
+        if (mode === TerrainEditorModeType.PAINT && setting.falloff !== undefined)
+            this.getTerrainCircleBrush(mode).setFalloff(setting.falloff);
     }
     getBlockInfo() {
-        const mode = this._editor.getMode(eTerrainEditorMode.SELECT); const index = mode.getCurrentBlockIndex() ?? [0, 0];
+        const mode = this._editor.getMode(TerrainEditorModeType.SELECT);
+        const index = mode.getCurrentBlockIndex() ?? [0, 0];
         const weight = mode.getCurrentWeightData();
         return {
             index: { x: index[0], y: index[1] },
             weight: weight ? { data: Array.from(weight.data), width: weight.width, height: weight.height } : null,
-            layers: mode.getCurrentLayerList().map((layer) => layer?.uuid ?? ''),
+            layers: mode.getCurrentLayerList().map(layer => layer?.uuid ?? ''),
         };
     }
-    emitNodeChange() { if (this.target) this.onComponentChanged(this.target.node); }
-    onKeyDown(event: ISceneKeyboardEvent) { if (event.shiftKey) this._isShiftDown = true; }
-    onKeyUp(event: ISceneKeyboardEvent) { if (event.keyCode === 16) this._isShiftDown = this._isConcave; }
-    onUpdate(deltaTime: number) { this._editor?.update(deltaTime, this._isShiftDown); }
-    onCameraControlModeChanged(mode: number) { if (mode !== 0 && this._editor?.isChanged) this.emitNodeChange(); }
-    updateTerrainAsset() { if (this.target?._asset) this.target.exportLayerListToAsset(this.target._asset); }
+    emitNodeChange() {
+        if (this.target) this.onComponentChanged(this.target.node);
+    }
+    onKeyDown(event: ISceneKeyboardEvent) {
+        if (event.shiftKey) this._isShiftDown = true;
+    }
+    onKeyUp(event: ISceneKeyboardEvent) {
+        if (event.keyCode === 16) this._isShiftDown = this._isConcave;
+    }
+    onUpdate(deltaTime: number) {
+        this._editor?.update(deltaTime, this._isShiftDown);
+    }
+    onCameraControlModeChanged(mode: number) {
+        if (mode !== 0 && this._editor?.isChanged) this.emitNodeChange();
+    }
+    updateTerrainAsset() {
+        if (this.target?._asset) this.target.exportLayerListToAsset(this.target._asset);
+    }
 
-    public onControllerMouseDown(event: GizmoMouseEvent) { event.propagationStopped = true; this._isShiftDown = event.shiftKey; this._editor.onMouseDown(event.x, event.y); }
-    public onControllerMouseMove(event: GizmoMouseEvent) { event.propagationStopped = true; this._editor.onMouseMove(event.x, event.y); }
-    public onControllerMouseUp(event: GizmoMouseEvent) { event.propagationStopped = true; if (this._editor.isChanged) this.emitNodeChange(); this._editor.onMouseUp(); }
-    public onControllerHoverOut() { this._editor.onHoverOut(); }
+    public onControllerMouseDown(event: GizmoMouseEvent) {
+        event.propagationStopped = true;
+        this._isShiftDown = event.shiftKey;
+        this._editor.onMouseDown(event.x, event.y);
+    }
+    public onControllerMouseMove(event: GizmoMouseEvent) {
+        event.propagationStopped = true;
+        this._editor.onMouseMove(event.x, event.y);
+    }
+    public onControllerMouseUp(event: GizmoMouseEvent) {
+        event.propagationStopped = true;
+        if (this._editor.isChanged) this.emitNodeChange();
+        this._editor.onMouseUp();
+    }
+    public onControllerHoverOut() {
+        this._editor.onHoverOut();
+    }
 }

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/gizmo-select.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/gizmo-select.ts
@@ -7,21 +7,27 @@ import { TerrainEditor } from './terrain-editor';
 import { TerrainEditorPaint } from './terrain-editor-paint';
 import { TerrainEditorSculpt } from './terrain-editor-sculpt';
 import { eTerrainEditorMode } from './terrain-editor-mode';
-import { TerrainBrushType, TerrainImageBrush } from './terrain-brush';
+import { TerrainBrushType, TerrainCircleBrush, TerrainImageBrush } from './terrain-brush';
 import type {
     ITerrainBlockData,
     ITerrainBrushPatch,
     ITerrainBrushState,
     ITerrainEditorState,
     ITerrainPaintSessionPatch,
+    ITerrainPaintBrushState,
     ITerrainSculptSessionPatch,
     TerrainEditorMode,
     TerrainSculptTool,
 } from '../../../../../common';
 import type { GizmoMouseEvent } from '../../utils/defines';
+import type { ISceneKeyboardEvent } from '../../../operation/types';
 
 interface IBrush { radius: number; strength: number; _setHeight: number; }
-interface ITerrainInfo { tileSize: number; weightMapSize: number; lightMapSize: number; blockCount: number[]; }
+interface IPaintBrush extends IBrush { falloff: number; }
+interface IBrushSetting { radius?: number; strength?: number; _setHeight?: number; _rotation?: number; falloff?: number; }
+interface ITerrainLayerValue { tileSize?: number; metallic?: number; roughness?: number; normalMap?: string | null; }
+interface ITerrainEditModeOption { isSculptDown?: boolean; isSmooth?: boolean; isFlatten?: boolean; isSetHeight?: boolean; }
+interface ITerrainInfo { tileSize: number; weightMapSize: number; lightMapSize: number; blockCount: [number, number]; }
 
 /** Component gizmo containing all Terrain editing operations. */
 export default class TerrainGizmo extends GizmoBase<Terrain> {
@@ -41,12 +47,12 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
     public applySmooth(value: boolean) { this._isSmooth = value; }
     public get isTerrainChange() { return !!this.target && Service.Terrain.isTerrainChange; }
     public set isTerrainChange(value: boolean) {
-        if (this.target) { (this.target as any).manager = Service.Terrain; (this.target as any).isTerrainChange = value; }
+        if (this.target) { this.target.manager = Service.Terrain; this.target.isTerrainChange = value; }
         if (value && this.target) Service.Terrain.select(this.target.node.uuid);
     }
 
     protected init() {
-        this._editor = new TerrainEditor((Service.Camera as any).getCamera?.() ?? null, this);
+        this._editor = new TerrainEditor(Service.Camera.getCamera() ?? null, this);
     }
     protected onShow() {
         this.registerCameraMovedEvent(); this.initEditor(); this._editor.updateBlockDepthOffset();
@@ -106,7 +112,7 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
                 brush: this.getTerrainBrushState(eTerrainEditorMode.SCULPT),
             },
             paint: {
-                brush: this.getTerrainBrushState(eTerrainEditorMode.PAINT),
+                brush: this.getTerrainPaintBrushState(),
             },
         };
     }
@@ -136,7 +142,10 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
     }
 
     public updateTerrainPaintSession(patch: ITerrainPaintSessionPatch): void {
-        if (patch.brush) this.updateTerrainBrush(eTerrainEditorMode.PAINT, patch.brush);
+        if (patch.brush) {
+            this.updateTerrainBrush(eTerrainEditorMode.PAINT, patch.brush);
+            if (typeof patch.brush.falloff === 'number') this.getTerrainCircleBrush(eTerrainEditorMode.PAINT).setFalloff(patch.brush.falloff);
+        }
         Service.Engine.repaintInEditMode();
     }
 
@@ -194,6 +203,14 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
         };
     }
 
+    /** Paint falloff is retained by the circle brush even while an image brush is selected. */
+    private getTerrainPaintBrushState(): ITerrainPaintBrushState {
+        return {
+            ...this.getTerrainBrushState(eTerrainEditorMode.PAINT),
+            falloff: this.getTerrainCircleBrush(eTerrainEditorMode.PAINT).getFalloff(),
+        };
+    }
+
     private updateTerrainBrush(mode: eTerrainEditorMode.SCULPT | eTerrainEditorMode.PAINT, patch: ITerrainBrushPatch): void {
         const editor = this.getTerrainBrushEditor(mode);
         const image = editor.getBrush(TerrainBrushType.IMAGE) as TerrainImageBrush;
@@ -210,9 +227,13 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
             : this._editor.getMode(eTerrainEditorMode.PAINT);
     }
 
+    private getTerrainCircleBrush(mode: eTerrainEditorMode.SCULPT | eTerrainEditorMode.PAINT): TerrainCircleBrush {
+        return this.getTerrainBrushEditor(mode).getBrush(TerrainBrushType.CIRCLE) as TerrainCircleBrush;
+    }
+
     async addLayerByUuid(uuid: string) {
         if (!this.target) return -1;
-        const texture = await loadAny<any>(uuid);
+        const texture = await loadAny<Texture2D>(uuid);
         const layer = new TerrainLayer(); layer.detailMap = texture; layer.tileSize = 1;
         const index = this.target.addLayer(layer); this.updateTerrainAsset(); this.isTerrainChange = true; this.emitNodeChange();
         Service.Engine.repaintInEditMode(); return index;
@@ -232,18 +253,18 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
         Service.Engine.repaintInEditMode();
     }
     async setSculptBrushRotation(rotation: number) {
-        (this._editor.getMode(eTerrainEditorMode.SCULPT) as any).setSculptBrushRotation(rotation);
+        this._editor.getMode(eTerrainEditorMode.SCULPT).setSculptBrushRotation(rotation);
     }
-    async setLayerValue(index: number, uuid: string, extVal: any) {
+    async setLayerValue(index: number, uuid: string, extVal?: ITerrainLayerValue) {
         if (!this.target) return null;
         const layer = this.target.getLayer(index); if (!layer) return null;
         if (extVal) {
-            if ('tileSize' in extVal) layer.tileSize = extVal.tileSize;
-            if ('metallic' in extVal) layer.metallic = extVal.metallic;
-            if ('roughness' in extVal) layer.roughness = extVal.roughness;
-            if ('normalMap' in extVal) layer.normalMap = extVal.normalMap ? await loadAny<any>(extVal.normalMap) : null;
+            if (extVal.tileSize !== undefined) layer.tileSize = extVal.tileSize;
+            if (extVal.metallic !== undefined) layer.metallic = extVal.metallic;
+            if (extVal.roughness !== undefined) layer.roughness = extVal.roughness;
+            if ('normalMap' in extVal) layer.normalMap = extVal.normalMap ? await loadAny<Texture2D>(extVal.normalMap) : null;
         }
-        if (uuid) layer.detailMap = await loadAny<any>(uuid);
+        if (uuid) layer.detailMap = await loadAny<Texture2D>(uuid);
         this.updateTerrainAsset(); this.isTerrainChange = true; this.emitNodeChange(); Service.Engine.repaintInEditMode();
         return index;
     }
@@ -263,7 +284,7 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
         });
     }
     getCurrentEditLayer() { return this._editor.getCurrentLayer(); }
-    setCurrentEditMode(mode: eTerrainEditorMode, option?: any) {
+    setCurrentEditMode(mode: eTerrainEditorMode, option?: ITerrainEditModeOption) {
         const config = Object.assign({ isSculptDown: false, isSmooth: false, isFlatten: false, isSetHeight: false }, option || {});
         this._isConcave = this._isShiftDown = !!config.isSculptDown; this._isSmooth = !!config.isSmooth;
         this._isFlatten = !!config.isFlatten; this._isSetHeight = !!config.isSetHeight;
@@ -271,23 +292,35 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
     }
     queryTerrainInfo(): ITerrainInfo | null {
         const info = this.target?.info; return info ? {
-            tileSize: info.tileSize, weightMapSize: info.weightMapSize, lightMapSize: info.lightMapSize, blockCount: [...info.blockCount],
+            tileSize: info.tileSize, weightMapSize: info.weightMapSize, lightMapSize: info.lightMapSize, blockCount: [info.blockCount[0], info.blockCount[1]],
         } : null;
     }
-    changeTerrainInfo(info: any) {
+    changeTerrainInfo(info: ITerrainInfo) {
         if (!this.target) return;
         const terrainInfo = new TerrainInfo(); Object.assign(terrainInfo, info); this.target.rebuild(terrainInfo);
         this.isTerrainChange = true; this.emitNodeChange(); Service.Engine.repaintInEditMode();
     }
-    queryBrushOfMode(mode: eTerrainEditorMode): IBrush | null {
+    queryBrushOfMode(mode: eTerrainEditorMode.SCULPT): IBrush;
+    queryBrushOfMode(mode: eTerrainEditorMode.PAINT): IPaintBrush;
+    queryBrushOfMode(mode: eTerrainEditorMode.MANAGE | eTerrainEditorMode.SELECT): null;
+    queryBrushOfMode(mode: eTerrainEditorMode): IBrush | IPaintBrush | null;
+    queryBrushOfMode(mode: eTerrainEditorMode): IBrush | IPaintBrush | null {
         if (mode !== eTerrainEditorMode.SCULPT && mode !== eTerrainEditorMode.PAINT) return null;
-        const brush = (this._editor.getMode(mode) as any).getCurrentBrush();
+        const brush = this._editor.getMode(mode).getCurrentBrush();
+        if (mode === eTerrainEditorMode.PAINT) {
+            return { radius: brush.radius, strength: brush.strength, _setHeight: brush._setHeight, falloff: this.getTerrainCircleBrush(mode).getFalloff() };
+        }
         return { radius: brush.radius, strength: brush.strength, _setHeight: brush._setHeight };
     }
-    setBrushOfMode(mode: eTerrainEditorMode, setting: any) {
+    setBrushOfMode(mode: eTerrainEditorMode, setting?: IBrushSetting) {
         if (mode !== eTerrainEditorMode.SCULPT && mode !== eTerrainEditorMode.PAINT) return;
-        const brush = (this._editor.getMode(mode) as any).getCurrentBrush();
-        for (const key of Object.keys(setting || {})) if (key !== 'material' && setting[key] !== undefined) brush[key] = setting[key];
+        const brush = this._editor.getMode(mode).getCurrentBrush();
+        if (!setting) return;
+        if (setting.radius !== undefined) brush.radius = setting.radius;
+        if (setting.strength !== undefined) brush.strength = setting.strength;
+        if (setting._setHeight !== undefined) brush._setHeight = setting._setHeight;
+        if (setting._rotation !== undefined) brush._rotation = setting._rotation;
+        if (mode === eTerrainEditorMode.PAINT && setting.falloff !== undefined) this.getTerrainCircleBrush(mode).setFalloff(setting.falloff);
     }
     getBlockInfo() {
         const mode = this._editor.getMode(eTerrainEditorMode.SELECT); const index = mode.getCurrentBlockIndex() ?? [0, 0];
@@ -295,12 +328,12 @@ export default class TerrainGizmo extends GizmoBase<Terrain> {
         return {
             index: { x: index[0], y: index[1] },
             weight: weight ? { data: Array.from(weight.data), width: weight.width, height: weight.height } : null,
-            layers: mode.getCurrentLayerList().map((layer: any) => layer?._uuid ?? ''),
+            layers: mode.getCurrentLayerList().map((layer) => layer?.uuid ?? ''),
         };
     }
     emitNodeChange() { if (this.target) this.onComponentChanged(this.target.node); }
-    onKeyDown(event: any) { if (event.shiftKey) this._isShiftDown = true; }
-    onKeyUp(event: any) { if (event.keyCode === 16) this._isShiftDown = this._isConcave; }
+    onKeyDown(event: ISceneKeyboardEvent) { if (event.shiftKey) this._isShiftDown = true; }
+    onKeyUp(event: ISceneKeyboardEvent) { if (event.keyCode === 16) this._isShiftDown = this._isConcave; }
     onUpdate(deltaTime: number) { this._editor?.update(deltaTime, this._isShiftDown); }
     onCameraControlModeChanged(mode: number) { if (mode !== 0 && this._editor?.isChanged) this.emitNodeChange(); }
     updateTerrainAsset() { if (this.target?._asset) this.target.exportLayerListToAsset(this.target._asset); }

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-brush.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-brush.ts
@@ -1,8 +1,14 @@
 import { Material, Terrain, Texture2D, Vec2, Vec3, Vec4, builtinResMgr, clamp } from 'cc';
 
-export enum TerrainBrushType { CIRCLE, IMAGE, _MAX }
+export enum TerrainBrushType {
+    CIRCLE,
+    IMAGE,
+    _MAX,
+}
 
-export class TerrainEdModifierKeyState { public siftPressed = false; }
+export class TerrainEdModifierKeyState {
+    public siftPressed = false;
+}
 
 const brushDepthOffsetDefaultRatios = 0.001;
 let brushDepthOffset = 0.05;
@@ -25,36 +31,63 @@ export class TerrainBrush {
     public _setHeight = 0;
     public _rotation = 0;
 
-    public get rotation() { return this._rotation / 180 * Math.PI; }
-    public getDelta(_x: number, _z: number) { return 0; }
+    public get rotation() {
+        return (this._rotation / 180) * Math.PI;
+    }
+    public getDelta(_x: number, _z: number) {
+        return 0;
+    }
     public getBound(bbmin: Vec2, bbmax: Vec2) {
         bbmin.set(this.position.x - this.radius, this.position.z - this.radius);
         bbmax.set(this.position.x + this.radius, this.position.z + this.radius);
     }
-    public update(_terrain: Terrain, pos: Vec3) { this.position.set(pos); }
+    public update(_terrain: Terrain, pos: Vec3) {
+        this.position.set(pos);
+    }
 }
 
 export class TerrainBrushData {
     public bmin: number[] = [0, 0];
     public bmax: number[] = [0, 0];
-    public width() { return this.bmax[0] - this.bmin[0] + 1; }
-    public height() { return this.bmax[1] - this.bmin[1] + 1; }
+    public width() {
+        return this.bmax[0] - this.bmin[0] + 1;
+    }
+    public height() {
+        return this.bmax[1] - this.bmin[1] + 1;
+    }
 }
 
-export enum eTerrainCircleBrushType { Linear, Smooth, Spherical, Tip }
+export enum TerrainCircleBrushType {
+    Linear,
+    Smooth,
+    Spherical,
+    Tip,
+}
 
 export class TerrainCircleBrush extends TerrainBrush {
-    protected type = eTerrainCircleBrushType.Linear;
+    protected type = TerrainCircleBrushType.Linear;
     protected falloff = 0.5;
 
-    constructor() { super(); this._updateMaterial(); }
-
-    public setType(type: eTerrainCircleBrushType) {
-        if (this.type !== type) { this.type = type; this._updateMaterial(); }
+    constructor() {
+        super();
+        this._updateMaterial();
     }
-    public getType() { return this.type; }
-    public getFalloff() { return this.falloff; }
-    public setFalloff(value: number) { this.falloff = clamp(value, 0, 1); }
+
+    public setType(type: TerrainCircleBrushType) {
+        if (this.type !== type) {
+            this.type = type;
+            this._updateMaterial();
+        }
+    }
+    public getType() {
+        return this.type;
+    }
+    public getFalloff() {
+        return this.falloff;
+    }
+    public setFalloff(value: number) {
+        this.falloff = clamp(value, 0, 1);
+    }
     public _updateMaterial() {
         const effect = (cc as any).EffectAsset?.get?.('internal/editor/terrain-circle-brush');
         if (effect) {
@@ -92,10 +125,18 @@ export class TerrainCircleBrush extends TerrainBrush {
         const falloff = this.falloff * this.radius;
         let value = 0;
         switch (this.type) {
-            case eTerrainCircleBrushType.Linear: value = TerrainCircleBrush._calculateFalloff_Linear(distance, radius, falloff); break;
-            case eTerrainCircleBrushType.Smooth: value = TerrainCircleBrush._calculateFalloff_Smooth(distance, radius, falloff); break;
-            case eTerrainCircleBrushType.Spherical: value = TerrainCircleBrush._calculateFalloff_Spherical(distance, radius, falloff); break;
-            case eTerrainCircleBrushType.Tip: value = TerrainCircleBrush._calculateFalloff_Tip(distance, radius, falloff); break;
+            case TerrainCircleBrushType.Linear:
+                value = TerrainCircleBrush._calculateFalloff_Linear(distance, radius, falloff);
+                break;
+            case TerrainCircleBrushType.Smooth:
+                value = TerrainCircleBrush._calculateFalloff_Smooth(distance, radius, falloff);
+                break;
+            case TerrainCircleBrushType.Spherical:
+                value = TerrainCircleBrush._calculateFalloff_Spherical(distance, radius, falloff);
+                break;
+            case TerrainCircleBrushType.Tip:
+                value = TerrainCircleBrush._calculateFalloff_Tip(distance, radius, falloff);
+                break;
         }
         return value * this.strength;
     }
@@ -136,7 +177,8 @@ export class TerrainImageBrush extends TerrainBrush {
         const source = nativeData?._src;
         const readImage = (image: CanvasImageSource, width: number, height: number) => {
             const canvas = document.createElement('canvas');
-            canvas.width = width; canvas.height = height;
+            canvas.width = width;
+            canvas.height = height;
             const context = canvas.getContext('2d');
             if (!context) return;
             context.drawImage(image, 0, 0, width, height);
@@ -152,15 +194,23 @@ export class TerrainImageBrush extends TerrainBrush {
             readImage(nativeData as CanvasImageSource, value.width, value.height);
         }
     }
-    public get image() { return this._image; }
+    public get image() {
+        return this._image;
+    }
     public static getColor(pixels: number[], width: number, height: number, u: number, v: number) {
-        u = clamp(u, 0, width - 1); v = clamp(v, 0, height - 1);
+        u = clamp(u, 0, width - 1);
+        v = clamp(v, 0, height - 1);
         return pixels[v * width + u];
     }
     public static sampleImage(pixels: number[], width: number, height: number, u: number, v: number) {
-        u *= width - 1; v *= height - 1;
-        const u0 = Math.floor(u), v0 = Math.floor(v), u1 = u0 + 1, v1 = v0 + 1;
-        const du = u - u0, dv = v - v0;
+        u *= width - 1;
+        v *= height - 1;
+        const u0 = Math.floor(u),
+            v0 = Math.floor(v),
+            u1 = u0 + 1,
+            v1 = v0 + 1;
+        const du = u - u0,
+            dv = v - v0;
         const c00 = this.getColor(pixels, width, height, u0, v0);
         const c10 = this.getColor(pixels, width, height, u1, v0);
         const c01 = this.getColor(pixels, width, height, u0, v1);
@@ -173,18 +223,24 @@ export class TerrainImageBrush extends TerrainBrush {
             : 1;
     }
     public getDelta(x: number, z: number) {
-        let dx = this.position.x - x, dz = this.position.z - z;
+        let dx = this.position.x - x,
+            dz = this.position.z - z;
         if (this.rotation) {
-            const sine = Math.sin(this.rotation), cosine = Math.cos(this.rotation);
+            const sine = Math.sin(this.rotation),
+                cosine = Math.cos(this.rotation);
             const tx = dx * cosine + dz * sine;
-            dz = -dx * sine + dz * cosine; dx = tx;
+            dz = -dx * sine + dz * cosine;
+            dx = tx;
         }
-        const u = dx / this.radius * 0.5 + 0.5, v = dz / this.radius * 0.5 + 0.5;
+        const u = (dx / this.radius) * 0.5 + 0.5,
+            v = (dz / this.radius) * 0.5 + 0.5;
         return u < 0 || u > 1 || v < 0 || v > 1 ? 0 : this.sample(u, v) * this.strength;
     }
     public getBound(bbmin: Vec2, bbmax: Vec2) {
-        const c = Math.abs(Math.cos(this.rotation)), s = Math.abs(Math.sin(this.rotation));
-        const halfX = this.radius * (c + s), halfZ = this.radius * (c + s);
+        const c = Math.abs(Math.cos(this.rotation)),
+            s = Math.abs(Math.sin(this.rotation));
+        const halfX = this.radius * (c + s),
+            halfZ = this.radius * (c + s);
         bbmin.set(this.position.x - halfX, this.position.z - halfZ);
         bbmax.set(this.position.x + halfX, this.position.z + halfZ);
     }

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-brush.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-brush.ts
@@ -53,6 +53,8 @@ export class TerrainCircleBrush extends TerrainBrush {
         if (this.type !== type) { this.type = type; this._updateMaterial(); }
     }
     public getType() { return this.type; }
+    public getFalloff() { return this.falloff; }
+    public setFalloff(value: number) { this.falloff = clamp(value, 0, 1); }
     public _updateMaterial() {
         const effect = (cc as any).EffectAsset?.get?.('internal/editor/terrain-circle-brush');
         if (effect) {

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-mode.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-mode.ts
@@ -1,13 +1,33 @@
 import type { Terrain } from 'cc';
+import type TerrainGizmo from './gizmo-select';
 
-export enum eTerrainEditorMode { MANAGE, SCULPT, PAINT, SELECT }
+export enum TerrainEditorModeType {
+    MANAGE,
+    SCULPT,
+    PAINT,
+    SELECT,
+}
 
-export class TerrainEditorMode {
-    protected _gizmo: any;
-    constructor(gizmo: any) { this._gizmo = gizmo; }
-    get gizmo() { return this._gizmo; }
-    public onUpdate(_terrain: Terrain, _dTime: number, _isShiftDown: boolean) {}
-    public onActivate() {}
-    public onDeactivate() {}
-    public forceUpdate() {}
+/**
+ * Base adapter for one Terrain editor mode.
+ *
+ * TerrainEditor invokes lifecycle hooks only while a Terrain is attached.
+ * deactivate() observes the outgoing Terrain, activate() observes the incoming
+ * Terrain, and implementations must not change the editor attachment.
+ */
+export abstract class TerrainEditorMode {
+    protected readonly _gizmo: TerrainGizmo;
+
+    constructor(gizmo: TerrainGizmo) {
+        this._gizmo = gizmo;
+    }
+
+    public get gizmo(): TerrainGizmo {
+        return this._gizmo;
+    }
+
+    public update(_terrain: Terrain, _deltaTime: number, _isShiftDown: boolean): void {}
+    public activate(): void {}
+    public deactivate(): void {}
+    public refreshPreview(): void {}
 }

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-paint.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-paint.ts
@@ -3,6 +3,7 @@ import { Service } from '../../../core/decorator';
 import { TerrainBrush, TerrainBrushType, TerrainCircleBrush, TerrainImageBrush } from './terrain-brush';
 import { TerrainEditorMode } from './terrain-editor-mode';
 import { TerrainWeightOperation, TerrainWeightUndoRedo } from './terrain-operation';
+import type TerrainGizmo from './gizmo-select';
 
 const clamp = math.clamp;
 
@@ -12,7 +13,7 @@ export class TerrainEditorPaint extends TerrainEditorMode {
     public _currentLayer = -1;
     public _currentBrush: TerrainBrush;
 
-    constructor(gizmo: any) {
+    constructor(gizmo: TerrainGizmo) {
         super(gizmo);
         const circle = new TerrainCircleBrush(); circle.strength = 5;
         const image = new TerrainImageBrush(); image.strength = 5;
@@ -33,7 +34,7 @@ export class TerrainEditorPaint extends TerrainEditorMode {
     public setCurrentLayer(layer: number) { this._currentLayer = layer; }
     public getCurrentLayer() { return this._currentLayer; }
 
-    public onUpdate(terrain: Terrain, deltaTime: number) {
+    public update(terrain: Terrain, deltaTime: number) {
         if (!this._undo) return;
         this._updateWeight(terrain, deltaTime); this.gizmo.isTerrainChange = true;
     }
@@ -58,8 +59,8 @@ export class TerrainEditorPaint extends TerrainEditorMode {
         if (this._undo?.data.length || this._undo?.redoOperations.length) Service.Undo.push(this._undo);
         this._undo = null;
     }
-    public forceUpdate() { TerrainBrush.updateBrushDepthOffsetToMaterial(this._currentBrush.material); }
-    public onDeactivate() {
+    public refreshPreview() { TerrainBrush.updateBrushDepthOffsetToMaterial(this._currentBrush.material); }
+    public deactivate() {
         if (!this.gizmo.editor.getEditTerrain()?._asset) this._currentLayer = -1;
     }
 

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-sculpt-tools.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-sculpt-tools.ts
@@ -1,14 +1,23 @@
 import type { Terrain } from 'cc';
 import { TerrainEdModifierKeyState } from './terrain-brush';
 
-export enum eTerrainTerrainEditorSculptToolMode { SCULPT, SMOOTH, FLATTEN, SET_HEIGHT }
+export enum TerrainSculptToolMode {
+    SCULPT,
+    SMOOTH,
+    FLATTEN,
+    SET_HEIGHT,
+}
 
 export class TerrainEditorSculptTool {
     start(_terrain: Terrain, _x: number, _y: number) {}
-    apply(_terrain: Terrain, _x: number, _y: number, h: number, _delta: number, _modifiers: TerrainEdModifierKeyState) { return h; }
+    apply(_terrain: Terrain, _x: number, _y: number, h: number, _delta: number, _modifiers: TerrainEdModifierKeyState) {
+        return h;
+    }
 }
 export class TerrainEditorSculptTool_Sculpt extends TerrainEditorSculptTool {
-    constructor(public _concave: boolean) { super(); }
+    constructor(public _concave: boolean) {
+        super();
+    }
     apply(_terrain: Terrain, _x: number, _y: number, h: number, delta: number, modifiers: TerrainEdModifierKeyState) {
         return h + (this._concave || modifiers.siftPressed ? -delta : delta);
     }
@@ -21,12 +30,17 @@ export class TerrainEditorSculptTool_Smooth extends TerrainEditorSculptTool {
 }
 export class TerrainEditorSculptTool_Flatten extends TerrainEditorSculptTool {
     protected _height = 0;
-    start(terrain: Terrain, x: number, y: number) { this._height = terrain.getHeightClamp(x, y); }
+    start(terrain: Terrain, x: number, y: number) {
+        this._height = terrain.getHeightClamp(x, y);
+    }
     apply(_terrain: Terrain, _x: number, _y: number, h: number, delta: number) {
         return h > this._height ? Math.max(h - delta, this._height) : Math.min(h + delta, this._height);
     }
 }
 export class TerrainEditorSculptTool_SetHeight extends TerrainEditorSculptTool_Flatten {
-    constructor(height: number) { super(); this._height = height; }
+    constructor(height: number) {
+        super();
+        this._height = height;
+    }
     start(_terrain: Terrain, _x: number, _y: number) {}
 }

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-sculpt.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-sculpt.ts
@@ -4,8 +4,9 @@ import {
     TerrainBrush, TerrainBrushType, TerrainCircleBrush, TerrainEdModifierKeyState, TerrainImageBrush,
 } from './terrain-brush';
 import { TerrainEditorMode } from './terrain-editor-mode';
+import type TerrainGizmo from './gizmo-select';
 import {
-    eTerrainTerrainEditorSculptToolMode, TerrainEditorSculptTool, TerrainEditorSculptTool_Flatten,
+    TerrainSculptToolMode, TerrainEditorSculptTool, TerrainEditorSculptTool_Flatten,
     TerrainEditorSculptTool_Sculpt, TerrainEditorSculptTool_SetHeight, TerrainEditorSculptTool_Smooth,
 } from './terrain-editor-sculpt-tools';
 import { TerrainHeightOperation, TerrainHeightUndoRedo } from './terrain-operation';
@@ -18,7 +19,7 @@ export class TerrainEditorSculpt extends TerrainEditorMode {
     public _currentBrush: TerrainBrush;
     private _currentTool: TerrainEditorSculptTool | null = null;
 
-    constructor(gizmo: any) {
+    constructor(gizmo: TerrainGizmo) {
         super(gizmo);
         const circle = new TerrainCircleBrush(); circle.strength = 5;
         const image = new TerrainImageBrush(); image.strength = 5;
@@ -41,13 +42,13 @@ export class TerrainEditorSculpt extends TerrainEditorMode {
     }
     public setSculptBrushRotation(rotation: number) { (this.getBrush(TerrainBrushType.IMAGE) as TerrainImageBrush)._rotation = rotation; }
 
-    public onUpdate(terrain: Terrain, deltaTime: number, isShiftDown: boolean) {
+    public update(terrain: Terrain, deltaTime: number, isShiftDown: boolean) {
         if (!this._currentTool) return;
         const modifiers = new TerrainEdModifierKeyState(); modifiers.siftPressed = isShiftDown;
         this._updateHeight(terrain, deltaTime, modifiers);
         this.gizmo.isTerrainChange = true;
     }
-    public forceUpdate() { TerrainBrush.updateBrushDepthOffsetToMaterial(this._currentBrush.material); }
+    public refreshPreview() { TerrainBrush.updateBrushDepthOffsetToMaterial(this._currentBrush.material); }
 
     public onUpdateBrushPosition(terrain: Terrain, position: Vec3) {
         const brush = this._currentBrush; brush.update(terrain, position);
@@ -67,14 +68,14 @@ export class TerrainEditorSculpt extends TerrainEditorMode {
 
     public onMouseDown(terrain: Terrain) {
         this._undo = new TerrainHeightUndoRedo(terrain);
-        let mode = eTerrainTerrainEditorSculptToolMode.SCULPT;
-        if (this.gizmo.isSmooth) mode = eTerrainTerrainEditorSculptToolMode.SMOOTH;
-        else if (this.gizmo.isFlatten) mode = eTerrainTerrainEditorSculptToolMode.FLATTEN;
-        else if (this.gizmo.isSetHeight) mode = eTerrainTerrainEditorSculptToolMode.SET_HEIGHT;
+        let mode = TerrainSculptToolMode.SCULPT;
+        if (this.gizmo.isSmooth) mode = TerrainSculptToolMode.SMOOTH;
+        else if (this.gizmo.isFlatten) mode = TerrainSculptToolMode.FLATTEN;
+        else if (this.gizmo.isSetHeight) mode = TerrainSculptToolMode.SET_HEIGHT;
         switch (mode) {
-            case eTerrainTerrainEditorSculptToolMode.SMOOTH: this._currentTool = new TerrainEditorSculptTool_Smooth(); break;
-            case eTerrainTerrainEditorSculptToolMode.FLATTEN: this._currentTool = new TerrainEditorSculptTool_Flatten(); break;
-            case eTerrainTerrainEditorSculptToolMode.SET_HEIGHT: this._currentTool = new TerrainEditorSculptTool_SetHeight(this._currentBrush._setHeight); break;
+            case TerrainSculptToolMode.SMOOTH: this._currentTool = new TerrainEditorSculptTool_Smooth(); break;
+            case TerrainSculptToolMode.FLATTEN: this._currentTool = new TerrainEditorSculptTool_Flatten(); break;
+            case TerrainSculptToolMode.SET_HEIGHT: this._currentTool = new TerrainEditorSculptTool_SetHeight(this._currentBrush._setHeight); break;
             default: this._currentTool = new TerrainEditorSculptTool_Sculpt(this.gizmo.isConcave); break;
         }
         const x = Math.floor(this._currentBrush.position.x / terrain.info.tileSize);

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-select.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor-select.ts
@@ -5,6 +5,7 @@ import { ServiceEvents } from '../../../core/global-events';
 import type { ITerrainBlockLayerSlot } from '../../../../../common';
 import { TerrainBrush } from './terrain-brush';
 import { TerrainEditorMode } from './terrain-editor-mode';
+import type TerrainGizmo from './gizmo-select';
 
 export class TerrainEditorWeightMapData {
     public data = new Uint8Array();
@@ -20,7 +21,7 @@ export class TerrainEditorSelect extends TerrainEditorMode {
     private _weightData: TerrainEditorWeightMapData | null = null;
     private _layerList: Array<Texture2D | null> = [];
 
-    constructor(gizmo: any) {
+    constructor(gizmo: TerrainGizmo) {
         super(gizmo);
         const effect = (cc as any).EffectAsset?.get?.('internal/editor/terrain-select-brush');
         if (effect) { this._selectMaterial = new Material(); this._selectMaterial.initialize({ effectAsset: effect }); }
@@ -70,8 +71,8 @@ export class TerrainEditorSelect extends TerrainEditorMode {
             };
         });
     }
-    public onDeactivate() { this.setSelectBlock(null); }
-    public forceUpdate() {
+    public deactivate() { this.setSelectBlock(null); }
+    public refreshPreview() {
         if (!this._selectBlock) return;
         TerrainBrush.updateBrushDepthOffsetToMaterial(this._selectMaterial);
         this._selectBlock.setBrushMaterial(this._selectMaterial); this._selectBlock._invalidMaterial();

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-editor.ts
@@ -3,7 +3,7 @@ import { Service } from '../../../core/decorator';
 import ControllerUtils from '../../utils/controller-utils';
 import { TerrainBrush } from './terrain-brush';
 import { TerrainEditorManage } from './terrain-editor-manage';
-import { TerrainEditorMode, eTerrainEditorMode } from './terrain-editor-mode';
+import { TerrainEditorMode, TerrainEditorModeType } from './terrain-editor-mode';
 import { TerrainEditorPaint } from './terrain-editor-paint';
 import { TerrainEditorSculpt } from './terrain-editor-sculpt';
 import { TerrainEditorSelect } from './terrain-editor-select';
@@ -25,67 +25,127 @@ export class TerrainEditor {
         this._cameraComp = camera;
         this._gizmo = gizmo;
         this._modes = [
-            new TerrainEditorManage(gizmo), new TerrainEditorSculpt(gizmo),
-            new TerrainEditorPaint(gizmo), new TerrainEditorSelect(gizmo),
+            new TerrainEditorManage(gizmo),
+            new TerrainEditorSculpt(gizmo),
+            new TerrainEditorPaint(gizmo),
+            new TerrainEditorSelect(gizmo),
         ];
-        this.setMode(eTerrainEditorMode.MANAGE);
+        this.setMode(TerrainEditorModeType.MANAGE);
     }
-    public setEditTerrain(terrain: Terrain | null) { this._terrain = terrain; }
-    public getEditTerrain() { return this._terrain; }
-    public setMode(mode: eTerrainEditorMode) {
-        this._currentMode?.onDeactivate(); this._currentMode = this._modes[mode]; this._currentMode.onActivate(); this.clearBrush();
+    public setEditTerrain(terrain: Terrain | null) {
+        if (this._terrain === terrain) return;
+        if (this._terrain) {
+            this._currentMode?.deactivate();
+            this.clearBrushMaterials();
+        }
+        this._terrain = terrain;
+        if (terrain) this._currentMode?.activate();
     }
-    public clearBrush() {
-        this._terrain?.getBlocks().forEach((block) => block.setBrushMaterial(null));
-        this._currentMode?.onDeactivate();
+    public getEditTerrain() {
+        return this._terrain;
     }
-    public getMode<T extends eTerrainEditorMode>(mode: T) { return this._modes[mode] as [TerrainEditorManage, TerrainEditorSculpt, TerrainEditorPaint, TerrainEditorSelect][T]; }
-    public getCurrentMode() { return this._currentMode; }
+    public setMode(mode: TerrainEditorModeType) {
+        const nextMode = this._modes[mode];
+        if (this._currentMode === nextMode) return;
+
+        if (!this._terrain) {
+            this._currentMode = nextMode;
+            return;
+        }
+
+        this._currentMode?.deactivate();
+        this.clearBrushMaterials();
+        this._currentMode = nextMode;
+        nextMode.activate();
+    }
+    public getMode<T extends TerrainEditorModeType>(mode: T) {
+        return this._modes[mode] as [
+            TerrainEditorManage,
+            TerrainEditorSculpt,
+            TerrainEditorPaint,
+            TerrainEditorSelect,
+        ][T];
+    }
+    public getCurrentMode() {
+        return this._currentMode;
+    }
     public getCurrentModeType() {
         const index = this._modes.indexOf(this._currentMode as any);
-        return index < 0 ? eTerrainEditorMode.SCULPT : index as eTerrainEditorMode;
+        return index < 0 ? TerrainEditorModeType.SCULPT : (index as TerrainEditorModeType);
     }
-    public setCurrentLayer(layer: number) { this.getMode(eTerrainEditorMode.PAINT).setCurrentLayer(layer); }
-    public getCurrentLayer() { return this.getMode(eTerrainEditorMode.PAINT).getCurrentLayer(); }
+    public setCurrentLayer(layer: number) {
+        this.getMode(TerrainEditorModeType.PAINT).setCurrentLayer(layer);
+    }
+    public getCurrentLayer() {
+        return this.getMode(TerrainEditorModeType.PAINT).getCurrentLayer();
+    }
     public update(deltaTime: number, shiftDown: boolean) {
         if (!this._currentMode || !this._terrain) return;
-        this._currentMode.onUpdate(this._terrain, deltaTime, shiftDown);
+        this._currentMode.update(this._terrain, deltaTime, shiftDown);
         Service.Engine.repaintInEditMode();
     }
     public onMouseDown(x: number, y: number) {
         if (!this._terrain) return;
         this.isChanged = false;
-        const sculpt = this.getMode(eTerrainEditorMode.SCULPT), paint = this.getMode(eTerrainEditorMode.PAINT), select = this.getMode(eTerrainEditorMode.SELECT);
-        if (this._currentMode === sculpt) { sculpt.onMouseDown(this._terrain); this.isChanged = true; }
-        else if (this._currentMode === paint) { paint.onMouseDown(this._terrain); this.isChanged = true; }
-        else if (this._currentMode === select && this._cameraComp) select.onMouseDown(this._terrain, this._cameraComp, x, y);
+        const sculpt = this.getMode(TerrainEditorModeType.SCULPT),
+            paint = this.getMode(TerrainEditorModeType.PAINT),
+            select = this.getMode(TerrainEditorModeType.SELECT);
+        if (this._currentMode === sculpt) {
+            sculpt.onMouseDown(this._terrain);
+            this.isChanged = true;
+        } else if (this._currentMode === paint) {
+            paint.onMouseDown(this._terrain);
+            this.isChanged = true;
+        } else if (this._currentMode === select && this._cameraComp)
+            select.onMouseDown(this._terrain, this._cameraComp, x, y);
         Service.Engine.repaintInEditMode();
     }
     public onMouseUp() {
         if (!this._terrain) return;
-        const sculpt = this.getMode(eTerrainEditorMode.SCULPT), paint = this.getMode(eTerrainEditorMode.PAINT);
-        if (this._currentMode === sculpt) sculpt.onMouseUp(); else if (this._currentMode === paint) paint.onMouseUp();
-        this.isChanged = false; Service.Engine.repaintInEditMode();
+        const sculpt = this.getMode(TerrainEditorModeType.SCULPT),
+            paint = this.getMode(TerrainEditorModeType.PAINT);
+        if (this._currentMode === sculpt) sculpt.onMouseUp();
+        else if (this._currentMode === paint) paint.onMouseUp();
+        this.isChanged = false;
+        Service.Engine.repaintInEditMode();
     }
     public onMouseMove(x: number, y: number) {
         if (!this._terrain || !this._cameraComp) return;
         const from = this._cameraComp.node.getWorldPosition();
-        tempVec3_2.set(x, y, 0); this._cameraComp.screenToWorld(tempVec3_2, tempVec3_1);
+        tempVec3_2.set(x, y, 0);
+        this._cameraComp.screenToWorld(tempVec3_2, tempVec3_1);
         Vec3.subtract(tempVec3_3, tempVec3_1, from).normalize();
         const hit = this._terrain.rayCheck(from, tempVec3_3, 0.35, true);
         if (!hit) return;
-        const sculpt = this.getMode(eTerrainEditorMode.SCULPT), paint = this.getMode(eTerrainEditorMode.PAINT);
-        if (this._currentMode === sculpt) { sculpt.onUpdateBrushPosition(this._terrain, hit); this.isChanged = true; }
-        else if (this._currentMode === paint) { paint.onUpdateBrushPosition(this._terrain, hit); this.isChanged = true; }
+        const sculpt = this.getMode(TerrainEditorModeType.SCULPT),
+            paint = this.getMode(TerrainEditorModeType.PAINT);
+        if (this._currentMode === sculpt) {
+            sculpt.onUpdateBrushPosition(this._terrain, hit);
+            this.isChanged = true;
+        } else if (this._currentMode === paint) {
+            paint.onUpdateBrushPosition(this._terrain, hit);
+            this.isChanged = true;
+        }
         Service.Engine.repaintInEditMode();
     }
     public onHoverOut() {
-        if (this._currentMode !== this.getMode(eTerrainEditorMode.SELECT)) { this.clearBrush(); Service.Engine.repaintInEditMode(); }
+        if (this._currentMode !== this.getMode(TerrainEditorModeType.SELECT)) {
+            this.clearBrushMaterials();
+            Service.Engine.repaintInEditMode();
+        }
     }
     public updateBlockDepthOffset() {
-        const node = this._gizmo.target?.node, camera = this._cameraComp;
+        const node = this._gizmo.target?.node,
+            camera = this._cameraComp;
         if (!node || !camera) return;
         TerrainBrush.updateBrushDepthOffset(ControllerUtils.getCameraDistanceFactor(node.position, camera.node));
-        if (this._currentMode === this.getMode(eTerrainEditorMode.SELECT)) { this.getMode(eTerrainEditorMode.SELECT).forceUpdate(); Service.Engine.repaintInEditMode(); }
+        if (this._currentMode === this.getMode(TerrainEditorModeType.SELECT)) {
+            this.getMode(TerrainEditorModeType.SELECT).refreshPreview();
+            Service.Engine.repaintInEditMode();
+        }
+    }
+
+    private clearBrushMaterials(): void {
+        this._terrain?.getBlocks().forEach(block => block.setBrushMaterial(null));
     }
 }

--- a/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-operation.ts
+++ b/src/core/scene/scene-process/service/gizmo/components/terrain/terrain-operation.ts
@@ -11,29 +11,45 @@ function commandMeta(type: string, terrain: Terrain): IUndoCommandMeta {
     };
 }
 
-export class TerrainHeightData { public x = 0; public y = 0; public value = 0; }
+export class TerrainHeightData {
+    public x = 0;
+    public y = 0;
+    public value = 0;
+}
 
 /** A single height delta applied during one brush update. */
 export class TerrainHeightOperation {
     protected _terrain: Terrain;
     public data: TerrainHeightData[] = [];
-    constructor(terrain: Terrain) { this._terrain = terrain; }
-    set terrain(value: Terrain) { this._terrain = value; }
-    get terrain() { return this._terrain; }
+    constructor(terrain: Terrain) {
+        this._terrain = terrain;
+    }
+    set terrain(value: Terrain) {
+        this._terrain = value;
+    }
+    get terrain() {
+        return this._terrain;
+    }
     public push(x: number, y: number, value: number) {
-        if (this.data.some((item) => item.x === x && item.y === y)) return;
+        if (this.data.some(item => item.x === x && item.y === y)) return;
         this.data.push(Object.assign(new TerrainHeightData(), { x, y, value }));
     }
     public apply() {
         const terrain = this._terrain;
         if (!terrain || !this.data.length) return;
-        let xmin = this.data[0].x, xmax = xmin, ymin = this.data[0].y, ymax = ymin;
+        let xmin = this.data[0].x,
+            xmax = xmin,
+            ymin = this.data[0].y,
+            ymax = ymin;
         for (const item of this.data) {
             terrain.setHeight(item.x, item.y, item.value);
-            xmin = Math.min(xmin, item.x); xmax = Math.max(xmax, item.x);
-            ymin = Math.min(ymin, item.y); ymax = Math.max(ymax, item.y);
+            xmin = Math.min(xmin, item.x);
+            xmax = Math.max(xmax, item.x);
+            ymin = Math.min(ymin, item.y);
+            ymax = Math.max(ymax, item.y);
         }
-        xmin = Math.max(0, xmin - 1); ymin = Math.max(0, ymin - 1);
+        xmin = Math.max(0, xmin - 1);
+        ymin = Math.max(0, ymin - 1);
         xmax = Math.min(terrain.info.vertexCount[0] - 1, xmax + 1);
         ymax = Math.min(terrain.info.vertexCount[1] - 1, ymax + 1);
         for (let y = ymin; y <= ymax; ++y) {
@@ -41,7 +57,10 @@ export class TerrainHeightOperation {
         }
         const range = new Rect(xmin, ymin, xmax - xmin + 1, ymax - ymin + 1);
         for (const block of terrain.getBlocks()) {
-            if (block.getRect().intersects(range)) { block._updateHeight(); block.update(); }
+            if (block.getRect().intersects(range)) {
+                block._updateHeight();
+                block.update();
+            }
         }
     }
 }
@@ -49,25 +68,45 @@ export class TerrainHeightOperation {
 export class TerrainHeightUndoRedo extends TerrainHeightOperation implements IUndoCommand {
     public readonly meta: IUndoCommandMeta;
     public redoOperations: TerrainHeightOperation[] = [];
-    constructor(terrain: Terrain) { super(terrain); this.meta = commandMeta('height', terrain); }
-    async undo(): Promise<IUndoRedoResult> { this.apply(); return { success: true, commandId: this.meta.id, label: this.meta.label }; }
+    constructor(terrain: Terrain) {
+        super(terrain);
+        this.meta = commandMeta('height', terrain);
+    }
+    async undo(): Promise<IUndoRedoResult> {
+        this.apply();
+        return { success: true, commandId: this.meta.id, label: this.meta.label };
+    }
     async redo(): Promise<IUndoRedoResult> {
         for (const operation of this.redoOperations) operation.apply();
         return { success: true, commandId: this.meta.id, label: this.meta.label };
     }
 }
 
-export class TerrainWeightData { public x = 0; public y = 0; public value = new Vec4(); }
+export class TerrainWeightData {
+    public x = 0;
+    public y = 0;
+    public value = new Vec4();
+}
 
 export class TerrainWeightOperation {
     protected _terrain: Terrain;
     public data: TerrainWeightData[] = [];
-    constructor(terrain: Terrain) { this._terrain = terrain; }
-    set terrain(value: Terrain) { this._terrain = value; }
-    get terrain() { return this._terrain; }
+    constructor(terrain: Terrain) {
+        this._terrain = terrain;
+    }
+    set terrain(value: Terrain) {
+        this._terrain = value;
+    }
+    get terrain() {
+        return this._terrain;
+    }
     public push(x: number, y: number, value: Vec4) {
-        if (this.data.some((item) => item.x === x && item.y === y)) return;
-        const item = new TerrainWeightData(); item.x = x; item.y = y; item.value.set(value); this.data.push(item);
+        if (this.data.some(item => item.x === x && item.y === y)) return;
+        const item = new TerrainWeightData();
+        item.x = x;
+        item.y = y;
+        item.value.set(value);
+        this.data.push(item);
     }
     public apply() {
         const terrain = this._terrain;
@@ -81,14 +120,20 @@ export class TerrainWeightOperation {
             );
             if (block) changed.add(block);
         }
-        for (const block of changed) { block._updateWeightMap(); block.update(); }
+        for (const block of changed) {
+            block._updateWeightMap();
+            block.update();
+        }
     }
 }
 
 export class TerrainBlockLayerData {
     public readonly block: TerrainBlock;
     public readonly layers: number[];
-    constructor(block: TerrainBlock, layers: number[]) { this.block = block; this.layers = [...layers]; }
+    constructor(block: TerrainBlock, layers: number[]) {
+        this.block = block;
+        this.layers = [...layers];
+    }
 }
 
 export class TerrainWeightUndoRedo extends TerrainWeightOperation implements IUndoCommand {
@@ -96,23 +141,28 @@ export class TerrainWeightUndoRedo extends TerrainWeightOperation implements IUn
     public readonly undoBlockLayers: TerrainBlockLayerData[] = [];
     public readonly redoBlockLayers: TerrainBlockLayerData[] = [];
     public readonly redoOperations: TerrainWeightOperation[] = [];
-    constructor(terrain: Terrain) { super(terrain); this.meta = commandMeta('weight', terrain); }
+    constructor(terrain: Terrain) {
+        super(terrain);
+        this.meta = commandMeta('weight', terrain);
+    }
     private applyLayers(items: TerrainBlockLayerData[]) {
         for (const item of items) item.layers.forEach((layer, index) => item.block.setLayer(index, layer));
     }
     async undo(): Promise<IUndoRedoResult> {
-        this.applyLayers(this.undoBlockLayers); this.apply();
+        this.applyLayers(this.undoBlockLayers);
+        this.apply();
         return { success: true, commandId: this.meta.id, label: this.meta.label };
     }
     async redo(): Promise<IUndoRedoResult> {
-        this.applyLayers(this.redoBlockLayers); for (const operation of this.redoOperations) operation.apply();
+        this.applyLayers(this.redoBlockLayers);
+        for (const operation of this.redoOperations) operation.apply();
         return { success: true, commandId: this.meta.id, label: this.meta.label };
     }
     public pushBlock(block: TerrainBlock, undoLayers: number[], redoLayers: number[]) {
-        const redo = this.redoBlockLayers.find((item) => item.block === block);
+        const redo = this.redoBlockLayers.find(item => item.block === block);
         if (redo) redo.layers.splice(0, redo.layers.length, ...redoLayers);
         else this.redoBlockLayers.push(new TerrainBlockLayerData(block, redoLayers));
-        if (!this.undoBlockLayers.some((item) => item.block === block)) {
+        if (!this.undoBlockLayers.some(item => item.block === block)) {
             this.undoBlockLayers.push(new TerrainBlockLayerData(block, undoLayers));
         }
     }
@@ -121,16 +171,30 @@ export class TerrainWeightUndoRedo extends TerrainWeightOperation implements IUn
 /** Kept for API compatibility with the 3.x layer operation implementation. */
 export class TerrainLayerOperation {
     protected _terrain: Terrain;
-    protected _layers: (any)[] = [];
-    constructor(terrain: Terrain) { this._terrain = terrain; }
-    set terrain(value: Terrain) { this._terrain = value; }
-    get terrain() { return this._terrain; }
-    setLayers() { this._layers = (this._terrain as any)._layerList?.slice?.() ?? []; }
-    apply() { this._layers.forEach((layer, index) => (this._terrain as any).setLayer(index, layer)); }
+    protected _layers: any[] = [];
+    constructor(terrain: Terrain) {
+        this._terrain = terrain;
+    }
+    set terrain(value: Terrain) {
+        this._terrain = value;
+    }
+    get terrain() {
+        return this._terrain;
+    }
+    setLayers() {
+        this._layers = (this._terrain as any)._layerList?.slice?.() ?? [];
+    }
+    apply() {
+        this._layers.forEach((layer, index) => (this._terrain as any).setLayer(index, layer));
+    }
 }
 
 export class TerrainLayerUndoRedo extends TerrainLayerOperation {
     public redoOperations: TerrainLayerOperation[] = [];
-    undo() { this.apply(); }
-    redo() { this.redoOperations.forEach((operation) => operation.apply()); }
+    undo() {
+        this.apply();
+    }
+    redo() {
+        this.redoOperations.forEach(operation => operation.apply());
+    }
 }

--- a/src/core/scene/scene-process/service/terrain.ts
+++ b/src/core/scene/scene-process/service/terrain.ts
@@ -4,6 +4,7 @@ import { ServiceEvents } from './core/global-events';
 import { getEditorNodeByUuid, getEditorNodeByPath } from './gizmo/utils/editor-node';
 import { loadAny } from './node/node-create';
 import { sceneAssetBinaryClient } from '../scene-asset-binary-client';
+import { TerrainLayerError } from '../../common';
 import type {
     ITerrainBlockData,
     ITerrainBrushPatch,
@@ -14,6 +15,7 @@ import type {
     ITerrainLayerState,
     ITerrainManageState,
     ITerrainPaintSessionPatch,
+    ITerrainPaintBrushPatch,
     ITerrainService,
     ITerrainSculptSessionPatch,
     ITerrainTarget,
@@ -45,6 +47,24 @@ const terrainEditorModes = new Set<TerrainEditorMode>(['manage', 'sculpt', 'pain
 const terrainSculptTools = new Set<NonNullable<ITerrainSculptSessionPatch['tool']>>([
     'bulge', 'sunken', 'smooth', 'flatten', 'set-height',
 ]);
+
+/**
+ * The built-in Texture2D sub-asset used for immediate Terrain layer creation.
+ *
+ * This is the `userData.redirect` Texture2D in
+ * `editor/assets/default-terrain/default-layer-texture.jpg.meta`; the root JPG UUID
+ * identifies an ImageAsset and must not be passed to `loadAny<Texture2D>`.
+ */
+const DEFAULT_TERRAIN_LAYER_DETAIL_MAP_UUID = '52ef29ed-bd92-4e94-ab2f-0ebc91bf3a60@6c48a';
+
+/** CLI-owned material defaults for an authoring-ready Terrain layer. */
+const defaultTerrainLayer: ITerrainLayerState = {
+    detailMapUuid: DEFAULT_TERRAIN_LAYER_DETAIL_MAP_UUID,
+    normalMapUuid: null,
+    metallic: 0,
+    roughness: 1,
+    tileSize: 1,
+};
 
 function copyTarget(target: ITerrainTarget): ITerrainTarget {
     return { nodeUuid: target.nodeUuid, componentUuid: target.componentUuid };
@@ -93,8 +113,14 @@ function normalizeSculptPatch(value: unknown): ITerrainSculptSessionPatch | unde
 
 function normalizePaintPatch(value: unknown): ITerrainPaintSessionPatch | undefined {
     if (!value || typeof value !== 'object') return undefined;
-    const brush = normalizeBrushPatch((value as ITerrainPaintSessionPatch).brush);
-    return brush ? { brush } : undefined;
+    const source = (value as ITerrainPaintSessionPatch).brush;
+    if (!source || typeof source !== 'object') return undefined;
+    const brush: ITerrainPaintBrushPatch = normalizeBrushPatch(source) ?? {};
+    if (Object.hasOwn(source, 'falloff')) {
+        if (typeof source.falloff !== 'number' || !Number.isFinite(source.falloff) || source.falloff < 0 || source.falloff > 1) return undefined;
+        brush.falloff = source.falloff;
+    }
+    return Object.keys(brush).length ? { brush } : undefined;
 }
 
 
@@ -370,16 +396,29 @@ export class TerrainService extends BaseService<ITerrainEvents> implements ITerr
         return result;
     }
 
-    /** Adds one complete layer; incompatible or unavailable textures leave Terrain untouched. */
-    public async addLayer(target: ITerrainTarget, layer: ITerrainLayerState): Promise<TerrainReadResult> {
-        const next = normalizeLayerState(layer);
+    /** Adds a complete layer, or applies the built-in Texture2D and CLI-owned defaults when omitted. */
+    public async addLayer(target: ITerrainTarget, layer?: ITerrainLayerState): Promise<TerrainReadResult> {
+        const usesDefaultLayer = layer === undefined;
+        const next = usesDefaultLayer ? defaultTerrainLayer : normalizeLayerState(layer);
         if (!next || !next.detailMapUuid) return this.read(target);
         const initial = this.resolveTarget(target);
         if (!initial) return isTerrainTarget(target) ? this.invalidResult(target) : this.read(target);
         const undoService = this.getTerrainUndoService();
         if (!undoService) return this.readResolved(target, initial.gizmo);
-        const assets = await this.loadLayerAssets(next);
-        if (!assets?.detailMap) return this.read(target);
+
+        let assets: ITerrainLayerAssets | null;
+        if (usesDefaultLayer) {
+            try {
+                assets = await this.loadDefaultTerrainLayerAssets();
+            } catch (error) {
+                const current = this.resolveTarget(target);
+                if (!current) return isTerrainTarget(target) ? this.invalidResult(target) : this.read(target);
+                throw error;
+            }
+        } else {
+            assets = await this.loadLayerAssets(next);
+            if (!assets?.detailMap) return this.read(target);
+        }
 
         const resolved = this.resolveTarget(target);
         if (!resolved) return isTerrainTarget(target) ? this.invalidResult(target) : this.read(target);
@@ -477,6 +516,22 @@ export class TerrainService extends BaseService<ITerrainEvents> implements ITerr
         } catch (error) {
             console.warn(`[Terrain] load ${usage} texture failed: ${uuid}`, error);
             return null;
+        }
+    }
+
+    /** Loads the CLI-owned default as a required internal asset and preserves the underlying failure. */
+    private async loadDefaultTerrainLayerAssets(): Promise<ITerrainLayerAssets> {
+        const message = 'The built-in default Terrain layer Detail Map is unavailable.';
+        try {
+            const detailMap = await loadAny<Texture2D>(DEFAULT_TERRAIN_LAYER_DETAIL_MAP_UUID);
+            if (!(detailMap instanceof Texture2D)) {
+                throw new TerrainLayerError('DEFAULT_DETAIL_MAP_UNAVAILABLE', message);
+            }
+            return { detailMap, normalMap: null };
+        } catch (error) {
+            console.error(`[Terrain] load layer texture failed: ${DEFAULT_TERRAIN_LAYER_DETAIL_MAP_UUID}`, error);
+            if (error instanceof TerrainLayerError) throw error;
+            throw new TerrainLayerError('DEFAULT_DETAIL_MAP_UNAVAILABLE', message, { cause: error });
         }
     }
 

--- a/src/core/scene/test/terrain-editor-lifecycle.test.ts
+++ b/src/core/scene/test/terrain-editor-lifecycle.test.ts
@@ -1,0 +1,164 @@
+const mockRepaintInEditMode = jest.fn();
+
+type MockModeName = 'manage' | 'sculpt' | 'paint' | 'select';
+interface MockMode {
+    activate: jest.Mock;
+    deactivate: jest.Mock;
+    update: jest.Mock;
+    refreshPreview: jest.Mock;
+}
+
+const mockModeInstances: Record<MockModeName, MockMode[]> = {
+    manage: [],
+    sculpt: [],
+    paint: [],
+    select: [],
+};
+
+function mockCreateMode(name: MockModeName) {
+    return class {
+        public activate = jest.fn();
+        public deactivate = jest.fn();
+        public update = jest.fn();
+        public refreshPreview = jest.fn();
+
+        constructor() {
+            mockModeInstances[name].push(this);
+        }
+    };
+}
+
+jest.mock('cc', () => {
+    class Camera {}
+    class Terrain {}
+    class Vec3 {
+        public set() { return this; }
+        public normalize() { return this; }
+        public static subtract(out: Vec3) { return out; }
+    }
+
+    return { Camera, Terrain, Vec3 };
+});
+
+jest.mock('../scene-process/service/core/decorator', () => ({
+    Service: { Engine: { repaintInEditMode: mockRepaintInEditMode } },
+}));
+
+jest.mock('../scene-process/service/gizmo/utils/controller-utils', () => ({
+    __esModule: true,
+    default: { getCameraDistanceFactor: jest.fn(() => 1) },
+}));
+
+jest.mock('../scene-process/service/gizmo/components/terrain/terrain-brush', () => ({
+    TerrainBrush: { updateBrushDepthOffset: jest.fn() },
+}));
+
+jest.mock('../scene-process/service/gizmo/components/terrain/terrain-editor-manage', () => ({
+    TerrainEditorManage: mockCreateMode('manage'),
+}));
+
+jest.mock('../scene-process/service/gizmo/components/terrain/terrain-editor-sculpt', () => ({
+    TerrainEditorSculpt: mockCreateMode('sculpt'),
+}));
+
+jest.mock('../scene-process/service/gizmo/components/terrain/terrain-editor-paint', () => {
+    const MockMode = mockCreateMode('paint');
+    return {
+        TerrainEditorPaint: class extends MockMode {
+            private _currentLayer = -1;
+
+            public setCurrentLayer(layer: number) {
+                this._currentLayer = layer;
+            }
+
+            public getCurrentLayer() {
+                return this._currentLayer;
+            }
+
+            public deactivate = jest.fn(() => {
+                this._currentLayer = -1;
+            });
+        },
+    };
+});
+
+jest.mock('../scene-process/service/gizmo/components/terrain/terrain-editor-select', () => ({
+    TerrainEditorSelect: mockCreateMode('select'),
+}));
+
+import type { Terrain } from 'cc';
+import { TerrainEditor } from '../scene-process/service/gizmo/components/terrain/terrain-editor';
+import { TerrainEditorModeType } from '../scene-process/service/gizmo/components/terrain/terrain-editor-mode';
+import type TerrainGizmo from '../scene-process/service/gizmo/components/terrain/gizmo-select';
+
+describe('TerrainEditor mode lifecycle', () => {
+    beforeEach(() => {
+        for (const instances of Object.values(mockModeInstances)) instances.length = 0;
+        mockRepaintInEditMode.mockReset();
+    });
+
+    it('activates attached modes once and keeps hover and redundant mode changes non-destructive', () => {
+        const block = { setBrushMaterial: jest.fn() };
+        const terrain = { getBlocks: () => [block] } as unknown as Terrain;
+        const editor = new TerrainEditor(null, {} as TerrainGizmo);
+        const manage = mockModeInstances.manage[0];
+        const paint = mockModeInstances.paint[0];
+        const select = mockModeInstances.select[0];
+
+        expect(manage.activate).not.toHaveBeenCalled();
+        editor.setEditTerrain(terrain);
+        expect(manage.activate).toHaveBeenCalledTimes(1);
+
+        editor.setMode(TerrainEditorModeType.PAINT);
+        expect(manage.deactivate).toHaveBeenCalledTimes(1);
+        expect(paint.activate).toHaveBeenCalledTimes(1);
+        expect(paint.deactivate).not.toHaveBeenCalled();
+        expect(block.setBrushMaterial).toHaveBeenCalledWith(null);
+
+        editor.setCurrentLayer(2);
+        editor.onHoverOut();
+        expect(editor.getCurrentLayer()).toBe(2);
+        expect(paint.deactivate).not.toHaveBeenCalled();
+
+        editor.setMode(TerrainEditorModeType.PAINT);
+        expect(paint.activate).toHaveBeenCalledTimes(1);
+        expect(paint.deactivate).not.toHaveBeenCalled();
+
+        editor.update(0.25, true);
+        expect(paint.update).toHaveBeenCalledWith(terrain, 0.25, true);
+
+        editor.setMode(TerrainEditorModeType.SELECT);
+        expect(paint.deactivate).toHaveBeenCalledTimes(1);
+        expect(select.activate).toHaveBeenCalledTimes(1);
+
+        editor.setMode(TerrainEditorModeType.SELECT);
+        expect(select.activate).toHaveBeenCalledTimes(1);
+        expect(select.deactivate).not.toHaveBeenCalled();
+
+        editor.setEditTerrain(null);
+        expect(select.deactivate).toHaveBeenCalledTimes(1);
+        expect(editor.getEditTerrain()).toBeNull();
+    });
+
+    it('does not invoke mode lifecycle hooks while detached', () => {
+        const terrain = { getBlocks: () => [] } as unknown as Terrain;
+        const editor = new TerrainEditor(null, {} as TerrainGizmo);
+        const manage = mockModeInstances.manage[0];
+        const paint = mockModeInstances.paint[0];
+        const select = mockModeInstances.select[0];
+
+        editor.setMode(TerrainEditorModeType.PAINT);
+        expect(manage.deactivate).not.toHaveBeenCalled();
+        expect(paint.activate).not.toHaveBeenCalled();
+
+        editor.setEditTerrain(terrain);
+        expect(paint.activate).toHaveBeenCalledTimes(1);
+
+        editor.setEditTerrain(null);
+        expect(paint.deactivate).toHaveBeenCalledTimes(1);
+
+        editor.setMode(TerrainEditorModeType.SELECT);
+        expect(paint.deactivate).toHaveBeenCalledTimes(1);
+        expect(select.activate).not.toHaveBeenCalled();
+    });
+});

--- a/src/core/scene/test/terrain-gizmo-lifecycle.test.ts
+++ b/src/core/scene/test/terrain-gizmo-lifecycle.test.ts
@@ -19,6 +19,7 @@ jest.mock('cc', () => {
         Terrain,
         TerrainInfo,
         TerrainLayer,
+        clamp: (value: number, min: number, max: number) => Math.min(max, Math.max(min, value)),
         TERRAIN_MAX_LAYER_COUNT: 4,
     };
 });
@@ -57,12 +58,14 @@ jest.mock('../scene-process/service/gizmo/components/terrain/terrain-editor', ()
 }));
 
 jest.mock('../scene-process/service/gizmo/components/terrain/terrain-brush', () => ({
-    TerrainBrushType: { IMAGE: 1 },
+    TerrainBrushType: { CIRCLE: 0, IMAGE: 1 },
+    TerrainCircleBrush: class { },
     TerrainImageBrush: class { },
 }));
 
 import { Terrain } from 'cc';
 import TerrainGizmo from '../scene-process/service/gizmo/components/terrain/gizmo-select';
+import { eTerrainEditorMode } from '../scene-process/service/gizmo/components/terrain/terrain-editor-mode';
 import { TerrainEditorSelect } from '../scene-process/service/gizmo/components/terrain/terrain-editor-select';
 
 describe('TerrainGizmo lifecycle', () => {
@@ -121,6 +124,68 @@ describe('TerrainGizmo lifecycle', () => {
 
         block?.weight?.data.fill(0);
         expect(source).toEqual(new Uint8Array([255, 0, 0, 0, 128, 127, 0, 0]));
+    });
+
+    it('clamps falloff through the real Terrain circle brush implementation', () => {
+        const { TerrainCircleBrush } = jest.requireActual<typeof import('../scene-process/service/gizmo/components/terrain/terrain-brush')>(
+            '../scene-process/service/gizmo/components/terrain/terrain-brush',
+        );
+        const brush = Object.create(TerrainCircleBrush.prototype) as InstanceType<typeof TerrainCircleBrush>;
+
+        brush.setFalloff(-0.1);
+        expect(brush.getFalloff()).toBe(0);
+        brush.setFalloff(0.4);
+        expect(brush.getFalloff()).toBe(0.4);
+        brush.setFalloff(1.1);
+        expect(brush.getFalloff()).toBe(1);
+    });
+
+    it('exposes and applies Paint falloff through the circle brush without changing the selected brush', () => {
+        let paintFalloff = 0.5;
+        const sculptCircle = { radius: 3, strength: 5, _setHeight: 9, _rotation: 0 };
+        const sculptImage = { image: { _uuid: 'sculpt-brush' }, _rotation: 15 };
+        const paintCircle = {
+            radius: 6,
+            strength: 4,
+            _setHeight: 0,
+            _rotation: 0,
+            getFalloff: jest.fn(() => paintFalloff),
+            setFalloff: jest.fn((value: number) => { paintFalloff = value; }),
+        };
+        const paintImage = { image: null, radius: 7, strength: 3, _setHeight: 0, _rotation: 0 };
+        const gizmo = new TerrainGizmo(null);
+        const terrain = new Terrain() as Terrain & { info: any; getLayer: jest.Mock };
+        terrain.info = { tileSize: 2, weightMapSize: 64, lightMapSize: 32, blockCount: [2, 3] };
+        terrain.getLayer = jest.fn(() => null);
+        gizmo.target = terrain;
+        (gizmo as any)._editor = {
+            getMode: (mode: number) => {
+                if (mode === 1) return {
+                    getCurrentBrush: () => sculptCircle,
+                    getBrush: (type: number) => type === 0 ? sculptCircle : sculptImage,
+                };
+                return {
+                    getCurrentBrush: () => paintImage,
+                    getBrush: (type: number) => type === 0 ? paintCircle : paintImage,
+                };
+            },
+            getCurrentModeType: () => 2,
+            getCurrentLayer: () => 0,
+        };
+
+        expect(gizmo.readTerrainState().paint.brush).toMatchObject({ kind: 'image', falloff: 0.5 });
+        expect(gizmo.queryBrushOfMode(eTerrainEditorMode.SCULPT)).toEqual({ radius: 3, strength: 5, _setHeight: 9 });
+        expect(gizmo.queryBrushOfMode(eTerrainEditorMode.PAINT)).toEqual({ radius: 7, strength: 3, _setHeight: 0, falloff: 0.5 });
+        expect(gizmo.queryBrushOfMode(eTerrainEditorMode.MANAGE)).toBeNull();
+
+        gizmo.updateTerrainPaintSession({ brush: { falloff: 0.2 } });
+        expect(paintCircle.setFalloff).toHaveBeenCalledWith(0.2);
+        expect(gizmo.queryBrushOfMode(eTerrainEditorMode.PAINT).falloff).toBe(0.2);
+
+        gizmo.setBrushOfMode(eTerrainEditorMode.PAINT, { falloff: 0.3 });
+        expect(paintCircle.setFalloff).toHaveBeenLastCalledWith(0.3);
+        expect(gizmo.queryBrushOfMode(eTerrainEditorMode.PAINT).falloff).toBe(0.3);
+        expect(paintImage).toMatchObject({ image: null, _rotation: 0 });
     });
 
     it('reads Block layer detail maps from the current Terrain state instead of the selection cache', () => {

--- a/src/core/scene/test/terrain-gizmo-lifecycle.test.ts
+++ b/src/core/scene/test/terrain-gizmo-lifecycle.test.ts
@@ -65,7 +65,7 @@ jest.mock('../scene-process/service/gizmo/components/terrain/terrain-brush', () 
 
 import { Terrain } from 'cc';
 import TerrainGizmo from '../scene-process/service/gizmo/components/terrain/gizmo-select';
-import { eTerrainEditorMode } from '../scene-process/service/gizmo/components/terrain/terrain-editor-mode';
+import { TerrainEditorModeType } from '../scene-process/service/gizmo/components/terrain/terrain-editor-mode';
 import { TerrainEditorSelect } from '../scene-process/service/gizmo/components/terrain/terrain-editor-select';
 
 describe('TerrainGizmo lifecycle', () => {
@@ -174,17 +174,17 @@ describe('TerrainGizmo lifecycle', () => {
         };
 
         expect(gizmo.readTerrainState().paint.brush).toMatchObject({ kind: 'image', falloff: 0.5 });
-        expect(gizmo.queryBrushOfMode(eTerrainEditorMode.SCULPT)).toEqual({ radius: 3, strength: 5, _setHeight: 9 });
-        expect(gizmo.queryBrushOfMode(eTerrainEditorMode.PAINT)).toEqual({ radius: 7, strength: 3, _setHeight: 0, falloff: 0.5 });
-        expect(gizmo.queryBrushOfMode(eTerrainEditorMode.MANAGE)).toBeNull();
+        expect(gizmo.queryBrushOfMode(TerrainEditorModeType.SCULPT)).toEqual({ radius: 3, strength: 5, _setHeight: 9 });
+        expect(gizmo.queryBrushOfMode(TerrainEditorModeType.PAINT)).toEqual({ radius: 7, strength: 3, _setHeight: 0, falloff: 0.5 });
+        expect(gizmo.queryBrushOfMode(TerrainEditorModeType.MANAGE)).toBeNull();
 
         gizmo.updateTerrainPaintSession({ brush: { falloff: 0.2 } });
         expect(paintCircle.setFalloff).toHaveBeenCalledWith(0.2);
-        expect(gizmo.queryBrushOfMode(eTerrainEditorMode.PAINT).falloff).toBe(0.2);
+        expect(gizmo.queryBrushOfMode(TerrainEditorModeType.PAINT).falloff).toBe(0.2);
 
-        gizmo.setBrushOfMode(eTerrainEditorMode.PAINT, { falloff: 0.3 });
+        gizmo.setBrushOfMode(TerrainEditorModeType.PAINT, { falloff: 0.3 });
         expect(paintCircle.setFalloff).toHaveBeenLastCalledWith(0.3);
-        expect(gizmo.queryBrushOfMode(eTerrainEditorMode.PAINT).falloff).toBe(0.3);
+        expect(gizmo.queryBrushOfMode(TerrainEditorModeType.PAINT).falloff).toBe(0.3);
         expect(paintImage).toMatchObject({ image: null, _rotation: 0 });
     });
 

--- a/src/core/scene/test/terrain-service.test.ts
+++ b/src/core/scene/test/terrain-service.test.ts
@@ -9,6 +9,7 @@ const mockUndo = {
     push: jest.fn(),
     isApplying: jest.fn(() => false),
 };
+const mockConsoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
 const mockConsoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
 
 jest.mock('cc', () => {
@@ -81,6 +82,7 @@ import type {
     TerrainBlockReadResult,
     TerrainReadResult,
 } from '../common/terrain';
+import { TerrainLayerError } from '../common/terrain';
 import { TerrainService } from '../scene-process/service/terrain';
 
 function clone<T>(value: T): T {
@@ -122,7 +124,7 @@ function createFixture(nodeUuid = 'node-a', componentUuid = 'terrain-a') {
             brush: { kind: 'image', imageUuid: 'sculpt-brush', radius: 3, strength: 5, rotation: 15, setHeight: 9 },
         },
         paint: {
-            brush: { kind: 'circle', imageUuid: null, radius: 6, strength: 4, rotation: 0, setHeight: 0 },
+            brush: { kind: 'circle', imageUuid: null, radius: 6, strength: 4, rotation: 0, setHeight: 0, falloff: 0.5 },
         },
     };
 
@@ -239,6 +241,7 @@ describe('TerrainService target-safe public capability', () => {
         mockUndo.push.mockReset();
         mockUndo.isApplying.mockReset();
         mockUndo.isApplying.mockReturnValue(false);
+        mockConsoleError.mockReset();
         mockConsoleWarn.mockReset();
     });
 
@@ -252,14 +255,17 @@ describe('TerrainService target-safe public capability', () => {
             service.setSculptSession(target, { tool: 'set-height', brush: { radius: 8, setHeight: 12 } });
             const brush = service.setSculptBrushAsset(target, 'brush');
             const paintBrush = service.setPaintBrushAsset(target, 'brush');
-            service.setPaintSession(target, { brush: { strength: 7 } });
+            service.setPaintSession(target, { brush: { strength: 7, falloff: 0.4 } });
+            // @ts-expect-error Falloff is a Paint-only session property.
+            service.setSculptSession(target, { brush: { falloff: 0.4 } });
             const manage = service.saveManage(target, { tileSize: 1, weightMapSize: 128, lightMapSize: 128, blockCount: [1, 1] });
+            const defaultLayer = service.addLayer(target);
             const add = service.addLayer(target, {
                 detailMapUuid: 'detail', normalMapUuid: null, metallic: 0, roughness: 1, tileSize: 1,
             });
             const update = service.updateLayer(target, 0, { roughness: 0.5 });
             const remove = service.removeLayer(target, 0);
-            return { read, block, brush, paintBrush, manage, add, update, remove };
+            return { read, block, brush, paintBrush, manage, defaultLayer, add, update, remove };
         };
 
         expect(assertPublicTerrainInterface).toBeDefined();
@@ -317,9 +323,9 @@ describe('TerrainService target-safe public capability', () => {
             valid: true,
             sculpt: { tool: 'set-height', brush: { radius: 8, strength: 6, rotation: 30, setHeight: 12 } },
         });
-        expect(service.setPaintSession(fixture.target, { brush: { strength: 7 } })).toMatchObject({
+        expect(service.setPaintSession(fixture.target, { brush: { strength: 7, falloff: 0.4 } })).toMatchObject({
             valid: true,
-            paint: { brush: { kind: 'circle', strength: 7 } },
+            paint: { brush: { kind: 'circle', strength: 7, falloff: 0.4 } },
         });
 
         expect(fixture.gizmo.setTerrainMode).toHaveBeenCalledWith('paint');
@@ -328,8 +334,38 @@ describe('TerrainService target-safe public capability', () => {
             tool: 'set-height',
             brush: { radius: 8, strength: 6, rotation: 30, setHeight: 12 },
         });
-        expect(fixture.gizmo.updateTerrainPaintSession).toHaveBeenCalledWith({ brush: { strength: 7 } });
+        expect(fixture.gizmo.updateTerrainPaintSession).toHaveBeenCalledWith({ brush: { strength: 7, falloff: 0.4 } });
         expect(mockEmit).toHaveBeenCalledWith('terrain:session-changed', fixture.target);
+    });
+
+    it('accepts only finite Paint falloff values within the inclusive unit interval', () => {
+        const fixture = createFixture();
+        mockQueryRegisteredService.mockReturnValue({ getComponentGizmo: () => fixture.gizmo });
+        const service = new TerrainService();
+        service.select(fixture.target.nodeUuid);
+
+        expect(service.setPaintSession(fixture.target, { brush: { falloff: 0 } })).toMatchObject({
+            valid: true,
+            paint: { brush: { falloff: 0 } },
+        });
+        expect(service.setPaintSession(fixture.target, { brush: { falloff: 1 } })).toMatchObject({
+            valid: true,
+            paint: { brush: { falloff: 1 } },
+        });
+
+        const updateCalls = fixture.gizmo.updateTerrainPaintSession.mock.calls.length;
+        for (const brush of [
+            { falloff: -0.1 },
+            { falloff: 1.1 },
+            { falloff: Number.NaN },
+            { strength: 9, falloff: -0.1 },
+        ]) {
+            expect(service.setPaintSession(fixture.target, { brush })).toMatchObject({
+                valid: true,
+                paint: { brush: { strength: 4, falloff: 1 } },
+            });
+        }
+        expect(fixture.gizmo.updateTerrainPaintSession).toHaveBeenCalledTimes(updateCalls);
     });
 
     it('assigns or clears only the explicit target Sculpt image brush and emits invalidation', async () => {
@@ -547,7 +583,36 @@ describe('TerrainService target-safe public capability', () => {
         expect(mockLoadAny).not.toHaveBeenCalled();
     });
 
-    it('reports a texture-load error while leaving the explicit Terrain unchanged', async () => {
+    it('creates an authoring-ready default layer with one Undo command', async () => {
+        const fixture = createFixture();
+        mockQueryRegisteredService.mockImplementation((name: string) => {
+            if (name === 'Gizmo') return { getComponentGizmo: () => fixture.gizmo };
+            if (name === 'Undo') return mockUndo;
+            return null;
+        });
+        mockLoadAny.mockImplementation(async (uuid: string) => new Texture2D(uuid));
+
+        const service = new TerrainService();
+        service.select(fixture.target.nodeUuid);
+
+        const added = await service.addLayer(fixture.target);
+        expect(added).toMatchObject({ valid: true });
+        if (!added.valid) throw new Error('Expected the explicit Terrain target to remain valid.');
+        expect(added.layers).toHaveLength(4);
+        expect(added.layers[1]).toEqual({
+            detailMapUuid: '52ef29ed-bd92-4e94-ab2f-0ebc91bf3a60@6c48a',
+            normalMapUuid: null,
+            metallic: 0,
+            roughness: 1,
+            tileSize: 1,
+        });
+
+        expect(mockLoadAny).toHaveBeenCalledWith('52ef29ed-bd92-4e94-ab2f-0ebc91bf3a60@6c48a');
+        expect(mockUndo.push).toHaveBeenCalledTimes(1);
+        expect(mockUndo.push.mock.calls[0][0].meta.type).toBe('terrain:add-layer');
+    });
+
+    it('reports a custom layer texture-load error without changing the explicit Terrain', async () => {
         const fixture = createFixture();
         mockQueryRegisteredService.mockImplementation((name: string) => {
             if (name === 'Gizmo') return { getComponentGizmo: () => fixture.gizmo };
@@ -565,6 +630,35 @@ describe('TerrainService target-safe public capability', () => {
         })).resolves.toEqual({ target: fixture.target, valid: true, assetUuid: 'terrain-asset', ...before });
 
         expect(mockConsoleWarn).toHaveBeenCalledWith('[Terrain] load layer texture failed: detail-load-error', error);
+        expect(fixture.state).toEqual(before);
+        expect(mockUndo.push).not.toHaveBeenCalled();
+    });
+
+    it('throws an internal error for an unavailable default Detail Map without changing a valid Terrain', async () => {
+        const fixture = createFixture();
+        mockQueryRegisteredService.mockImplementation((name: string) => {
+            if (name === 'Gizmo') return { getComponentGizmo: () => fixture.gizmo };
+            if (name === 'Undo') return mockUndo;
+            return null;
+        });
+        const error = new Error('asset database unavailable');
+        mockLoadAny.mockRejectedValue(error);
+
+        const service = new TerrainService();
+        service.select(fixture.target.nodeUuid);
+        const before = clone(fixture.state);
+
+        const thrown = await service.addLayer(fixture.target).catch((caught: unknown) => caught);
+        expect(thrown).toBeInstanceOf(TerrainLayerError);
+        expect(thrown).toMatchObject({
+            name: 'TerrainLayerError',
+            code: 'DEFAULT_DETAIL_MAP_UNAVAILABLE',
+            cause: error,
+        });
+        expect(mockConsoleError).toHaveBeenCalledWith(
+            '[Terrain] load layer texture failed: 52ef29ed-bd92-4e94-ab2f-0ebc91bf3a60@6c48a',
+            error,
+        );
         expect(fixture.state).toEqual(before);
         expect(mockUndo.push).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the camera and terrain editing systems, focusing on type safety, extensibility, and better state management for paint brushes and layers. The changes include new and refined TypeScript interfaces, improved runtime type safety, and enhanced API flexibility for terrain and camera services.

**Camera Service Improvements:**
- Added a `getCamera()` method to the `ICameraService` interface and its implementation, allowing safe access to the editor camera instance. The camera reference is now optional, and all usages are updated accordingly. [[1]](diffhunk://#diff-236c8d6114426713ca31879fd417272b88ccc3df66d13517caafc93a61f061a2L1-R1) [[2]](diffhunk://#diff-236c8d6114426713ca31879fd417272b88ccc3df66d13517caafc93a61f061a2R29-R30) [[3]](diffhunk://#diff-d0abef9793dfb90a13c6121e2fe305bbcd8b203062aef20775b9159ecac66357L22-R22) [[4]](diffhunk://#diff-d0abef9793dfb90a13c6121e2fe305bbcd8b203062aef20775b9159ecac66357L364-R380) [[5]](diffhunk://#diff-d0abef9793dfb90a13c6121e2fe305bbcd8b203062aef20775b9159ecac66357L468-R469) [[6]](diffhunk://#diff-a3cb29e43c224250957aaaa2273c38a3011e1d2b28583b3003f080e24cac1f4bL44-R55)
- Updated test snapshots to reflect the new camera import and interface changes. [[1]](diffhunk://#diff-a8348e31674835a05155d991b06289ab32594d5ea8f97984df20bd3ddb354d1dL5710-R5711) [[2]](diffhunk://#diff-a8348e31674835a05155d991b06289ab32594d5ea8f97984df20bd3ddb354d1dR6498)

**Terrain Paint Brush and Session State:**
- Introduced `ITerrainPaintBrushState` and `ITerrainPaintBrushPatch` to explicitly support a `falloff` property for paint brushes, improving type safety and clarity. All relevant state and session patch interfaces are updated to use these types. [[1]](diffhunk://#diff-7535fb0def00ea6f588e7adae95d9326c0293126ecd8d264e1cc1e4b2b81f3e4R60-R64) [[2]](diffhunk://#diff-7535fb0def00ea6f588e7adae95d9326c0293126ecd8d264e1cc1e4b2b81f3e4L60-R73) [[3]](diffhunk://#diff-7535fb0def00ea6f588e7adae95d9326c0293126ecd8d264e1cc1e4b2b81f3e4R126-R130) [[4]](diffhunk://#diff-7535fb0def00ea6f588e7adae95d9326c0293126ecd8d264e1cc1e4b2b81f3e4L106-R139) [[5]](diffhunk://#diff-a8348e31674835a05155d991b06289ab32594d5ea8f97984df20bd3ddb354d1dR7426-R7436)
- Updated terrain gizmo logic to properly handle and retain paint brush `falloff` values, ensuring consistent UI and editing behavior. [[1]](diffhunk://#diff-a3cb29e43c224250957aaaa2273c38a3011e1d2b28583b3003f080e24cac1f4bL109-R115) [[2]](diffhunk://#diff-a3cb29e43c224250957aaaa2273c38a3011e1d2b28583b3003f080e24cac1f4bL139-R148) [[3]](diffhunk://#diff-a3cb29e43c224250957aaaa2273c38a3011e1d2b28583b3003f080e24cac1f4bR206-R213) [[4]](diffhunk://#diff-a3cb29e43c224250957aaaa2273c38a3011e1d2b28583b3003f080e24cac1f4bR230-R236)

**Terrain Layer and Service API:**
- The `addLayer` method in `ITerrainService` now accepts an optional layer argument, defaulting to built-in values when omitted, enhancing API flexibility. [[1]](diffhunk://#diff-7535fb0def00ea6f588e7adae95d9326c0293126ecd8d264e1cc1e4b2b81f3e4L183-R217) [[2]](diffhunk://#diff-a8348e31674835a05155d991b06289ab32594d5ea8f97984df20bd3ddb354d1dL7459-R7467)
- Added `TerrainLayerError` and error code types to standardize error reporting for layer authoring failures.

**Runtime and Type Safety Enhancements:**
- Declared runtime fields on the engine's `Terrain` component for editor integration, improving type safety and maintainability. [[1]](diffhunk://#diff-7535fb0def00ea6f588e7adae95d9326c0293126ecd8d264e1cc1e4b2b81f3e4R3-R10) [[2]](diffhunk://#diff-a3cb29e43c224250957aaaa2273c38a3011e1d2b28583b3003f080e24cac1f4bL44-R55)

**Miscellaneous Fixes and Refactoring:**
- Improved type annotations and argument handling in terrain layer and brush-related methods for better safety and code clarity. [[1]](diffhunk://#diff-a3cb29e43c224250957aaaa2273c38a3011e1d2b28583b3003f080e24cac1f4bL10-R30) [[2]](diffhunk://#diff-a3cb29e43c224250957aaaa2273c38a3011e1d2b28583b3003f080e24cac1f4bL235-R267)

**File Formatting**
- reformat some files in terrain module

These changes collectively enhance the robustness, maintainability, and usability of the camera and terrain editing subsystems.