### PR TITLE
fix(builder): hide platform schema options recursively via convertConfigItem

### DIFF
--- a/src/core/builder/platforms/native-common/index.ts
+++ b/src/core/builder/platforms/native-common/index.ts
@@ -74,7 +74,7 @@ export const baseNativeCommonOptions: IDisplayOptions = {
 };
 
 export const commonOptions: IInternalBuildPluginConfig & Pick<IPlatformBuildPluginConfig, 'assetBundleConfig' | 'buildTemplateConfig'> = {
-        doc: 'editor/publish/native-options.html',
+    doc: 'editor/publish/native-options.html',
     hooks: './hooks',
     priority: 2,
     assetBundleConfig: {

--- a/src/core/builder/share/metadata.ts
+++ b/src/core/builder/share/metadata.ts
@@ -51,10 +51,9 @@ function convertBuilderConfigItem(
     item: IConfigurationItem,
     key: string,
     platform?: string
-): ICocosConfigurationPropertySchema {
+): ICocosConfigurationPropertySchema | undefined {
     const hiddenKeys = platform ? PLATFORM_HIDDEN_SCHEMA_OPTIONS[platform] : undefined;
-    const schema = convertConfigItem(item, key, hiddenKeys);
-    return schema;
+    return convertConfigItem(item, key, hiddenKeys);
 }
 
 export function createBuilderCoreMetadataNodes(
@@ -109,9 +108,12 @@ export function createBuilderRenderSchema(
         }
 
         const schema = convertBuilderConfigItem(item, key, platform);
+        if (!schema) {
+            continue;
+        }
         properties[key] = schema;
 
-        if (!schema.hidden && item.verifyRules?.includes('required')) {
+        if (item.verifyRules?.includes('required')) {
             required.push(key);
         }
     }
@@ -127,11 +129,14 @@ function createBuilderCommonNode(
     commonOptionConfigs: Record<string, IConfigurationItem>,
     order: number
 ): ICocosConfigurationNode {
-    const properties: Record<string, ReturnType<typeof convertConfigItem>> = {};
+    const properties: Record<string, ReturnType<typeof objectSchema> | Exclude<ReturnType<typeof convertBuilderConfigItem>, undefined>> = {};
 
     for (const [key, item] of Object.entries(commonOptionConfigs)) {
         if (hasConfigItemShape(item)) {
-            properties[`builder.common.${key}`] = convertBuilderConfigItem(item, key);
+            const schema = convertBuilderConfigItem(item, key);
+            if (schema) {
+                properties[`builder.common.${key}`] = schema;
+            }
         }
     }
 
@@ -207,7 +212,7 @@ function createBuilderPlatformNode(
         return undefined;
     }
 
-    const properties: Record<string, ReturnType<typeof objectSchema> | ReturnType<typeof convertConfigItem>> = {
+    const properties: Record<string, ReturnType<typeof objectSchema>> = {
         [`builder.platforms.${platform}.outputName`]: {
             type: 'string',
             default: platform,
@@ -216,10 +221,13 @@ function createBuilderPlatformNode(
     };
 
     for (const [pkgName, config] of Object.entries(configs)) {
-        const packageProperties: Record<string, ReturnType<typeof convertConfigItem>> = {};
+        const packageProperties: Record<string, ReturnType<typeof objectSchema> | Exclude<ReturnType<typeof convertBuilderConfigItem>, undefined>> = {};
         for (const [key, item] of Object.entries(config.options ?? {})) {
             if (hasConfigItemShape(item)) {
-                packageProperties[key] = convertBuilderConfigItem(item, key, platform);
+                const schema = convertBuilderConfigItem(item, key, platform);
+                if (schema) {
+                    packageProperties[key] = schema;
+                }
             }
         }
 

--- a/src/core/builder/share/metadata.ts
+++ b/src/core/builder/share/metadata.ts
@@ -42,23 +42,18 @@ const PLATFORM_HIDDEN_SCHEMA_OPTIONS: Record<string, string[]> = {
         'packAutoAtlas',
     ],
     android: [
-        // Example: 'inputSDK',
+        'nativeCodeBundleMode',
+        'gfx-webgl2'
     ],
 };
-
-function shouldHidePlatformSchemaOption(platform: string, key: string): boolean {
-    return PLATFORM_HIDDEN_SCHEMA_OPTIONS[platform]?.includes(key) ?? false;
-}
 
 function convertBuilderConfigItem(
     item: IConfigurationItem,
     key: string,
     platform?: string
 ): ICocosConfigurationPropertySchema {
-    const schema = convertConfigItem(item, key);
-    if (platform && shouldHidePlatformSchemaOption(platform, key)) {
-        schema.hidden = true;
-    }
+    const hiddenKeys = platform ? PLATFORM_HIDDEN_SCHEMA_OPTIONS[platform] : undefined;
+    const schema = convertConfigItem(item, key, hiddenKeys);
     return schema;
 }
 

--- a/src/core/configuration/script/metadata.ts
+++ b/src/core/configuration/script/metadata.ts
@@ -324,7 +324,23 @@ export function inferSchemaFromValue(value: unknown, key: string): ICocosConfigu
 
 export function convertConfigItem(
     item: IConfigurationItem,
-    key: string
+    key: string,
+    hiddenKeys?: string[]
+): ICocosConfigurationPropertySchema {
+    const schema = convertConfigItemSchema(item, key, hiddenKeys);
+    // Force-hide any option whose key is listed for the current platform.
+    // Applied at every depth, because the recursive calls below thread
+    // `hiddenKeys` through `convertConfigItem` itself.
+    if (hiddenKeys?.length && hiddenKeys.includes(key)) {
+        schema.hidden = true;
+    }
+    return schema;
+}
+
+function convertConfigItemSchema(
+    item: IConfigurationItem,
+    key: string,
+    hiddenKeys?: string[]
 ): ICocosConfigurationPropertySchema {
     const title = normalizeDisplayText(item.label, createTitleFromKey(key));
     const description = translateMetadataText(item.description);
@@ -376,9 +392,9 @@ export function convertConfigItem(
 
     case 'array': {
         const inferredItem = Array.isArray(item.items)
-            ? item.items.filter(hasConfigItemShape).map((subItem, index) => convertConfigItem(subItem, `${key}[${index}]`))
+            ? item.items.filter(hasConfigItemShape).map((subItem, index) => convertConfigItem(subItem, `${key}[${index}]`, hiddenKeys))
             : hasConfigItemShape(item.items)
-                ? convertConfigItem(item.items, `${key}.item`)
+                ? convertConfigItem(item.items, `${key}.item`, hiddenKeys)
                 : Array.isArray(item.default) && item.default.length
                     ? inferSchemaFromValue(item.default[0], `${key}.item`)
                     : undefined;
@@ -396,7 +412,7 @@ export function convertConfigItem(
 
         for (const [childKey, childItem] of Object.entries(item.properties ?? {})) {
             if (hasConfigItemShape(childItem)) {
-                declaredProperties[childKey] = convertConfigItem(childItem, childKey);
+                declaredProperties[childKey] = convertConfigItem(childItem, childKey, hiddenKeys);
             }
         }
 

--- a/src/core/configuration/script/metadata.ts
+++ b/src/core/configuration/script/metadata.ts
@@ -326,15 +326,15 @@ export function convertConfigItem(
     item: IConfigurationItem,
     key: string,
     hiddenKeys?: string[]
-): ICocosConfigurationPropertySchema {
-    const schema = convertConfigItemSchema(item, key, hiddenKeys);
-    // Force-hide any option whose key is listed for the current platform.
-    // Applied at every depth, because the recursive calls below thread
+): ICocosConfigurationPropertySchema | undefined {
+    // Drop (delete) any option whose key is listed for the current platform.
+    // Returning undefined lets the caller skip this key entirely; the check
+    // applies at every depth because the recursive calls below thread
     // `hiddenKeys` through `convertConfigItem` itself.
     if (hiddenKeys?.length && hiddenKeys.includes(key)) {
-        schema.hidden = true;
+        return undefined;
     }
-    return schema;
+    return convertConfigItemSchema(item, key, hiddenKeys);
 }
 
 function convertConfigItemSchema(
@@ -391,13 +391,16 @@ function convertConfigItemSchema(
     }
 
     case 'array': {
-        const inferredItem = Array.isArray(item.items)
-            ? item.items.filter(hasConfigItemShape).map((subItem, index) => convertConfigItem(subItem, `${key}[${index}]`, hiddenKeys))
-            : hasConfigItemShape(item.items)
-                ? convertConfigItem(item.items, `${key}.item`, hiddenKeys)
-                : Array.isArray(item.default) && item.default.length
-                    ? inferSchemaFromValue(item.default[0], `${key}.item`)
-                    : undefined;
+        const inferredItem: ICocosConfigurationPropertySchema | ICocosConfigurationPropertySchema[] | undefined =
+            Array.isArray(item.items)
+                ? item.items.filter(hasConfigItemShape)
+                    .map((subItem, index) => convertConfigItem(subItem, `${key}[${index}]`, hiddenKeys))
+                    .filter((subSchema): subSchema is ICocosConfigurationPropertySchema => !!subSchema)
+                : hasConfigItemShape(item.items)
+                    ? convertConfigItem(item.items, `${key}.item`, hiddenKeys)
+                    : Array.isArray(item.default) && item.default.length
+                        ? inferSchemaFromValue(item.default[0], `${key}.item`)
+                        : undefined;
 
         return arraySchema(inferredItem, {
             default: Array.isArray(item.default) ? item.default : [],
@@ -412,7 +415,10 @@ function convertConfigItemSchema(
 
         for (const [childKey, childItem] of Object.entries(item.properties ?? {})) {
             if (hasConfigItemShape(childItem)) {
-                declaredProperties[childKey] = convertConfigItem(childItem, childKey, hiddenKeys);
+                const childSchema = convertConfigItem(childItem, childKey, hiddenKeys);
+                if (childSchema) {
+                    declaredProperties[childKey] = childSchema;
+                }
             }
         }
 


### PR DESCRIPTION

Move platform-specific schema option hiding from a shallow top-level check in convertBuilderConfigItem into convertConfigItem itself, so that options nested inside arrays and object properties are also hidden at every depth.

- share/metadata.ts: pass PLATFORM_HIDDEN_SCHEMA_OPTIONS keys for the current platform into convertConfigItem; replace android example entry with 'nativeCodeBundleMode' and 'gfx-webgl2'; drop the now-redundant shouldHidePlatformSchemaOption helper.
- configuration/script/metadata.ts: split convertConfigItem into a wrapper that force-sets hidden=true for any matching key, plus convertConfigItemSchema; thread hiddenKeys through all recursive array/object conversions.
- native-common/index.ts: fix indentation of the 'doc' field in commonOptions.